### PR TITLE
CLI `balance`: show unit when printing balances

### DIFF
--- a/crates/cdk-cli/src/sub_commands/balance.rs
+++ b/crates/cdk-cli/src/sub_commands/balance.rs
@@ -21,7 +21,7 @@ pub async fn mint_balances(
 
     for (i, (mint_url, amount)) in wallets.iter().enumerate() {
         let mint_url = mint_url.clone();
-        println!("{i}: {mint_url} {amount}");
+        println!("{i}: {mint_url} {amount} {unit}");
         wallets_vec.push((mint_url, *amount))
     }
     Ok(wallets_vec)


### PR DESCRIPTION
Since mints can support different currencies, it's useful to know what kind of balance is listed with the CLI's `balance` command.