### PR TITLE
Get blinded secrets

### DIFF
--- a/bindings/cdk-js/src/nuts/nut00/currency_unit.rs
+++ b/bindings/cdk-js/src/nuts/nut00/currency_unit.rs
@@ -9,6 +9,7 @@ pub enum JsCurrencyUnit {
     Msat,
     Usd,
     Eur,
+    Hash,
 }
 
 impl From<CurrencyUnit> for JsCurrencyUnit {
@@ -18,6 +19,7 @@ impl From<CurrencyUnit> for JsCurrencyUnit {
             CurrencyUnit::Msat => JsCurrencyUnit::Msat,
             CurrencyUnit::Usd => JsCurrencyUnit::Usd,
             CurrencyUnit::Eur => JsCurrencyUnit::Eur,
+            CurrencyUnit::Hash => JsCurrencyUnit::Hash,
         }
     }
 }
@@ -29,6 +31,7 @@ impl From<JsCurrencyUnit> for CurrencyUnit {
             JsCurrencyUnit::Msat => CurrencyUnit::Msat,
             JsCurrencyUnit::Usd => CurrencyUnit::Usd,
             JsCurrencyUnit::Eur => CurrencyUnit::Eur,
+            JsCurrencyUnit::Hash => CurrencyUnit::Hash,
         }
     }
 }

--- a/crates/cdk-strike/src/lib.rs
+++ b/crates/cdk-strike/src/lib.rs
@@ -129,6 +129,7 @@ impl MintLightning for Strike {
             CurrencyUnit::Msat => StrikeCurrencyUnit::BTC,
             CurrencyUnit::Usd => StrikeCurrencyUnit::USD,
             CurrencyUnit::Eur => StrikeCurrencyUnit::EUR,
+            CurrencyUnit::Hash => unimplemented!(),
         };
 
         let payment_quote_request = PayInvoiceQuoteRequest {
@@ -274,6 +275,7 @@ pub(crate) fn from_strike_amount(
                 bail!("Could not convert to EUR");
             }
         }
+        CurrencyUnit::Hash => unimplemented!(),
     }
 }
 
@@ -301,5 +303,6 @@ where
                 amount: euro.round() / 100.0,
             }
         }
+        CurrencyUnit::Hash => unimplemented!(),
     }
 }

--- a/crates/cdk/src/cdk_database/mod.rs
+++ b/crates/cdk/src/cdk_database/mod.rs
@@ -172,7 +172,7 @@ pub trait WalletDatabase: Debug {
 #[async_trait]
 pub trait MintDatabase: fmt::Debug {
     /// Mint Database Error
-    type Err: Into<Error> + From<Error>;
+    type Err: Into<Error> + From<Error> + Debug;
 
     /// Add Active Keyset
     async fn set_active_keyset(&self, unit: CurrencyUnit, id: Id) -> Result<(), Self::Err>;

--- a/crates/cdk/src/cdk_database/mod.rs
+++ b/crates/cdk/src/cdk_database/mod.rs
@@ -2,6 +2,7 @@
 
 #[cfg(any(feature = "wallet", feature = "mint"))]
 use std::collections::HashMap;
+use std::fmt;
 use std::fmt::Debug;
 
 #[cfg(any(feature = "wallet", feature = "mint"))]
@@ -169,7 +170,7 @@ pub trait WalletDatabase: Debug {
 /// Mint Database trait
 #[cfg(feature = "mint")]
 #[async_trait]
-pub trait MintDatabase {
+pub trait MintDatabase: fmt::Debug {
     /// Mint Database Error
     type Err: Into<Error> + From<Error>;
 

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -26,7 +26,7 @@ pub mod types;
 pub use types::{MeltQuote, MintQuote};
 
 /// Cashu Mint
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Mint {
     /// Mint Url
     pub mint_url: MintUrl,

--- a/crates/cdk/src/nuts/nut00/mod.rs
+++ b/crates/cdk/src/nuts/nut00/mod.rs
@@ -323,6 +323,8 @@ pub enum CurrencyUnit {
     Usd,
     /// Euro
     Eur,
+    /// Hash
+    Hash,
 }
 
 #[cfg(feature = "mint")]
@@ -334,6 +336,7 @@ impl CurrencyUnit {
             Self::Msat => 1,
             Self::Usd => 2,
             Self::Eur => 3,
+            Self::Hash => 4,
         }
     }
 }
@@ -346,6 +349,7 @@ impl FromStr for CurrencyUnit {
             "msat" => Ok(Self::Msat),
             "usd" => Ok(Self::Usd),
             "eur" => Ok(Self::Eur),
+            "hash" => Ok(Self::Hash),
             _ => Err(Error::UnsupportedUnit),
         }
     }
@@ -358,6 +362,7 @@ impl fmt::Display for CurrencyUnit {
             CurrencyUnit::Msat => write!(f, "msat"),
             CurrencyUnit::Usd => write!(f, "usd"),
             CurrencyUnit::Eur => write!(f, "eur"),
+            CurrencyUnit::Hash => write!(f, "hash"),
         }
     }
 }

--- a/crates/cdk/src/nuts/nut02.rs
+++ b/crates/cdk/src/nuts/nut02.rs
@@ -105,6 +105,20 @@ impl Id {
             id: bytes[1..].try_into()?,
         })
     }
+
+    /// [`Id`] to u64
+    pub fn to_u64(&self) -> u64 {
+        let bytes = self.to_bytes();
+        let mut array = [0u8; 8];
+        array[..bytes.len()].copy_from_slice(&bytes);
+        u64::from_be_bytes(array)
+    }
+
+    /// [`Id`] from u64
+    pub fn from_u64(value: u64) -> Result<Self, Error> {
+        let bytes = value.to_be_bytes();
+        Self::from_bytes(&bytes)
+    }
 }
 
 impl TryFrom<Id> for u64 {

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -580,7 +580,6 @@ impl Wallet {
     ///   minted tokens
     /// - `count`: How many tokens were previously generated from this keyset +
     ///   1
-    /// - `xpriv`: The extended private key used for generating secrets
     ///
     /// # Returns
     ///
@@ -600,7 +599,6 @@ impl Wallet {
         amount_split_target: &SplitTarget,
         spending_conditions: Option<&SpendingConditions>,
         count: u32,
-        xpriv: ExtendedPrivKey,
     ) -> Result<PreMintSecrets, Error> {
         // Move the match logic into this function.
         match spending_conditions {
@@ -613,7 +611,7 @@ impl Wallet {
             None => Ok(PreMintSecrets::from_xpriv(
                 active_keyset_id,
                 count,
-                xpriv,
+                self.xpriv,
                 quote_info_amount,
                 amount_split_target,
             )?),
@@ -694,7 +692,6 @@ impl Wallet {
             &amount_split_target,
             spending_conditions.as_ref(),
             count,
-            self.xpriv,
         )?;
 
         let mint_res = self

--- a/flake.nix
+++ b/flake.nix
@@ -45,12 +45,14 @@
                 pname = "flexbox-multibuild";
                 src = rustSrc;
               }).overrideArgs commonArgs;
-            in rec {
+            in
+            rec {
               workspaceDeps = craneLib.buildWorkspaceDepsOnly { };
               workspaceBuild =
                 craneLib.buildWorkspace { cargoArtifacts = workspaceDeps; };
             });
-      in {
+      in
+      {
         devShells = flakeboxLib.mkShells {
           toolchain = toolchainNative;
           packages = [ ];


### PR DESCRIPTION
Get blinded secrets in a dedicated function. This enables developers to provide their own network transport to the cashu mint.

Not sure why it wanted to reformat the entire codebase but I split that into a separate commit to make reviewing this PR easier.