### PR TITLE
Align various wallet.balance() methods

### DIFF
--- a/crates/cdk/src/wallet/balance.rs
+++ b/crates/cdk/src/wallet/balance.rs
@@ -1,9 +1,6 @@
-use std::collections::HashMap;
-
 use tracing::instrument;
 
 use crate::nuts::nut00::ProofsMethods;
-use crate::nuts::CurrencyUnit;
 use crate::{Amount, Error, Wallet};
 
 impl Wallet {
@@ -15,29 +12,13 @@ impl Wallet {
 
     /// Total pending balance
     #[instrument(skip(self))]
-    pub async fn total_pending_balance(&self) -> Result<HashMap<CurrencyUnit, Amount>, Error> {
-        let proofs = self.get_pending_proofs().await?;
-
-        // TODO If only the proofs for this wallet's unit are retrieved, why build a map with key = unit?
-        let balances = proofs.iter().fold(HashMap::new(), |mut acc, proof| {
-            *acc.entry(self.unit.clone()).or_insert(Amount::ZERO) += proof.amount;
-            acc
-        });
-
-        Ok(balances)
+    pub async fn total_pending_balance(&self) -> Result<Amount, Error> {
+        Ok(self.get_pending_proofs().await?.total_amount()?)
     }
 
     /// Total reserved balance
     #[instrument(skip(self))]
-    pub async fn total_reserved_balance(&self) -> Result<HashMap<CurrencyUnit, Amount>, Error> {
-        let proofs = self.get_reserved_proofs().await?;
-
-        // TODO If only the proofs for this wallet's unit are retrieved, why build a map with key = unit?
-        let balances = proofs.iter().fold(HashMap::new(), |mut acc, proof| {
-            *acc.entry(self.unit.clone()).or_insert(Amount::ZERO) += proof.amount;
-            acc
-        });
-
-        Ok(balances)
+    pub async fn total_reserved_balance(&self) -> Result<Amount, Error> {
+        Ok(self.get_reserved_proofs().await?.total_amount()?)
     }
 }


### PR DESCRIPTION
### Description

This PR addresses a few wallet TODOs that re-align `total_pending_balance` and `total_reserved_balance` to the same signature as `total_balance`.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED 

- Aligned wallet `total_pending_balance` and `total_reserved_balance` signatures

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
