### PR TITLE
Amount selection

### DIFF
--- a/bindings/cdk-js/src/wallet.rs
+++ b/bindings/cdk-js/src/wallet.rs
@@ -216,7 +216,7 @@ impl JsWallet {
 
         Ok(self
             .inner
-            .receive(&encoded_token, signing_keys, preimages)
+            .receive(&encoded_token, None, signing_keys, preimages)
             .await
             .map_err(into_err)?
             .into())
@@ -251,6 +251,7 @@ impl JsWallet {
                 &unit.into(),
                 memo,
                 Amount::from(amount),
+                None,
                 conditions,
             )
             .await
@@ -288,6 +289,7 @@ impl JsWallet {
                 &mint_url,
                 &unit.into(),
                 Some(Amount::from(amount)),
+                None,
                 proofs,
                 conditions,
             )

--- a/crates/cdk/src/amount.rs
+++ b/crates/cdk/src/amount.rs
@@ -27,8 +27,11 @@ impl Amount {
         let mut parts = vec![];
         let mut parts_total = Amount::ZERO;
 
-        match target {
-            &SplitTarget::Value(amount) => {
+        match *target {
+            SplitTarget::None => {
+                parts = self.split();
+            }
+            SplitTarget::Value(amount) => {
                 if self.le(&amount) {
                     return self.split();
                 }
@@ -60,8 +63,12 @@ impl Amount {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Serialize, Deserialize,
+)]
 pub enum SplitTarget {
+    #[default]
+    None,
     Value(Amount),
 }
 

--- a/crates/cdk/src/amount.rs
+++ b/crates/cdk/src/amount.rs
@@ -24,17 +24,15 @@ impl Amount {
 
     /// Split into parts that are powers of two by target
     pub fn split_targeted(&self, target: &SplitTarget) -> Vec<Self> {
-        let mut parts = vec![];
-        let mut parts_total = Amount::ZERO;
-
-        match *target {
-            SplitTarget::None => {
-                parts = self.split();
-            }
+        let mut parts = match *target {
+            SplitTarget::None => self.split(),
             SplitTarget::Value(amount) => {
                 if self.le(&amount) {
                     return self.split();
                 }
+
+                let mut parts_total = Amount::ZERO;
+                let mut parts = Vec::new();
 
                 // The powers of two that are need to create target value
                 let parts_of_value = amount.split();
@@ -55,8 +53,10 @@ impl Amount {
                         }
                     }
                 }
+
+                parts
             }
-        }
+        };
 
         parts.sort();
         parts
@@ -68,10 +68,10 @@ impl Amount {
     Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Serialize, Deserialize,
 )]
 pub enum SplitTarget {
-    /// Default target least amount of proofs
+    /// Default target; least amount of proofs
     #[default]
     None,
-    /// Tagrget amount for wallet to have most proofs that add up to value
+    /// Target amount for wallet to have most proofs that add up to value
     Value(Amount),
 }
 

--- a/crates/cdk/src/amount.rs
+++ b/crates/cdk/src/amount.rs
@@ -63,12 +63,15 @@ impl Amount {
     }
 }
 
+/// Kinds of targeting that are supported
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Serialize, Deserialize,
 )]
 pub enum SplitTarget {
+    /// Default target least amount of proofs
     #[default]
     None,
+    /// Tagrget amount for wallet to have most proofs that add up to value
     Value(Amount),
 }
 

--- a/crates/cdk/src/nuts/nut00.rs
+++ b/crates/cdk/src/nuts/nut00.rs
@@ -16,6 +16,7 @@ use url::Url;
 
 use super::nut10;
 use super::nut11::SpendingConditions;
+use crate::amount::SplitTarget;
 use crate::dhke::{blind_message, hash_to_curve};
 use crate::nuts::nut01::{PublicKey, SecretKey};
 use crate::nuts::nut11::{serde_p2pk_witness, P2PKWitness};
@@ -426,9 +427,10 @@ impl PreMintSecrets {
     pub fn with_conditions(
         keyset_id: Id,
         amount: Amount,
+        amount_split_target: SplitTarget,
         conditions: SpendingConditions,
     ) -> Result<Self, Error> {
-        let amount_split = amount.split();
+        let amount_split = amount.split_targeted(&amount_split_target);
 
         let mut output = Vec::with_capacity(amount_split.len());
 

--- a/crates/cdk/src/nuts/nut00.rs
+++ b/crates/cdk/src/nuts/nut00.rs
@@ -356,8 +356,12 @@ pub struct PreMintSecrets {
 
 impl PreMintSecrets {
     /// Outputs for speceifed amount with random secret
-    pub fn random(keyset_id: Id, amount: Amount) -> Result<Self, Error> {
-        let amount_split = amount.split();
+    pub fn random(
+        keyset_id: Id,
+        amount: Amount,
+        amount_split_target: &SplitTarget,
+    ) -> Result<Self, Error> {
+        let amount_split = amount.split_targeted(amount_split_target);
 
         let mut output = Vec::with_capacity(amount_split.len());
 
@@ -427,10 +431,10 @@ impl PreMintSecrets {
     pub fn with_conditions(
         keyset_id: Id,
         amount: Amount,
-        amount_split_target: SplitTarget,
+        amount_split_target: &SplitTarget,
         conditions: SpendingConditions,
     ) -> Result<Self, Error> {
-        let amount_split = amount.split_targeted(&amount_split_target);
+        let amount_split = amount.split_targeted(amount_split_target);
 
         let mut output = Vec::with_capacity(amount_split.len());
 

--- a/crates/cdk/src/nuts/nut13.rs
+++ b/crates/cdk/src/nuts/nut13.rs
@@ -7,6 +7,7 @@ use bitcoin::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey};
 use super::nut00::{BlindedMessage, PreMint, PreMintSecrets};
 use super::nut01::SecretKey;
 use super::nut02::Id;
+use crate::amount::SplitTarget;
 use crate::dhke::blind_message;
 use crate::error::Error;
 use crate::secret::Secret;
@@ -46,12 +47,13 @@ impl PreMintSecrets {
         xpriv: ExtendedPrivKey,
         amount: Amount,
         zero_amount: bool,
+        amount_split_target: &SplitTarget,
     ) -> Result<Self, Error> {
         let mut pre_mint_secrets = PreMintSecrets::default();
 
         let mut counter = counter;
 
-        for amount in amount.split() {
+        for amount in amount.split_targeted(amount_split_target) {
             let secret = Secret::from_xpriv(xpriv, keyset_id, counter)?;
             let blinding_factor = SecretKey::from_xpriv(xpriv, keyset_id, counter)?;
 

--- a/crates/cdk/src/util/mod.rs
+++ b/crates/cdk/src/util/mod.rs
@@ -3,10 +3,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use bitcoin::hashes::sha256::Hash as Sha256;
-use bitcoin::hashes::Hash;
-use bitcoin::secp256k1::rand::{self, RngCore};
-use bitcoin::secp256k1::{All, Secp256k1};
+use bitcoin::secp256k1::{rand, All, Secp256k1};
 #[cfg(target_arch = "wasm32")]
 use instant::SystemTime;
 use once_cell::sync::Lazy;
@@ -24,15 +21,7 @@ pub static SECP256K1: Lazy<Secp256k1<All>> = Lazy::new(|| {
     ctx
 });
 
-pub fn random_hash() -> Vec<u8> {
-    let mut rng = rand::thread_rng();
-    let mut random_bytes: [u8; 32] = [0u8; Sha256::LEN];
-    rng.fill_bytes(&mut random_bytes);
-
-    let hash = Sha256::hash(&random_bytes);
-    hash.to_byte_array().to_vec()
-}
-
+/// Seconds since unix epoch
 pub fn unix_time() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/crates/cdk/src/wallet.rs
+++ b/crates/cdk/src/wallet.rs
@@ -1195,7 +1195,11 @@ impl Wallet {
 
     #[cfg(feature = "nostr")]
     #[instrument(skip_all)]
-    pub async fn nostr_receive(&self, nostr_signing_key: SecretKey) -> Result<Amount, Error> {
+    pub async fn nostr_receive(
+        &self,
+        nostr_signing_key: SecretKey,
+        amount_split_target: Option<SplitTarget>,
+    ) -> Result<Amount, Error> {
         use nostr_sdk::{Keys, Kind};
 
         let verifying_key = nostr_signing_key.public_key();
@@ -1241,7 +1245,12 @@ impl Wallet {
         let mut total_received = Amount::ZERO;
         for token in tokens.iter() {
             match self
-                .receive(token, Some(vec![nostr_signing_key.clone()]), None)
+                .receive(
+                    token,
+                    amount_split_target,
+                    Some(vec![nostr_signing_key.clone()]),
+                    None,
+                )
                 .await
             {
                 Ok(amount) => total_received += amount,


### PR DESCRIPTION
Enables splitting to a target. 

Currently implemented is `SplitTarget::Value` to be used in the case where a specific amount or proofs that add up to a specific amount is desired. 