### PR TITLE
fakewallet values in config

### DIFF
--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -55,3 +55,10 @@ ln_backend = "cln"
 # address = ""
 # macaroon_file = ""
 # cert_file = ""
+
+# [fake_wallet]
+# supported_units = ["sat"]
+# fee_percent = 0.02
+# reserve_fee_min = 1
+# min_delay_time = 1
+# max_delay_time = 3

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -108,6 +108,18 @@ pub struct FakeWallet {
     pub max_delay_time: u64,
 }
 
+impl Default for FakeWallet {
+    fn default() -> Self {
+        Self {
+            supported_units: vec![CurrencyUnit::Sat],
+            fee_percent: 0.02,
+            reserve_fee_min: 2.into(),
+            min_delay_time: 1,
+            max_delay_time: 3,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum DatabaseEngine {

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -108,18 +108,6 @@ pub struct FakeWallet {
     pub max_delay_time: u64,
 }
 
-impl Default for FakeWallet {
-    fn default() -> Self {
-        Self {
-            supported_units: vec![CurrencyUnit::Sat],
-            fee_percent: 0.02,
-            reserve_fee_min: 2.into(),
-            min_delay_time: 1,
-            max_delay_time: 3,
-        }
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum DatabaseEngine {
@@ -206,12 +194,32 @@ impl Settings {
         let settings: Settings = config.try_deserialize()?;
 
         match settings.ln.ln_backend {
-            LnBackend::Cln => assert!(settings.cln.is_some()),
-            LnBackend::Strike => assert!(settings.strike.is_some()),
-            LnBackend::LNbits => assert!(settings.lnbits.is_some()),
-            LnBackend::Phoenixd => assert!(settings.phoenixd.is_some()),
-            LnBackend::Lnd => assert!(settings.lnd.is_some()),
-            LnBackend::FakeWallet => (),
+            LnBackend::Cln => assert!(
+                settings.cln.is_some(),
+                "CLN backend requires a valid config."
+            ),
+            LnBackend::Strike => assert!(
+                settings.strike.is_some(),
+                "Strike backend requires a valid config."
+            ),
+            LnBackend::LNbits => assert!(
+                settings.lnbits.is_some(),
+                "LNbits backend requires a valid config"
+            ),
+            LnBackend::Phoenixd => assert!(
+                settings.phoenixd.is_some(),
+                "Phoenixd backend requires a valid config"
+            ),
+            LnBackend::Lnd => {
+                assert!(
+                    settings.lnd.is_some(),
+                    "LND backend requires a valid config."
+                )
+            }
+            LnBackend::FakeWallet => assert!(
+                settings.fake_wallet.is_some(),
+                "FakeWallet backend requires a valid config."
+            ),
         }
 
         Ok(settings)


### PR DESCRIPTION
## Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
when runing `cargo run --bin cdk-mintd` with fakewallet set in config.toml it gives the error
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.16s
     Running `target/debug/cdk-mintd`
thread 'main' panicked at crates/cdk-mintd/src/main.rs:214:60:
Fake wallet defined
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## This PR 
- adds the defaults for fakewallet to the sample config.toml file
- adds custom error output to assertion to assertion

### assertion before
```
thread 'main' panicked at crates/cdk-mintd/src/config.rs:227:38:
assertion failed: settings.fake_wallet.is_some()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### assertion after
```
thread 'main' panicked at crates/cdk-mintd/src/config.rs:219:38:
FakeWallet backend requires a valid config.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
