### PR TITLE
fix(wallet): swap for proofs with conditons in send

### DIFF
--- a/crates/cdk/src/wallet.rs
+++ b/crates/cdk/src/wallet.rs
@@ -730,14 +730,16 @@ impl Wallet {
     ) -> Result<String, Error> {
         let input_proofs = self.select_proofs(mint_url.clone(), unit, amount).await?;
 
-        let send_proofs = match input_proofs
-            .iter()
-            .map(|p| p.amount)
-            .sum::<Amount>()
-            .eq(&amount)
-        {
-            true => Some(input_proofs),
-            false => {
+        let send_proofs = match (
+            input_proofs
+                .iter()
+                .map(|p| p.amount)
+                .sum::<Amount>()
+                .eq(&amount),
+            &conditions,
+        ) {
+            (true, None) => Some(input_proofs),
+            _ => {
                 self.swap(mint_url, unit, Some(amount), input_proofs, conditions)
                     .await?
             }


### PR DESCRIPTION
Since proofs with conditions are saved to the proofs table this simple check will work for now. In the future when melt with conditions is added this will need to be updated 