### PR TITLE
Provide sorting method for selecting proofs to swap

### DIFF
--- a/crates/cdk/examples/proof-selection.rs
+++ b/crates/cdk/examples/proof-selection.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use cdk::amount::SplitTarget;
 use cdk::cdk_database::WalletMemoryDatabase;
 use cdk::nuts::{CurrencyUnit, MintQuoteState};
-use cdk::wallet::Wallet;
+use cdk::wallet::{SelectProofsOptions, Wallet};
 use cdk::Amount;
 use rand::Rng;
 use tokio::time::sleep;
@@ -51,7 +51,11 @@ async fn main() {
     let proofs = wallet.get_proofs().await.unwrap();
 
     let selected = wallet
-        .select_proofs_to_send(Amount::from(64), proofs, false)
+        .select_proofs(
+            Amount::from(64),
+            proofs,
+            SelectProofsOptions::default().include_fees(false),
+        )
         .await
         .unwrap();
 

--- a/crates/cdk/src/nuts/nut01/public_key.rs
+++ b/crates/cdk/src/nuts/nut01/public_key.rs
@@ -92,6 +92,16 @@ impl PublicKey {
         SECP256K1.verify_schnorr(sig, &msg, &self.inner.x_only_public_key().0)?;
         Ok(())
     }
+
+    #[cfg(test)]
+    pub fn random() -> Self {
+        Self {
+            inner: secp256k1::PublicKey::from_secret_key(
+                &SECP256K1,
+                &secp256k1::SecretKey::new(&mut rand::thread_rng()),
+            ),
+        }
+    }
 }
 
 impl FromStr for PublicKey {

--- a/crates/cdk/src/nuts/nut02.rs
+++ b/crates/cdk/src/nuts/nut02.rs
@@ -105,6 +105,14 @@ impl Id {
             id: bytes[1..].try_into()?,
         })
     }
+
+    #[cfg(test)]
+    pub fn random() -> Self {
+        Self {
+            version: KeySetVersion::Version00,
+            id: rand::random(),
+        }
+    }
 }
 
 impl TryFrom<Id> for u64 {

--- a/crates/cdk/src/wallet/melt.rs
+++ b/crates/cdk/src/wallet/melt.rs
@@ -11,7 +11,7 @@ use crate::{
     Amount, Error, Wallet,
 };
 
-use super::{proofs::SelectProofsMethod, MeltQuote};
+use super::{proofs::ProofSelectionMethod, MeltQuote};
 
 impl Wallet {
     /// Melt Quote
@@ -297,7 +297,7 @@ impl Wallet {
             .select_proofs_to_swap(
                 inputs_needed_amount,
                 available_proofs,
-                SelectProofsMethod::Closest,
+                ProofSelectionMethod::Closest,
             )
             .await?;
 

--- a/crates/cdk/src/wallet/melt.rs
+++ b/crates/cdk/src/wallet/melt.rs
@@ -297,7 +297,7 @@ impl Wallet {
             .select_proofs_to_swap(
                 inputs_needed_amount,
                 available_proofs,
-                SelectProofsMethod::ClosestFirst,
+                SelectProofsMethod::Closest,
             )
             .await?;
 

--- a/crates/cdk/src/wallet/melt.rs
+++ b/crates/cdk/src/wallet/melt.rs
@@ -11,10 +11,7 @@ use crate::{
     Amount, Error, Wallet,
 };
 
-use super::{
-    proofs::{ProofSelectionMethod, SelectProofsOptions},
-    MeltQuote,
-};
+use super::{proofs::SelectProofsOptions, MeltQuote};
 
 impl Wallet {
     /// Melt Quote
@@ -300,7 +297,7 @@ impl Wallet {
             .select_proofs(
                 inputs_needed_amount,
                 available_proofs,
-                SelectProofsOptions::default().method(ProofSelectionMethod::Least),
+                SelectProofsOptions::default(),
             )
             .await?;
 

--- a/crates/cdk/src/wallet/melt.rs
+++ b/crates/cdk/src/wallet/melt.rs
@@ -300,7 +300,7 @@ impl Wallet {
             .select_proofs(
                 inputs_needed_amount,
                 available_proofs,
-                SelectProofsOptions::default().method(ProofSelectionMethod::Fewest),
+                SelectProofsOptions::default().method(ProofSelectionMethod::Least),
             )
             .await?;
 

--- a/crates/cdk/src/wallet/melt.rs
+++ b/crates/cdk/src/wallet/melt.rs
@@ -300,7 +300,7 @@ impl Wallet {
             .select_proofs(
                 inputs_needed_amount,
                 available_proofs,
-                SelectProofsOptions::default().method(ProofSelectionMethod::Least),
+                SelectProofsOptions::default().method(ProofSelectionMethod::Fewest),
             )
             .await?;
 

--- a/crates/cdk/src/wallet/melt.rs
+++ b/crates/cdk/src/wallet/melt.rs
@@ -11,7 +11,10 @@ use crate::{
     Amount, Error, Wallet,
 };
 
-use super::{proofs::ProofSelectionMethod, MeltQuote};
+use super::{
+    proofs::{ProofSelectionMethod, SelectProofsOptions},
+    MeltQuote,
+};
 
 impl Wallet {
     /// Melt Quote
@@ -294,10 +297,10 @@ impl Wallet {
         let available_proofs = self.get_proofs().await?;
 
         let input_proofs = self
-            .select_proofs_to_swap(
+            .select_proofs(
                 inputs_needed_amount,
                 available_proofs,
-                ProofSelectionMethod::Closest,
+                SelectProofsOptions::default().method(ProofSelectionMethod::Least),
             )
             .await?;
 

--- a/crates/cdk/src/wallet/melt.rs
+++ b/crates/cdk/src/wallet/melt.rs
@@ -11,7 +11,7 @@ use crate::{
     Amount, Error, Wallet,
 };
 
-use super::MeltQuote;
+use super::{proofs::SelectProofsMethod, MeltQuote};
 
 impl Wallet {
     /// Melt Quote
@@ -294,7 +294,11 @@ impl Wallet {
         let available_proofs = self.get_proofs().await?;
 
         let input_proofs = self
-            .select_proofs_to_swap(inputs_needed_amount, available_proofs)
+            .select_proofs_to_swap(
+                inputs_needed_amount,
+                available_proofs,
+                SelectProofsMethod::ClosestFirst,
+            )
             .await?;
 
         self.melt_proofs(quote_id, input_proofs).await

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -36,6 +36,7 @@ pub mod types;
 pub mod util;
 
 pub use multi_mint_wallet::MultiMintWallet;
+pub use proofs::{ProofSelectionMethod, SelectProofsOptions};
 pub use types::{MeltQuote, MintQuote, SendKind};
 
 /// CDK Wallet

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -472,7 +472,7 @@ mod tests {
     }
 
     #[test]
-    fn test_select_fewest_proofs_over_amount() {
+    fn test_select_least_proofs_over_amount() {
         let keyset_id = Id::random();
         let c_1 = PublicKey::random();
         let proofs = vec![

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -245,18 +245,12 @@ fn sort_proofs(proofs: &mut Proofs, method: ProofSelectionMethod, amount: Amount
         ProofSelectionMethod::Largest | ProofSelectionMethod::Least => {
             proofs.sort_by(|a: &Proof, b: &Proof| b.cmp(a))
         }
-        ProofSelectionMethod::Closest => proofs.sort_by(|a: &Proof, b: &Proof| {
-            let a_diff = if a.amount > amount {
-                a.amount - amount
+        ProofSelectionMethod::Closest => proofs.sort_by_key(|p| {
+            if p.amount > amount {
+                p.amount - amount
             } else {
-                amount - a.amount
-            };
-            let b_diff = if b.amount > amount {
-                b.amount - amount
-            } else {
-                amount - b.amount
-            };
-            a_diff.cmp(&b_diff)
+                amount - p.amount
+            }
         }),
         ProofSelectionMethod::Smallest => proofs.sort(),
     }
@@ -272,7 +266,9 @@ fn select_least_proofs_over_amount(
         amount,
         fees
     );
-    let max_sum = Amount::try_sum(proofs.iter().map(|p| p.amount)).ok()? + 1.into();
+    let max_sum = Amount::try_sum(proofs.iter().map(|p| p.amount))
+        .ok()?
+        .checked_add(1.into())?;
     if max_sum < amount || proofs.is_empty() || amount == Amount::ZERO {
         return None;
     }

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -282,13 +282,17 @@ fn select_least_proofs_over_amount(
         filtered_proofs.push(next_highest_proof.clone());
     }
 
-    let max_sum = Amount::try_sum(filtered_proofs.iter().map(|p| p.amount))
-        .ok()?
-        .checked_add(1.into())?;
+    let max_sum = Amount::try_sum(filtered_proofs.iter().map(|p| p.amount)).ok()?;
     if max_sum < amount || filtered_proofs.is_empty() || amount == Amount::ZERO {
         return None;
     }
+
+    // Determine the size of the DP table, return None if it is too large
     let table_len = u64::from(max_sum + 1.into()) as usize;
+    if table_len > 1_000_000 {
+        return None;
+    }
+
     let mut dp = vec![None; table_len];
     let mut paths = vec![Vec::<Proof>::with_capacity(0); table_len];
 
@@ -305,7 +309,7 @@ fn select_least_proofs_over_amount(
 
             if let Some(current_sum) = dp[t as usize] {
                 let new_sum = current_sum + proof.amount;
-                let target_index = (t as u64 + u64::from(proof.amount)) as usize;
+                let target_index = t + u64::from(proof.amount) as usize;
 
                 // Double check new bounds
                 if target_index >= dp.len() || target_index >= paths.len() {
@@ -370,7 +374,7 @@ fn select_least_proofs_over_amount(
 
 /// Select proofs options
 pub struct SelectProofsOptions {
-    /// Allow inactive keys (if `true`, inactive keys will be selected first in largest order)
+    /// Prefer inactive keys (if `true`, inactive keys will be selected first in largest order)
     pub prefer_inactive_keys: bool,
     /// Include fees to add to the selection amount
     pub include_fees: bool,
@@ -381,19 +385,19 @@ pub struct SelectProofsOptions {
 impl SelectProofsOptions {
     /// Create new [`SelectProofsOptions`]
     pub fn new(
-        allow_inactive_keys: bool,
+        prefer_inactive_keys: bool,
         include_fees: bool,
         method: ProofSelectionMethod,
     ) -> Self {
         Self {
-            prefer_inactive_keys: allow_inactive_keys,
+            prefer_inactive_keys,
             include_fees,
             method,
         }
     }
 
-    /// Allow inactive keys (if `true`, inactive keys will be selected first in largest order)
-    pub fn allow_inactive_keys(mut self, allow_inactive_keys: bool) -> Self {
+    /// Prefer inactive keys (if `true`, inactive keys will be selected first in largest order)
+    pub fn prefer_inactive_keys(mut self, allow_inactive_keys: bool) -> Self {
         self.prefer_inactive_keys = allow_inactive_keys;
         self
     }
@@ -431,7 +435,7 @@ pub enum ProofSelectionMethod {
     Closest,
     /// The smallest value proofs first
     Smallest,
-    /// Select the least value of proofs equal to or over the specified amount
+    /// Select the least value of proofs equal to or over the specified amount (best-effort, may fallback to largest)
     Least,
 }
 
@@ -581,6 +585,29 @@ mod tests {
         );
         assert!(
             select_least_proofs_over_amount(&vec![], Amount::from(1), HashMap::new()).is_none()
+        );
+
+        // OOM protection
+        let proofs = vec![
+            Proof {
+                amount: Amount::from(1_048_576),
+                keyset_id,
+                secret: Secret::generate(),
+                c: PublicKey::random(),
+                witness: None,
+                dleq: None,
+            },
+            Proof {
+                amount: Amount::from(2_097_152),
+                keyset_id,
+                secret: Secret::generate(),
+                c: PublicKey::random(),
+                witness: None,
+                dleq: None,
+            },
+        ];
+        assert!(
+            select_least_proofs_over_amount(&proofs, Amount::from(1), HashMap::new()).is_none()
         );
     }
 }

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -388,7 +388,7 @@ pub enum ProofSelectionMethod {
     Closest,
     /// Select proofs with the smallest amount first
     Smallest,
-    /// Select least number of proofs over the amount
+    /// Select least total proof amount over the specified amount
     Least,
 }
 

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -283,8 +283,8 @@ impl Wallet {
 
 fn sort_proofs(proofs: &mut Proofs, method: SelectProofsMethod, amount: Amount) {
     match method {
-        SelectProofsMethod::LargestFirst => proofs.sort_by(|a: &Proof, b: &Proof| b.cmp(a)),
-        SelectProofsMethod::ClosestFirst => proofs.sort_by(|a: &Proof, b: &Proof| {
+        SelectProofsMethod::Largest => proofs.sort_by(|a: &Proof, b: &Proof| b.cmp(a)),
+        SelectProofsMethod::Closest => proofs.sort_by(|a: &Proof, b: &Proof| {
             let a_diff = if a.amount > amount {
                 a.amount - amount
             } else {
@@ -297,7 +297,7 @@ fn sort_proofs(proofs: &mut Proofs, method: SelectProofsMethod, amount: Amount) 
             };
             a_diff.cmp(&b_diff)
         }),
-        SelectProofsMethod::SmallestFirst => proofs.sort(),
+        SelectProofsMethod::Smallest => proofs.sort(),
     }
 }
 
@@ -306,11 +306,11 @@ fn sort_proofs(proofs: &mut Proofs, method: SelectProofsMethod, amount: Amount) 
 pub enum SelectProofsMethod {
     /// Select proofs with the largest amount first
     #[default]
-    LargestFirst,
+    Largest,
     /// Select proofs closest to the amount first
-    ClosestFirst,
+    Closest,
     /// Select proofs with the smallest amount first
-    SmallestFirst,
+    Smallest,
 }
 
 #[cfg(test)]
@@ -354,19 +354,19 @@ mod tests {
             },
         ];
 
-        fn assert_proof_order(proofs: &Vec<Proof>, order: Vec<u64>) {
+        fn assert_proof_order(proofs: &[Proof], order: Vec<u64>) {
             for (p, a) in proofs.iter().zip(order.iter()) {
                 assert_eq!(p.amount, Amount::from(*a));
             }
         }
 
-        sort_proofs(&mut proofs, SelectProofsMethod::LargestFirst, amount);
+        sort_proofs(&mut proofs, SelectProofsMethod::Largest, amount);
         assert_proof_order(&proofs, vec![1024, 256, 1]);
 
-        sort_proofs(&mut proofs, SelectProofsMethod::ClosestFirst, amount);
+        sort_proofs(&mut proofs, SelectProofsMethod::Closest, amount);
         assert_proof_order(&proofs, vec![256, 1, 1024]);
 
-        sort_proofs(&mut proofs, SelectProofsMethod::SmallestFirst, amount);
+        sort_proofs(&mut proofs, SelectProofsMethod::Smallest, amount);
         assert_proof_order(&proofs, vec![1, 256, 1024]);
     }
 }

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -307,7 +307,7 @@ fn select_least_proofs_over_amount(
                 continue;
             }
 
-            if let Some(current_sum) = dp[t as usize] {
+            if let Some(current_sum) = dp[t] {
                 let new_sum = current_sum + proof.amount;
                 let target_index = t + u64::from(proof.amount) as usize;
 

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -313,8 +313,13 @@ fn select_least_proofs_over_amount(
 
     // Find the smallest sum greater than or equal to the target amount
     for t in u64::from(amount)..=u64::from(max_sum) {
-        if let Some(proofs_amount) = dp[t as usize] {
-            let proofs = &paths[t as usize];
+        let idx = t as usize;
+        if idx >= dp.len() || idx >= paths.len() {
+            continue;
+        }
+
+        if let Some(proofs_amount) = dp[idx] {
+            let proofs = &paths[idx];
             let proofs_sum =
                 Amount::try_sum(proofs.iter().map(|p| p.amount)).unwrap_or(Amount::ZERO);
             if proofs_sum != proofs_amount {
@@ -331,7 +336,7 @@ fn select_least_proofs_over_amount(
             let fee = calculate_fee(&proofs_count, &fees).unwrap_or(Amount::ZERO);
 
             if proofs_amount >= amount + fee {
-                let proofs = paths[t as usize].clone();
+                let proofs = paths[idx].clone();
                 tracing::trace!(
                     "Selected proofs for amount {} with fee {}: {:?}",
                     amount,

--- a/crates/cdk/src/wallet/send.rs
+++ b/crates/cdk/src/wallet/send.rs
@@ -6,7 +6,7 @@ use crate::{
     Amount, Error, Wallet,
 };
 
-use super::{proofs::SelectProofsOptions, SendKind};
+use super::{proofs::SelectProofsOptions, ProofSelectionMethod, SendKind};
 
 impl Wallet {
     /// Send specific proofs
@@ -116,7 +116,9 @@ impl Wallet {
             .select_proofs(
                 amount,
                 available_proofs,
-                SelectProofsOptions::default().include_fees(include_fees),
+                SelectProofsOptions::default()
+                    .include_fees(include_fees)
+                    .method(ProofSelectionMethod::Least),
             )
             .await;
 

--- a/crates/cdk/src/wallet/send.rs
+++ b/crates/cdk/src/wallet/send.rs
@@ -6,7 +6,7 @@ use crate::{
     Amount, Error, Wallet,
 };
 
-use super::{proofs::ProofSelectionMethod, SendKind};
+use super::{proofs::SelectProofsOptions, SendKind};
 
 impl Wallet {
     /// Send specific proofs
@@ -86,10 +86,10 @@ impl Wallet {
                     let available_proofs = available_proofs.into_iter().map(|p| p.proof).collect();
 
                     let proofs_to_swap = self
-                        .select_proofs_to_swap(
+                        .select_proofs(
                             amount,
                             available_proofs,
-                            ProofSelectionMethod::Largest,
+                            SelectProofsOptions::default().include_fees(include_fees),
                         )
                         .await?;
 
@@ -113,7 +113,11 @@ impl Wallet {
         };
 
         let selected = self
-            .select_proofs_to_send(amount, available_proofs, include_fees)
+            .select_proofs(
+                amount,
+                available_proofs,
+                SelectProofsOptions::default().include_fees(include_fees),
+            )
             .await;
 
         let send_proofs: Proofs = match (send_kind, selected, conditions.clone()) {

--- a/crates/cdk/src/wallet/send.rs
+++ b/crates/cdk/src/wallet/send.rs
@@ -89,7 +89,7 @@ impl Wallet {
                         .select_proofs_to_swap(
                             amount,
                             available_proofs,
-                            SelectProofsMethod::LargestFirst,
+                            SelectProofsMethod::Largest,
                         )
                         .await?;
 

--- a/crates/cdk/src/wallet/send.rs
+++ b/crates/cdk/src/wallet/send.rs
@@ -118,7 +118,7 @@ impl Wallet {
                 available_proofs,
                 SelectProofsOptions::default()
                     .include_fees(include_fees)
-                    .method(ProofSelectionMethod::Fewest),
+                    .method(ProofSelectionMethod::Least),
             )
             .await;
 

--- a/crates/cdk/src/wallet/send.rs
+++ b/crates/cdk/src/wallet/send.rs
@@ -118,7 +118,7 @@ impl Wallet {
                 available_proofs,
                 SelectProofsOptions::default()
                     .include_fees(include_fees)
-                    .method(ProofSelectionMethod::Least),
+                    .method(ProofSelectionMethod::Fewest),
             )
             .await;
 

--- a/crates/cdk/src/wallet/send.rs
+++ b/crates/cdk/src/wallet/send.rs
@@ -6,7 +6,7 @@ use crate::{
     Amount, Error, Wallet,
 };
 
-use super::{proofs::SelectProofsMethod, SendKind};
+use super::{proofs::ProofSelectionMethod, SendKind};
 
 impl Wallet {
     /// Send specific proofs
@@ -89,7 +89,7 @@ impl Wallet {
                         .select_proofs_to_swap(
                             amount,
                             available_proofs,
-                            SelectProofsMethod::Largest,
+                            ProofSelectionMethod::Largest,
                         )
                         .await?;
 

--- a/crates/cdk/src/wallet/send.rs
+++ b/crates/cdk/src/wallet/send.rs
@@ -6,7 +6,7 @@ use crate::{
     Amount, Error, Wallet,
 };
 
-use super::SendKind;
+use super::{proofs::SelectProofsMethod, SendKind};
 
 impl Wallet {
     /// Send specific proofs
@@ -85,8 +85,13 @@ impl Wallet {
 
                     let available_proofs = available_proofs.into_iter().map(|p| p.proof).collect();
 
-                    let proofs_to_swap =
-                        self.select_proofs_to_swap(amount, available_proofs).await?;
+                    let proofs_to_swap = self
+                        .select_proofs_to_swap(
+                            amount,
+                            available_proofs,
+                            SelectProofsMethod::LargestFirst,
+                        )
+                        .await?;
 
                     let proofs_with_conditions = self
                         .swap(

--- a/crates/cdk/src/wallet/send.rs
+++ b/crates/cdk/src/wallet/send.rs
@@ -6,7 +6,7 @@ use crate::{
     Amount, Error, Wallet,
 };
 
-use super::{proofs::SelectProofsOptions, ProofSelectionMethod, SendKind};
+use super::{proofs::SelectProofsOptions, SendKind};
 
 impl Wallet {
     /// Send specific proofs
@@ -116,9 +116,7 @@ impl Wallet {
             .select_proofs(
                 amount,
                 available_proofs,
-                SelectProofsOptions::default()
-                    .include_fees(include_fees)
-                    .method(ProofSelectionMethod::Least),
+                SelectProofsOptions::default().include_fees(include_fees),
             )
             .await;
 

--- a/crates/cdk/src/wallet/swap.rs
+++ b/crates/cdk/src/wallet/swap.rs
@@ -15,7 +15,7 @@ use crate::Amount;
 use crate::Error;
 use crate::Wallet;
 
-use super::proofs::ProofSelectionMethod;
+use super::proofs::SelectProofsOptions;
 
 impl Wallet {
     /// Swap
@@ -176,7 +176,11 @@ impl Wallet {
         }
 
         let proofs = self
-            .select_proofs_to_swap(amount, available_proofs, ProofSelectionMethod::Largest)
+            .select_proofs(
+                amount,
+                available_proofs,
+                SelectProofsOptions::default().include_fees(include_fees),
+            )
             .await?;
 
         self.swap(

--- a/crates/cdk/src/wallet/swap.rs
+++ b/crates/cdk/src/wallet/swap.rs
@@ -15,6 +15,8 @@ use crate::Amount;
 use crate::Error;
 use crate::Wallet;
 
+use super::proofs::SelectProofsMethod;
+
 impl Wallet {
     /// Swap
     #[instrument(skip(self, input_proofs))]
@@ -173,7 +175,9 @@ impl Wallet {
             return Err(Error::InsufficientFunds);
         }
 
-        let proofs = self.select_proofs_to_swap(amount, available_proofs).await?;
+        let proofs = self
+            .select_proofs_to_swap(amount, available_proofs, SelectProofsMethod::LargestFirst)
+            .await?;
 
         self.swap(
             Some(amount),

--- a/crates/cdk/src/wallet/swap.rs
+++ b/crates/cdk/src/wallet/swap.rs
@@ -179,7 +179,9 @@ impl Wallet {
             .select_proofs(
                 amount,
                 available_proofs,
-                SelectProofsOptions::default().include_fees(include_fees),
+                SelectProofsOptions::default()
+                    .allow_inactive_keys(true)
+                    .include_fees(include_fees),
             )
             .await?;
 

--- a/crates/cdk/src/wallet/swap.rs
+++ b/crates/cdk/src/wallet/swap.rs
@@ -15,7 +15,7 @@ use crate::Amount;
 use crate::Error;
 use crate::Wallet;
 
-use super::proofs::SelectProofsMethod;
+use super::proofs::ProofSelectionMethod;
 
 impl Wallet {
     /// Swap
@@ -176,7 +176,7 @@ impl Wallet {
         }
 
         let proofs = self
-            .select_proofs_to_swap(amount, available_proofs, SelectProofsMethod::Largest)
+            .select_proofs_to_swap(amount, available_proofs, ProofSelectionMethod::Largest)
             .await?;
 
         self.swap(

--- a/crates/cdk/src/wallet/swap.rs
+++ b/crates/cdk/src/wallet/swap.rs
@@ -180,7 +180,7 @@ impl Wallet {
                 amount,
                 available_proofs,
                 SelectProofsOptions::default()
-                    .allow_inactive_keys(true)
+                    .prefer_inactive_keys(true)
                     .include_fees(include_fees),
             )
             .await?;

--- a/crates/cdk/src/wallet/swap.rs
+++ b/crates/cdk/src/wallet/swap.rs
@@ -176,7 +176,7 @@ impl Wallet {
         }
 
         let proofs = self
-            .select_proofs_to_swap(amount, available_proofs, SelectProofsMethod::LargestFirst)
+            .select_proofs_to_swap(amount, available_proofs, SelectProofsMethod::Largest)
             .await?;
 
         self.swap(


### PR DESCRIPTION
Following up on a conversation with @thesimplekid about proof selection.

The `Wallet` now has a single `select_proofs` that uses a `SelectProofsOptions` struct to control which proofs are selected.

One notable change is the method of selecting **active** proofs. The four methods are now exposed:
- `Largest`: the highest value first
- `Closest`: the closest in value first
- `Smallest`: the smallest in value first
- `Fewest`: the fewest number of proofs over the amount