### PR TITLE
Further Checks on MPP Melt Quotes

### DIFF
--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 
+use cashu::{CurrencyUnit, PaymentMethod};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use thiserror::Error;
@@ -51,6 +52,12 @@ pub enum Error {
     /// Amountless Invoice Not supported
     #[error("Amount Less Invoice is not allowed")]
     AmountLessNotAllowed,
+    /// Multi-Part Internal Melt Quotes are not supported
+    #[error("Multi-Part Internal Melt Quotes are not supported")]
+    InternalMultiPartMeltQuote,
+    /// Multi-Part Payment not supported for unit and method
+    #[error("Multi-Part payment is not supported for unit `{0}` and method `{1}`")]
+    MppUnitMethodNotSupported(CurrencyUnit, PaymentMethod),
 
     // Mint Errors
     /// Minting is disabled


### PR DESCRIPTION
### Description
More checks for MPP melt quotes:

- if MPP and internal (there is a mint quote for the request), error.
- if MPP but unit-method combo unsupported, error.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

#### CHANGED
* `check_melt_request_acceptable` now an async function.

----

### Checklist

* [ x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ x] I ran `just final-check` before committing
