### PR TITLE
Add wallet tracing and fix receive bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ cdk = { path = "./crates/cdk", default-features = false }
 cdk-rexie = { path = "./crates/cdk-rexie", default-features = false }
 tokio = { version = "1.32", default-features = false }
 thiserror = "1"
-tracing = { version = "0.1", default-features = false }
+tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 serde-wasm-bindgen = { version = "0.6.5", default-features = false }

--- a/crates/cdk-redb/src/wallet.rs
+++ b/crates/cdk-redb/src/wallet.rs
@@ -302,7 +302,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn add_keys(&self, keys: Keys) -> Result<(), Self::Err> {
         let db = self.db.lock().await;
         let write_txn = db.begin_write().map_err(Error::from)?;

--- a/crates/cdk-redb/src/wallet.rs
+++ b/crates/cdk-redb/src/wallet.rs
@@ -10,6 +10,7 @@ use cdk::types::{MeltQuote, MintQuote};
 use cdk::url::UncheckedUrl;
 use redb::{Database, MultimapTableDefinition, ReadableTable, TableDefinition};
 use tokio::sync::Mutex;
+use tracing::instrument;
 
 use super::error::Error;
 
@@ -79,6 +80,7 @@ impl RedbWalletDatabase {
 impl WalletDatabase for RedbWalletDatabase {
     type Err = cdk_database::Error;
 
+    #[instrument(skip(self))]
     async fn add_mint(
         &self,
         mint_url: UncheckedUrl,
@@ -104,6 +106,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn get_mint(&self, mint_url: UncheckedUrl) -> Result<Option<MintInfo>, Self::Err> {
         let db = self.db.lock().await;
         let read_txn = db.begin_read().map_err(Into::<Error>::into)?;
@@ -119,6 +122,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(None)
     }
 
+    #[instrument(skip(self))]
     async fn get_mints(&self) -> Result<HashMap<UncheckedUrl, Option<MintInfo>>, Self::Err> {
         let db = self.db.lock().await;
         let read_txn = db.begin_read().map_err(Error::from)?;
@@ -138,6 +142,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(mints)
     }
 
+    #[instrument(skip(self))]
     async fn add_mint_keysets(
         &self,
         mint_url: UncheckedUrl,
@@ -168,6 +173,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn get_mint_keysets(
         &self,
         mint_url: UncheckedUrl,
@@ -188,6 +194,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(keysets)
     }
 
+    #[instrument(skip_all)]
     async fn add_mint_quote(&self, quote: MintQuote) -> Result<(), Self::Err> {
         let db = self.db.lock().await;
         let write_txn = db.begin_write().map_err(Error::from)?;
@@ -209,6 +216,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
+    #[instrument(skip_all)]
     async fn get_mint_quote(&self, quote_id: &str) -> Result<Option<MintQuote>, Self::Err> {
         let db = self.db.lock().await;
         let read_txn = db.begin_read().map_err(Into::<Error>::into)?;
@@ -223,6 +231,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(None)
     }
 
+    #[instrument(skip_all)]
     async fn remove_mint_quote(&self, quote_id: &str) -> Result<(), Self::Err> {
         let db = self.db.lock().await;
         let write_txn = db.begin_write().map_err(Error::from)?;
@@ -239,6 +248,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
+    #[instrument(skip_all)]
     async fn add_melt_quote(&self, quote: MeltQuote) -> Result<(), Self::Err> {
         let db = self.db.lock().await;
         let write_txn = db.begin_write().map_err(Error::from)?;
@@ -260,6 +270,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
+    #[instrument(skip_all)]
     async fn get_melt_quote(&self, quote_id: &str) -> Result<Option<MeltQuote>, Self::Err> {
         let db = self.db.lock().await;
         let read_txn = db.begin_read().map_err(Error::from)?;
@@ -274,6 +285,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(None)
     }
 
+    #[instrument(skip_all)]
     async fn remove_melt_quote(&self, quote_id: &str) -> Result<(), Self::Err> {
         let db = self.db.lock().await;
         let write_txn = db.begin_write().map_err(Error::from)?;
@@ -290,6 +302,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn add_keys(&self, keys: Keys) -> Result<(), Self::Err> {
         let db = self.db.lock().await;
         let write_txn = db.begin_write().map_err(Error::from)?;
@@ -309,6 +322,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn get_keys(&self, id: &Id) -> Result<Option<Keys>, Self::Err> {
         let db = self.db.lock().await;
         let read_txn = db.begin_read().map_err(Error::from)?;
@@ -321,6 +335,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(None)
     }
 
+    #[instrument(skip(self))]
     async fn remove_keys(&self, id: &Id) -> Result<(), Self::Err> {
         let db = self.db.lock().await;
         let write_txn = db.begin_write().map_err(Error::from)?;
@@ -336,6 +351,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
+    #[instrument(skip(self, proofs))]
     async fn add_proofs(&self, mint_url: UncheckedUrl, proofs: Proofs) -> Result<(), Self::Err> {
         let db = self.db.lock().await;
 
@@ -360,6 +376,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn get_proofs(&self, mint_url: UncheckedUrl) -> Result<Option<Proofs>, Self::Err> {
         let db = self.db.lock().await;
         let read_txn = db.begin_read().map_err(Error::from)?;
@@ -377,6 +394,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(proofs)
     }
 
+    #[instrument(skip(self, proofs))]
     async fn remove_proofs(
         &self,
         mint_url: UncheckedUrl,
@@ -405,6 +423,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
+    #[instrument(skip(self, proofs))]
     async fn add_pending_proofs(
         &self,
         mint_url: UncheckedUrl,
@@ -433,6 +452,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn get_pending_proofs(
         &self,
         mint_url: UncheckedUrl,
@@ -453,6 +473,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(proofs)
     }
 
+    #[instrument(skip(self, proofs))]
     async fn remove_pending_proofs(
         &self,
         mint_url: UncheckedUrl,
@@ -481,6 +502,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn increment_keyset_counter(&self, keyset_id: &Id, count: u64) -> Result<(), Self::Err> {
         let db = self.db.lock().await;
 
@@ -512,6 +534,7 @@ impl WalletDatabase for RedbWalletDatabase {
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn get_keyset_counter(&self, keyset_id: &Id) -> Result<Option<u64>, Self::Err> {
         let db = self.db.lock().await;
         let read_txn = db.begin_read().map_err(Error::from)?;

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -21,25 +21,39 @@ nut13 = ["dep:bip39"]
 async-trait = "0.1"
 base64 = "0.22" # bitcoin uses v0.13 (optional dep)
 bip39 = { version = "2.0", optional = true }
-bitcoin = { version = "0.30", features = ["serde", "rand", "rand-std"] } # lightning-invoice uses v0.30
+bitcoin = { version = "0.30", features = [
+    "serde",
+    "rand",
+    "rand-std",
+] } # lightning-invoice uses v0.30
 http = "1.0"
 lightning-invoice = { version = "0.30", features = ["serde"] }
 once_cell = "1.19"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "socks"], optional = true }
-serde = { version = "1.0", default-features = false, features = ["derive"]}
+reqwest = { version = "0.12", default-features = false, features = [
+    "json",
+    "rustls-tls",
+    "socks",
+], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 serde_with = "3.4"
-tracing = { version = "0.1", default-features = false }
+tracing = { version = "0.1", default-features = false, features = [
+    "attributes",
+    "log",
+] }
 thiserror = "1.0"
 url = "2.3"
 uuid = { version = "1.6", features = ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread", "time", "macros", "sync"] }
+tokio = { workspace = true, features = [
+    "rt-multi-thread",
+    "time",
+    "macros",
+    "sync",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 getrandom = { version = "0.2", features = ["js"] }
-instant = { version = "0.1", features = [ "wasm-bindgen", "inaccurate" ] }
-
-
+instant = { version = "0.1", features = ["wasm-bindgen", "inaccurate"] }

--- a/crates/cdk/src/client.rs
+++ b/crates/cdk/src/client.rs
@@ -3,6 +3,7 @@
 use reqwest::Client;
 use serde_json::Value;
 use thiserror::Error;
+use tracing::instrument;
 use url::Url;
 
 use crate::error::ErrorResponse;
@@ -74,6 +75,7 @@ impl HttpClient {
     }
 
     /// Get Active Mint Keys [NUT-01]
+    #[instrument(skip(self))]
     pub async fn get_mint_keys(&self, mint_url: Url) -> Result<Vec<KeySet>, Error> {
         let url = join_url(mint_url, &["v1", "keys"])?;
         let keys = self.inner.get(url).send().await?.json::<Value>().await?;
@@ -83,6 +85,7 @@ impl HttpClient {
     }
 
     /// Get Keyset Keys [NUT-01]
+    #[instrument(skip(self))]
     pub async fn get_mint_keyset(&self, mint_url: Url, keyset_id: Id) -> Result<KeySet, Error> {
         let url = join_url(mint_url, &["v1", "keys", &keyset_id.to_string()])?;
         let keys = self
@@ -99,6 +102,7 @@ impl HttpClient {
     }
 
     /// Get Keysets [NUT-02]
+    #[instrument(skip(self))]
     pub async fn get_mint_keysets(&self, mint_url: Url) -> Result<KeysetResponse, Error> {
         let url = join_url(mint_url, &["v1", "keysets"])?;
         let res = self.inner.get(url).send().await?.json::<Value>().await?;
@@ -113,6 +117,7 @@ impl HttpClient {
     }
 
     /// Mint Quote [NUT-04]
+    #[instrument(skip(self))]
     pub async fn post_mint_quote(
         &self,
         mint_url: Url,
@@ -137,6 +142,7 @@ impl HttpClient {
     }
 
     /// Mint Tokens [NUT-04]
+    #[instrument(skip(self, quote, premint_secrets))]
     pub async fn post_mint(
         &self,
         mint_url: Url,
@@ -169,6 +175,7 @@ impl HttpClient {
     }
 
     /// Melt Quote [NUT-05]
+    #[instrument(skip(self))]
     pub async fn post_melt_quote(
         &self,
         mint_url: Url,
@@ -194,6 +201,7 @@ impl HttpClient {
 
     /// Melt [NUT-05]
     /// [Nut-08] Lightning fee return if outputs defined
+    #[instrument(skip(self, quote, inputs, outputs))]
     pub async fn post_melt(
         &self,
         mint_url: Url,
@@ -222,6 +230,7 @@ impl HttpClient {
     }
 
     /// Split Token [NUT-06]
+    #[instrument(skip(self, swap_request))]
     pub async fn post_swap(
         &self,
         mint_url: Url,
@@ -241,6 +250,7 @@ impl HttpClient {
     }
 
     /// Get Mint Info [NUT-06]
+    #[instrument(skip(self))]
     pub async fn get_mint_info(&self, mint_url: Url) -> Result<MintInfo, Error> {
         let url = join_url(mint_url, &["v1", "info"])?;
 
@@ -255,6 +265,7 @@ impl HttpClient {
     }
 
     /// Spendable check [NUT-07]
+    #[instrument(skip(self))]
     pub async fn post_check_state(
         &self,
         mint_url: Url,
@@ -281,6 +292,7 @@ impl HttpClient {
         }
     }
 
+    #[instrument(skip(self, request))]
     pub async fn post_restore(
         &self,
         mint_url: Url,

--- a/crates/cdk/src/client.rs
+++ b/crates/cdk/src/client.rs
@@ -75,7 +75,7 @@ impl HttpClient {
     }
 
     /// Get Active Mint Keys [NUT-01]
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     pub async fn get_mint_keys(&self, mint_url: Url) -> Result<Vec<KeySet>, Error> {
         let url = join_url(mint_url, &["v1", "keys"])?;
         let keys = self.inner.get(url).send().await?.json::<Value>().await?;

--- a/crates/cdk/src/wallet.rs
+++ b/crates/cdk/src/wallet.rs
@@ -162,12 +162,12 @@ impl Wallet {
         Ok(balances)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     pub async fn get_proofs(&self, mint_url: UncheckedUrl) -> Result<Option<Proofs>, Error> {
         Ok(self.localstore.get_proofs(mint_url).await?)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     pub async fn add_mint(&self, mint_url: UncheckedUrl) -> Result<Option<MintInfo>, Error> {
         let mint_info = match self
             .client
@@ -188,7 +188,7 @@ impl Wallet {
         Ok(mint_info)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     pub async fn get_keyset_keys(
         &self,
         mint_url: &UncheckedUrl,
@@ -210,7 +210,7 @@ impl Wallet {
         Ok(keys)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     pub async fn get_mint_keysets(
         &self,
         mint_url: &UncheckedUrl,
@@ -225,7 +225,7 @@ impl Wallet {
     }
 
     /// Get active mint keyset
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     pub async fn get_active_mint_keys(
         &self,
         mint_url: &UncheckedUrl,
@@ -246,7 +246,7 @@ impl Wallet {
     }
 
     /// Refresh Mint keys
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     pub async fn refresh_mint_keys(&self, mint_url: &UncheckedUrl) -> Result<(), Error> {
         let current_mint_keysets_info = self
             .client
@@ -285,7 +285,7 @@ impl Wallet {
     }
 
     /// Check if a proof is spent
-    #[instrument(skip(self, proofs))]
+    #[instrument(skip(self, proofs), fields(mint_url = %mint_url))]
     pub async fn check_proofs_spent(
         &self,
         mint_url: UncheckedUrl,
@@ -307,7 +307,7 @@ impl Wallet {
     }
 
     /// Mint Quote
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     pub async fn mint_quote(
         &mut self,
         mint_url: UncheckedUrl,
@@ -334,6 +334,7 @@ impl Wallet {
     }
 
     /// Mint quote status
+    #[instrument(skip(self, quote_id), fields(mint_url = %mint_url))]
     pub async fn mint_quote_status(
         &self,
         mint_url: UncheckedUrl,
@@ -359,6 +360,7 @@ impl Wallet {
         Ok(response)
     }
 
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     async fn active_mint_keyset(
         &mut self,
         mint_url: &UncheckedUrl,
@@ -389,7 +391,7 @@ impl Wallet {
         Err(Error::NoActiveKeyset)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     async fn active_keys(
         &mut self,
         mint_url: &UncheckedUrl,
@@ -415,7 +417,7 @@ impl Wallet {
     }
 
     /// Mint
-    #[instrument(skip(self, quote_id))]
+    #[instrument(skip(self, quote_id), fields(mint_url = %mint_url))]
     pub async fn mint(&mut self, mint_url: UncheckedUrl, quote_id: &str) -> Result<Amount, Error> {
         // Check that mint is in store of mints
         if self.localstore.get_mint(mint_url.clone()).await?.is_none() {
@@ -523,7 +525,7 @@ impl Wallet {
     }
 
     /// Swap
-    #[instrument(skip(self, input_proofs))]
+    #[instrument(skip(self, input_proofs), fields(mint_url = %mint_url))]
     pub async fn swap(
         &mut self,
         mint_url: &UncheckedUrl,
@@ -631,7 +633,7 @@ impl Wallet {
     }
 
     /// Create Swap Payload
-    #[instrument(skip(self, proofs))]
+    #[instrument(skip(self, proofs), fields(mint_url = %mint_url))]
     async fn create_swap(
         &mut self,
         mint_url: &UncheckedUrl,
@@ -762,7 +764,7 @@ impl Wallet {
     }
 
     /// Send
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     pub async fn send(
         &mut self,
         mint_url: &UncheckedUrl,
@@ -799,7 +801,7 @@ impl Wallet {
     }
 
     /// Melt Quote
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     pub async fn melt_quote(
         &mut self,
         mint_url: UncheckedUrl,
@@ -831,6 +833,7 @@ impl Wallet {
     }
 
     /// Melt quote status
+    #[instrument(skip(self, quote_id), fields(mint_url = %mint_url))]
     pub async fn melt_quote_status(
         &self,
         mint_url: UncheckedUrl,
@@ -857,7 +860,7 @@ impl Wallet {
     }
 
     // Select proofs
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     pub async fn select_proofs(
         &self,
         mint_url: UncheckedUrl,
@@ -918,7 +921,7 @@ impl Wallet {
     }
 
     /// Melt
-    #[instrument(skip(self, quote_id))]
+    #[instrument(skip(self, quote_id), fields(mint_url = %mint_url))]
     pub async fn melt(&mut self, mint_url: &UncheckedUrl, quote_id: &str) -> Result<Melted, Error> {
         let quote_info = self.localstore.get_melt_quote(quote_id).await?;
 
@@ -1180,7 +1183,7 @@ impl Wallet {
         Ok(())
     }
 
-    #[instrument(skip(self, proofs))]
+    #[instrument(skip(self, proofs), fields(mint_url = %mint_url))]
     pub fn proofs_to_token(
         &self,
         mint_url: UncheckedUrl,
@@ -1192,7 +1195,7 @@ impl Wallet {
     }
 
     #[cfg(feature = "nut13")]
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(mint_url = %mint_url))]
     pub async fn restore(&mut self, mint_url: UncheckedUrl) -> Result<Amount, Error> {
         // Check that mint is in store of mints
         if self.localstore.get_mint(mint_url.clone()).await?.is_none() {


### PR DESCRIPTION
This follows up on a Discord conversation to add better tracing to the `Wallet`. Please verify that the proper arguments are skipped for security purposes.

Additionally, it fixes a bug where new mints were not added to the store from a received token, causing balance calculations to be incorrect.