### PR TITLE
CLI `decode-token`: use CBOR diagnostic format instead of pure JSON

### DIFF
--- a/crates/cdk-cli/src/sub_commands/decode_token.rs
+++ b/crates/cdk-cli/src/sub_commands/decode_token.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use cdk::nuts::Token;
+use cdk::util::serialize_to_cbor_diag;
 use clap::Args;
 
 #[derive(Args)]
@@ -13,6 +14,6 @@ pub struct DecodeTokenSubCommand {
 pub fn decode_token(sub_command_args: &DecodeTokenSubCommand) -> Result<()> {
     let token = Token::from_str(&sub_command_args.token)?;
 
-    println!("{:}", serde_json::to_string_pretty(&token)?);
+    println!("{:}", serialize_to_cbor_diag(&token)?);
     Ok(())
 }

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -27,6 +27,7 @@ bitcoin = { version= "0.30", features = [
     "rand-std",
 ] } # lightning-invoice uses v0.30
 ciborium = { version = "0.2.2", default-features = false, features = ["std"] }
+cbor-diag = "0.1.12"
 lightning-invoice = { version = "0.31", features = ["serde"] }
 once_cell = "1.19"
 regex = "1"

--- a/crates/cdk/src/util/mod.rs
+++ b/crates/cdk/src/util/mod.rs
@@ -3,6 +3,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use anyhow::Result;
 use bitcoin::secp256k1::{rand, All, Secp256k1};
 #[cfg(target_arch = "wasm32")]
 use instant::SystemTime;
@@ -27,4 +28,15 @@ pub fn unix_time() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+/// Serializes a struct to the CBOR diagnostic notation.
+///
+/// See <https://www.rfc-editor.org/rfc/rfc8949.html#name-diagnostic-notation>
+pub fn serialize_to_cbor_diag<T: serde::Serialize>(data: &T) -> Result<String> {
+    let mut cbor_buffer = Vec::new();
+    ciborium::ser::into_writer(data, &mut cbor_buffer)?;
+
+    let diag = cbor_diag::parse_bytes(&cbor_buffer)?;
+    Ok(diag.to_diag_pretty())
 }


### PR DESCRIPTION
Before this PR, `decode-token` printed the pure JSON representation of a token. For V3 that is straightforward, but for V4 tokens the byte array fields were printed as arrays of numbers (decimal representation of each byte value).

<details>
<summary>Example output before PR</summary>

```
cargo run -- decode-token cashuBo2F0gqJhaUgA_9SLj17PgGFwgaNhYQFhc3hAYWNjMTI0MzVlN2I4NDg0YzNjZjE4NTAxNDkyMThhZjkwZjcxNmE1MmJmNGE1ZWQzNDdlNDhlY2MxM2Y3NzM4OGFjWCECRFODGd5IXVW-07KaZCvuWHk3WrnnpiDhHki6SCQh88-iYWlIAK0mjE0fWCZhcIKjYWECYXN4QDEzMjNkM2Q0NzA3YTU4YWQyZTIzYWRhNGU5ZjFmNDlmNWE1YjRhYzdiNzA4ZWIwZDYxZjczOGY0ODMwN2U4ZWVhY1ghAjRWqhENhLSsdHrr2Cw7AFrKUL9Ffr1XN6RBT6w659lNo2FhAWFzeEA1NmJjYmNiYjdjYzY0MDZiM2ZhNWQ1N2QyMTc0ZjRlZmY4YjQ0MDJiMTc2OTI2ZDNhNTdkM2MzZGNiYjU5ZDU3YWNYIQJzEpxXGeWZN5qXSmJjY8MzxWyvwObQGr5G1YCCgHicY2FtdWh0dHA6Ly9sb2NhbGhvc3Q6MzMzOGF1Y3NhdA


{
  "m": "http://localhost:3338",
  "u": "sat",
  "t": [
    {
      "i": [
        0,
        255,
        212,
        139,
        143,
        94,
        207,
        128
      ],
      "p": [
        {
          "a": 1,
          "s": "acc12435e7b8484c3cf1850149218af90f716a52bf4a5ed347e48ecc13f77388",
          "c": [
            2,
            68,
            83,
            131,
            25,
            222,
            72,
            93,
            85,
            190,
            211,
            178,
            154,
            100,
            43,
            238,
            88,
            121,
            55,
            90,
            185,
            231,
            166,
            32,
            225,
            30,
            72,
            186,
            72,
            36,
            33,
            243,
            207
          ],
          "d": null
        }
      ]
    },
    {
      "i": [
        0,
        173,
        38,
        140,
        77,
        31,
        88,
        38
      ],
      "p": [
        {
          "a": 2,
          "s": "1323d3d4707a58ad2e23ada4e9f1f49f5a5b4ac7b708eb0d61f738f48307e8ee",
          "c": [
            2,
            52,
            86,
            170,
            17,
            13,
            132,
            180,
            172,
            116,
            122,
            235,
            216,
            44,
            59,
            0,
            90,
            202,
            80,
            191,
            69,
            126,
            189,
            87,
            55,
            164,
            65,
            79,
            172,
            58,
            231,
            217,
            77
          ],
          "d": null
        },
        {
          "a": 1,
          "s": "56bcbcbb7cc6406b3fa5d57d2174f4eff8b4402b176926d3a57d3c3dcbb59d57",
          "c": [
            2,
            115,
            18,
            156,
            87,
            25,
            229,
            153,
            55,
            154,
            151,
            74,
            98,
            99,
            99,
            195,
            51,
            197,
            108,
            175,
            192,
            230,
            208,
            26,
            190,
            70,
            213,
            128,
            130,
            128,
            120,
            156,
            99
          ],
          "d": null
        }
      ]
    }
  ]
}

```

</details>

NUT-00 defines[^1] how a TokenV4 JSON should look like. That is essentially the Diagnostic Notation described[^2] in the CBOR spec. There, byte array fields are represented like `h'00ad268c4d1f5826'`, which is an `h` followed by the hex representation wrapped in single quotes.

This PR updates `decode-token` in `cdk-cli` to print the diagnostic notation instead of the pure JSON representation of a token. This brings decoded TokenV4s in line with the format described in NUT-00, especially around how byte array fields should be handled.


<details>
<summary>Example output after PR</summary>

```
cargo run -- decode-token cashuBo2F0gqJhaUgA_9SLj17PgGFwgaNhYQFhc3hAYWNjMTI0MzVlN2I4NDg0YzNjZjE4NTAxNDkyMThhZjkwZjcxNmE1MmJmNGE1ZWQzNDdlNDhlY2MxM2Y3NzM4OGFjWCECRFODGd5IXVW-07KaZCvuWHk3WrnnpiDhHki6SCQh88-iYWlIAK0mjE0fWCZhcIKjYWECYXN4QDEzMjNkM2Q0NzA3YTU4YWQyZTIzYWRhNGU5ZjFmNDlmNWE1YjRhYzdiNzA4ZWIwZDYxZjczOGY0ODMwN2U4ZWVhY1ghAjRWqhENhLSsdHrr2Cw7AFrKUL9Ffr1XN6RBT6w659lNo2FhAWFzeEA1NmJjYmNiYjdjYzY0MDZiM2ZhNWQ1N2QyMTc0ZjRlZmY4YjQ0MDJiMTc2OTI2ZDNhNTdkM2MzZGNiYjU5ZDU3YWNYIQJzEpxXGeWZN5qXSmJjY8MzxWyvwObQGr5G1YCCgHicY2FtdWh0dHA6Ly9sb2NhbGhvc3Q6MzMzOGF1Y3NhdA


{
    "m": "http://localhost:3338",
    "u": "sat",
    "t": [
        {
            "i": h'00ffd48b8f5ecf80',
            "p": [
                {
                    "a": 1,
                    "s": "acc12435e7b8484c3cf1850149218af90f716a52bf4a5ed347e48ecc13f77388",
                    "c": h'0244538319de485d55bed3b29a642bee5879375ab9e7a620e11e48ba482421f3cf',
                    "d": null,
                },
            ],
        },
        {
            "i": h'00ad268c4d1f5826',
            "p": [
                {
                    "a": 2,
                    "s": "1323d3d4707a58ad2e23ada4e9f1f49f5a5b4ac7b708eb0d61f738f48307e8ee",
                    "c": h'023456aa110d84b4ac747aebd82c3b005aca50bf457ebd5737a4414fac3ae7d94d',
                    "d": null,
                },
                {
                    "a": 1,
                    "s": "56bcbcbb7cc6406b3fa5d57d2174f4eff8b4402b176926d3a57d3c3dcbb59d57",
                    "c": h'0273129c5719e599379a974a626363c333c56cafc0e6d01abe46d5808280789c63',
                    "d": null,
                },
            ],
        },
    ],
}

```

</details>

[^1]: https://github.com/cashubtc/nuts/blob/main/00.md#example-1
[^2]: https://www.rfc-editor.org/rfc/rfc8949.html#name-diagnostic-notation