### PR TITLE
Fix `TokenV4`: make `unit` mandatory

### DIFF
--- a/crates/cdk/src/wallet/mint.rs
+++ b/crates/cdk/src/wallet/mint.rs
@@ -48,7 +48,6 @@ impl Wallet {
         let unit = self.unit;
 
         // If we have a description, we check that the mint supports it.
-        // If we have a description, we check that the mint supports it.
         if description.is_some() {
             let mint_method_settings = self
                 .localstore

--- a/crates/cdk/src/wallet/send.rs
+++ b/crates/cdk/src/wallet/send.rs
@@ -16,12 +16,7 @@ impl Wallet {
         let ys = proofs.ys()?;
         self.localstore.reserve_proofs(ys).await?;
 
-        Ok(Token::new(
-            self.mint_url.clone(),
-            proofs,
-            memo,
-            Some(self.unit),
-        ))
+        Ok(Token::new(self.mint_url.clone(), proofs, memo, self.unit))
     }
 
     /// Send

--- a/crates/cdk/src/wallet/types.rs
+++ b/crates/cdk/src/wallet/types.rs
@@ -54,8 +54,7 @@ pub enum SendKind {
     OnlineExact,
     /// Prefer offline send if difference is less then tolerance
     OnlineTolerance(Amount),
-    /// Wallet cannot do an online swap and selectedp proof must be exactly send
-    /// amount
+    /// Wallet cannot do an online swap and selected proof must be exactly send amount
     OfflineExact,
     /// Wallet must remain offline but can over pay if below tolerance
     OfflineTolerance(Amount),


### PR DESCRIPTION
This PR makes `TokenV4::unit` mandatory, as per NUT-00.

`TokenV3::unit` remains optional.