### PR TITLE
Update Id::try_from to return a u32 and remove redundant logic in nut13::derive_path_from_keyset_id

### DIFF
--- a/crates/cdk/src/nuts/nut02.rs
+++ b/crates/cdk/src/nuts/nut02.rs
@@ -123,6 +123,7 @@ impl Id {
 }
 
 // Used to generate a compressed unique identifier as part of the NUT13 spec
+// This is a one-way function
 impl From<Id> for u32 {
     fn from(value: Id) -> Self {
         let hex_bytes: [u8; 8] = value.as_bytes();

--- a/crates/cdk/src/nuts/nut02.rs
+++ b/crates/cdk/src/nuts/nut02.rs
@@ -114,14 +114,33 @@ impl Id {
     }
 }
 
-impl TryFrom<Id> for u64 {
+impl TryFrom<Id> for u32 {
     type Error = Error;
     fn try_from(value: Id) -> Result<Self, Self::Error> {
         let hex_bytes: [u8; 8] = value.to_bytes().try_into().map_err(|_| Error::Length)?;
 
         let int = u64::from_be_bytes(hex_bytes);
 
-        Ok(int % (2_u64.pow(31) - 1))
+        let result = (int % (2_u64.pow(31) - 1)) as u32;
+        Ok(result)
+    }
+}
+
+impl TryFrom<u64> for Id {
+    type Error = Error;
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        let bytes = value.to_be_bytes();
+        Self::from_bytes(&bytes)
+    }
+}
+
+impl TryFrom<Id> for u64 {
+    type Error = Error;
+
+    fn try_from(value: Id) -> Result<Self, Self::Error> {
+        let bytes = value.to_bytes();
+        let byte_array: [u8; 8] = bytes.try_into().map_err(|_| Error::Length)?;
+        Ok(u64::from_be_bytes(byte_array))
     }
 }
 
@@ -490,8 +509,26 @@ mod test {
     fn test_to_int() {
         let id = Id::from_str("009a1f293253e41e").unwrap();
 
-        let id_int = u64::try_from(id).unwrap();
+        let id_int = u32::try_from(id).unwrap();
         assert_eq!(864559728, id_int)
+    }
+
+    #[test]
+    fn test_to_u64_and_back() {
+        let id = Id::from_str("009a1f293253e41e").unwrap();
+
+        let id_long = u64::try_from(id).unwrap();
+        assert_eq!(43381408211919902, id_long);
+
+        let new_id = Id::try_from(id_long).unwrap();
+        assert_eq!(id, new_id);
+    }
+
+    #[test]
+    fn test_id_from_invalid_byte_length() {
+        let three_bytes = [0x01, 0x02, 0x03];
+        let result = Id::from_bytes(&three_bytes);
+        assert!(result.is_err(), "Expected an invalid byte length error");
     }
 
     #[test]

--- a/crates/cdk/src/nuts/nut02.rs
+++ b/crates/cdk/src/nuts/nut02.rs
@@ -496,17 +496,6 @@ mod test {
     }
 
     #[test]
-    fn test_to_u64_and_back() {
-        let id = Id::from_str("009a1f293253e41e").unwrap();
-
-        let id_long = u64::try_from(id).unwrap();
-        assert_eq!(43381408211919902, id_long);
-
-        let new_id = Id::try_from(id_long).unwrap();
-        assert_eq!(id, new_id);
-    }
-
-    #[test]
     fn test_id_from_invalid_byte_length() {
         let three_bytes = [0x01, 0x02, 0x03];
         let result = Id::from_bytes(&three_bytes);

--- a/crates/cdk/src/nuts/nut02.rs
+++ b/crates/cdk/src/nuts/nut02.rs
@@ -126,24 +126,6 @@ impl TryFrom<Id> for u32 {
     }
 }
 
-impl TryFrom<u64> for Id {
-    type Error = Error;
-    fn try_from(value: u64) -> Result<Self, Self::Error> {
-        let bytes = value.to_be_bytes();
-        Self::from_bytes(&bytes)
-    }
-}
-
-impl TryFrom<Id> for u64 {
-    type Error = Error;
-
-    fn try_from(value: Id) -> Result<Self, Self::Error> {
-        let bytes = value.to_bytes();
-        let byte_array: [u8; 8] = bytes.try_into().map_err(|_| Error::Length)?;
-        Ok(u64::from_be_bytes(byte_array))
-    }
-}
-
 impl fmt::Display for Id {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&format!("{}{}", self.version, hex::encode(self.id)))

--- a/crates/cdk/src/nuts/nut13.rs
+++ b/crates/cdk/src/nuts/nut13.rs
@@ -170,7 +170,8 @@ impl PreMintSecrets {
 }
 
 fn derive_path_from_keyset_id(id: Id) -> Result<DerivationPath, Error> {
-    let index = u32::try_from(id)? % (2u32.pow(31) - 1);
+    let index = u32::try_from(id)?;
+
     let keyset_child_number = ChildNumber::from_hardened_idx(index)?;
     Ok(DerivationPath::from(vec![
         ChildNumber::from_hardened_idx(129372)?,
@@ -184,6 +185,7 @@ mod tests {
     use std::str::FromStr;
 
     use bip39::Mnemonic;
+    use bitcoin::bip32::DerivationPath;
     use bitcoin::Network;
 
     use super::*;
@@ -230,6 +232,25 @@ mod tests {
         for (i, test_r) in test_rs.iter().enumerate() {
             let r = SecretKey::from_xpriv(xpriv, keyset_id, i.try_into().unwrap()).unwrap();
             assert_eq!(r, SecretKey::from_hex(test_r).unwrap())
+        }
+    }
+
+    #[test]
+    fn test_derive_path_from_keyset_id() {
+        let test_cases = [
+            ("009a1f293253e41e", "m/129372'/0'/864559728'"),
+            ("0000000000000000", "m/129372'/0'/0'"),
+            ("00ffffffffffffff", "m/129372'/0'/33554431'"),
+        ];
+
+        for (id_hex, expected_path) in test_cases {
+            let id = Id::from_str(id_hex).unwrap();
+            let path = derive_path_from_keyset_id(id).unwrap();
+            assert_eq!(
+                DerivationPath::from_str(expected_path).unwrap(),
+                path,
+                "Path derivation failed for ID {id_hex}"
+            );
         }
     }
 }

--- a/crates/cdk/src/nuts/nut13.rs
+++ b/crates/cdk/src/nuts/nut13.rs
@@ -170,7 +170,7 @@ impl PreMintSecrets {
 }
 
 fn derive_path_from_keyset_id(id: Id) -> Result<DerivationPath, Error> {
-    let index = u32::try_from(id)?;
+    let index = u32::from(id);
 
     let keyset_child_number = ChildNumber::from_hardened_idx(index)?;
     Ok(DerivationPath::from(vec![

--- a/crates/cdk/src/nuts/nut13.rs
+++ b/crates/cdk/src/nuts/nut13.rs
@@ -170,7 +170,7 @@ impl PreMintSecrets {
 }
 
 fn derive_path_from_keyset_id(id: Id) -> Result<DerivationPath, Error> {
-    let index = (u64::try_from(id)? % (2u64.pow(31) - 1)) as u32;
+    let index = u32::try_from(id)? % (2u32.pow(31) - 1);
     let keyset_child_number = ChildNumber::from_hardened_idx(index)?;
     Ok(DerivationPath::from(vec![
         ChildNumber::from_hardened_idx(129372)?,


### PR DESCRIPTION
Recreating [this PR ](https://github.com/cashubtc/cdk/pull/447)without including other contributors' changes in the diff.

The existing `TryFrom<Id>` trait implementation returns a u64 but can only contain values that fit within a u32 according to the [nut13 protocol definition](https://github.com/cashubtc/nuts/blob/main/13.md#keyset-id). This PR changes the existing implementation to return a u32 and defines two new TryFrom trait implementations that can be used to convert a keyset ID to and from a u64 with no data loss.

I have also opened a PR to clarify the language in NUT13 [here](https://github.com/cashubtc/nuts/pull/189).