### PR TITLE
Fix `None` derivation path index for custom currencies

### DIFF
--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -590,10 +590,7 @@ fn create_new_keyset<C: secp256k1::Signing>(
 }
 
 fn derivation_path_from_unit(unit: CurrencyUnit, index: u32) -> Option<DerivationPath> {
-    let unit_index = match unit.derivation_index() {
-        Some(index) => index,
-        None => return None,
-    };
+    let unit_index = unit.derivation_index();
 
     Some(DerivationPath::from(vec![
         ChildNumber::from_hardened_idx(0).expect("0 is a valid index"),
@@ -696,6 +693,25 @@ mod tests {
             .collect();
 
         assert_eq!(amounts_and_pubkeys, expected_amounts_and_pubkeys);
+    }
+
+    #[test]
+    fn mint_mod_derivation_path_from_unit() {
+        // Test valid cases
+        let test_cases = vec![
+            (CurrencyUnit::Sat, 0, "0'/0'/0'"),
+            (CurrencyUnit::Usd, 21, "0'/2'/21'"),
+            (
+                CurrencyUnit::Custom("DOGE".to_string(), 69),
+                420,
+                "0'/69'/420'",
+            ),
+        ];
+
+        for (unit, index, expected) in test_cases {
+            let path = derivation_path_from_unit(unit, index).unwrap();
+            assert_eq!(path.to_string(), expected);
+        }
     }
 
     use cdk_database::mint_memory::MintMemoryDatabase;

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -610,7 +610,7 @@ mod tests {
     use crate::types::LnKey;
 
     #[test]
-    fn mint_mod_generate_keyset_from_seed() {
+    fn test_generate_keyset_from_seed() {
         let seed = "test_seed".as_bytes();
         let keyset = MintKeySet::generate_from_seed(
             &Secp256k1::new(),
@@ -652,7 +652,7 @@ mod tests {
     }
 
     #[test]
-    fn mint_mod_generate_keyset_from_xpriv() {
+    fn test_generate_keyset_from_xpriv() {
         let seed = "test_seed".as_bytes();
         let network = Network::Bitcoin;
         let xpriv = Xpriv::new_master(network, seed).expect("Failed to create xpriv");
@@ -696,11 +696,14 @@ mod tests {
     }
 
     #[test]
-    fn mint_mod_derivation_path_from_unit() {
-        // Test valid cases
+    fn test_derivation_path_from_unit() {
         let test_cases = vec![
+            // min value for a hardened derivation path index
             (CurrencyUnit::Sat, 0, "0'/0'/0'"),
+            // max value for a hardened derivation path index
+            (CurrencyUnit::Msat, i32::MAX as u32, "0'/1'/2147483647'"),
             (CurrencyUnit::Usd, 21, "0'/2'/21'"),
+            (CurrencyUnit::Eur, 1337, "0'/3'/1337'"),
             (
                 CurrencyUnit::Custom("DOGE".to_string(), 69),
                 420,


### PR DESCRIPTION
### Description

You can't actually start a mint using a custom currency unit. It panics with `Error:UnsupportedUnit`. The failure starts in `Mint::new` when it retrieves a `None` derivation path.

This PR attempts to fix the issue by requiring the derivation path to be specified when `CurrencyUnit::Custom` is instantiated. Any u32 derivation path will be accepted except 0-3 which are already allocated to the 4 original currencies.

When converting `CurrencyUnit` to a string and back it appends the derivation path after the currency string with a colon like in this example: `ZUKBUX:12345`. There is probably room to improve this. For example we could add a new function to differentiate the full string from just the currency string. I'm open to ideas.

I added unit tests for the new functionality.

-----

### Notes to the reviewers

I considered creating a deterministic derivation path by hashing the currency string. This could be cool but it would be inflexible and non-standard. I went with a user-defined approach instead.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED
- `CurrencyUnit::Custom` now requires a derivation path index u32
- `CurrencyUnit::derivation_index()` now returns `u32` instead of `Option<u32>`
- `Display` now includes a colon and the derivation path index at the end of the string
- `FromStr` expects to read the derivation path index in the same format

#### ADDED
tests for new functionality

#### REMOVED

#### FIXED
`Mint::new()` no longer fails if you specify a custom currency

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
