### PR TITLE
fix: typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ The project is split up into several crates in the `crates/` directory:
 
 * Libraries:
     * [**cdk**](./crates/cdk/): Rust implementation of Cashu protocol.
-    * [**cdk-sqlite**](./crates/cdk-sqlite/): Sqlite Storage backend.
+    * [**cdk-sqlite**](./crates/cdk-sqlite/): SQLite Storage backend.
     * [**cdk-redb**](./crates/cdk-redb/): Redb Storage backend.
-    * [**cdk-rexie**](./crates/cdk-rexie/): Rexie Storage backend for browsers
+    * [**cdk-rexie**](./crates/cdk-rexie/): Rexie Storage backend for browsers.
     * [**cdk-axum**](./crates/cdk-axum/): Axum webserver for mint.
     * [**cdk-cln**](./crates/cdk-cln/): CLN Lightning backend for mint.
     * [**cdk-strike**](./crates/cdk-strike/): Strike Lightning backend for mint.

--- a/crates/cdk-rexie/README.md
+++ b/crates/cdk-rexie/README.md
@@ -1,5 +1,5 @@
 
-# Cashu Development Kit Redb Storage Backend
+# Cashu Development Kit Rexie Storage Backend
 
 **ALPHA** This library is in early development, the api will change and should be used with caution.
 

--- a/crates/cdk-sqlite/Cargo.toml
+++ b/crates/cdk-sqlite/Cargo.toml
@@ -3,7 +3,7 @@ name = "cdk-sqlite"
 version = { workspace = true }
 edition = "2021"
 authors = ["CDK Developers"]
-description = "Sqlite storage backend for CDK"
+description = "SQLite storage backend for CDK"
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/cdk-sqlite/README.md
+++ b/crates/cdk-sqlite/README.md
@@ -1,5 +1,5 @@
 
-# Cashu Development Kit Redb Storage Backend
+# Cashu Development Kit SQLite Storage Backend
 
 **ALPHA** This library is in early development, the api will change and should be used with caution.
 


### PR DESCRIPTION
* there were a copy-paste errors in README.md files of cdk-rexie and cdk-sqlite which claimed these are a redb storage backends
* Sqlite -> SQLite