### PR TITLE
fix: make capitalization of error messages consistent

### DIFF
--- a/crates/cdk-cln/src/error.rs
+++ b/crates/cdk-cln/src/error.rs
@@ -9,7 +9,7 @@ pub enum Error {
     #[error("Unknown invoice amount")]
     UnknownInvoiceAmount,
     /// Wrong CLN response
-    #[error("Wrong cln response")]
+    #[error("Wrong CLN response")]
     WrongClnResponse,
     /// Unknown invoice
     #[error("Unknown invoice")]

--- a/crates/cdk-redb/src/error.rs
+++ b/crates/cdk-redb/src/error.rs
@@ -47,13 +47,13 @@ pub enum Error {
     #[error(transparent)]
     CDKNUT00(#[from] cdk::nuts::nut00::Error),
     /// Unknown Mint Info
-    #[error("Unknown Mint Info")]
+    #[error("Unknown mint info")]
     UnknownMintInfo,
     /// Unknown Proof Y
-    #[error("Unknown Proof Y")]
+    #[error("Unknown proof Y")]
     UnknownY,
     /// Unknown Database Version
-    #[error("Unknown Database Version")]
+    #[error("Unknown database version")]
     UnknownDatabaseVersion,
 }
 

--- a/crates/cdk-sqlite/src/mint/error.rs
+++ b/crates/cdk-sqlite/src/mint/error.rs
@@ -32,8 +32,8 @@ pub enum Error {
     /// BIP32 Error
     #[error(transparent)]
     BIP32(#[from] bitcoin::bip32::Error),
-    /// Could Not Initialize Db
-    #[error("Could not initialize Db")]
+    /// Could Not Initialize Database
+    #[error("Could not initialize database")]
     CouldNotInitialize,
     /// Invalid Database Path
     #[error("Invalid database path")]

--- a/crates/cdk-sqlite/src/wallet/error.rs
+++ b/crates/cdk-sqlite/src/wallet/error.rs
@@ -38,8 +38,8 @@ pub enum Error {
     /// BIP32 Error
     #[error(transparent)]
     BIP32(#[from] bitcoin::bip32::Error),
-    /// Could Not Initialize Db
-    #[error("Could not initialize Db")]
+    /// Could Not Initialize Database
+    #[error("Could not initialize database")]
     CouldNotInitialize,
     /// Invalid Database Path
     #[error("Invalid database path")]

--- a/crates/cdk/src/nuts/nut00/mod.rs
+++ b/crates/cdk/src/nuts/nut00/mod.rs
@@ -42,7 +42,7 @@ pub enum Error {
     #[error("Unsupported unit")]
     UnsupportedUnit,
     /// Invalid Url
-    #[error("Invalid Url")]
+    #[error("Invalid URL")]
     InvalidUrl,
     /// Serde Json error
     #[error(transparent)]

--- a/crates/cdk/src/nuts/nut05.rs
+++ b/crates/cdk/src/nuts/nut05.rs
@@ -19,7 +19,7 @@ use crate::{Amount, Bolt11Invoice};
 #[derive(Debug, Error)]
 pub enum Error {
     /// Unknown Quote State
-    #[error("Unknown Quote State")]
+    #[error("Unknown quote state")]
     UnknownState,
 }
 

--- a/crates/cdk/src/nuts/nut07.rs
+++ b/crates/cdk/src/nuts/nut07.rs
@@ -14,7 +14,7 @@ use super::nut01::PublicKey;
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum Error {
     /// Unknown State error
-    #[error("Unknown State")]
+    #[error("Unknown state")]
     UnknownState,
 }
 

--- a/crates/cdk/src/nuts/nut11/mod.rs
+++ b/crates/cdk/src/nuts/nut11/mod.rs
@@ -43,25 +43,25 @@ pub enum Error {
     #[error("Invalid signature")]
     InvalidSignature,
     /// Unknown tag in P2PK secret
-    #[error("Unknown Tag P2PK secret")]
+    #[error("Unknown tag P2PK secret")]
     UnknownTag,
     /// Unknown Sigflag
-    #[error("Unknown Sigflag")]
+    #[error("Unknown sigflag")]
     UnknownSigFlag,
     /// P2PK Spend conditions not meet
-    #[error("P2PK Spend conditions are not met")]
+    #[error("P2PK spend conditions are not met")]
     SpendConditionsNotMet,
     /// Pubkey must be in data field of P2PK
-    #[error("P2PK Required in secret data")]
+    #[error("P2PK required in secret data")]
     P2PKPubkeyRequired,
     /// Unknown Kind
     #[error("Kind not found")]
     KindNotFound,
     /// HTLC hash invalid
-    #[error("Invalid Hash")]
+    #[error("Invalid hash")]
     InvalidHash,
     /// Witness Signatures not provided
-    #[error("Witness Signatures not provided")]
+    #[error("Witness signatures not provided")]
     SignaturesNotProvided,
     /// Parse Url Error
     #[error(transparent)]

--- a/crates/cdk/src/nuts/nut12.rs
+++ b/crates/cdk/src/nuts/nut12.rs
@@ -17,14 +17,14 @@ use crate::{Amount, SECP256K1};
 /// NUT12 Error
 #[derive(Debug, Error)]
 pub enum Error {
-    /// Missing Dleq Proof
-    #[error("No Dleq Proof provided")]
+    /// Missing DLEQ Proof
+    #[error("No DLEQ proof provided")]
     MissingDleqProof,
-    /// Incomplete Dleq Proof
-    #[error("Incomplete DLEQ Proof")]
+    /// Incomplete DLEQ Proof
+    #[error("Incomplete DLEQ proof")]
     IncompleteDleqProof,
-    /// Invalid Dleq Proof
-    #[error("Invalid Dleq Prood")]
+    /// Invalid DLEQ Proof
+    #[error("Invalid DLEQ proof")]
     InvalidDleqProof,
     /// Cashu Error
     #[error(transparent)]

--- a/crates/cdk/src/nuts/nut14/mod.rs
+++ b/crates/cdk/src/nuts/nut14/mod.rs
@@ -28,7 +28,7 @@ pub enum Error {
     #[error("Locktime in past")]
     LocktimeInPast,
     /// Hash Required
-    #[error("Hash Required")]
+    #[error("Hash required")]
     HashRequired,
     /// Hash is not valid
     #[error("Hash is not valid")]

--- a/crates/cdk/src/wallet/error.rs
+++ b/crates/cdk/src/wallet/error.rs
@@ -13,55 +13,55 @@ use crate::util::hex;
 #[derive(Debug, Error)]
 pub enum Error {
     /// Insufficient Funds
-    #[error("Insufficient Funds")]
+    #[error("Insufficient funds")]
     InsufficientFunds,
     /// Quote Expired
-    #[error("Quote Expired")]
+    #[error("Quote expired")]
     QuoteExpired,
     /// Unknown Quote
-    #[error("Quote Unknown")]
+    #[error("Quote unknown")]
     QuoteUnknown,
     /// Not active keyset
     #[error("No active keyset")]
     NoActiveKeyset,
-    /// Invalid DLEQ prood
-    #[error("Could not verify Dleq")]
+    /// Invalid DLEQ proof
+    #[error("Could not verify DLEQ proof")]
     CouldNotVerifyDleq,
     /// P2PK spending conditions not met
-    #[error("P2PK Condition Not met `{0}`")]
+    #[error("P2PK condition not met `{0}`")]
     P2PKConditionsNotMet(String),
     /// Invalid Spending Conditions
-    #[error("Invalid Spending Conditions: `{0}`")]
+    #[error("Invalid spending conditions: `{0}`")]
     InvalidSpendConditions(String),
     /// Preimage not provided
     #[error("Preimage not provided")]
     PreimageNotProvided,
     /// Unknown Key
-    #[error("Unknown Key")]
+    #[error("Unknown key")]
     UnknownKey,
     /// Spending Locktime not provided
     #[error("Spending condition locktime not provided")]
     LocktimeNotProvided,
-    /// Unknown Keyset
-    #[error("Url Path segments could not be joined")]
+    /// Url path segments could not be joined
+    #[error("Url path segments could not be joined")]
     UrlPathSegments,
     /// Quote not paid
     #[error("Quote not paid")]
     QuoteNotePaid,
-    /// Token Already spent error
-    #[error("Token Already Spent Error")]
+    /// Token Already Spent
+    #[error("Token already spent")]
     TokenAlreadySpent,
     /// Unit Not supported
     #[error("Unit not supported for method")]
     UnitNotSupported,
     /// Bolt11 invoice does not have amount
-    #[error("Invoice Amount undefined")]
+    #[error("Invoice amount undefined")]
     InvoiceAmountUndefined,
     /// Incorrect quote amount
     #[error("Incorrect quote amount")]
     IncorrectQuoteAmount,
     /// Keyset Not Found
-    #[error("Keyset Not Found")]
+    #[error("Keyset not found")]
     KeysetNotFound,
     /// Receive can only be used with tokens from single mint
     #[error("Multiple mint tokens not supported by receive. Please deconstruct the token and use receive with_proof")]
@@ -74,16 +74,16 @@ pub enum Error {
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
     ///  Unknown error response
-    #[error("Unknown Error response: `{0}`")]
+    #[error("Unknown error response: `{0}`")]
     UnknownErrorResponse(String),
     /// Hex Error
     #[error(transparent)]
     HexError(#[from] hex::Error),
     /// Unknown Wallet
-    #[error("Unknown Wallet: `{0}`")]
+    #[error("Unknown wallet: `{0}`")]
     UnknownWallet(WalletKey),
     /// Incorrect Wallet
-    #[error("Incorrect Wallet: `{0}`")]
+    #[error("Incorrect wallet: `{0}`")]
     IncorrectWallet(String),
     /// Max Fee Ecxeded
     #[error("Max fee exceeded")]


### PR DESCRIPTION
I went through the error messages and make the capitalization consistent (only first letter of error message is in capital letters, lest is lower case - except for abbreviations such as DLEQ)