### PR TITLE
`mintd`: Add support for HTTP compression

### DIFF
--- a/crates/cdk-mintd/Cargo.toml
+++ b/crates/cdk-mintd/Cargo.toml
@@ -30,7 +30,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 futures = { version = "0.3.28", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
 bip39 = "2.0"
-tower-http = { version = "0.4.4", features = ["cors"] }
+tower-http = { version = "0.4.4", features = ["cors", "compression-full"] }
 lightning-invoice = { version = "0.32.0", features = ["serde", "std"] }
 home = "0.5.5"
 url = "2.3"

--- a/crates/cdk-mintd/src/main.rs
+++ b/crates/cdk-mintd/src/main.rs
@@ -9,7 +9,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Result};
-use axum::Router;
+use axum::http::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use axum::{middleware, Router};
 use bip39::Mnemonic;
 use cdk::cdk_database::{self, MintDatabase};
 use cdk::cdk_lightning;
@@ -24,6 +27,7 @@ use cdk_redb::MintRedbDatabase;
 use cdk_sqlite::MintSqliteDatabase;
 use clap::Parser;
 use tokio::sync::Notify;
+use tower_http::compression::CompressionLayer;
 use tower_http::cors::CorsLayer;
 use tracing_subscriber::EnvFilter;
 #[cfg(feature = "swagger")]
@@ -296,6 +300,8 @@ async fn main() -> anyhow::Result<()> {
 
     let mut mint_service = Router::new()
         .merge(v1_service)
+        .layer(CompressionLayer::new())
+        .layer(middleware::from_fn(logging_middleware))
         .layer(CorsLayer::permissive());
 
     #[cfg(feature = "swagger")]
@@ -342,6 +348,29 @@ async fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Logs infos about the request and the response
+async fn logging_middleware<B>(req: Request<B>, next: Next<B>) -> Response {
+    let start = std::time::Instant::now();
+    let path = req.uri().path().to_owned();
+    let method = req.method().clone();
+
+    let response = next.run(req).await;
+
+    let duration = start.elapsed();
+    let status = response.status();
+    let compression = response
+        .headers()
+        .get("content-encoding")
+        .map(|h| h.to_str().unwrap_or("none"))
+        .unwrap_or("none");
+
+    tracing::trace!(
+        "Request: {method} {path} | Status: {status} | Compression: {compression} | Duration: {duration:?}",
+    );
+
+    response
 }
 
 fn work_dir() -> Result<PathBuf> {

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
     "rustls-tls-native-roots",
     "socks",
+    "zstd", "brotli", "gzip", "deflate"
 ], optional = true }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"

--- a/flake.nix
+++ b/flake.nix
@@ -140,11 +140,15 @@
               cargo update -p serde_with --precise 3.1.0
               cargo update -p regex --precise 1.9.6
               cargo update -p backtrace --precise 0.3.58
+              cargo update -p async-compression --precise 0.4.3
+              cargo update -p zstd-sys --precise 2.0.8+zstd.1.5.5
+
               # For wasm32-unknown-unknown target
               cargo update -p bumpalo --precise 3.12.0
               cargo update -p moka --precise 0.11.1
               cargo update -p triomphe --precise 0.1.11
               cargo update -p url --precise 2.5.2
+
               ";
               buildInputs = buildInputs ++ WASMInputs ++ [ msrv_toolchain ];
               inherit nativeBuildInputs;
@@ -164,10 +168,13 @@
                 cargo update -p home --precise 0.5.5
                 cargo update -p tokio --precise 1.38.1
                 cargo update -p tokio-stream --precise 0.1.15
+                cargo update -p tokio-util --precise 0.7.11
                 cargo update -p serde_with --precise 3.1.0
                 cargo update -p reqwest --precise 0.12.4
                 cargo update -p url --precise 2.5.2
                 cargo update -p allocator-api2 --precise 0.2.18
+                cargo update -p async-compression --precise 0.4.3
+                cargo update -p zstd-sys --precise 2.0.8+zstd.1.5.5
               '';
               buildInputs = buildInputs ++ WASMInputs ++ [ db_msrv_toolchain ];
               inherit nativeBuildInputs;


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

Fixes #471

-----

### Notes to the reviewers

Compression on the mint can be tested with
```
curl -s -I -H "Accept-Encoding: zstd, br, deflate, gzip" http://localhost:8085/v1/info
```
and the console output should contain a log like
```
Request: GET /v1/info | Status: 200 OK | Compression: zstd | Duration: 289.875µs
```

Calls made by clients that don't signal support for compression
```
curl -s -I http://localhost:8085/v1/info
```
should result in
```
Request: HEAD /v1/info | Status: 200 OK | Compression: none | Duration: 552.875µs
```

To test compression on the wallet client, run in `cdk-cli`:
```
cargo run -- mint-info http://localhost:8085
```
and the mint console should again output an entry with `Compression: zstd`.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

- Added support for HTTP compression in wallet and mint

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
