### PR TITLE
Refactor to_unit into amount module

### DIFF
--- a/crates/cdk-cln/src/error.rs
+++ b/crates/cdk-cln/src/error.rs
@@ -23,6 +23,9 @@ pub enum Error {
     /// Cln Rpc Error
     #[error(transparent)]
     ClnRpc(#[from] cln_rpc::RpcError),
+    /// Amount Error
+    #[error(transparent)]
+    Amount(#[from] cdk::amount::Error),
 }
 
 impl From<Error> for cdk::cdk_lightning::Error {

--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -10,10 +10,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use cdk::amount::Amount;
+use cdk::amount::{to_unit, Amount};
 use cdk::cdk_lightning::{
-    self, to_unit, CreateInvoiceResponse, MintLightning, PayInvoiceResponse, PaymentQuoteResponse,
-    Settings,
+    self, CreateInvoiceResponse, MintLightning, PayInvoiceResponse, PaymentQuoteResponse, Settings,
 };
 use cdk::mint::FeeReserve;
 use cdk::nuts::{

--- a/crates/cdk-fake-wallet/src/lib.rs
+++ b/crates/cdk-fake-wallet/src/lib.rs
@@ -13,10 +13,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::secp256k1::{Secp256k1, SecretKey};
-use cdk::amount::Amount;
+use cdk::amount::{to_unit, Amount};
 use cdk::cdk_lightning::{
-    self, to_unit, CreateInvoiceResponse, MintLightning, PayInvoiceResponse, PaymentQuoteResponse,
-    Settings,
+    self, CreateInvoiceResponse, MintLightning, PayInvoiceResponse, PaymentQuoteResponse, Settings,
 };
 use cdk::mint;
 use cdk::mint::FeeReserve;

--- a/crates/cdk-lnbits/src/lib.rs
+++ b/crates/cdk-lnbits/src/lib.rs
@@ -9,10 +9,9 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use axum::Router;
-use cdk::amount::Amount;
+use cdk::amount::{to_unit, Amount, MSAT_IN_SAT};
 use cdk::cdk_lightning::{
-    self, to_unit, CreateInvoiceResponse, MintLightning, PayInvoiceResponse, PaymentQuoteResponse,
-    Settings, MSAT_IN_SAT,
+    self, CreateInvoiceResponse, MintLightning, PayInvoiceResponse, PaymentQuoteResponse, Settings,
 };
 use cdk::mint::FeeReserve;
 use cdk::nuts::{

--- a/crates/cdk-lnd/src/lib.rs
+++ b/crates/cdk-lnd/src/lib.rs
@@ -12,10 +12,9 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
-use cdk::amount::Amount;
+use cdk::amount::{to_unit, Amount, MSAT_IN_SAT};
 use cdk::cdk_lightning::{
-    self, to_unit, CreateInvoiceResponse, MintLightning, PayInvoiceResponse, PaymentQuoteResponse,
-    Settings, MSAT_IN_SAT,
+    self, CreateInvoiceResponse, MintLightning, PayInvoiceResponse, PaymentQuoteResponse, Settings,
 };
 use cdk::mint::FeeReserve;
 use cdk::nuts::{

--- a/crates/cdk-phoenixd/src/lib.rs
+++ b/crates/cdk-phoenixd/src/lib.rs
@@ -9,10 +9,9 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use axum::Router;
-use cdk::amount::Amount;
+use cdk::amount::{to_unit, Amount, MSAT_IN_SAT};
 use cdk::cdk_lightning::{
-    self, to_unit, CreateInvoiceResponse, MintLightning, PayInvoiceResponse, PaymentQuoteResponse,
-    Settings, MSAT_IN_SAT,
+    self, CreateInvoiceResponse, MintLightning, PayInvoiceResponse, PaymentQuoteResponse, Settings,
 };
 use cdk::mint::FeeReserve;
 use cdk::nuts::{

--- a/crates/cdk/src/amount.rs
+++ b/crates/cdk/src/amount.rs
@@ -370,4 +370,47 @@ mod tests {
 
         assert_eq!(total, 10001.into());
     }
+
+    #[test]
+    fn test_amount_to_unit() {
+        let amount = Amount::from(1000);
+        let current_unit = CurrencyUnit::Sat;
+        let target_unit = CurrencyUnit::Msat;
+
+        let converted = to_unit(amount, &current_unit, &target_unit).unwrap();
+
+        assert_eq!(converted, 1000000.into());
+
+        let amount = Amount::from(1000);
+        let current_unit = CurrencyUnit::Msat;
+        let target_unit = CurrencyUnit::Sat;
+
+        let converted = to_unit(amount, &current_unit, &target_unit).unwrap();
+
+        assert_eq!(converted, 1.into());
+
+        let amount = Amount::from(1);
+        let current_unit = CurrencyUnit::Usd;
+        let target_unit = CurrencyUnit::Usd;
+
+        let converted = to_unit(amount, &current_unit, &target_unit).unwrap();
+
+        assert_eq!(converted, 1.into());
+
+        let amount = Amount::from(1);
+        let current_unit = CurrencyUnit::Eur;
+        let target_unit = CurrencyUnit::Eur;
+
+        let converted = to_unit(amount, &current_unit, &target_unit).unwrap();
+
+        assert_eq!(converted, 1.into());
+
+        let amount = Amount::from(1);
+        let current_unit = CurrencyUnit::Sat;
+        let target_unit = CurrencyUnit::Eur;
+
+        let converted = to_unit(amount, &current_unit, &target_unit);
+
+        assert!(converted.is_err());
+    }
 }

--- a/crates/cdk/src/cdk_lightning/mod.rs
+++ b/crates/cdk/src/cdk_lightning/mod.rs
@@ -41,9 +41,9 @@ pub enum Error {
     /// Parse Error
     #[error(transparent)]
     Parse(#[from] ParseOrSemanticError),
-    /// Cannot convert units
-    #[error("Cannot convert units")]
-    CannotConvertUnits,
+    /// Amount Error
+    #[error(transparent)]
+    Amount(#[from] crate::amount::Error),
 }
 
 /// MintLighting Trait
@@ -150,28 +150,4 @@ pub struct Settings {
     pub unit: CurrencyUnit,
     /// Invoice Description supported
     pub invoice_description: bool,
-}
-
-/// Msats in sat
-pub const MSAT_IN_SAT: u64 = 1000;
-
-/// Helper function to convert units
-pub fn to_unit<T>(
-    amount: T,
-    current_unit: &CurrencyUnit,
-    target_unit: &CurrencyUnit,
-) -> Result<Amount, Error>
-where
-    T: Into<u64>,
-{
-    let amount = amount.into();
-    match (current_unit, target_unit) {
-        (CurrencyUnit::Sat, CurrencyUnit::Sat) => Ok(amount.into()),
-        (CurrencyUnit::Msat, CurrencyUnit::Msat) => Ok(amount.into()),
-        (CurrencyUnit::Sat, CurrencyUnit::Msat) => Ok((amount * MSAT_IN_SAT).into()),
-        (CurrencyUnit::Msat, CurrencyUnit::Sat) => Ok((amount / MSAT_IN_SAT).into()),
-        (CurrencyUnit::Usd, CurrencyUnit::Usd) => Ok(amount.into()),
-        (CurrencyUnit::Eur, CurrencyUnit::Eur) => Ok(amount.into()),
-        _ => Err(Error::CannotConvertUnits),
-    }
 }

--- a/crates/cdk/src/mint/melt.rs
+++ b/crates/cdk/src/mint/melt.rs
@@ -12,8 +12,8 @@ use crate::dhke::hash_to_curve;
 use crate::nuts::nut11::enforce_sig_flag;
 use crate::nuts::nut11::EnforceSigFlag;
 use crate::{
-    cdk_lightning::to_unit, mint::SigFlag, nuts::Id, nuts::MeltQuoteState, types::LnKey,
-    util::unix_time, Amount, Error,
+    amount::to_unit, mint::SigFlag, nuts::Id, nuts::MeltQuoteState, types::LnKey, util::unix_time,
+    Amount, Error,
 };
 
 use super::nut05::MeltBolt11Response;


### PR DESCRIPTION
In a couple of my codebases, I've found it helpful to expose the `to_unit` outside of a mint setting. Since `cdk_lightning` is behind the `mint` feature, I think moving it into the `amount` module would be beneficial so that the `mint` feature does not need to be enabled.