### PR TITLE
fix: insufficient funds bug in proof_selection example

### DIFF
--- a/crates/cdk/examples/proof_selection.rs
+++ b/crates/cdk/examples/proof_selection.rs
@@ -51,7 +51,7 @@ async fn main() {
     let proofs = wallet.get_proofs().await.unwrap();
 
     let selected = wallet
-        .select_proofs_to_send(Amount::from(65), proofs, false)
+        .select_proofs_to_send(Amount::from(64), proofs, false)
         .await
         .unwrap();
 


### PR DESCRIPTION
For some reason this example was minting a token worth 64 sats and attempting to generate proofs for 65 sats worth of tokens. We can either decrement the proof request to match the amount for the one ecash token or mint 1 more sat to match the proof request amount.