### PR TITLE
fix: Unknown Error response error

### DIFF
--- a/crates/cdk/src/client.rs
+++ b/crates/cdk/src/client.rs
@@ -27,14 +27,14 @@ pub enum Error {
     /// From hex error
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
-    ///  Min req error
-    #[error("Unknown Error response")]
-    UnknownErrorResponse(crate::error::ErrorResponse),
+    ///  Unknown error response
+    #[error("Unknown Error response: `{0}`")]
+    UnknownErrorResponse(String),
 }
 
 impl From<ErrorResponse> for Error {
     fn from(err: ErrorResponse) -> Error {
-        Self::UnknownErrorResponse(err)
+        Self::UnknownErrorResponse(err.to_string())
     }
 }
 

--- a/crates/cdk/src/error.rs
+++ b/crates/cdk/src/error.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::string::FromUtf8Error;
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use thiserror::Error;
 
 use crate::util::hex;
@@ -97,14 +98,24 @@ impl fmt::Display for ErrorResponse {
 
 impl ErrorResponse {
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
-        if let Ok(res) = serde_json::from_str::<ErrorResponse>(json) {
-            Ok(res)
-        } else {
-            Ok(Self {
+        match serde_json::from_str::<ErrorResponse>(json) {
+            Ok(res) => Ok(res),
+            Err(_) => Ok(Self {
                 code: 999,
                 error: Some(json.to_string()),
                 detail: None,
-            })
+            }),
+        }
+    }
+
+    pub fn from_value(value: Value) -> Result<Self, serde_json::Error> {
+        match serde_json::from_value::<ErrorResponse>(value.clone()) {
+            Ok(res) => Ok(res),
+            Err(_) => Ok(Self {
+                code: 999,
+                error: Some(value.to_string()),
+                detail: None,
+            }),
         }
     }
 }

--- a/crates/cdk/src/error.rs
+++ b/crates/cdk/src/error.rs
@@ -1,5 +1,6 @@
 //! Errors
 
+use std::fmt;
 use std::string::FromUtf8Error;
 
 use serde::{Deserialize, Serialize};
@@ -80,6 +81,18 @@ pub struct ErrorResponse {
     pub code: u32,
     pub error: Option<String>,
     pub detail: Option<String>,
+}
+
+impl fmt::Display for ErrorResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "code: {}, error: {}, detail: {}",
+            self.code,
+            self.error.clone().unwrap_or_default(),
+            self.detail.clone().unwrap_or_default()
+        )
+    }
 }
 
 impl ErrorResponse {

--- a/crates/cdk/src/nuts/nut13.rs
+++ b/crates/cdk/src/nuts/nut13.rs
@@ -15,7 +15,6 @@ use crate::{Amount, SECP256K1};
 
 impl Secret {
     pub fn from_xpriv(xpriv: ExtendedPrivKey, keyset_id: Id, counter: u32) -> Result<Self, Error> {
-        tracing::debug!("Deriving secret for {} with count {}", keyset_id, counter);
         let path = derive_path_from_keyset_id(keyset_id)?
             .child(ChildNumber::from_hardened_idx(counter)?)
             .child(ChildNumber::from_normal_idx(0)?);
@@ -29,7 +28,6 @@ impl Secret {
 
 impl SecretKey {
     pub fn from_xpriv(xpriv: ExtendedPrivKey, keyset_id: Id, counter: u32) -> Result<Self, Error> {
-        tracing::debug!("Deriving key for {} with count {}", keyset_id, counter);
         let path = derive_path_from_keyset_id(keyset_id)?
             .child(ChildNumber::from_hardened_idx(counter)?)
             .child(ChildNumber::from_normal_idx(1)?);


### PR DESCRIPTION
This allows for unknown error responses to simply be returned as strings closing #121. Error response should still be more structured and improved in #121 for known common error responses. 