### PR TITLE
multiple active keysets and return active keyset with lowest fee 

### DIFF
--- a/crates/cdk/src/error.rs
+++ b/crates/cdk/src/error.rs
@@ -154,7 +154,7 @@ pub enum Error {
     /// No active keyset
     #[error("No active keyset")]
     NoActiveKeyset,
-     /// No active keyset
+    /// No active keyset
     #[error("No active keyset with lowest fee")]
     NoActiveKeysetWithLowestFee,
     /// Incorrect quote amount

--- a/crates/cdk/src/error.rs
+++ b/crates/cdk/src/error.rs
@@ -154,6 +154,9 @@ pub enum Error {
     /// No active keyset
     #[error("No active keyset")]
     NoActiveKeyset,
+     /// No active keyset
+    #[error("No active keyset with lowest fee")]
+    NoActiveKeysetWithLowestFee,
     /// Incorrect quote amount
     #[error("Incorrect quote amount")]
     IncorrectQuoteAmount,

--- a/crates/cdk/src/error.rs
+++ b/crates/cdk/src/error.rs
@@ -154,9 +154,6 @@ pub enum Error {
     /// No active keyset
     #[error("No active keyset")]
     NoActiveKeyset,
-    /// No active keyset
-    #[error("No active keyset with lowest fee")]
-    NoActiveKeysetWithLowestFee,
     /// Incorrect quote amount
     #[error("Incorrect quote amount")]
     IncorrectQuoteAmount,

--- a/crates/cdk/src/wallet/keysets.rs
+++ b/crates/cdk/src/wallet/keysets.rs
@@ -88,4 +88,16 @@ impl Wallet {
 
         Ok(active_keysets)
     }
+
+    /// Get active keyset for mint with the lowest fees
+    ///
+    /// Queries mint for current keysets then gets [`Keys`] for any unknown
+    /// keysets
+    #[instrument(skip(self))]
+    pub async fn get_active_mint_keyset(&self) -> Result<KeySetInfo, Error> {
+        let active_keysets =  self.get_active_mint_keysets().await?;
+
+        let keyset_with_lowest_fee = active_keysets.into_iter().min_by_key(|key| key.input_fee_ppk).ok_or(Error::NoActiveKeysetWithLowestFee)?;
+        Ok(keyset_with_lowest_fee)
+    }
 }

--- a/crates/cdk/src/wallet/keysets.rs
+++ b/crates/cdk/src/wallet/keysets.rs
@@ -44,14 +44,14 @@ impl Wallet {
 
         Ok(keysets.keysets)
     }
-    
+
     /// Get active keyset for mint
     ///
     /// Queries mint for current keysets then gets [`Keys`] for any unknown
     /// keysets
     #[instrument(skip(self))]
     pub async fn get_active_mint_keysets(&self) -> Result<Vec<KeySetInfo>, Error> {
-            let keysets = self.client.get_mint_keysets(self.mint_url.clone()).await?;
+        let keysets = self.client.get_mint_keysets(self.mint_url.clone()).await?;
         let keysets = keysets.keysets;
 
         self.localstore
@@ -95,9 +95,12 @@ impl Wallet {
     /// keysets
     #[instrument(skip(self))]
     pub async fn get_active_mint_keyset(&self) -> Result<KeySetInfo, Error> {
-        let active_keysets =  self.get_active_mint_keysets().await?;
+        let active_keysets = self.get_active_mint_keysets().await?;
 
-        let keyset_with_lowest_fee = active_keysets.into_iter().min_by_key(|key| key.input_fee_ppk).ok_or(Error::NoActiveKeysetWithLowestFee)?;
+        let keyset_with_lowest_fee = active_keysets
+            .into_iter()
+            .min_by_key(|key| key.input_fee_ppk)
+            .ok_or(Error::NoActiveKeysetWithLowestFee)?;
         Ok(keyset_with_lowest_fee)
     }
 }

--- a/crates/cdk/src/wallet/keysets.rs
+++ b/crates/cdk/src/wallet/keysets.rs
@@ -44,14 +44,14 @@ impl Wallet {
 
         Ok(keysets.keysets)
     }
-
+    
     /// Get active keyset for mint
     ///
     /// Queries mint for current keysets then gets [`Keys`] for any unknown
     /// keysets
     #[instrument(skip(self))]
-    pub async fn get_active_mint_keyset(&self) -> Result<KeySetInfo, Error> {
-        let keysets = self.client.get_mint_keysets(self.mint_url.clone()).await?;
+    pub async fn get_active_mint_keysets(&self) -> Result<Vec<KeySetInfo>, Error> {
+            let keysets = self.client.get_mint_keysets(self.mint_url.clone()).await?;
         let keysets = keysets.keysets;
 
         self.localstore
@@ -86,6 +86,6 @@ impl Wallet {
             }
         }
 
-        active_keysets.first().ok_or(Error::NoActiveKeyset).cloned()
+        Ok(active_keysets)
     }
 }

--- a/crates/cdk/src/wallet/keysets.rs
+++ b/crates/cdk/src/wallet/keysets.rs
@@ -100,7 +100,7 @@ impl Wallet {
         let keyset_with_lowest_fee = active_keysets
             .into_iter()
             .min_by_key(|key| key.input_fee_ppk)
-            .ok_or(Error::NoActiveKeysetWithLowestFee)?;
+            .ok_or(Error::NoActiveKeyset)?;
         Ok(keyset_with_lowest_fee)
     }
 }


### PR DESCRIPTION
PR That closes issue #422 

 function `get_active_mint_keyset` to call that `get_active_mint_keysets` function and then select the keyset that should be used, the one with the lowest fee