### PR TITLE
cdk-cln: bump cln-rpc dependency to 0.2.0

### DIFF
--- a/crates/cdk-cln/Cargo.toml
+++ b/crates/cdk-cln/Cargo.toml
@@ -13,7 +13,7 @@ description = "CDK ln backend for cln"
 async-trait = "0.1"
 bitcoin = { version = "0.32.2", default-features = false }
 cdk = { path = "../cdk", version = "0.4.0", default-features = false, features = ["mint"] }
-cln-rpc = "0.1.9"
+cln-rpc = "0.2.0"
 futures = { version = "0.3.28", default-features = false }
 tokio = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["attributes", "log"] }


### PR DESCRIPTION
fixes https://github.com/cashubtc/cdk/issues/364