### PR TITLE
Fix precommit scrips check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
         flakeboxLib = flakebox.lib.${system} { };
         rustSrc = flakeboxLib.filterSubPaths {
           root = builtins.path {
-            name = "cashu-sdk";
+            name = "cdk";
             path = ./.;
           };
           paths = [ "crates/cashu" "crates/cashu-sdk" ];
@@ -30,7 +30,7 @@
         toolchainsStd = flakeboxLib.mkStdToolchains { };
 
         toolchainNative = flakeboxLib.mkFenixToolchain {
-          targets = (pkgs.lib.getAttrs [ "default" ] targetsStd);
+          targets = (pkgs.lib.getAttrs [ "default" "wasm32-unknown" ] targetsStd);
         };
 
         commonArgs = {

--- a/misc/scripts/check-crates.sh
+++ b/misc/scripts/check-crates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/misc/scripts/check-crates.sh
+++ b/misc/scripts/check-crates.sh
@@ -28,6 +28,9 @@ buildargs=(
     "-p cdk --no-default-features --features wallet"
     "-p cdk --no-default-features --features mint"
     "-p cdk --no-default-features --features nut13"
+    "-p cdk-redb"
+    "-p cdk-redb --no-default-features --features wallet"
+    "-p cdk-redb --no-default-features --features mint"
 )
 
 for arg in "${buildargs[@]}"; do

--- a/misc/scripts/check-docs.sh
+++ b/misc/scripts/check-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/misc/scripts/check-fmt.sh
+++ b/misc/scripts/check-fmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -9,9 +9,6 @@ if [[ "$#" -gt 0 && "$1" == "check" ]]; then
     flags="--check"
 fi
 
-# Install toolchain
-rustup install nightly-2024-01-11
-rustup component add rustfmt --toolchain nightly-2024-01-11
 
 # Check workspace crates
-cargo +nightly-2024-01-11 fmt --all -- --config format_code_in_doc_comments=true $flags
+cargo fmt --all -- --config format_code_in_doc_comments=true $flags

--- a/misc/scripts/check.sh
+++ b/misc/scripts/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -exuo pipefail
 

--- a/misc/scripts/precommit.sh
+++ b/misc/scripts/precommit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -exuo pipefail
 


### PR DESCRIPTION
This removes rustup from the scripts. As rust versions should be managed through the nix shell and not rust up.