### PR TITLE
Send current state of the subscriptions

### DIFF
--- a/crates/cdk-axum/src/ws/subscribe.rs
+++ b/crates/cdk-axum/src/ws/subscribe.rs
@@ -3,7 +3,10 @@ use super::{
     WsContext, WsError, JSON_RPC_VERSION,
 };
 use cdk::{
-    nuts::nut17::{NotificationPayload, Params},
+    nuts::{
+        nut17::{Kind, NotificationPayload, Params},
+        MeltQuoteBolt11Response, MintQuoteBolt11Response, ProofState, PublicKey,
+    },
     pub_sub::SubId,
 };
 
@@ -11,17 +14,26 @@ use cdk::{
 pub struct Method(Params);
 
 #[derive(Debug, Clone, serde::Serialize)]
+/// The response to a subscription request
 pub struct Response {
+    /// Status
     status: String,
+    /// Subscription ID
     #[serde(rename = "subId")]
     sub_id: SubId,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
+/// The notification
+///
+/// This is the notification that is sent to the client when an event matches a
+/// subscription
 pub struct Notification {
+    /// The subscription ID
     #[serde(rename = "subId")]
     pub sub_id: SubId,
 
+    /// The notification payload
     pub payload: NotificationPayload,
 }
 
@@ -39,13 +51,96 @@ impl From<(SubId, NotificationPayload)> for WsNotification<Notification> {
 impl WsHandle for Method {
     type Response = Response;
 
+    /// The `handle` method is called when a client sends a subscription request
     async fn handle(self, context: &mut WsContext) -> Result<Self::Response, WsError> {
         let sub_id = self.0.id.clone();
         if context.subscriptions.contains_key(&sub_id) {
+            // Subscription ID already exits. Returns an error instead of
+            // replacing the other subscription or avoiding it.
             return Err(WsError::InvalidParams);
         }
-        let mut subscription = context.state.mint.pubsub_manager.subscribe(self.0).await;
+
+        let mut subscription = context
+            .state
+            .mint
+            .pubsub_manager
+            .subscribe(self.0.clone())
+            .await;
         let publisher = context.publisher.clone();
+
+        let current_notification_to_send: Vec<NotificationPayload> = match self.0.kind {
+            Kind::Bolt11MeltQuote => {
+                let queries = self
+                    .0
+                    .filters
+                    .iter()
+                    .map(|id| context.state.mint.localstore.get_melt_quote(id))
+                    .collect::<Vec<_>>();
+
+                futures::future::try_join_all(queries)
+                    .await
+                    .map(|quotes| {
+                        quotes
+                            .into_iter()
+                            .filter_map(|quote| quote.map(|x| x.into()))
+                            .map(|x: MeltQuoteBolt11Response| x.into())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            }
+            Kind::Bolt11MintQuote => {
+                let queries = self
+                    .0
+                    .filters
+                    .iter()
+                    .map(|id| context.state.mint.localstore.get_mint_quote(id))
+                    .collect::<Vec<_>>();
+
+                futures::future::try_join_all(queries)
+                    .await
+                    .map(|quotes| {
+                        quotes
+                            .into_iter()
+                            .filter_map(|quote| quote.map(|x| x.into()))
+                            .map(|x: MintQuoteBolt11Response| x.into())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            }
+            Kind::ProofState => {
+                if let Ok(public_keys) = self
+                    .0
+                    .filters
+                    .iter()
+                    .map(PublicKey::from_hex)
+                    .collect::<Result<Vec<PublicKey>, _>>()
+                {
+                    context
+                        .state
+                        .mint
+                        .localstore
+                        .get_proofs_states(&public_keys)
+                        .await
+                        .map(|x| {
+                            x.into_iter()
+                                .enumerate()
+                                .filter_map(|(idx, state)| {
+                                    state.map(|state| (public_keys[idx], state).into())
+                                })
+                                .map(|x: ProofState| x.into())
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default()
+                } else {
+                    vec![]
+                }
+            }
+        };
+
+        for notification in current_notification_to_send.into_iter() {
+            let _ = publisher.send((sub_id.clone(), notification)).await;
+        }
+
         context.subscriptions.insert(
             sub_id.clone(),
             tokio::spawn(async move {

--- a/crates/cdk-integration-tests/tests/regtest.rs
+++ b/crates/cdk-integration-tests/tests/regtest.rs
@@ -113,6 +113,18 @@ async fn test_regtest_mint_melt_round_trip() -> Result<()> {
     assert!(melt_response.state == MeltQuoteState::Paid);
 
     let (sub_id, payload) = get_notification(&mut reader, Duration::from_millis(15000)).await;
+    // first message is the current state
+    assert_eq!("test-sub", sub_id);
+    let payload = match payload {
+        NotificationPayload::MeltQuoteBolt11Response(melt) => melt,
+        _ => panic!("Wrong payload"),
+    };
+    assert_eq!(payload.amount + payload.fee_reserve, 100.into());
+    assert_eq!(payload.quote, melt.id);
+    assert_eq!(payload.state, MeltQuoteState::Unpaid);
+
+    // get current state
+    let (sub_id, payload) = get_notification(&mut reader, Duration::from_millis(15000)).await;
     assert_eq!("test-sub", sub_id);
     let payload = match payload {
         NotificationPayload::MeltQuoteBolt11Response(melt) => melt,

--- a/crates/cdk-integration-tests/tests/regtest.rs
+++ b/crates/cdk-integration-tests/tests/regtest.rs
@@ -35,7 +35,7 @@ async fn get_notification<T: StreamExt<Item = Result<Message, E>> + Unpin, E: De
         .unwrap();
 
     let mut response: serde_json::Value =
-        serde_json::from_str(&msg.to_text().unwrap()).expect("valid json");
+        serde_json::from_str(msg.to_text().unwrap()).expect("valid json");
 
     let mut params_raw = response
         .as_object_mut()

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "1"
 serde_with = "3"
 tracing = { version = "0.1", default-features = false, features = ["attributes", "log"] }
 thiserror = "1"
-futures = { version = "0.3.28", default-features = false, optional = true }
+futures = { version = "0.3.28", default-features = false, optional = true, features = ["alloc"] }
 url = "2.3"
 utoipa = { version = "4", optional = true }
 uuid = { version = "1", features = ["v4"] }

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -185,7 +185,7 @@ impl Mint {
         Ok(Self {
             mint_url: MintUrl::from_str(mint_url)?,
             keysets: Arc::new(RwLock::new(active_keysets)),
-            pubsub_manager: Default::default(),
+            pubsub_manager: Arc::new(localstore.clone().into()),
             secp_ctx,
             quote_ttl,
             xpriv,

--- a/crates/cdk/src/nuts/mod.rs
+++ b/crates/cdk/src/nuts/mod.rs
@@ -18,6 +18,7 @@ pub mod nut12;
 pub mod nut13;
 pub mod nut14;
 pub mod nut15;
+#[cfg(feature = "mint")]
 pub mod nut17;
 pub mod nut18;
 
@@ -48,5 +49,6 @@ pub use nut11::{Conditions, P2PKWitness, SigFlag, SpendingConditions};
 pub use nut12::{BlindSignatureDleq, ProofDleq};
 pub use nut14::HTLCWitness;
 pub use nut15::{Mpp, MppMethodSettings, Settings as NUT15Settings};
+#[cfg(feature = "mint")]
 pub use nut17::{NotificationPayload, PubSubManager};
 pub use nut18::{PaymentRequest, PaymentRequestPayload, Transport};

--- a/crates/cdk/src/nuts/nut06.rs
+++ b/crates/cdk/src/nuts/nut06.rs
@@ -5,7 +5,7 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::nut01::PublicKey;
-use super::{nut04, nut05, nut15, nut17, MppMethodSettings};
+use super::{nut04, nut05, nut15, MppMethodSettings};
 
 /// Mint Version
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -238,7 +238,8 @@ pub struct Nuts {
     /// NUT17 Settings
     #[serde(default)]
     #[serde(rename = "17")]
-    pub nut17: nut17::SupportedSettings,
+    #[cfg(feature = "mint")]
+    pub nut17: super::nut17::SupportedSettings,
 }
 
 impl Nuts {

--- a/crates/cdk/src/nuts/nut17.rs
+++ b/crates/cdk/src/nuts/nut17.rs
@@ -1,14 +1,15 @@
 //! Specific Subscription for the cdk crate
 
 use crate::{
+    cdk_database::{self, MintDatabase},
     nuts::{
         MeltQuoteBolt11Response, MeltQuoteState, MintQuoteBolt11Response, MintQuoteState,
         ProofState,
     },
-    pub_sub::{self, Index, Indexable, SubscriptionGlobalId},
+    pub_sub::{self, Index, Indexable, OnNewSubscription, SubscriptionGlobalId},
 };
 use serde::{Deserialize, Serialize};
-use std::ops::Deref;
+use std::{collections::HashMap, ops::Deref, sync::Arc};
 
 /// Subscription Parameter according to the standard
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,7 +60,7 @@ impl Default for SupportedMethods {
 
 pub use crate::pub_sub::SubId;
 
-use super::{BlindSignature, CurrencyUnit, PaymentMethod};
+use super::{BlindSignature, CurrencyUnit, PaymentMethod, PublicKey};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -144,16 +145,125 @@ impl From<Params> for Vec<Index<(String, Kind)>> {
     }
 }
 
-/// Manager
 #[derive(Default)]
+/// Subscription Init
+///
+/// This struct triggers code when a new subscription is created.
+///
+/// It is used to send the initial state of the subscription to the client.
+pub struct SubscriptionInit(Option<Arc<dyn MintDatabase<Err = cdk_database::Error> + Send + Sync>>);
+
+#[async_trait::async_trait]
+impl OnNewSubscription for SubscriptionInit {
+    type Event = NotificationPayload;
+    type Index = (String, Kind);
+
+    async fn on_new_subscription(
+        &self,
+        request: &[&Self::Index],
+    ) -> Result<Vec<Self::Event>, String> {
+        let datastore = if let Some(localstore) = self.0.as_ref() {
+            localstore
+        } else {
+            return Ok(vec![]);
+        };
+
+        let mut to_return = vec![];
+
+        for (kind, values) in request.iter().fold(
+            HashMap::new(),
+            |mut acc: HashMap<&Kind, Vec<&String>>, (data, kind)| {
+                acc.entry(kind).or_default().push(data);
+                acc
+            },
+        ) {
+            match kind {
+                Kind::Bolt11MeltQuote => {
+                    let queries = values
+                        .iter()
+                        .map(|id| datastore.get_melt_quote(id))
+                        .collect::<Vec<_>>();
+
+                    to_return.extend(
+                        futures::future::try_join_all(queries)
+                            .await
+                            .map(|quotes| {
+                                quotes
+                                    .into_iter()
+                                    .filter_map(|quote| quote.map(|x| x.into()))
+                                    .map(|x: MeltQuoteBolt11Response| x.into())
+                                    .collect::<Vec<_>>()
+                            })
+                            .map_err(|e| e.to_string())?,
+                    );
+                }
+                Kind::Bolt11MintQuote => {
+                    let queries = values
+                        .iter()
+                        .map(|id| datastore.get_mint_quote(id))
+                        .collect::<Vec<_>>();
+
+                    to_return.extend(
+                        futures::future::try_join_all(queries)
+                            .await
+                            .map(|quotes| {
+                                quotes
+                                    .into_iter()
+                                    .filter_map(|quote| quote.map(|x| x.into()))
+                                    .map(|x: MintQuoteBolt11Response| x.into())
+                                    .collect::<Vec<_>>()
+                            })
+                            .map_err(|e| e.to_string())?,
+                    );
+                }
+                Kind::ProofState => {
+                    let public_keys = values
+                        .iter()
+                        .map(PublicKey::from_hex)
+                        .collect::<Result<Vec<PublicKey>, _>>()
+                        .map_err(|e| e.to_string())?;
+
+                    to_return.extend(
+                        datastore
+                            .get_proofs_states(&public_keys)
+                            .await
+                            .map_err(|e| e.to_string())?
+                            .into_iter()
+                            .enumerate()
+                            .filter_map(|(idx, state)| {
+                                state.map(|state| (public_keys[idx], state).into())
+                            })
+                            .map(|state: ProofState| state.into()),
+                    );
+                }
+            }
+        }
+
+        Ok(to_return)
+    }
+}
+
+/// Manager
 /// Publish–subscribe manager
 ///
 /// Nut-17 implementation is system-wide and not only through the WebSocket, so
 /// it is possible for another part of the system to subscribe to events.
-pub struct PubSubManager(pub_sub::Manager<NotificationPayload, (String, Kind)>);
+pub struct PubSubManager(pub_sub::Manager<NotificationPayload, (String, Kind), SubscriptionInit>);
+
+impl Default for PubSubManager {
+    fn default() -> Self {
+        PubSubManager(SubscriptionInit::default().into())
+    }
+}
+
+impl From<Arc<dyn MintDatabase<Err = cdk_database::Error> + Send + Sync>> for PubSubManager {
+    fn from(val: Arc<dyn MintDatabase<Err = cdk_database::Error> + Send + Sync>) -> Self {
+        PubSubManager(SubscriptionInit(Some(val)).into())
+    }
+}
 
 impl Deref for PubSubManager {
-    type Target = pub_sub::Manager<NotificationPayload, (String, Kind)>;
+    type Target = pub_sub::Manager<NotificationPayload, (String, Kind), SubscriptionInit>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/crates/cdk/src/nuts/nut17/on_subscription.rs
+++ b/crates/cdk/src/nuts/nut17/on_subscription.rs
@@ -1,0 +1,110 @@
+//! On Subscription
+//!
+//! This module contains the code that is triggered when a new subscription is created.
+use super::{Kind, NotificationPayload};
+use crate::{
+    cdk_database::{self, MintDatabase},
+    nuts::{MeltQuoteBolt11Response, MintQuoteBolt11Response, ProofState, PublicKey},
+    pub_sub::OnNewSubscription,
+};
+use std::{collections::HashMap, sync::Arc};
+
+#[derive(Default)]
+/// Subscription Init
+///
+/// This struct triggers code when a new subscription is created.
+///
+/// It is used to send the initial state of the subscription to the client.
+pub struct OnSubscription(
+    pub(crate) Option<Arc<dyn MintDatabase<Err = cdk_database::Error> + Send + Sync>>,
+);
+
+#[async_trait::async_trait]
+impl OnNewSubscription for OnSubscription {
+    type Event = NotificationPayload;
+    type Index = (String, Kind);
+
+    async fn on_new_subscription(
+        &self,
+        request: &[&Self::Index],
+    ) -> Result<Vec<Self::Event>, String> {
+        let datastore = if let Some(localstore) = self.0.as_ref() {
+            localstore
+        } else {
+            return Ok(vec![]);
+        };
+
+        let mut to_return = vec![];
+
+        for (kind, values) in request.iter().fold(
+            HashMap::new(),
+            |mut acc: HashMap<&Kind, Vec<&String>>, (data, kind)| {
+                acc.entry(kind).or_default().push(data);
+                acc
+            },
+        ) {
+            match kind {
+                Kind::Bolt11MeltQuote => {
+                    let queries = values
+                        .iter()
+                        .map(|id| datastore.get_melt_quote(id))
+                        .collect::<Vec<_>>();
+
+                    to_return.extend(
+                        futures::future::try_join_all(queries)
+                            .await
+                            .map(|quotes| {
+                                quotes
+                                    .into_iter()
+                                    .filter_map(|quote| quote.map(|x| x.into()))
+                                    .map(|x: MeltQuoteBolt11Response| x.into())
+                                    .collect::<Vec<_>>()
+                            })
+                            .map_err(|e| e.to_string())?,
+                    );
+                }
+                Kind::Bolt11MintQuote => {
+                    let queries = values
+                        .iter()
+                        .map(|id| datastore.get_mint_quote(id))
+                        .collect::<Vec<_>>();
+
+                    to_return.extend(
+                        futures::future::try_join_all(queries)
+                            .await
+                            .map(|quotes| {
+                                quotes
+                                    .into_iter()
+                                    .filter_map(|quote| quote.map(|x| x.into()))
+                                    .map(|x: MintQuoteBolt11Response| x.into())
+                                    .collect::<Vec<_>>()
+                            })
+                            .map_err(|e| e.to_string())?,
+                    );
+                }
+                Kind::ProofState => {
+                    let public_keys = values
+                        .iter()
+                        .map(PublicKey::from_hex)
+                        .collect::<Result<Vec<PublicKey>, _>>()
+                        .map_err(|e| e.to_string())?;
+
+                    to_return.extend(
+                        datastore
+                            .get_proofs_states(&public_keys)
+                            .await
+                            .map_err(|e| e.to_string())?
+                            .into_iter()
+                            .enumerate()
+                            .filter_map(|(idx, state)| {
+                                state.map(|state| (public_keys[idx], state).into())
+                            })
+                            .map(|state: ProofState| state.into()),
+                    );
+                }
+            }
+        }
+
+        Ok(to_return)
+    }
+}


### PR DESCRIPTION
Improve #394

Make WebSocket subscriptions send the current status when subscribing. It would also be interesting to implement this logic into the PubSub crate. If we do this, this solution would be agnostic to the WebSocket, and any other bit of the rust code that wants to subscribe would inherit messages of current status when they subscribe. What are your thoughts @thesimplekid ?