### PR TITLE
Include pure integration tests in `just final-check`, fix edge-case

### DIFF
--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -167,7 +167,7 @@ pub async fn create_and_start_test_mint() -> anyhow::Result<Arc<Mint>> {
     mint_builder = mint_builder.add_ln_backend(
         CurrencyUnit::Sat,
         PaymentMethod::Bolt11,
-        MintMeltLimits::default(),
+        MintMeltLimits::new(1, 1_000),
         ln_fake_backend,
     );
 

--- a/crates/cdk/src/mint/builder.rs
+++ b/crates/cdk/src/mint/builder.rs
@@ -242,8 +242,8 @@ impl MintBuilder {
     }
 }
 
-/// Mint Melt Limits
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+/// Mint and Melt Limits
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MintMeltLimits {
     /// Min mint amount
     pub mint_min: Amount,
@@ -256,7 +256,7 @@ pub struct MintMeltLimits {
 }
 
 impl MintMeltLimits {
-    /// Create new [`MintMeltLimits`]
+    /// Create new [`MintMeltLimits`]. The `min` and `max` limits apply to both minting and melting.
     pub fn new(min: u64, max: u64) -> Self {
         Self {
             mint_min: min.into(),

--- a/justfile
+++ b/justfile
@@ -47,6 +47,9 @@ test: build
   fi
   cargo test --lib
 
+  # Run pure integration tests
+  cargo test -p cdk-integration-tests --test integration_tests_pure
+
 # run `cargo clippy` on everything
 clippy *ARGS="--locked --offline --workspace --all-targets":
   cargo clippy {{ARGS}}


### PR DESCRIPTION
### Description

This PR
- includes the pure integration tests in `just final-check`
- fixes an edge case found by running the pure integration tests: initializing a mint with `MintMeltLimits::default()` would cause any minting and melting to fail with `AmountOutofLimitRange`. This is because the default is `min=0` and `max=0`. By removing the default, this forces the caller(s) to explicitly set the limits via `MintMeltLimits::new(min, max)`.

-----

### Notes to the reviewers

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

* Include pure integration tests in local check (`just final-check`)

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
