### PR TITLE
Managment rpc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
             --bin cdk-mintd --no-default-features --features swagger,
             --bin cdk-mintd --no-default-features --features redis,
             --bin cdk-mintd --no-default-features --features "redis swagger",
+            --bin cdk-mintd --no-default-features --features management-rpc,
+            --bin cdk-mint-cli,
           ]
     steps:
       - name: checkout
@@ -213,6 +215,7 @@ jobs:
             -p cdk-phoenixd,
             -p cdk-fake-wallet,
             -p cdk-cln,
+            -p cdk-mint-rpc,
           ]
     steps:
       - name: checkout

--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,2 +1,1 @@
 [language-server.rust-analyzer.config]
-cargo = { features = ["wallet", "mint", "swagger", "redis"] }

--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ The project is split up into several crates in the `crates/` directory:
     * [**cdk-lnbits**](./crates/cdk-lnbits/): [LNbits](https://lnbits.com/) Lightning backend for mint.
     * [**cdk-phoenixd**](./crates/cdk-phoenixd/): Phoenixd Lightning backend for mint.
     * [**cdk-fake-wallet**](./crates/cdk-fake-wallet/): Fake Lightning backend for mint. To be used only for testing, quotes are automatically filled.
+    * [**cdk-mint-rpc**](./crates/cdk-mint-rpc/): Mint management gRPC server and cli.
 * Binaries:
     * [**cdk-cli**](./crates/cdk-cli/): Cashu wallet CLI.
     * [**cdk-mintd**](./crates/cdk-mintd/): Cashu Mint Binary.
+    * [**cdk-mint-cli**](./crates/cdk-mint-rpc/): Cashu Mint managemtn gRCP client cli.
 
 
 ## Development 

--- a/crates/cashu/src/nuts/nut04.rs
+++ b/crates/cashu/src/nuts/nut04.rs
@@ -240,4 +240,16 @@ impl Settings {
 
         None
     }
+
+    /// Remove [`MintMethodSettings`] for unit method pair
+    pub fn remove_settings(
+        &mut self,
+        unit: &CurrencyUnit,
+        method: &PaymentMethod,
+    ) -> Option<MintMethodSettings> {
+        self.methods
+            .iter()
+            .position(|settings| &settings.method == method && &settings.unit == unit)
+            .map(|index| self.methods.remove(index))
+    }
 }

--- a/crates/cashu/src/nuts/nut05.rs
+++ b/crates/cashu/src/nuts/nut05.rs
@@ -399,6 +399,18 @@ impl Settings {
 
         None
     }
+
+    /// Remove [`MeltMethodSettings`] for unit method pair
+    pub fn remove_settings(
+        &mut self,
+        unit: &CurrencyUnit,
+        method: &PaymentMethod,
+    ) -> Option<MeltMethodSettings> {
+        self.methods
+            .iter()
+            .position(|settings| settings.method.eq(method) && settings.unit.eq(unit))
+            .map(|index| self.methods.remove(index))
+    }
 }
 
 /// Melt Settings

--- a/crates/cashu/src/nuts/nut06.rs
+++ b/crates/cashu/src/nuts/nut06.rs
@@ -26,6 +26,12 @@ impl MintVersion {
     }
 }
 
+impl std::fmt::Display for MintVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.name, self.version)
+    }
+}
+
 impl Serialize for MintVersion {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/cdk-axum/Cargo.toml
+++ b/crates/cdk-axum/Cargo.toml
@@ -28,7 +28,7 @@ futures = { version = "0.3.28", default-features = false }
 moka = { version = "0.11.1", features = ["future"] }
 serde_json = "1"
 paste = "1.0.15"
-serde = { version = "1.0.210", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 sha2 = "0.10.8"
 redis = { version = "0.23.3", features = [

--- a/crates/cdk-cli/Cargo.toml
+++ b/crates/cdk-cli/Cargo.toml
@@ -17,7 +17,7 @@ bip39 = "2.0"
 cdk = { path = "../cdk", version = "0.6.0", default-features = false, features = ["wallet"]}
 cdk-redb = { path = "../cdk-redb", version = "0.6.0", default-features = false, features = ["wallet"] }
 cdk-sqlite = { path = "../cdk-sqlite", version = "0.6.0", default-features = false, features = ["wallet"] }
-clap = { version = "4.4.8", features = ["derive", "env", "default"] }
+clap = { version = "~4.0.32", features = ["derive"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", default-features = false }

--- a/crates/cdk-integration-tests/tests/mint.rs
+++ b/crates/cdk-integration-tests/tests/mint.rs
@@ -17,6 +17,7 @@ use cdk::nuts::{
     PreMintSecrets, ProofState, Proofs, SecretKey, SpendingConditions, State, SwapRequest,
 };
 use cdk::subscription::{IndexableParams, Params};
+use cdk::types::QuoteTTL;
 use cdk::util::unix_time;
 use cdk::Mint;
 use cdk_fake_wallet::FakeWallet;
@@ -465,10 +466,15 @@ async fn test_correct_keyset() -> Result<()> {
     mint_builder = mint_builder
         .with_name("regtest mint".to_string())
         .with_description("regtest mint".to_string())
-        .with_quote_ttl(10000, 1000)
         .with_seed(mnemonic.to_seed_normalized("").to_vec());
 
     let mint = mint_builder.build().await?;
+
+    localstore
+        .set_mint_info(mint_builder.mint_info.clone())
+        .await?;
+    let quote_ttl = QuoteTTL::new(10000, 10000);
+    localstore.set_quote_ttl(quote_ttl).await?;
 
     mint.rotate_next_keyset(CurrencyUnit::Sat, 32, 0).await?;
     mint.rotate_next_keyset(CurrencyUnit::Sat, 32, 0).await?;

--- a/crates/cdk-mint-rpc/Cargo.toml
+++ b/crates/cdk-mint-rpc/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "cdk-mint-rpc"
+version = "0.6.0"
+edition = "2021"
+authors = ["CDK Developers"]
+description = "CDK mintd mint managment RPC client and server"
+license = "MIT"
+homepage = "https://github.com/cashubtc/cdk"
+repository = "https://github.com/cashubtc/cdk.git"
+rust-version = "1.63.0"                            # MSRV
+
+[[bin]]
+name = "cdk-mint-cli"
+path = "src/bin/mint_rpc_cli.rs"
+
+[dependencies]
+anyhow = "1"
+cdk = { path = "../cdk", version = "0.6.0", default-features = false, features = [
+    "mint",
+] }
+clap = { version = "~4.0.32", features = ["derive"] }
+tonic = { version = "0.9", features = [
+    "channel",
+    "tls",
+    "tls-webpki-roots",
+] }
+tracing = { version = "0.1", default-features = false, features = [
+    "attributes",
+    "log",
+] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tokio = { version = "1", default-features = false }
+serde_json = "1"
+serde = { version = "1", features = ["derive"] }
+thiserror = "1"
+prost = "0.11.0"
+home = "0.5.5"
+
+
+[build-dependencies]
+tonic-build = "0.9"

--- a/crates/cdk-mint-rpc/README.md
+++ b/crates/cdk-mint-rpc/README.md
@@ -1,0 +1,93 @@
+
+# Cashu Mint Management RPC
+
+This crate is a grpc client and server to control and manage a cdk mint. This crate exposes a server complnate that can be imported as library compontant, see its usage in `cdk-mintd`. The client can be used as a cli by running `cargo r --bin cdk-mint-cli`.
+
+The server can be run with or without certificate authentication. For running with authentication follow the below steps to create certificates.
+
+
+# gRPC TLS Certificate Generation Guide
+
+This guide explains how to generate the necessary TLS certificates for securing gRPC communication between client and server.
+
+## Overview
+
+The script generates the following certificates and keys:
+- Certificate Authority (CA) certificate and key
+- Server certificate and key
+- Client certificate and key
+
+All certificates are generated in PEM format, which is commonly used in Unix/Linux systems.
+
+## Prerequisites
+
+- OpenSSL installed on your system
+- Bash shell environment
+
+## Generated Files
+
+The script will create the following files:
+- `ca.key` - Certificate Authority private key
+- `ca.pem` - Certificate Authority certificate
+- `server.key` - Server private key
+- `server.pem` - Server certificate
+- `client.key` - Client private key
+- `client.pem` - Client certificate
+
+## Usage
+
+1. Save the script as `generate_certs.sh`
+2. Make it executable:
+   ```bash
+   chmod +x generate_certs.sh
+   ```
+3. Run the script:
+   ```bash
+   ./generate_certs.sh
+   ```
+
+## Certificate Details
+
+### Certificate Authority (CA)
+- 4096-bit RSA key
+- Valid for 365 days
+- Used to sign both server and client certificates
+
+### Server Certificate
+- 4096-bit RSA key
+- Valid for 365 days
+- Includes Subject Alternative Names (SAN):
+  - DNS: localhost
+  - DNS: my-server
+  - IP: 127.0.0.1
+
+### Client Certificate
+- 4096-bit RSA key
+- Valid for 365 days
+- Used for client authentication
+
+
+## Verification
+
+The script includes verification steps to ensure the certificates are properly generated:
+```bash
+# Verify server certificate
+openssl verify -CAfile ca.pem server.pem
+
+# Verify client certificate
+openssl verify -CAfile ca.pem client.pem
+```
+
+## Security Notes
+
+1. Keep private keys (*.key files) secure and never share them
+2. The CA certificate (ca.pem) needs to be distributed to both client and server
+3. Server needs:
+   - server.key
+   - server.pem
+   - ca.pem
+4. Client needs:
+   - client.key
+   - client.pem
+   - ca.pem
+

--- a/crates/cdk-mint-rpc/build.rs
+++ b/crates/cdk-mint-rpc/build.rs
@@ -1,0 +1,5 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=src/proto/cdk-mint-rpc.proto");
+    tonic_build::compile_protos("src/proto/cdk-mint-rpc.proto")?;
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/generate_certs.sh
+++ b/crates/cdk-mint-rpc/generate_certs.sh
@@ -1,0 +1,47 @@
+# Generate private key for Certificate Authority (CA)
+openssl genrsa -out ca.key 4096
+
+# Generate CA certificate
+openssl req -new -x509 -days 365 -key ca.key -out ca.pem -subj "/C=US/ST=State/L=City/O=Organization/OU=Unit/CN=MyCA"
+
+# Generate private key for Server
+openssl genrsa -out server.key 4096
+
+# Generate Certificate Signing Request (CSR) for Server
+openssl req -new -key server.key -out server.csr -subj "/C=US/ST=State/L=City/O=Organization/OU=Unit/CN=localhost"
+
+# Generate Server certificate
+openssl x509 -req -days 365 -in server.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out server.pem -extfile <(printf "subjectAltName=DNS:localhost,DNS:my-server,IP:127.0.0.1")
+
+# Generate private key for Client
+openssl genrsa -out client.key 4096
+
+# Generate CSR for Client
+openssl req -new -key client.key -out client.csr -subj "/C=US/ST=State/L=City/O=Organization/OU=Unit/CN=client"
+
+# Generate Client certificate
+openssl x509 -req -days 365 -in client.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out client.pem
+
+# Verify the certificates
+echo "Verifying Server Certificate:"
+openssl verify -CAfile ca.pem server.pem
+
+echo "Verifying Client Certificate:"
+openssl verify -CAfile ca.pem client.pem
+
+# Clean up CSR files (optional)
+rm server.csr client.csr
+
+# Display certificate information
+echo "Server Certificate Info:"
+openssl x509 -in server.pem -text -noout | grep "Subject:\|Issuer:\|DNS:\|IP Address:"
+
+echo "Client Certificate Info:"
+openssl x509 -in client.pem -text -noout | grep "Subject:\|Issuer:"
+
+# Final files you'll need:
+# - ca.pem (Certificate Authority certificate)
+# - server.key (Server private key)
+# - server.pem (Server certificate)
+# - client.key (Client private key)
+# - client.pem (Client certificate)

--- a/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
+++ b/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
@@ -1,0 +1,196 @@
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+use cdk_mint_rpc::cdk_mint_client::CdkMintClient;
+use cdk_mint_rpc::mint_rpc_cli::subcommands;
+use cdk_mint_rpc::GetInfoRequest;
+use clap::{Parser, Subcommand};
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
+use tonic::Request;
+use tracing::Level;
+use tracing_subscriber::EnvFilter;
+
+const DEFAULT_WORK_DIR: &str = ".cdk-mint-rpc-cli";
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    /// Address of RPC server
+    #[arg(short, long, default_value = "http://127.0.0.1:8086")]
+    addr: String,
+
+    /// Logging level
+    #[arg(short, long, default_value = "debug")]
+    log_level: Level,
+
+    /// Path to working dir
+    #[arg(short, long)]
+    work_dir: Option<PathBuf>,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Get info
+    GetInfo,
+    /// Update motd
+    UpdateMotd(subcommands::UpdateMotdCommand),
+    /// Update short description
+    UpdateShortDescription(subcommands::UpdateShortDescriptionCommand),
+    /// Update long description
+    UpdateLongDescription(subcommands::UpdateLongDescriptionCommand),
+    /// Update name
+    UpdateName(subcommands::UpdateNameCommand),
+    /// Update icon url
+    UpdateIconUrl(subcommands::UpdateIconUrlCommand),
+    /// Add Url
+    AddUrl(subcommands::AddUrlCommand),
+    /// Remove Url
+    RemoveUrl(subcommands::RemoveUrlCommand),
+    /// Add contact
+    AddContact(subcommands::AddContactCommand),
+    /// Remove contact
+    RemoveContact(subcommands::RemoveContactCommand),
+    /// Update nut04
+    UpdateNut04(subcommands::UpdateNut04Command),
+    /// Update nut05
+    UpdateNut05(subcommands::UpdateNut05Command),
+    /// Update quote ttl
+    UpdateQuoteTtl(subcommands::UpdateQuoteTtlCommand),
+    /// Update Nut04 quote
+    UpdateNut04QuoteState(subcommands::UpdateNut04QuoteCommand),
+    /// Rotate next keyset
+    RotateNextKeyset(subcommands::RotateNextKeysetCommand),
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args: Cli = Cli::parse();
+    let default_filter = args.log_level;
+
+    let sqlx_filter = "sqlx=warn,hyper_util=warn,reqwest=warn";
+
+    let env_filter = EnvFilter::new(format!("{},{}", default_filter, sqlx_filter));
+
+    // Parse input
+    tracing_subscriber::fmt().with_env_filter(env_filter).init();
+
+    let cli = Cli::parse();
+
+    let work_dir = match &args.work_dir {
+        Some(work_dir) => work_dir.clone(),
+        None => {
+            let home_dir = home::home_dir().ok_or(anyhow!("Could not find home dir"))?;
+
+            home_dir.join(DEFAULT_WORK_DIR)
+        }
+    };
+
+    std::fs::create_dir_all(&work_dir)?;
+    tracing::debug!("Using work dir: {}", work_dir.display());
+
+    let channel = if work_dir.join("tls").is_dir() {
+        // TLS directory exists, configure TLS
+        let server_root_ca_cert = std::fs::read_to_string(work_dir.join("tls/ca.pem")).unwrap();
+        let server_root_ca_cert = Certificate::from_pem(server_root_ca_cert);
+        let client_cert = std::fs::read_to_string(work_dir.join("tls/client.pem"))?;
+        let client_key = std::fs::read_to_string(work_dir.join("tls/client.key"))?;
+        let client_identity = Identity::from_pem(client_cert, client_key);
+        let tls = ClientTlsConfig::new()
+            .ca_certificate(server_root_ca_cert)
+            .identity(client_identity);
+
+        Channel::from_shared(cli.addr.to_string())?
+            .tls_config(tls)?
+            .connect()
+            .await?
+    } else {
+        // No TLS directory, skip TLS configuration
+        Channel::from_shared(cli.addr.to_string())?
+            .connect()
+            .await?
+    };
+
+    let mut client = CdkMintClient::new(channel);
+
+    match cli.command {
+        Commands::GetInfo => {
+            let response = client.get_info(Request::new(GetInfoRequest {})).await?;
+            let info = response.into_inner();
+            println!(
+                "name:             {}",
+                info.name.unwrap_or("None".to_string())
+            );
+            println!(
+                "version:          {}",
+                info.version.unwrap_or("None".to_string())
+            );
+            println!(
+                "description:      {}",
+                info.description.unwrap_or("None".to_string())
+            );
+            println!(
+                "long description: {}",
+                info.long_description.unwrap_or("None".to_string())
+            );
+            println!("motd: {}", info.motd.unwrap_or("None".to_string()));
+            println!("icon_url: {}", info.icon_url.unwrap_or("None".to_string()));
+
+            for url in info.urls {
+                println!("mint_url: {}", url);
+            }
+
+            for contact in info.contact {
+                println!("method: {}, info: {}", contact.method, contact.info);
+            }
+            println!("total issued:     {} sat", info.total_issued);
+            println!("total redeemed:   {} sat", info.total_redeemed);
+        }
+        Commands::UpdateMotd(sub_command_args) => {
+            subcommands::update_motd(&mut client, &sub_command_args).await?;
+        }
+        Commands::UpdateShortDescription(sub_command_args) => {
+            subcommands::update_short_description(&mut client, &sub_command_args).await?;
+        }
+        Commands::UpdateLongDescription(sub_command_args) => {
+            subcommands::update_long_description(&mut client, &sub_command_args).await?;
+        }
+        Commands::UpdateName(sub_command_args) => {
+            subcommands::update_name(&mut client, &sub_command_args).await?;
+        }
+        Commands::UpdateIconUrl(sub_command_args) => {
+            subcommands::update_icon_url(&mut client, &sub_command_args).await?;
+        }
+        Commands::AddUrl(sub_command_args) => {
+            subcommands::add_url(&mut client, &sub_command_args).await?;
+        }
+        Commands::RemoveUrl(sub_command_args) => {
+            subcommands::remove_url(&mut client, &sub_command_args).await?;
+        }
+        Commands::AddContact(sub_command_args) => {
+            subcommands::add_contact(&mut client, &sub_command_args).await?;
+        }
+        Commands::RemoveContact(sub_command_args) => {
+            subcommands::remove_contact(&mut client, &sub_command_args).await?;
+        }
+        Commands::UpdateNut04(sub_command_args) => {
+            subcommands::update_nut04(&mut client, &sub_command_args).await?;
+        }
+        Commands::UpdateNut05(sub_command_args) => {
+            subcommands::update_nut05(&mut client, &sub_command_args).await?;
+        }
+        Commands::UpdateQuoteTtl(sub_command_args) => {
+            subcommands::update_quote_ttl(&mut client, &sub_command_args).await?;
+        }
+        Commands::UpdateNut04QuoteState(sub_command_args) => {
+            subcommands::update_nut04_quote_state(&mut client, &sub_command_args).await?;
+        }
+        Commands::RotateNextKeyset(sub_command_args) => {
+            subcommands::rotate_next_keyset(&mut client, &sub_command_args).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/client.rs
+++ b/crates/cdk-mint-rpc/src/client.rs
@@ -1,0 +1,27 @@
+use thiserror::Error;
+
+use crate::cdk_mint_rpc::cdk_mint_client::CdkMintClient;
+use crate::cdk_mint_rpc::cdk_mint_server::CdkMint;
+
+/// Error
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Transport error
+    #[error(transparent)]
+    Transport(#[from] tonic::transport::Error),
+}
+
+pub struct MintRPCClient {
+    inner: CdkMintClient<tonic::transport::Channel>,
+}
+
+impl MintRPCClient {
+    pub async fn new(url: String) -> Result<Self, Error> {
+        Ok(Self {
+            inner: CdkMintClient::connect(url).await?,
+        })
+    }
+}
+
+#[tonic::async_trait]
+impl CdkMint for MintRPCClient {}

--- a/crates/cdk-mint-rpc/src/lib.rs
+++ b/crates/cdk-mint-rpc/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod proto;
+
+pub mod mint_rpc_cli;
+
+pub use proto::*;

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/mod.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/mod.rs
@@ -1,0 +1,1 @@
+pub mod subcommands;

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
@@ -1,0 +1,25 @@
+mod rotate_next_keyset;
+mod update_contact;
+mod update_icon_url;
+mod update_long_description;
+mod update_motd;
+mod update_name;
+mod update_nut04;
+mod update_nut04_quote;
+mod update_nut05;
+mod update_short_description;
+mod update_ttl;
+mod update_urls;
+
+pub use rotate_next_keyset::{rotate_next_keyset, RotateNextKeysetCommand};
+pub use update_contact::{add_contact, remove_contact, AddContactCommand, RemoveContactCommand};
+pub use update_icon_url::{update_icon_url, UpdateIconUrlCommand};
+pub use update_long_description::{update_long_description, UpdateLongDescriptionCommand};
+pub use update_motd::{update_motd, UpdateMotdCommand};
+pub use update_name::{update_name, UpdateNameCommand};
+pub use update_nut04::{update_nut04, UpdateNut04Command};
+pub use update_nut04_quote::{update_nut04_quote_state, UpdateNut04QuoteCommand};
+pub use update_nut05::{update_nut05, UpdateNut05Command};
+pub use update_short_description::{update_short_description, UpdateShortDescriptionCommand};
+pub use update_ttl::{update_quote_ttl, UpdateQuoteTtlCommand};
+pub use update_urls::{add_url, remove_url, AddUrlCommand, RemoveUrlCommand};

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/rotate_next_keyset.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/rotate_next_keyset.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::transport::Channel;
+use tonic::Request;
+
+use crate::cdk_mint_client::CdkMintClient;
+use crate::RotateNextKeysetRequest;
+
+#[derive(Args)]
+pub struct RotateNextKeysetCommand {
+    #[arg(short, long)]
+    #[arg(default_value = "sat")]
+    unit: String,
+    #[arg(short, long)]
+    max_order: Option<u8>,
+    #[arg(short, long)]
+    input_fee_ppk: Option<u64>,
+}
+
+pub async fn rotate_next_keyset(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &RotateNextKeysetCommand,
+) -> Result<()> {
+    let response = client
+        .rotate_next_keyset(Request::new(RotateNextKeysetRequest {
+            unit: sub_command_args.unit.clone(),
+            max_order: sub_command_args.max_order.map(|m| m.into()),
+            input_fee_ppk: sub_command_args.input_fee_ppk,
+        }))
+        .await?;
+
+    let response = response.into_inner();
+
+    println!(
+        "Rotated to new keyset {} for unit {} with a max order of {} and fee of {}",
+        response.id, response.unit, response.max_order, response.input_fee_ppk
+    );
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_contact.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_contact.rs
@@ -1,0 +1,47 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::transport::Channel;
+use tonic::Request;
+
+use crate::cdk_mint_client::CdkMintClient;
+use crate::UpdateContactRequest;
+
+#[derive(Args)]
+pub struct AddContactCommand {
+    method: String,
+    info: String,
+}
+
+pub async fn add_contact(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &AddContactCommand,
+) -> Result<()> {
+    let _response = client
+        .add_contact(Request::new(UpdateContactRequest {
+            method: sub_command_args.method.clone(),
+            info: sub_command_args.info.clone(),
+        }))
+        .await?;
+
+    Ok(())
+}
+
+#[derive(Args)]
+pub struct RemoveContactCommand {
+    method: String,
+    info: String,
+}
+
+pub async fn remove_contact(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &RemoveContactCommand,
+) -> Result<()> {
+    let _response = client
+        .remove_contact(Request::new(UpdateContactRequest {
+            method: sub_command_args.method.clone(),
+            info: sub_command_args.info.clone(),
+        }))
+        .await?;
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_icon_url.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_icon_url.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::transport::Channel;
+use tonic::Request;
+
+use crate::cdk_mint_client::CdkMintClient;
+use crate::UpdateIconUrlRequest;
+
+#[derive(Args)]
+pub struct UpdateIconUrlCommand {
+    name: String,
+}
+
+pub async fn update_icon_url(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &UpdateIconUrlCommand,
+) -> Result<()> {
+    let _response = client
+        .update_icon_url(Request::new(UpdateIconUrlRequest {
+            icon_url: sub_command_args.name.clone(),
+        }))
+        .await?;
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_long_description.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_long_description.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::transport::Channel;
+use tonic::Request;
+
+use crate::cdk_mint_client::CdkMintClient;
+use crate::UpdateDescriptionRequest;
+
+#[derive(Args)]
+pub struct UpdateLongDescriptionCommand {
+    description: String,
+}
+
+pub async fn update_long_description(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &UpdateLongDescriptionCommand,
+) -> Result<()> {
+    let _response = client
+        .update_long_description(Request::new(UpdateDescriptionRequest {
+            description: sub_command_args.description.clone(),
+        }))
+        .await?;
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_motd.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_motd.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::transport::Channel;
+use tonic::Request;
+
+use crate::cdk_mint_client::CdkMintClient;
+use crate::UpdateMotdRequest;
+
+#[derive(Args)]
+pub struct UpdateMotdCommand {
+    motd: String,
+}
+
+pub async fn update_motd(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &UpdateMotdCommand,
+) -> Result<()> {
+    let _response = client
+        .update_motd(Request::new(UpdateMotdRequest {
+            motd: sub_command_args.motd.clone(),
+        }))
+        .await?;
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_name.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_name.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::transport::Channel;
+use tonic::Request;
+
+use crate::cdk_mint_client::CdkMintClient;
+use crate::UpdateNameRequest;
+
+#[derive(Args)]
+pub struct UpdateNameCommand {
+    name: String,
+}
+
+pub async fn update_name(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &UpdateNameCommand,
+) -> Result<()> {
+    let _response = client
+        .update_name(Request::new(UpdateNameRequest {
+            name: sub_command_args.name.clone(),
+        }))
+        .await?;
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_nut04.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_nut04.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::transport::Channel;
+use tonic::Request;
+
+use crate::cdk_mint_client::CdkMintClient;
+use crate::UpdateNut04Request;
+
+#[derive(Args)]
+pub struct UpdateNut04Command {
+    #[arg(short, long)]
+    #[arg(default_value = "sat")]
+    unit: String,
+    #[arg(short, long)]
+    #[arg(default_value = "bolt11")]
+    method: String,
+    #[arg(long)]
+    min_amount: Option<u64>,
+    #[arg(long)]
+    max_amount: Option<u64>,
+    #[arg(long)]
+    disabled: Option<bool>,
+    #[arg(long)]
+    description: Option<bool>,
+}
+
+pub async fn update_nut04(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &UpdateNut04Command,
+) -> Result<()> {
+    let _response = client
+        .update_nut04(Request::new(UpdateNut04Request {
+            method: sub_command_args.method.clone(),
+            unit: sub_command_args.unit.clone(),
+            disabled: sub_command_args.disabled,
+            min: sub_command_args.min_amount,
+            max: sub_command_args.max_amount,
+            description: sub_command_args.description,
+        }))
+        .await?;
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_nut04_quote.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_nut04_quote.rs
@@ -1,0 +1,32 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::transport::Channel;
+use tonic::Request;
+
+use crate::cdk_mint_client::CdkMintClient;
+use crate::UpdateNut04QuoteRequest;
+
+#[derive(Args)]
+pub struct UpdateNut04QuoteCommand {
+    quote_id: String,
+    #[arg(default_value = "PAID")]
+    state: String,
+}
+
+pub async fn update_nut04_quote_state(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &UpdateNut04QuoteCommand,
+) -> Result<()> {
+    let response = client
+        .update_nut04_quote(Request::new(UpdateNut04QuoteRequest {
+            quote_id: sub_command_args.quote_id.clone(),
+            state: sub_command_args.state.clone(),
+        }))
+        .await?;
+
+    let response = response.into_inner();
+
+    println!("Quote {} updated to {}", response.quote_id, response.state);
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_nut05.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_nut05.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::transport::Channel;
+use tonic::Request;
+
+use crate::cdk_mint_client::CdkMintClient;
+use crate::UpdateNut05Request;
+
+#[derive(Args)]
+pub struct UpdateNut05Command {
+    #[arg(short, long)]
+    #[arg(default_value = "sat")]
+    unit: String,
+    #[arg(short, long)]
+    #[arg(default_value = "bolt11")]
+    method: String,
+    #[arg(long)]
+    min_amount: Option<u64>,
+    #[arg(long)]
+    max_amount: Option<u64>,
+    #[arg(long)]
+    disabled: Option<bool>,
+}
+
+pub async fn update_nut05(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &UpdateNut05Command,
+) -> Result<()> {
+    let _response = client
+        .update_nut05(Request::new(UpdateNut05Request {
+            method: sub_command_args.method.clone(),
+            unit: sub_command_args.unit.clone(),
+            disabled: sub_command_args.disabled,
+            min: sub_command_args.min_amount,
+            max: sub_command_args.max_amount,
+        }))
+        .await?;
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_short_description.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_short_description.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::transport::Channel;
+use tonic::Request;
+
+use crate::cdk_mint_client::CdkMintClient;
+use crate::UpdateDescriptionRequest;
+
+#[derive(Args)]
+pub struct UpdateShortDescriptionCommand {
+    description: String,
+}
+
+pub async fn update_short_description(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &UpdateShortDescriptionCommand,
+) -> Result<()> {
+    let _response = client
+        .update_short_description(Request::new(UpdateDescriptionRequest {
+            description: sub_command_args.description.clone(),
+        }))
+        .await?;
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_ttl.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_ttl.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::transport::Channel;
+use tonic::Request;
+
+use crate::cdk_mint_client::CdkMintClient;
+use crate::UpdateQuoteTtlRequest;
+
+#[derive(Args)]
+pub struct UpdateQuoteTtlCommand {
+    #[arg(long)]
+    mint_ttl: Option<u64>,
+    #[arg(long)]
+    melt_ttl: Option<u64>,
+}
+pub async fn update_quote_ttl(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &UpdateQuoteTtlCommand,
+) -> Result<()> {
+    let _response = client
+        .update_quote_ttl(Request::new(UpdateQuoteTtlRequest {
+            mint_ttl: sub_command_args.mint_ttl,
+            melt_ttl: sub_command_args.melt_ttl,
+        }))
+        .await?;
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_urls.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_urls.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::transport::Channel;
+use tonic::Request;
+
+use crate::cdk_mint_client::CdkMintClient;
+use crate::UpdateUrlRequest;
+
+#[derive(Args)]
+pub struct AddUrlCommand {
+    url: String,
+}
+
+pub async fn add_url(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &AddUrlCommand,
+) -> Result<()> {
+    let _response = client
+        .add_url(Request::new(UpdateUrlRequest {
+            url: sub_command_args.url.clone(),
+        }))
+        .await?;
+
+    Ok(())
+}
+
+#[derive(Args)]
+pub struct RemoveUrlCommand {
+    url: String,
+}
+
+pub async fn remove_url(
+    client: &mut CdkMintClient<Channel>,
+    sub_command_args: &RemoveUrlCommand,
+) -> Result<()> {
+    let _response = client
+        .remove_url(Request::new(UpdateUrlRequest {
+            url: sub_command_args.url.clone(),
+        }))
+        .await?;
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/proto/cdk-mint-rpc.proto
+++ b/crates/cdk-mint-rpc/src/proto/cdk-mint-rpc.proto
@@ -1,0 +1,115 @@
+syntax = "proto3";
+
+package cdk_mint_rpc;
+
+service CdkMint {
+    rpc GetInfo(GetInfoRequest) returns (GetInfoResponse) {}
+    rpc UpdateMotd(UpdateMotdRequest) returns (UpdateResponse) {}
+    rpc UpdateShortDescription(UpdateDescriptionRequest) returns (UpdateResponse) {}
+    rpc UpdateLongDescription(UpdateDescriptionRequest) returns (UpdateResponse) {}
+    rpc UpdateIconUrl(UpdateIconUrlRequest) returns (UpdateResponse) {}
+    rpc UpdateName(UpdateNameRequest) returns (UpdateResponse) {}
+    rpc AddUrl(UpdateUrlRequest) returns (UpdateResponse) {}
+    rpc RemoveUrl(UpdateUrlRequest) returns (UpdateResponse) {}
+    rpc AddContact(UpdateContactRequest) returns (UpdateResponse) {}
+    rpc RemoveContact(UpdateContactRequest) returns (UpdateResponse) {}
+    rpc UpdateNut04(UpdateNut04Request) returns (UpdateResponse) {}
+    rpc UpdateNut05(UpdateNut05Request) returns (UpdateResponse) {}
+    rpc UpdateQuoteTtl(UpdateQuoteTtlRequest) returns (UpdateResponse) {}
+    rpc UpdateNut04Quote(UpdateNut04QuoteRequest) returns (UpdateNut04QuoteRequest) {}
+    rpc RotateNextKeyset(RotateNextKeysetRequest) returns (RotateNextKeysetResponse) {}
+}
+
+message GetInfoRequest {
+}
+
+message ContactInfo {
+    string method = 1;
+    string info = 2;
+}
+
+message GetInfoResponse {
+    optional string name = 1;
+    optional string version = 2;
+    optional string description = 3;
+    optional string long_description = 4;
+    repeated ContactInfo contact = 5;
+    optional string motd = 6;
+    optional string icon_url = 7;
+    repeated string urls = 8;
+    uint64 total_issued = 9;
+    uint64 total_redeemed = 10;
+}
+
+message UpdateResponse{
+}
+
+message UpdateMotdRequest {
+    string motd = 1;
+}
+
+message UpdateDescriptionRequest {
+    string description = 1;
+}
+
+
+message UpdateIconUrlRequest {
+    string icon_url = 1;
+}
+
+message UpdateNameRequest {
+    string name = 1;
+}
+
+
+message UpdateUrlRequest {
+    string url = 1;
+}
+
+message UpdateContactRequest {
+    string method = 1;
+    string info = 2;
+}
+
+message UpdateNut04Request {
+    string unit = 1;
+    string method = 2;
+    optional bool disabled = 3;
+    optional uint64 min = 4;
+    optional uint64 max = 5;
+    optional bool description = 6;
+}
+
+
+message UpdateNut05Request {
+    string unit = 1;
+    string method = 2;
+    optional bool disabled = 3;
+    optional uint64 min = 4;
+    optional uint64 max = 5;
+}
+
+message UpdateQuoteTtlRequest {
+    optional uint64 mint_ttl = 1;
+    optional uint64 melt_ttl = 2;
+}
+
+
+message UpdateNut04QuoteRequest {
+    string quote_id = 1;
+    string state = 2;
+}
+
+message RotateNextKeysetRequest {
+    string unit = 1;
+    optional uint32 max_order = 2;
+    optional uint64 input_fee_ppk = 3;
+}
+
+
+message RotateNextKeysetResponse {
+    string id = 1;
+    string unit = 2;
+    uint32 max_order = 3;
+    uint64 input_fee_ppk = 4;
+}

--- a/crates/cdk-mint-rpc/src/proto/mod.rs
+++ b/crates/cdk-mint-rpc/src/proto/mod.rs
@@ -1,0 +1,5 @@
+tonic::include_proto!("cdk_mint_rpc");
+
+mod server;
+
+pub use server::MintRPCServer;

--- a/crates/cdk-mintd/Cargo.toml
+++ b/crates/cdk-mintd/Cargo.toml
@@ -6,8 +6,13 @@ authors = ["CDK Developers"]
 license = "MIT"
 homepage = "https://github.com/cashubtc/cdk"
 repository = "https://github.com/cashubtc/cdk.git"
-rust-version = "1.63.0"                            # MSRV
 description = "CDK mint binary"
+
+[features]
+default = ["management-rpc"]
+swagger = ["cdk-axum/swagger", "dep:utoipa", "dep:utoipa-swagger-ui"]
+redis = ["cdk-axum/redis"]
+management-rpc = ["cdk-mint-rpc"]
 
 [dependencies]
 anyhow = "1"
@@ -28,8 +33,9 @@ cdk-lnd = { path = "../cdk-lnd", version = "0.6.0", default-features = false }
 cdk-fake-wallet = { path = "../cdk-fake-wallet", version = "0.6.0", default-features = false }
 cdk-strike = { path = "../cdk-strike", version = "0.6.0" }
 cdk-axum = { path = "../cdk-axum", version = "0.6.0", default-features = false }
+cdk-mint-rpc = { path = "../cdk-mint-rpc", version = "0.6.0", default-features = false, optional = true }
 config = { version = "0.13.3", features = ["toml"] }
-clap = { version = "4.4.8", features = ["derive", "env", "default"] }
+clap = { version = "~4.0.32", features = ["derive"] }
 tokio = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = [
     "attributes",
@@ -38,14 +44,10 @@ tracing = { version = "0.1", default-features = false, features = [
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 futures = { version = "0.3.28", default-features = false }
 serde = { version = "1", default-features = false, features = ["derive"] }
-bip39 = "2.0"
+bip39 = { version = "2.0", features = ["rand"] }
 tower-http = { version = "0.4.4", features = ["cors", "compression-full"] }
 lightning-invoice = { version = "0.32.0", features = ["serde", "std"] }
 home = "0.5.5"
 url = "2.3"
 utoipa = { version = "4", optional = true }
 utoipa-swagger-ui = { version = "4", features = ["axum"], optional = true }
-
-[features]
-swagger = ["cdk-axum/swagger", "dep:utoipa", "dep:utoipa-swagger-ui"]
-redis = ["cdk-axum/redis"]

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -6,6 +6,12 @@ mnemonic = ""
 # input_fee_ppk = 0
 # enable_swagger_ui = false
 
+[mint_management_rpc]
+enabled = true
+# address = "127.0.0.1"
+# port = 8086
+
+
 [info.http_cache]
 # memory or redis
 backend = "memory"
@@ -15,7 +21,8 @@ tti = 60
 # key_prefix = "mintd"
 # connection_string = "redis://localhost"
 
-
+# NOTE: If [mint_management_rpc] is enabled these values will only be used on first start up.
+# Further changes must be made through the rpc.
 [mint_info]
 # name = "cdk-mintd mutiney net mint"
 # Hex pubkey of mint

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -187,6 +187,8 @@ pub struct Settings {
     pub lnd: Option<Lnd>,
     pub fake_wallet: Option<FakeWallet>,
     pub database: Database,
+    #[cfg(feature = "management-rpc")]
+    pub mint_management_rpc: Option<MintManagementRpc>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -207,6 +209,17 @@ pub struct MintInfo {
     pub contact_nostr_public_key: Option<String>,
     /// Contact email
     pub contact_email: Option<String>,
+}
+
+#[cfg(feature = "management-rpc")]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MintManagementRpc {
+    /// When this is set to `true` the mint use the config file for the initial set up on first start.
+    /// Changes to the `[mint_info]` after this **MUST** be made via the RPC changes to the config file or env vars will be ignored.
+    pub enabled: bool,
+    pub address: Option<String>,
+    pub port: Option<u16>,
+    pub tls_dir_path: Option<PathBuf>,
 }
 
 impl Settings {

--- a/crates/cdk/src/mint/keysets.rs
+++ b/crates/cdk/src/mint/keysets.rs
@@ -89,7 +89,7 @@ impl Mint {
 
     /// Add current keyset to inactive keysets
     /// Generate new keyset
-    #[instrument(skip(self))]
+    #[instrument(skip(self, custom_paths))]
     pub async fn rotate_keyset(
         &self,
         unit: CurrencyUnit,
@@ -115,10 +115,12 @@ impl Mint {
         );
         let id = keyset_info.id;
         self.localstore.add_keyset_info(keyset_info.clone()).await?;
-        self.localstore.set_active_keyset(unit, id).await?;
+        self.localstore.set_active_keyset(unit.clone(), id).await?;
 
         let mut keysets = self.keysets.write().await;
         keysets.insert(id, keyset);
+
+        tracing::info!("Rotated to new keyset {} for {}", id, unit);
 
         Ok(keyset_info)
     }

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv};
 use bitcoin::secp256k1::{self, Secp256k1};
-use cdk_common::common::LnKey;
+use cdk_common::common::{LnKey, QuoteTTL};
 use cdk_common::database::{self, MintDatabase};
 use cdk_common::mint::MintKeySetInfo;
 use futures::StreamExt;
@@ -192,6 +192,21 @@ impl Mint {
     /// Get mint info
     pub async fn mint_info(&self) -> Result<MintInfo, Error> {
         Ok(self.localstore.get_mint_info().await?)
+    }
+
+    /// Set mint info
+    pub async fn set_mint_info(&self, mint_info: MintInfo) -> Result<(), Error> {
+        Ok(self.localstore.set_mint_info(mint_info).await?)
+    }
+
+    /// Get quote ttl
+    pub async fn quote_ttl(&self) -> Result<QuoteTTL, Error> {
+        Ok(self.localstore.get_quote_ttl().await?)
+    }
+
+    /// Set quote ttl
+    pub async fn set_quote_ttl(&self, quote_ttl: QuoteTTL) -> Result<(), Error> {
+        Ok(self.localstore.set_quote_ttl(quote_ttl).await?)
     }
 
     /// Wait for any invoice to be paid

--- a/flake.nix
+++ b/flake.nix
@@ -244,6 +244,13 @@
               cargo update -p async-compression --precise 0.4.3
               cargo update -p zstd-sys --precise 2.0.8+zstd.1.5.5
 
+              cargo update -p clap_lex --precise 0.3.0
+              cargo update -p regex --precise 1.9.6
+              cargo update -p petgraph  --precise 0.6.2
+              cargo update -p hashbrown@0.15.2  --precise 0.15.0
+              cargo update -p async-stream --precise 0.3.5
+              cargo update -p home --precise 0.5.5
+
               # For wasm32-unknown-unknown target
               cargo update -p bumpalo --precise 3.12.0
               cargo update -p moka --precise 0.11.1
@@ -291,6 +298,7 @@
                 export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [
                   pkgs.zlib
                   ]}:$LD_LIBRARY_PATH
+                export RUST_SRC_PATH=${nightly_toolchain}/lib/rustlib/src/rust/library
               '';
               buildInputs = buildInputs ++ [ nightly_toolchain ];
               inherit nativeBuildInputs;


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----
closes #456 
### Notes to the reviewers

A mint management rpc can be started by enabling it in the mintd config. There is a gprpc client cli that can be run by  running `cargo r --bin cdk-mint-cli` to update the mint settings. 

If the rpc server is enabled the mint will only read settings from the config file the first time after that the rpc must be used and changes to the mint info in the config file will not be used.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
