### PR TITLE
Minor improvement cache avoid clone

### DIFF
--- a/crates/cdk-axum/src/ws/subscribe.rs
+++ b/crates/cdk-axum/src/ws/subscribe.rs
@@ -54,12 +54,7 @@ impl WsHandle for Method {
             return Err(WsError::InvalidParams);
         }
 
-        let mut subscription = context
-            .state
-            .mint
-            .pubsub_manager
-            .subscribe(self.0.clone())
-            .await;
+        let mut subscription = context.state.mint.pubsub_manager.subscribe(self.0).await;
         let publisher = context.publisher.clone();
         context.subscriptions.insert(
             sub_id.clone(),


### PR DESCRIPTION
### Description

Avoid cloning to serialize to JSON; instead, dereference the object, as Serde needs a reference to the object.

This minor improvement was found when researching the caching layer (to propose a fix for #478)

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
