### PR TITLE
Remove dependency on `rand`

### DIFF
--- a/crates/cashu/Cargo.toml
+++ b/crates/cashu/Cargo.toml
@@ -36,6 +36,5 @@ serde_with = "3"
 instant = { version = "0.1", features = ["wasm-bindgen", "inaccurate"] }
 
 [dev-dependencies]
-rand = "0.8.5"
 bip39 = "2.0"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/cashu/src/nuts/nut02.rs
+++ b/crates/cashu/src/nuts/nut02.rs
@@ -375,7 +375,7 @@ impl From<&MintKeys> for Id {
 mod test {
     use std::str::FromStr;
 
-    use rand::RngCore;
+    use bitcoin::secp256k1::rand::{self, RngCore};
 
     use super::{KeySetInfo, Keys, KeysetResponse};
     use crate::nuts::nut02::{Error, Id};

--- a/crates/cdk-cli/Cargo.toml
+++ b/crates/cdk-cli/Cargo.toml
@@ -23,7 +23,6 @@ serde_json = "1"
 tokio = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["attributes", "log"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-rand = "0.8.5"
 home = "0.5.5"
 nostr-sdk = { version = "0.35.0", default-features = false, features = [
     "nip04",

--- a/crates/cdk-cli/src/main.rs
+++ b/crates/cdk-cli/src/main.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
+use bip39::rand::{thread_rng, Rng};
 use bip39::Mnemonic;
 use cdk::cdk_database;
 use cdk::cdk_database::WalletDatabase;
@@ -12,7 +13,6 @@ use cdk::wallet::{MultiMintWallet, Wallet};
 use cdk_redb::WalletRedbDatabase;
 use cdk_sqlite::WalletSqliteDatabase;
 use clap::{Parser, Subcommand};
-use rand::Rng;
 use tracing::Level;
 use tracing_subscriber::EnvFilter;
 use url::Url;
@@ -128,7 +128,7 @@ async fn main() -> Result<()> {
             Mnemonic::from_str(&contents)?
         }
         Err(_e) => {
-            let mut rng = rand::thread_rng();
+            let mut rng = thread_rng();
             let random_bytes: [u8; 32] = rng.gen();
 
             let mnemonic = Mnemonic::from_entropy(&random_bytes)?;

--- a/crates/cdk-fake-wallet/Cargo.toml
+++ b/crates/cdk-fake-wallet/Cargo.toml
@@ -22,4 +22,3 @@ serde = "1"
 serde_json = "1"
 lightning-invoice = { version = "0.32.0", features = ["serde", "std"] }
 tokio-stream = "0.1.15"
-rand = "0.8.5"

--- a/crates/cdk-fake-wallet/src/lib.rs
+++ b/crates/cdk-fake-wallet/src/lib.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bitcoin::hashes::{sha256, Hash};
+use bitcoin::secp256k1::rand::{thread_rng, Rng};
 use bitcoin::secp256k1::{Secp256k1, SecretKey};
 use cdk::amount::{to_unit, Amount, MSAT_IN_SAT};
 use cdk::cdk_lightning::{
@@ -26,7 +27,6 @@ use error::Error;
 use futures::stream::StreamExt;
 use futures::Stream;
 use lightning_invoice::{Bolt11Invoice, Currency, InvoiceBuilder, PaymentSecret};
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tokio::time;
@@ -281,7 +281,7 @@ pub fn create_fake_invoice(amount_msat: u64, description: String) -> Bolt11Invoi
     )
     .unwrap();
 
-    let mut rng = rand::thread_rng();
+    let mut rng = thread_rng();
     let mut random_bytes = [0u8; 32];
     rng.fill(&mut random_bytes);
 

--- a/crates/cdk-mintd/Cargo.toml
+++ b/crates/cdk-mintd/Cargo.toml
@@ -45,7 +45,6 @@ home = "0.5.5"
 url = "2.3"
 utoipa = { version = "4", optional = true }
 utoipa-swagger-ui = { version = "4", features = ["axum"], optional = true }
-rand = "0.8.5"
 
 [features]
 swagger = ["cdk-axum/swagger", "dep:utoipa", "dep:utoipa-swagger-ui"]

--- a/crates/cdk-mintd/src/setup.rs
+++ b/crates/cdk-mintd/src/setup.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, bail};
 use axum::{async_trait, Router};
+use bip39::rand::{thread_rng, Rng};
 use cdk::cdk_lightning::MintLightning;
 use cdk::mint::FeeReserve;
 use cdk::mint_url::MintUrl;
 use cdk::nuts::CurrencyUnit;
-use rand::Rng;
 use tokio::sync::Mutex;
 use url::Url;
 
@@ -217,7 +217,7 @@ impl LnBackendSetup for config::FakeWallet {
         };
 
         // calculate random delay time
-        let mut rng = rand::thread_rng();
+        let mut rng = thread_rng();
         let delay_time = rng.gen_range(self.min_delay_time..=self.max_delay_time);
 
         let fake_wallet = cdk_fake_wallet::FakeWallet::new(


### PR DESCRIPTION
### Description

This PR replaces direct dependencies on `rand` with re-using existing, re-exported versions of `rand`.

This makes the dependency tree smaller and avoids accidentally including multiple `rand` versions, i.e. our explicit one in addition to the existing transitive one(s).

-----

### Notes to the reviewers

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

* Remove direct dependencies on `rand`

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
