### PR TITLE
Fix minting and melting error on fresh `mintd` with RPC disabled

### DIFF
--- a/crates/cdk-mintd/src/main.rs
+++ b/crates/cdk-mintd/src/main.rs
@@ -22,7 +22,7 @@ use cdk::mint::{MintBuilder, MintMeltLimits};
 use cdk::nuts::nut17::SupportedMethods;
 use cdk::nuts::nut19::{CachedEndpoint, Method as NUT19Method, Path as NUT19Path};
 use cdk::nuts::{ContactInfo, CurrencyUnit, MintVersion, PaymentMethod};
-use cdk::types::LnKey;
+use cdk::types::{LnKey, QuoteTTL};
 use cdk_axum::cache::HttpCache;
 #[cfg(feature = "management-rpc")]
 use cdk_mint_rpc::MintRPCServer;
@@ -403,6 +403,7 @@ async fn main() -> anyhow::Result<()> {
     } else {
         tracing::warn!("RPC not enabled, using mint info from config.");
         mint.set_mint_info(mint_builder.mint_info).await?;
+        mint.set_quote_ttl(QuoteTTL::new(10_000, 10_000)).await?;
     }
 
     let axum_result = axum::Server::bind(


### PR DESCRIPTION
### Description

When a mint is started with
- a clean DB (i.e. not with a pre-existing DB from before the RPC flag was introduced in #543) and
- RPC disabled

then minting will fail with an "Unknown quote TTL" error.

This PR fixes this by setting default fallback values for the `QuoteTTL` on mint startuo, in case RPC is disabled.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

- Fixed mint and melt error on mint initialized with RPC interface disabled

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
