### PR TITLE
Fix mint delete unspent

### DIFF
--- a/crates/cdk-common/src/database/mint.rs
+++ b/crates/cdk-common/src/database/mint.rs
@@ -86,8 +86,14 @@ pub trait Database {
     /// Get [`MintKeySetInfo`]s
     async fn get_keyset_infos(&self) -> Result<Vec<MintKeySetInfo>, Self::Err>;
 
-    /// Add spent [`Proofs`]
+    /// Add  [`Proofs`]
     async fn add_proofs(&self, proof: Proofs, quote_id: Option<Uuid>) -> Result<(), Self::Err>;
+    /// Remove [`Proofs`]
+    async fn remove_proofs(
+        &self,
+        ys: &[PublicKey],
+        quote_id: Option<Uuid>,
+    ) -> Result<(), Self::Err>;
     /// Get [`Proofs`] by ys
     async fn get_proofs_by_ys(&self, ys: &[PublicKey]) -> Result<Vec<Option<Proof>>, Self::Err>;
     /// Get ys by quote id

--- a/crates/cdk-redb/src/mint/mod.rs
+++ b/crates/cdk-redb/src/mint/mod.rs
@@ -534,6 +534,36 @@ impl MintDatabase for MintRedbDatabase {
         Ok(())
     }
 
+    async fn remove_proofs(
+        &self,
+        ys: &[PublicKey],
+        quote_id: Option<Uuid>,
+    ) -> Result<(), Self::Err> {
+        let write_txn = self.db.begin_write().map_err(Error::from)?;
+
+        {
+            let mut proofs_table = write_txn.open_table(PROOFS_TABLE).map_err(Error::from)?;
+
+            for y in ys {
+                proofs_table.remove(&y.to_bytes()).map_err(Error::from)?;
+            }
+        }
+
+        if let Some(quote_id) = quote_id {
+            let mut quote_proofs_table = write_txn
+                .open_multimap_table(QUOTE_PROOFS_TABLE)
+                .map_err(Error::from)?;
+
+            quote_proofs_table
+                .remove_all(quote_id.as_bytes())
+                .map_err(Error::from)?;
+        }
+
+        write_txn.commit().map_err(Error::from)?;
+
+        Ok(())
+    }
+
     async fn get_proofs_by_ys(&self, ys: &[PublicKey]) -> Result<Vec<Option<Proof>>, Self::Err> {
         let read_txn = self.db.begin_read().map_err(Error::from)?;
         let table = read_txn.open_table(PROOFS_TABLE).map_err(Error::from)?;

--- a/crates/cdk/src/cdk_database/mint_memory.rs
+++ b/crates/cdk/src/cdk_database/mint_memory.rs
@@ -284,6 +284,27 @@ impl MintDatabase for MintMemoryDatabase {
         Ok(())
     }
 
+    async fn remove_proofs(
+        &self,
+        ys: &[PublicKey],
+        quote_id: Option<Uuid>,
+    ) -> Result<(), Self::Err> {
+        {
+            let mut db_proofs = self.proofs.write().await;
+
+            ys.iter().for_each(|y| {
+                db_proofs.remove(&y.to_bytes());
+            });
+        }
+
+        if let Some(quote_id) = quote_id {
+            let mut quote_proofs = self.quote_proofs.lock().await;
+            quote_proofs.remove(&quote_id);
+        }
+
+        Ok(())
+    }
+
     async fn get_proofs_by_ys(&self, ys: &[PublicKey]) -> Result<Vec<Option<Proof>>, Self::Err> {
         let spent_proofs = self.proofs.read().await;
 

--- a/crates/cdk/src/mint/melt.rs
+++ b/crates/cdk/src/mint/melt.rs
@@ -385,7 +385,7 @@ impl Mint {
         let input_ys = melt_request.inputs.ys()?;
 
         self.localstore
-            .update_proofs_states(&input_ys, State::Unspent)
+            .remove_proofs(&input_ys, Some(melt_request.quote))
             .await?;
 
         self.localstore


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

When a proof is unspent we do not need to store it in the db, storing can lead to a bloated database.

-----
closes #568 
### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
