### PR TITLE
fix: check phd has valid payment id

### DIFF
--- a/crates/cdk-phoenixd/src/lib.rs
+++ b/crates/cdk-phoenixd/src/lib.rs
@@ -4,6 +4,7 @@
 #![warn(rustdoc::bare_urls)]
 
 use std::pin::Pin;
+use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -268,6 +269,19 @@ impl MintLightning for Phoenixd {
         &self,
         payment_id: &str,
     ) -> Result<PayInvoiceResponse, Self::Err> {
+        // We can only check the status of the payment if we have the payment id not if we only have a payment hash.
+        // In phd this is a uuid, that we get after getting a response from the pay invoice
+        if let Err(_err) = uuid::Uuid::from_str(payment_id) {
+            tracing::warn!("Could not check status of payment, no payment id");
+            return Ok(PayInvoiceResponse {
+                payment_lookup_id: payment_id.to_string(),
+                payment_preimage: None,
+                status: MeltQuoteState::Unknown,
+                total_spent: Amount::ZERO,
+                unit: CurrencyUnit::Sat,
+            });
+        }
+
         let res = self.phoenixd_api.get_outgoing_invoice(payment_id).await;
 
         let state = match res {


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

Since PHD returns a payment id after a attempting a payment this is what is used to check the state of a payment if we do not have this we cannot check and will get an error from phd. To avoid this we make sure we have an id in the right form before attempting to check if we do not the payment is in a unknown state. 

closes: https://github.com/cashubtc/cdk/issues/384


### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->


#### FIXED
cdk-phd: Error on check if we do not have the payment id ([thesimplekid])

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
