### PR TITLE
docs(dev): add workaround for integration tests for macos

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -86,6 +86,8 @@ just test
 just itest REDB/SQLITE/MEMEORY
 ```
 
+NOTE: if this command fails on macos change the nix channel to unstable (in the `flake.nix` file modify `nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";` to `nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";`)
+
 ### Running Format
 ```bash
 just format


### PR DESCRIPTION
### Description

Add a workaround on how to run the integration tests on macos

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED
workaround in dev guide on how to run the integration tests on macos
#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
