### PR TITLE
build: add rust-toolchain.toml file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel="1.82.0"
+components = ["rustfmt", "clippy", "rust-analyzer"]
+


### PR DESCRIPTION
Let me know what you think but, especially for open source, I prefer to pin the version of the language to make sure that all contributors are working with the same one and that no bugs or changes in behaviors they may encounter are due to running a different version of the language

Run `cargo install` at the project root to download and install the language version and the components we listed.