### PR TITLE
`mintd`: sort pks by amount in `/v1/keys`

### DIFF
--- a/crates/cdk/src/amount.rs
+++ b/crates/cdk/src/amount.rs
@@ -4,8 +4,9 @@
 
 use std::cmp::Ordering;
 use std::fmt;
+use std::str::FromStr;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
 use crate::nuts::CurrencyUnit;
@@ -207,6 +208,54 @@ impl std::ops::Div for Amount {
 
     fn div(self, other: Self) -> Self::Output {
         Amount(self.0 / other.0)
+    }
+}
+
+/// String wrapper for an [Amount].
+///
+/// It ser-/deserializes the inner [Amount] to a string, while at the same time using the [u64]
+/// value of the [Amount] for comparison and ordering. This helps automatically sort the keys of
+/// a [BTreeMap] when [AmountStr] is used as key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AmountStr(Amount);
+
+impl AmountStr {
+    pub(crate) fn from(amt: Amount) -> Self {
+        Self(amt)
+    }
+}
+
+impl PartialOrd<Self> for AmountStr {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AmountStr {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for AmountStr {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        u64::from_str(&s)
+            .map(Amount)
+            .map(Self)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+impl Serialize for AmountStr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
     }
 }
 

--- a/crates/cdk/src/nuts/nut02.rs
+++ b/crates/cdk/src/nuts/nut02.rs
@@ -25,6 +25,7 @@ use thiserror::Error;
 use super::nut01::Keys;
 #[cfg(feature = "mint")]
 use super::nut01::{MintKeyPair, MintKeys};
+use crate::amount::AmountStr;
 use crate::nuts::nut00::CurrencyUnit;
 use crate::util::hex;
 #[cfg(feature = "mint")]
@@ -197,9 +198,9 @@ impl From<&Keys> for Id {
             5 - prefix it with a keyset ID version byte
         */
 
-        let mut keys: Vec<(&String, &super::PublicKey)> = map.iter().collect();
+        let mut keys: Vec<(&AmountStr, &super::PublicKey)> = map.iter().collect();
 
-        keys.sort_by_key(|(k, _v)| u64::from_str(k).unwrap());
+        keys.sort_by_key(|(amt, _v)| *amt);
 
         let pubkeys_concat: Vec<u8> = keys
             .iter()


### PR DESCRIPTION
This PR brings two related changes:
- it ensures the mint keys exposed in `/v1/keys/{keyset_id}` are sorted by amount. Before, they were sorted alphabetically for the `String` representation of `Amounts` (`"123", "2", "33"` vs now `"2", "33", "123"`).
- it simplifies the first step in `Id` generation, namely the sorting of pubkeys. Before, there were two conversions (`Amount` to `String` to `u64`) before sorting, for each `PublicKey`. Now, the two conversions are skipped and the keys are directly sorted by `Amount`.