### PR TITLE
fix(wallet): stop sqlite from overwritting keyset counter

### DIFF
--- a/crates/cdk-cli/src/main.rs
+++ b/crates/cdk-cli/src/main.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
     let args: Cli = Cli::parse();
     let default_filter = args.log_level;
 
-    let sqlx_filter = "sqlx=warn";
+    let sqlx_filter = "sqlx=warn,hyper_util=warn,reqwest=warn";
 
     let env_filter = EnvFilter::new(format!("{},{}", default_filter, sqlx_filter));
 
@@ -132,7 +132,9 @@ async fn main() -> Result<()> {
             let random_bytes: [u8; 32] = rng.gen();
 
             let mnemonic = Mnemonic::from_entropy(&random_bytes)?;
-            tracing::info!("Using randomly generated seed you will not be able to restore");
+            tracing::info!("Creating new seed");
+
+            fs::write(seed_path, mnemonic.to_string())?;
 
             mnemonic
         }

--- a/crates/cdk/src/wallet/mint.rs
+++ b/crates/cdk/src/wallet/mint.rs
@@ -256,6 +256,12 @@ impl Wallet {
         self.localstore.remove_mint_quote(&quote_info.id).await?;
 
         if spending_conditions.is_none() {
+            tracing::debug!(
+                "Incrementing keyset {} counter by {}",
+                active_keyset_id,
+                proofs.len()
+            );
+
             // Update counter for keyset
             self.localstore
                 .increment_keyset_counter(&active_keyset_id, proofs.len() as u32)


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----
fixes #399 

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED
cdk-sqlite: keyset counter was overwritten when keyset was fetched from mint ([thesimplekid]).

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
