### PR TITLE
Introduce `cdk-database`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
             -p cdk --no-default-features --features mint,
             -p cdk --no-default-features --features "mint swagger",
             -p cdk-redb,
+            -p cdk-database,
             -p cdk-sqlite,
             -p cdk-axum --no-default-features,
             -p cdk-axum --no-default-features --features swagger,

--- a/crates/cdk-database/Cargo.toml
+++ b/crates/cdk-database/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cdk-database"
+version = "0.6.1"
+edition = "2021"
+description = "CDK database engine selection crate"
+
+[features]
+mint = ["cdk-sqlite/mint", "cdk-redb/mint"]
+wallet = ["cdk-sqlite/wallet", "cdk-redb/wallet"]
+default = ["mint", "wallet"]
+
+[dependencies]
+cdk-common = { path = "../cdk-common" }
+cdk-sqlite = { path = "../cdk-sqlite", default-features = false }
+cdk-redb = { path = "../cdk-redb", default-features = false }
+serde = { version = "1.0.217", features = ["derive"] }

--- a/crates/cdk-database/src/lib.rs
+++ b/crates/cdk-database/src/lib.rs
@@ -1,0 +1,59 @@
+//! CDK-Database instance
+//!
+//! This crate will create a database instance based on the provided engine.
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use cdk_redb::MintRedbDatabase;
+use cdk_sqlite::MintSqliteDatabase;
+use serde::{Deserialize, Serialize};
+
+/// Database engine definition
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum DatabaseEngine {
+    #[default]
+    Sqlite,
+    Redb,
+}
+
+impl std::str::FromStr for DatabaseEngine {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "sqlite" => Ok(DatabaseEngine::Sqlite),
+            "redb" => Ok(DatabaseEngine::Redb),
+            _ => Err(format!("Unknown database engine: {}", s)),
+        }
+    }
+}
+
+impl DatabaseEngine {
+    /// Convert the database instance into a mint database
+    pub async fn mint<P: Into<PathBuf>>(
+        self,
+        work_dir: P,
+    ) -> Result<
+        Arc<
+            dyn cdk_common::database::MintDatabase<Err = cdk_common::database::Error>
+                + Sync
+                + Send
+                + 'static,
+        >,
+        cdk_common::database::Error,
+    > {
+        match self {
+            DatabaseEngine::Sqlite => {
+                let sql_db_path = work_dir.into().join("cdk-mintd.sqlite");
+                let db = MintSqliteDatabase::new(&sql_db_path).await?;
+                db.migrate().await;
+                Ok(Arc::new(db))
+            }
+            DatabaseEngine::Redb => {
+                let redb_path = work_dir.into().join("cdk-mintd.redb");
+                Ok(Arc::new(MintRedbDatabase::new(&redb_path)?))
+            }
+        }
+    }
+}

--- a/crates/cdk-mintd/Cargo.toml
+++ b/crates/cdk-mintd/Cargo.toml
@@ -15,14 +15,9 @@ axum = "0.6.20"
 cdk = { path = "../cdk", version = "0.6.0", default-features = false, features = [
     "mint",
 ] }
-cdk-redb = { path = "../cdk-redb", version = "0.6.0", default-features = false, features = [
-    "mint",
-] }
-cdk-sqlite = { path = "../cdk-sqlite", version = "0.6.0", default-features = false, features = [
-    "mint",
-] }
 cdk-cln = { path = "../cdk-cln", version = "0.6.0", default-features = false }
 cdk-lnbits = { path = "../cdk-lnbits", version = "0.6.0", default-features = false }
+cdk-database = { path = "../cdk-database" }
 cdk-phoenixd = { path = "../cdk-phoenixd", version = "0.6.0", default-features = false }
 cdk-lnd = { path = "../cdk-lnd", version = "0.6.0", default-features = false }
 cdk-fake-wallet = { path = "../cdk-fake-wallet", version = "0.6.0", default-features = false }

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use cdk::nuts::{CurrencyUnit, PublicKey};
 use cdk::Amount;
 use cdk_axum::cache;
+use cdk_database::DatabaseEngine;
 use config::{Config, ConfigError, File};
 use serde::{Deserialize, Serialize};
 
@@ -147,26 +148,6 @@ fn default_min_delay_time() -> u64 {
 
 fn default_max_delay_time() -> u64 {
     3
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum DatabaseEngine {
-    #[default]
-    Sqlite,
-    Redb,
-}
-
-impl std::str::FromStr for DatabaseEngine {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "sqlite" => Ok(DatabaseEngine::Sqlite),
-            "redb" => Ok(DatabaseEngine::Redb),
-            _ => Err(format!("Unknown database engine: {}", s)),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/cdk-mintd/src/env_vars.rs
+++ b/crates/cdk-mintd/src/env_vars.rs
@@ -4,10 +4,11 @@ use std::str::FromStr;
 
 use anyhow::{anyhow, bail, Result};
 use cdk::nuts::CurrencyUnit;
+use cdk_database::DatabaseEngine;
 
 use crate::config::{
-    Cln, Database, DatabaseEngine, FakeWallet, Info, LNbits, Ln, LnBackend, Lnd, MintInfo,
-    Phoenixd, Settings, Strike,
+    Cln, Database, FakeWallet, Info, LNbits, Ln, LnBackend, Lnd, MintInfo, Phoenixd, Settings,
+    Strike,
 };
 
 pub const ENV_WORK_DIR: &str = "CDK_MINTD_WORK_DIR";
@@ -72,15 +73,15 @@ pub const ENV_FAKE_WALLET_MIN_DELAY: &str = "CDK_MINTD_FAKE_WALLET_MIN_DELAY";
 pub const ENV_FAKE_WALLET_MAX_DELAY: &str = "CDK_MINTD_FAKE_WALLET_MAX_DELAY";
 
 impl Settings {
-    pub fn from_env(&mut self) -> Result<Self> {
+    pub fn from_env(mut self) -> Result<Self> {
         if let Ok(database) = env::var(DATABASE_ENV_VAR) {
             let engine = DatabaseEngine::from_str(&database).map_err(|err| anyhow!(err))?;
             self.database = Database { engine };
         }
 
-        self.info = self.info.clone().from_env();
-        self.mint_info = self.mint_info.clone().from_env();
-        self.ln = self.ln.clone().from_env();
+        self.info = self.info.from_env();
+        self.mint_info = self.mint_info.from_env();
+        self.ln = self.ln.from_env();
 
         match self.ln.ln_backend {
             LnBackend::Cln => {
@@ -104,7 +105,7 @@ impl Settings {
             LnBackend::None => bail!("Ln backend must be set"),
         }
 
-        Ok(self.clone())
+        Ok(self)
     }
 }
 


### PR DESCRIPTION

### Description

This is a crate that makes it easier to create a database instance based on an enum that can be constructed from a CLI or an env variable.

This PR has been abstracted from #509, which makit es easier to create binaries that share the same settings / databases as the mintd web-server.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
