### PR TITLE
fix(mint): reset proofs in swap to unspent if error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - cdk(mint): On `swap` verify correct number of sigs on outputs when `SigAll` ([thesimplekid]).
 - cdk(mint): Use amount in payment_quote response from ln backend ([thesimplekid]).
 - cdk(mint): Create new keysets for added supported units ([thesimplekid]).
+- cdk(mint): If there is an error in swap proofs should be reset to unspent ([thesimplekid]).
 
 ### Removed
 - cdk(wallet): Remove unused argument `SplitTarget` on `melt` ([thesimplekid]).

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -76,3 +76,6 @@ required-features = ["wallet"]
 rand.workspace = true
 bip39.workspace = true
 anyhow.workspace = true
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bench)'] }


### PR DESCRIPTION
If an error occurs before the tokens are spent in a swap the state should be reset to unspent from pending so a wallet can try to spent again.