### PR TITLE
Fix potential keyset lock race condition

### DIFF
--- a/crates/cdk/src/mint.rs
+++ b/crates/cdk/src/mint.rs
@@ -763,14 +763,15 @@ impl Mint {
         if keysets.contains_key(id) {
             return Ok(());
         }
+        drop(keysets);
 
-        let mut keysets = self.keysets.write().await;
         let keyset_info = self
             .localstore
             .get_keyset_info(id)
             .await?
             .ok_or(Error::UnknownKeySet)?;
         let id = keyset_info.id;
+        let mut keysets = self.keysets.write().await;
         keysets.insert(id, self.generate_keyset(keyset_info));
         Ok(())
     }


### PR DESCRIPTION
I introduced a potential deadlock in the mint when loading keysets.

Now, the read lock is explicitly dropped, and then the write lock is acquired only at the end of the function when needed.