### PR TITLE
test: first mint unit tests

### DIFF
--- a/crates/cdk/src/nuts/nut02.rs
+++ b/crates/cdk/src/nuts/nut02.rs
@@ -9,6 +9,8 @@ use std::array::TryFromSliceError;
 use std::collections::BTreeMap;
 
 #[cfg(feature = "mint")]
+use bitcoin::bip32::DerivationPath;
+#[cfg(feature = "mint")]
 use bitcoin::bip32::{ChildNumber, ExtendedPrivKey};
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::Hash;
@@ -23,8 +25,6 @@ use thiserror::Error;
 use super::nut01::Keys;
 #[cfg(feature = "mint")]
 use super::nut01::{MintKeyPair, MintKeys};
-#[cfg(feature = "mint")]
-use crate::mint::MintKeySetInfo;
 use crate::nuts::nut00::CurrencyUnit;
 use crate::util::hex;
 #[cfg(feature = "mint")]
@@ -324,18 +324,18 @@ impl MintKeySet {
     pub fn generate_from_seed<C: secp256k1::Signing>(
         secp: &Secp256k1<C>,
         seed: &[u8],
-        info: MintKeySetInfo,
+        max_order: u8,
+        currency_unit: CurrencyUnit,
+        derivation_path: DerivationPath,
     ) -> Self {
         let xpriv =
             ExtendedPrivKey::new_master(bitcoin::Network::Bitcoin, seed).expect("RNG busted");
-        let max_order = info.max_order;
-        let unit = info.unit;
         Self::generate(
             secp,
             xpriv
-                .derive_priv(secp, &info.derivation_path)
+                .derive_priv(secp, &derivation_path)
                 .expect("RNG busted"),
-            unit,
+            currency_unit,
             max_order,
         )
     }
@@ -344,16 +344,16 @@ impl MintKeySet {
     pub fn generate_from_xpriv<C: secp256k1::Signing>(
         secp: &Secp256k1<C>,
         xpriv: ExtendedPrivKey,
-        info: MintKeySetInfo,
+        max_order: u8,
+        currency_unit: CurrencyUnit,
+        derivation_path: DerivationPath,
     ) -> Self {
-        let max_order = info.max_order;
-        let unit = info.unit;
         Self::generate(
             secp,
             xpriv
-                .derive_priv(secp, &info.derivation_path)
+                .derive_priv(secp, &derivation_path)
                 .expect("RNG busted"),
-            unit,
+            currency_unit,
             max_order,
         )
     }


### PR DESCRIPTION
First attempt to add some unit tests. I tried to start with a few fundamental operations. I hope to build up to more complex tests. This was mostly a learning exercise but I'm opening a draft PR to get some initial feedback on my approach. Is this useful? Is it redundant with existing tests? What additional assertions would be helpful?

I will probably want to move the new mint code to a helper function for use in other tests.

I think I uncovered an issue with `MintKeySet::generate_from_seed`. It requires a `MintKeysetInfo` struct, which includes an ID that is derived from the keysets but we haven't generated the keysets yet. It might be a good idea to change the function signature to accept `max_order`, `unit`, and `derivation_path` individually instead of the entire keyset info struct.