### PR TITLE
Make delay time in fake wallet configurable

### DIFF
--- a/crates/cdk-mintd/Cargo.toml
+++ b/crates/cdk-mintd/Cargo.toml
@@ -36,6 +36,7 @@ home = "0.5.5"
 url = "2.3"
 utoipa = { version = "4", optional = true }
 utoipa-swagger-ui = { version = "4", features = ["axum"], optional = true }
+rand = "0.8.5"
 
 [features]
 swagger = ["cdk-axum/swagger", "dep:utoipa", "dep:utoipa-swagger-ui"]

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use cdk::nuts::{CurrencyUnit, PublicKey};
 use cdk::Amount;
 use config::{Config, ConfigError, File};
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -111,15 +110,12 @@ pub struct FakeWallet {
 
 impl Default for FakeWallet {
     fn default() -> Self {
-        let mut rng = rand::thread_rng();
-        let min_rang = rng.gen_range(1..=1000);
-        let max_rang = rng.gen_range(1..=1000);
         Self {
             supported_units: vec![CurrencyUnit::Sat],
             fee_percent: 0.02,
             reserve_fee_min: 2.into(),
-            min_delay_time: min_rang,
-            max_delay_time: max_rang,
+            min_delay_time: 1,
+            max_delay_time: 3,
         }
     }
 }

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use cdk::nuts::{CurrencyUnit, PublicKey};
 use cdk::Amount;
 use config::{Config, ConfigError, File};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -104,14 +105,21 @@ pub struct FakeWallet {
     pub supported_units: Vec<CurrencyUnit>,
     pub fee_percent: f32,
     pub reserve_fee_min: Amount,
+    pub min_delay_time: u64,
+    pub max_delay_time: u64,
 }
 
 impl Default for FakeWallet {
     fn default() -> Self {
+        let mut rng = rand::thread_rng();
+        let min_rang = rng.gen_range(1..=1000);
+        let max_rang = rng.gen_range(1..=1000);
         Self {
             supported_units: vec![CurrencyUnit::Sat],
             fee_percent: 0.02,
             reserve_fee_min: 2.into(),
+            min_delay_time: min_rang,
+            max_delay_time: max_rang,
         }
     }
 }

--- a/crates/cdk-mintd/src/setup.rs
+++ b/crates/cdk-mintd/src/setup.rs
@@ -216,12 +216,14 @@ impl LnBackendSetup for config::FakeWallet {
             min_fee_reserve: self.reserve_fee_min,
             percent_fee_reserve: self.fee_percent,
         };
+        // calculate
+        let delay_time = (self.min_delay_time + self.max_delay_time) / 2;
 
         let fake_wallet = cdk_fake_wallet::FakeWallet::new(
             fee_reserve,
             HashMap::default(),
             HashSet::default(),
-            3,
+            delay_time,
         );
 
         Ok(fake_wallet)

--- a/crates/cdk-mintd/src/setup.rs
+++ b/crates/cdk-mintd/src/setup.rs
@@ -5,6 +5,7 @@ use std::{
 
 use anyhow::{anyhow, bail};
 use axum::{async_trait, Router};
+use rand::Rng;
 
 use cdk::{cdk_lightning::MintLightning, mint::FeeReserve, mint_url::MintUrl, nuts::CurrencyUnit};
 use tokio::sync::Mutex;
@@ -216,8 +217,11 @@ impl LnBackendSetup for config::FakeWallet {
             min_fee_reserve: self.reserve_fee_min,
             percent_fee_reserve: self.fee_percent,
         };
-        // calculate
-        let delay_time = (self.min_delay_time + self.max_delay_time) / 2;
+
+        // calculate random delay time
+        let mut rng = rand::thread_rng();
+        let delay_time = rng.gen_range(self.min_delay_time..=self.max_delay_time);
+       
 
         let fake_wallet = cdk_fake_wallet::FakeWallet::new(
             fee_reserve,

--- a/crates/cdk-mintd/src/setup.rs
+++ b/crates/cdk-mintd/src/setup.rs
@@ -221,7 +221,6 @@ impl LnBackendSetup for config::FakeWallet {
         // calculate random delay time
         let mut rng = rand::thread_rng();
         let delay_time = rng.gen_range(self.min_delay_time..=self.max_delay_time);
-       
 
         let fake_wallet = cdk_fake_wallet::FakeWallet::new(
             fee_reserve,


### PR DESCRIPTION
PR that closed issue: #443 

added min and max delay range field to the `FakeWallet` struct, then calculate the average value inside the setup function, and pass the value in` cdk_fake_wallet::FakeWallet::new()`