### PR TITLE
Melt token with amountless

### DIFF
--- a/crates/cdk-mintd/src/main.rs
+++ b/crates/cdk-mintd/src/main.rs
@@ -148,6 +148,7 @@ async fn main() -> anyhow::Result<()> {
                 CurrencyUnit::Sat,
                 PaymentMethod::Bolt11,
                 mint_melt_limits,
+                Some(false),
                 cln.clone(),
             );
         }
@@ -167,6 +168,7 @@ async fn main() -> anyhow::Result<()> {
                     unit,
                     PaymentMethod::Bolt11,
                     mint_melt_limits,
+                    Some(false),
                     Arc::new(strike),
                 );
             }
@@ -181,6 +183,7 @@ async fn main() -> anyhow::Result<()> {
                 CurrencyUnit::Sat,
                 PaymentMethod::Bolt11,
                 mint_melt_limits,
+                Some(false),
                 Arc::new(lnbits),
             );
         }
@@ -194,6 +197,7 @@ async fn main() -> anyhow::Result<()> {
                 CurrencyUnit::Sat,
                 PaymentMethod::Bolt11,
                 mint_melt_limits,
+                Some(false),
                 Arc::new(phd),
             );
         }
@@ -207,6 +211,7 @@ async fn main() -> anyhow::Result<()> {
                 CurrencyUnit::Sat,
                 PaymentMethod::Bolt11,
                 mint_melt_limits,
+                Some(false),
                 Arc::new(lnd),
             );
         }
@@ -224,6 +229,7 @@ async fn main() -> anyhow::Result<()> {
                     unit.clone(),
                     PaymentMethod::Bolt11,
                     mint_melt_limits,
+                    Some(false),
                     fake.clone(),
                 );
             }

--- a/crates/cdk/src/error.rs
+++ b/crates/cdk/src/error.rs
@@ -45,6 +45,9 @@ pub enum Error {
     /// Amount overflow
     #[error("Amount Overflow")]
     AmountOverflow,
+    /// Amountless Invoice Not supported
+    #[error("Amount Less Invoice is not allowed")]
+    AmountLessNotAllowed,
 
     // Mint Errors
     /// Minting is disabled

--- a/crates/cdk/src/mint/builder.rs
+++ b/crates/cdk/src/mint/builder.rs
@@ -108,12 +108,14 @@ impl MintBuilder {
         unit: CurrencyUnit,
         method: PaymentMethod,
         limits: MintMeltLimits,
+        support_amount_less: Option<bool>,
         ln_backend: Arc<dyn MintLightning<Err = cdk_lightning::Error> + Send + Sync>,
     ) -> Self {
         let ln_key = LnKey {
             unit: unit.clone(),
             method,
         };
+        let support_amount_less = support_amount_less.unwrap_or(false);
 
         let mut ln = self.ln.unwrap_or_default();
 
@@ -150,6 +152,7 @@ impl MintBuilder {
                     unit,
                     min_amount: Some(limits.melt_min),
                     max_amount: Some(limits.melt_max),
+                    amount_less: support_amount_less,
                 };
                 self.mint_info.nuts.nut05.methods.push(melt_method_settings);
                 self.mint_info.nuts.nut05.disabled = false;

--- a/crates/cdk/src/nuts/nut05.rs
+++ b/crates/cdk/src/nuts/nut05.rs
@@ -36,6 +36,8 @@ pub struct MeltQuoteBolt11Request {
     pub request: Bolt11Invoice,
     /// Unit wallet would like to pay with
     pub unit: CurrencyUnit,
+    /// amount for paying amountless bolt11 invoice
+    pub amount: Option<Amount>,
     /// Payment Options
     pub options: Option<Mpp>,
 }
@@ -264,6 +266,8 @@ pub struct MeltMethodSettings {
     /// Max Amount
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_amount: Option<Amount>,
+    /// Amountless
+    pub amount_less: bool,
 }
 
 impl Settings {
@@ -288,6 +292,9 @@ impl Settings {
     }
 }
 
+/// meting with an amount_less invoice
+//  pub amount_less: Option<Amount>,
+
 /// Melt Settings
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "swagger", derive(utoipa::ToSchema), schema(as = nut05::Settings))]
@@ -305,6 +312,7 @@ impl Default for Settings {
             unit: CurrencyUnit::Sat,
             min_amount: Some(Amount::from(1)),
             max_amount: Some(Amount::from(1000000)),
+            amount_less: false,
         };
 
         Settings {

--- a/crates/cdk/src/wallet/melt.rs
+++ b/crates/cdk/src/wallet/melt.rs
@@ -63,6 +63,7 @@ impl Wallet {
             request: Bolt11Invoice::from_str(&request)?,
             unit: self.unit.clone(),
             options,
+            amount: Some(amount),
         };
 
         let quote_res = self


### PR DESCRIPTION
### Description
Base on the PR: [https://github.com/cashubtc/nuts/pull/173](https://github.com/cashubtc/nuts/pull/173)

mint can accept amountless invoice when melting token, 

added setting in `MeltMethodSettings` for `amount_less` also handle cases where we are trying to melt token and amount_less invoice is provvided

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
