### PR TITLE
Update example.config.toml-add to strike info

### DIFF
--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -33,6 +33,7 @@ ln_backend = "cln"
 # cln_path = ""
 
 # [strike]
+# For the Webhook subscription, the url under [info] must be a valid, absolute, non-local, https url 
 # api_key=""
 # Optional default sats
 # supported_units=[""]


### PR DESCRIPTION
For the Webhook subscription, the url under [info] must be a valid, absolute, non-local, https url