### PR TITLE
Consolidate `Wallet::get_proofs` variants

### DIFF
--- a/crates/cdk-integration-tests/tests/fake_wallet.rs
+++ b/crates/cdk-integration-tests/tests/fake_wallet.rs
@@ -104,7 +104,7 @@ async fn test_fake_melt_payment_fail() -> Result<()> {
     assert!(melt.is_err());
 
     // The mint should have unset proofs from pending since payment failed
-    let all_proof = wallet.get_proofs().await?;
+    let all_proof = wallet.get_unspent_proofs().await?;
     let states = wallet.check_proofs_spent(all_proof).await?;
     for state in states {
         assert!(state.state == State::Unspent);
@@ -344,7 +344,7 @@ async fn test_fake_melt_change_in_quote() -> Result<()> {
 
     let invoice = create_fake_invoice(9000, serde_json::to_string(&fake_description).unwrap());
 
-    let proofs = wallet.get_proofs().await?;
+    let proofs = wallet.get_unspent_proofs().await?;
 
     let melt_quote = wallet.melt_quote(invoice.to_string(), None).await?;
 

--- a/crates/cdk-integration-tests/tests/regtest.rs
+++ b/crates/cdk-integration-tests/tests/regtest.rs
@@ -111,7 +111,7 @@ async fn test_restore() -> Result<()> {
     assert!(wallet_2.total_balance().await? == 0.into());
 
     let restored = wallet_2.restore().await?;
-    let proofs = wallet_2.get_proofs().await?;
+    let proofs = wallet_2.get_unspent_proofs().await?;
 
     wallet_2
         .swap(None, SplitTarget::default(), proofs, None, false)
@@ -121,7 +121,7 @@ async fn test_restore() -> Result<()> {
 
     assert!(wallet_2.total_balance().await? == 100.into());
 
-    let proofs = wallet.get_proofs().await?;
+    let proofs = wallet.get_unspent_proofs().await?;
 
     let states = wallet.check_proofs_spent(proofs).await?;
 

--- a/crates/cdk/examples/proof-selection.rs
+++ b/crates/cdk/examples/proof-selection.rs
@@ -48,7 +48,7 @@ async fn main() {
         println!("Minted {}", receive_amount);
     }
 
-    let proofs = wallet.get_proofs().await.unwrap();
+    let proofs = wallet.get_unspent_proofs().await.unwrap();
 
     let selected = wallet
         .select_proofs_to_send(Amount::from(64), proofs, false)

--- a/crates/cdk/src/wallet/melt.rs
+++ b/crates/cdk/src/wallet/melt.rs
@@ -286,7 +286,7 @@ impl Wallet {
 
         let inputs_needed_amount = quote_info.amount + quote_info.fee_reserve;
 
-        let available_proofs = self.get_proofs().await?;
+        let available_proofs = self.get_unspent_proofs().await?;
 
         let input_proofs = self
             .select_proofs_to_swap(inputs_needed_amount, available_proofs)

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -181,7 +181,7 @@ impl Wallet {
     /// Get amounts needed to refill proof state
     #[instrument(skip(self))]
     pub async fn amounts_needed_for_state_target(&self) -> Result<Vec<Amount>, Error> {
-        let unspent_proofs = self.get_proofs().await?;
+        let unspent_proofs = self.get_unspent_proofs().await?;
 
         let amounts_count: HashMap<usize, usize> =
             unspent_proofs

--- a/crates/cdk/src/wallet/multi_mint_wallet.rs
+++ b/crates/cdk/src/wallet/multi_mint_wallet.rs
@@ -125,7 +125,7 @@ impl MultiMintWallet {
         let mut mint_proofs = BTreeMap::new();
 
         for (WalletKey { mint_url, unit: u }, wallet) in self.wallets.lock().await.iter() {
-            let wallet_proofs = wallet.get_proofs().await?;
+            let wallet_proofs = wallet.get_unspent_proofs().await?;
             mint_proofs.insert(mint_url.clone(), (wallet_proofs, *u));
         }
         Ok(mint_proofs)

--- a/crates/cdk/src/wallet/send.rs
+++ b/crates/cdk/src/wallet/send.rs
@@ -43,19 +43,14 @@ impl Wallet {
             }
         }
 
-        let mint_url = &self.mint_url;
-        let unit = &self.unit;
         let available_proofs = self
-            .localstore
-            .get_proofs(
-                Some(mint_url.clone()),
-                Some(*unit),
+            .get_proofs_with(
                 Some(vec![State::Unspent]),
                 conditions.clone().map(|c| vec![c]),
             )
             .await?;
 
-        let (available_proofs, proofs_sum) = available_proofs.into_iter().map(|p| p.proof).fold(
+        let (available_proofs, proofs_sum) = available_proofs.into_iter().fold(
             (Vec::new(), Amount::ZERO),
             |(mut acc1, mut acc2), p| {
                 acc2 += p.amount;
@@ -66,20 +61,9 @@ impl Wallet {
         let available_proofs = if proofs_sum < amount {
             match &conditions {
                 Some(conditions) => {
-                    let available_proofs = self
-                        .localstore
-                        .get_proofs(
-                            Some(mint_url.clone()),
-                            Some(*unit),
-                            Some(vec![State::Unspent]),
-                            None,
-                        )
-                        .await?;
+                    let unspent_proofs = self.get_unspent_proofs().await?;
 
-                    let available_proofs = available_proofs.into_iter().map(|p| p.proof).collect();
-
-                    let proofs_to_swap =
-                        self.select_proofs_to_swap(amount, available_proofs).await?;
+                    let proofs_to_swap = self.select_proofs_to_swap(amount, unspent_proofs).await?;
 
                     let proofs_with_conditions = self
                         .swap(
@@ -90,12 +74,10 @@ impl Wallet {
                             include_fees,
                         )
                         .await?;
-                    proofs_with_conditions.ok_or(Error::InsufficientFunds)?
+                    proofs_with_conditions.ok_or(Error::InsufficientFunds)
                 }
-                None => {
-                    return Err(Error::InsufficientFunds);
-                }
-            }
+                None => Err(Error::InsufficientFunds),
+            }?
         } else {
             available_proofs
         };


### PR DESCRIPTION
This PR consolidates a few similar calls.