### PR TITLE
Add filtering for mint quote states in database

### DIFF
--- a/crates/cdk-common/src/database/mint.rs
+++ b/crates/cdk-common/src/database/mint.rs
@@ -49,6 +49,11 @@ pub trait Database {
     ) -> Result<Option<MintMintQuote>, Self::Err>;
     /// Get Mint Quotes
     async fn get_mint_quotes(&self) -> Result<Vec<MintMintQuote>, Self::Err>;
+    /// Get Mint Quotes with state
+    async fn get_mint_quotes_with_state(
+        &self,
+        state: MintQuoteState,
+    ) -> Result<Vec<MintMintQuote>, Self::Err>;
     /// Remove [`MintMintQuote`]
     async fn remove_mint_quote(&self, quote_id: &Uuid) -> Result<(), Self::Err>;
 

--- a/crates/cdk-sqlite/src/mint/mod.rs
+++ b/crates/cdk-sqlite/src/mint/mod.rs
@@ -431,6 +431,43 @@ FROM mint_quote
         }
     }
 
+    async fn get_mint_quotes_with_state(
+        &self,
+        state: MintQuoteState,
+    ) -> Result<Vec<MintQuote>, Self::Err> {
+        let mut transaction = self.pool.begin().await.map_err(Error::from)?;
+        let rec = sqlx::query(
+            r#"
+SELECT * 
+FROM mint_quote 
+WHERE state = ?
+        "#,
+        )
+        .bind(state.to_string())
+        .fetch_all(&mut transaction)
+        .await;
+
+        match rec {
+            Ok(rows) => {
+                transaction.commit().await.map_err(Error::from)?;
+                let mint_quotes = rows
+                    .into_iter()
+                    .map(sqlite_row_to_mint_quote)
+                    .collect::<Result<Vec<MintQuote>, _>>()?;
+
+                Ok(mint_quotes)
+            }
+            Err(err) => {
+                tracing::error!("SQLite get mint quotes");
+                if let Err(err) = transaction.rollback().await {
+                    tracing::error!("Could not rollback sql transaction: {}", err);
+                }
+
+                return Err(Error::from(err).into());
+            }
+        }
+    }
+
     async fn remove_mint_quote(&self, quote_id: &Uuid) -> Result<(), Self::Err> {
         let mut transaction = self.pool.begin().await.map_err(Error::from)?;
 

--- a/crates/cdk/src/cdk_database/mint_memory.rs
+++ b/crates/cdk/src/cdk_database/mint_memory.rs
@@ -194,6 +194,21 @@ impl MintDatabase for MintMemoryDatabase {
         Ok(self.mint_quotes.read().await.values().cloned().collect())
     }
 
+    async fn get_mint_quotes_with_state(
+        &self,
+        state: MintQuoteState,
+    ) -> Result<Vec<MintQuote>, Self::Err> {
+        let mint_quotes = self.mint_quotes.read().await;
+
+        let pending_quotes = mint_quotes
+            .values()
+            .filter(|q| q.state == state)
+            .cloned()
+            .collect();
+
+        Ok(pending_quotes)
+    }
+
     async fn remove_mint_quote(&self, quote_id: &Uuid) -> Result<(), Self::Err> {
         self.mint_quotes.write().await.remove(quote_id);
 

--- a/crates/cdk/src/mint/mint_nut04.rs
+++ b/crates/cdk/src/mint/mint_nut04.rs
@@ -178,23 +178,23 @@ impl Mint {
     /// Get pending mint quotes
     #[instrument(skip_all)]
     pub async fn get_pending_mint_quotes(&self) -> Result<Vec<MintQuote>, Error> {
-        let mint_quotes = self.localstore.get_mint_quotes().await?;
+        let mint_quotes = self
+            .localstore
+            .get_mint_quotes_with_state(MintQuoteState::Pending)
+            .await?;
 
-        Ok(mint_quotes
-            .into_iter()
-            .filter(|p| p.state == MintQuoteState::Pending)
-            .collect())
+        Ok(mint_quotes)
     }
 
     /// Get pending mint quotes
     #[instrument(skip_all)]
     pub async fn get_unpaid_mint_quotes(&self) -> Result<Vec<MintQuote>, Error> {
-        let mint_quotes = self.localstore.get_mint_quotes().await?;
+        let mint_quotes = self
+            .localstore
+            .get_mint_quotes_with_state(MintQuoteState::Unpaid)
+            .await?;
 
-        Ok(mint_quotes
-            .into_iter()
-            .filter(|p| p.state == MintQuoteState::Unpaid)
-            .collect())
+        Ok(mint_quotes)
     }
 
     /// Remove mint quote


### PR DESCRIPTION
Introduces a new mint `Database` method to filter mint quotes by states in-db to save some memory.