### PR TITLE
BYO network transport when minting tokens

### DIFF
--- a/crates/cashu/src/amount.rs
+++ b/crates/cashu/src/amount.rs
@@ -228,6 +228,16 @@ impl AmountStr {
     pub(crate) fn from(amt: Amount) -> Self {
         Self(amt)
     }
+
+    pub fn inner(&self) -> Amount {
+        self.0
+    }
+}
+
+impl From<Amount> for AmountStr {
+    fn from(amt: Amount) -> Self {
+        Self(amt)
+    }
 }
 
 impl PartialOrd<Self> for AmountStr {

--- a/crates/cdk-common/src/database/wallet.rs
+++ b/crates/cdk-common/src/database/wallet.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 
 use async_trait::async_trait;
+use cashu::PreMintSecrets;
 
 use super::Error;
 use crate::common::ProofInfo;
@@ -117,4 +118,17 @@ pub trait Database: Debug {
         verifying_key: PublicKey,
         last_checked: u32,
     ) -> Result<(), Self::Err>;
+
+    /// Store premint secrets
+    async fn add_premint_secrets(
+        &self,
+        quote_id: &str,
+        premint_secrets: &PreMintSecrets,
+    ) -> Result<(), Self::Err>;
+
+    /// Retrieve premint secrets
+    async fn get_premint_secrets(
+        &self,
+        quote_id: &str,
+    ) -> Result<Option<PreMintSecrets>, Self::Err>;
 }

--- a/crates/cdk-redb/src/wallet/mod.rs
+++ b/crates/cdk-redb/src/wallet/mod.rs
@@ -13,7 +13,8 @@ use cdk_common::mint_url::MintUrl;
 use cdk_common::util::unix_time;
 use cdk_common::wallet::{self, MintQuote};
 use cdk_common::{
-    database, CurrencyUnit, Id, KeySetInfo, Keys, MintInfo, PublicKey, SpendingConditions, State,
+    database, CurrencyUnit, Id, KeySetInfo, Keys, MintInfo, PreMintSecrets, PublicKey,
+    SpendingConditions, State,
 };
 use redb::{Database, MultimapTableDefinition, ReadableTable, TableDefinition};
 use tracing::instrument;
@@ -739,5 +740,20 @@ impl WalletDatabase for WalletRedbDatabase {
         write_txn.commit().map_err(Error::from)?;
 
         Ok(())
+    }
+
+    async fn add_premint_secrets(
+        &self,
+        quote_id: &str,
+        premint_secrets: &PreMintSecrets,
+    ) -> Result<(), Self::Err> {
+        todo!()
+    }
+
+    async fn get_premint_secrets(
+        &self,
+        quote_id: &str,
+    ) -> Result<Option<PreMintSecrets>, Self::Err> {
+        todo!()
     }
 }

--- a/crates/cdk-sqlite/src/wallet/mod.rs
+++ b/crates/cdk-sqlite/src/wallet/mod.rs
@@ -12,8 +12,8 @@ use cdk_common::nuts::{MeltQuoteState, MintQuoteState};
 use cdk_common::secret::Secret;
 use cdk_common::wallet::{self, MintQuote};
 use cdk_common::{
-    database, Amount, CurrencyUnit, Id, KeySetInfo, Keys, MintInfo, Proof, PublicKey, SecretKey,
-    SpendingConditions, State,
+    database, Amount, CurrencyUnit, Id, KeySetInfo, Keys, MintInfo, PreMintSecrets, Proof,
+    PublicKey, SecretKey, SpendingConditions, State,
 };
 use error::Error;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqliteRow};
@@ -777,6 +777,21 @@ VALUES (?, ?);
         .map_err(Error::from)?;
 
         Ok(())
+    }
+
+    async fn add_premint_secrets(
+        &self,
+        quote_id: &str,
+        premint_secrets: &PreMintSecrets,
+    ) -> Result<(), Self::Err> {
+        todo!()
+    }
+
+    async fn get_premint_secrets(
+        &self,
+        quote_id: &str,
+    ) -> Result<Option<PreMintSecrets>, Self::Err> {
+        todo!()
     }
 }
 

--- a/crates/cdk/src/wallet/keysets.rs
+++ b/crates/cdk/src/wallet/keysets.rs
@@ -25,14 +25,13 @@ impl Wallet {
         Ok(keys)
     }
 
-    /// Straight up yolo those keys into the db no cap
+    /// Add a keyset to the local database and update keyset info
     pub async fn add_keyset(
         &self,
         keys: Keys,
         active: bool,
         input_fee_ppk: u64,
     ) -> Result<(), Error> {
-        // add to localstore
         self.localstore.add_keys(keys.clone()).await?;
 
         let keyset_info = KeySetInfo {
@@ -42,7 +41,6 @@ impl Wallet {
             input_fee_ppk,
         };
 
-        // somehow also add to localstore...why do I need to make two different calls?
         self.localstore
             .add_mint_keysets(self.mint_url.clone(), vec![keyset_info])
             .await?;

--- a/crates/cdk/src/wallet/keysets.rs
+++ b/crates/cdk/src/wallet/keysets.rs
@@ -25,6 +25,31 @@ impl Wallet {
         Ok(keys)
     }
 
+    /// Straight up yolo those keys into the db no cap
+    pub async fn add_keyset(
+        &self,
+        keys: Keys,
+        active: bool,
+        input_fee_ppk: u64,
+    ) -> Result<(), Error> {
+        // add to localstore
+        self.localstore.add_keys(keys.clone()).await?;
+
+        let keyset_info = KeySetInfo {
+            id: Id::from(&keys),
+            active,
+            unit: self.unit.clone(),
+            input_fee_ppk,
+        };
+
+        // somehow also add to localstore...why do I need to make two different calls?
+        self.localstore
+            .add_mint_keysets(self.mint_url.clone(), vec![keyset_info])
+            .await?;
+
+        Ok(())
+    }
+
     /// Get keysets for mint
     ///
     /// Queries mint for all keysets
@@ -96,5 +121,110 @@ impl Wallet {
             .min_by_key(|key| key.input_fee_ppk)
             .ok_or(Error::NoActiveKeyset)?;
         Ok(keyset_with_lowest_fee)
+    }
+
+    /// Get active keyset for mint from local without querying the mint
+    #[instrument(skip(self))]
+    pub async fn get_active_mint_keyset_local(&self) -> Result<KeySetInfo, Error> {
+        let active_keysets = match self
+            .localstore
+            .get_mint_keysets(self.mint_url.clone())
+            .await?
+        {
+            Some(keysets) => keysets
+                .into_iter()
+                .filter(|k| k.active && k.unit == self.unit)
+                .collect::<Vec<KeySetInfo>>(),
+            None => {
+                vec![]
+            }
+        };
+
+        let keyset_with_lowest_fee = active_keysets
+            .into_iter()
+            .min_by_key(|key| key.input_fee_ppk)
+            .ok_or(Error::NoActiveKeyset)?;
+
+        Ok(keyset_with_lowest_fee)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::cdk_database::WalletMemoryDatabase;
+    use crate::nuts;
+    use crate::Wallet;
+    use bitcoin::bip32::DerivationPath;
+    use bitcoin::bip32::Xpriv;
+    use bitcoin::key::Secp256k1;
+    use cdk_common::KeySet;
+    use cdk_common::KeySetInfo;
+    use cdk_common::MintKeySet;
+    use nuts::CurrencyUnit;
+    use std::sync::Arc;
+
+    fn create_new_keyset() -> (KeySet, KeySetInfo) {
+        let secp = Secp256k1::new();
+        let seed = [0u8; 32]; // Default seed for testing
+        let xpriv = Xpriv::new_master(bitcoin::Network::Bitcoin, &seed).expect("RNG busted");
+
+        let derivation_path = DerivationPath::default();
+        let unit = CurrencyUnit::Custom("HASH".to_string());
+        let max_order = 64;
+
+        let keyset: KeySet = MintKeySet::generate(
+            &secp,
+            xpriv
+                .derive_priv(&secp, &derivation_path)
+                .expect("RNG busted"),
+            unit.clone(),
+            max_order,
+        )
+        .into();
+
+        let keyset_info = KeySetInfo {
+            id: keyset.id,
+            unit: keyset.unit.clone(),
+            active: true,
+            input_fee_ppk: 0,
+        };
+
+        (keyset, keyset_info)
+    }
+
+    fn create_wallet() -> Wallet {
+        use rand::Rng;
+
+        let seed = rand::thread_rng().gen::<[u8; 32]>();
+        let mint_url = "https://testnut.cashu.space";
+
+        let localstore = WalletMemoryDatabase::default();
+        Wallet::new(
+            mint_url,
+            CurrencyUnit::Custom("HASH".to_string()),
+            Arc::new(localstore),
+            &seed,
+            None,
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_add_and_get_active_mint_keysets_local() {
+        let (keyset, keyset_info) = create_new_keyset();
+
+        let wallet = create_wallet();
+
+        // Add the keyset
+        wallet.add_keyset(keyset.keys, true, 0).await.unwrap();
+
+        // Retrieve the keysets locally
+        let active_keyset = wallet.get_active_mint_keyset_local().await.unwrap();
+
+        // Validate the retrieved keyset
+        assert_eq!(active_keyset.id, keyset_info.id);
+        assert_eq!(active_keyset.active, keyset_info.active);
+        assert_eq!(active_keyset.unit, keyset_info.unit);
+        assert_eq!(active_keyset.input_fee_ppk, keyset_info.input_fee_ppk);
     }
 }

--- a/crates/cdk/src/wallet/mint.rs
+++ b/crates/cdk/src/wallet/mint.rs
@@ -1,3 +1,4 @@
+use cdk_common::{BlindSignature, CurrencyUnit};
 use tracing::instrument;
 
 use super::MintQuote;
@@ -5,7 +6,7 @@ use crate::amount::SplitTarget;
 use crate::dhke::construct_proofs;
 use crate::nuts::nut00::ProofsMethods;
 use crate::nuts::{
-    nut12, MintBolt11Request, MintQuoteBolt11Request, MintQuoteBolt11Response, PreMintSecrets,
+    nut12, Id, MintBolt11Request, MintQuoteBolt11Request, MintQuoteBolt11Response, PreMintSecrets,
     Proofs, SecretKey, SpendingConditions, State,
 };
 use crate::types::ProofInfo;
@@ -288,5 +289,196 @@ impl Wallet {
         self.localstore.update_proofs(proof_infos, vec![]).await?;
 
         Ok(proofs)
+    }
+
+    /// Generates blinded secrets to send to the mint for signing. This function
+    /// is appropriate if the caller is providing their own network
+    /// transport. Otherwise use `mint`, which makes a network request to
+    /// the mint.
+    ///
+    /// # Parameters
+    ///
+    /// - `&self`: A reference to the current instance
+    /// - `active_keyset_id`: The ID of the active keyset
+    /// - `quote_info_amount`: The amount to be minted
+    /// - `amount_split_target`: Strategy for splitting amount into discrete
+    ///   tokens
+    /// - `spending_conditions`: Optional spending conditions to apply to the
+    ///   minted tokens
+    /// - `count`: How many tokens were previously generated from this keyset +
+    ///   1
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing `PreMintSecrets` if successful, or an `Error`
+    /// otherwise.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the creation of `PreMintSecrets`
+    /// fails.
+    ///
+    /// ```
+    pub fn generate_premint_secrets(
+        &self,
+        active_keyset_id: Id,
+        quote_info_amount: Amount,
+        amount_split_target: &SplitTarget,
+        spending_conditions: Option<&SpendingConditions>,
+        count: u32,
+    ) -> Result<PreMintSecrets, Error> {
+        let premint_secrets = match &spending_conditions {
+            Some(spending_conditions) => PreMintSecrets::with_conditions(
+                active_keyset_id,
+                quote_info_amount,
+                amount_split_target,
+                spending_conditions,
+            )?,
+            None => PreMintSecrets::from_xpriv(
+                active_keyset_id,
+                count,
+                self.xpriv,
+                quote_info_amount,
+                amount_split_target,
+            )?,
+        };
+
+        Ok(premint_secrets)
+    }
+
+    pub async fn gen_ehash_premint_secrets(
+        &self,
+        amount: u64,
+        quote_id: &str,
+        mint_url: &str,
+    ) -> Result<PreMintSecrets, Error> {
+        // check for existing quote
+        if let Some(_) = self.localstore.get_mint_quote(quote_id).await? {
+            return Err(Error::PaidQuote);
+        }
+        self.localstore
+            .add_mint_quote(MintQuote {
+                id: quote_id.to_string(),
+                mint_url: mint_url.parse()?,
+                amount: Amount::from(amount),
+                unit: CurrencyUnit::Custom("HASH".to_string()),
+                // TODO what to put here? needs to identify the mining share
+                // probably channel_id:sequence_number
+                request: "todo".to_string(),
+                state: MintQuoteState::Paid,
+                // TODO should we set an expiry?
+                expiry: u64::MAX,
+                secret_key: None,
+            })
+            .await?;
+
+        let active_keyset_id = self.get_active_mint_keyset_local().await?.id;
+
+        let count = self
+            .localstore
+            .get_keyset_counter(&active_keyset_id)
+            .await?;
+
+        let count = count.map_or(0, |c| c + 1);
+
+        let premint_secrets = self.generate_premint_secrets(
+            active_keyset_id,
+            // TODO when do we want to set amount?
+            Amount::from(amount),
+            &SplitTarget::None,
+            None,
+            count,
+        )?;
+
+        self.localstore
+            .add_premint_secrets(quote_id, &premint_secrets)
+            .await?;
+
+        Ok(premint_secrets)
+    }
+
+    pub async fn gen_ehash_proofs(
+        &self,
+        signatures: [Option<BlindSignature>; 64],
+        quote_id: &str,
+    ) -> Result<Amount, Error> {
+        // TODO pass this in, it will break if the keyset changes before getting proofs
+        let active_keyset_id = self.get_active_mint_keyset_local().await?.id;
+        let keys = self.get_keyset_keys(active_keyset_id).await?;
+        let premint_secrets = match self.localstore.get_premint_secrets(quote_id).await? {
+            Some(premint_secrets) => premint_secrets,
+            None => return Err(Error::UnknownQuote),
+        };
+
+        if premint_secrets.keyset_id != active_keyset_id {
+            return Err(Error::UnknownKeySet);
+        }
+
+        let mut verified_signatures = Vec::new();
+        let mut premint_rs = Vec::new();
+        let mut premint_secrets_vec = Vec::new();
+
+        // verify each signature
+        for sig_opt in signatures.iter() {
+            if let Some(sig) = sig_opt {
+                // Find the secret corresponding to the signature using amount field
+                if let Some(matching_secret) = premint_secrets
+                    .secrets
+                    .iter()
+                    .find(|secret| secret.amount == sig.amount)
+                {
+                    // Ensure the keyset for the signature matches the active keyset
+                    let keys = self.get_keyset_keys(sig.keyset_id).await?;
+                    let key = keys.amount_key(sig.amount).ok_or(Error::AmountKey)?;
+
+                    match sig.verify_dleq(key, matching_secret.blinded_message.blinded_secret) {
+                        Ok(_) | Err(nut12::Error::MissingDleqProof) => {
+                            // Add verified signature and related premint data
+                            verified_signatures.push(sig.clone());
+                            premint_rs.push(matching_secret.r.clone());
+                            premint_secrets_vec.push(matching_secret.secret.clone());
+                        }
+                        Err(_) => return Err(Error::CouldNotVerifyDleq),
+                    }
+                } else {
+                    return Err(Error::Custom(String::from("Secret not found")));
+                }
+            }
+        }
+
+        // Construct proofs
+        let proofs = construct_proofs(verified_signatures, premint_rs, premint_secrets_vec, &keys)?;
+        // TODO rebase to latest master and remove this (proofs are returned now)
+        println!("proofs {:?}", proofs);
+
+        let minted_amount = proofs.total_amount()?;
+
+        // update keyset token counter
+        self.localstore
+            .increment_keyset_counter(&active_keyset_id, proofs.len() as u32)
+            .await?;
+
+        let proofs = proofs
+            .into_iter()
+            .map(|proof| {
+                ProofInfo::new(
+                    proof,
+                    self.mint_url.clone(),
+                    State::Unspent,
+                    CurrencyUnit::Custom("HASH".to_string()),
+                )
+            })
+            .collect::<Result<Vec<ProofInfo>, _>>()?;
+
+        // store new proofs in wallet
+        self.localstore
+            .update_proofs(proofs.clone(), vec![])
+            .await?;
+
+        // Remove Quote
+        // TODO handle result
+        self.localstore.remove_mint_quote(quote_id).await;
+
+        Ok(minted_amount)
     }
 }


### PR DESCRIPTION
### Description

Hashpool operates on a slightly different model from typical ecash mints. It generates ecash tokens atomically when validating mining pool shares. In order to accomplish atomicity we need to piggyback the ecash operations on existing mining protocol messages. This means the ecash mint and wallet will not be able to make synchronous HTTP calls during the process of minting new tokens, which is the default assumption in cdk.

Here's the new flow:
1. miner finds a valid share above the pool difficulty threshold
1. proxy/wallet generates a new premint secret and saves it to the wallet
1. proxy/wallet submits a mining share and premint secret to the pool/mint
1. pool validates the mining share
1. mint creates a new quote using the block header hash of the mining share as a quote ID (is this necessary or useful?)
1. mint signs the blinded secret
1. pool returns this signature in the 'mining share accepted' message payload
1. proxy receives the signature from the mint
1. proxy retrieves the blinded secret from the cashu wallet
1. wallet validates the signature and stores the proof as an ecash token

There are two main differences with this design:
1. the wallet must store keysets and blinded secrets locally
2. the wallet must rely on local information about the mint rather than querying the mint at will

-----

### Notes to the reviewers

I have exposed some helper functions to convert between `Amount` and `AmountStr`. This helps the wallet store blinded secrets using a BTreeMap. This is kind of a code smell (Why are we converting to a string for indexing purposes? Shouldn't the data structure handle this for us?) but it was the shortest path to victory during development. I'm not sure if this is necessary. Hoping to get some clarity in this PR.

I didn't discuss it in the minting flow above but mint keysets will be propagated by the pool in a mining message payload and stored locally in the wallet. This requires a new function to add mint keysets to the wallet without making any HTTP calls.

I have opened this PR in draft state with many TODO comments and macros. I will fix these issues in due time but I wanted to get feedback on my general approach.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
