### PR TITLE
Keyset ID: fix deserialization edge-case, add unit tests

### DIFF
--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -35,7 +35,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 ], optional = true }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
-serde_with = "3.1"
+serde_with = "3"
 tracing = { version = "0.1", default-features = false, features = ["attributes", "log"] }
 thiserror = "1"
 futures = { version = "0.3.28", default-features = false, optional = true }


### PR DESCRIPTION
This PR fixes an edge-case where the keyset ID could be deserialized from a string starting with a non `00` byte into a valid keyset ID with the version byte `00`.

The PR also
- replaces the custom serializer and deserializer with `serde` annotations
- adds more serialization and deserialization unit tests