### PR TITLE
fix openApi attributes to keyset id to present it as a string

### DIFF
--- a/crates/cashu/src/nuts/nut00/mod.rs
+++ b/crates/cashu/src/nuts/nut00/mod.rs
@@ -116,6 +116,7 @@ pub struct BlindedMessage {
     ///
     /// ID from which we expect a signature.
     #[serde(rename = "id")]
+    #[cfg_attr(feature = "swagger", schema(value_type = String))]
     pub keyset_id: Id,
     /// Blinded secret message (B_)
     ///
@@ -161,6 +162,7 @@ pub struct BlindSignature {
     ///
     /// ID of the mint keys that signed the token.
     #[serde(rename = "id")]
+    #[cfg_attr(feature = "swagger", schema(value_type = String))]
     pub keyset_id: Id,
     /// Blinded signature (C_)
     ///
@@ -240,6 +242,7 @@ pub struct Proof {
     pub amount: Amount,
     /// `Keyset id`
     #[serde(rename = "id")]
+    #[cfg_attr(feature = "swagger", schema(value_type = String))]
     pub keyset_id: Id,
     /// Secret message
     #[cfg_attr(feature = "swagger", schema(value_type = String))]

--- a/crates/cashu/src/nuts/nut02.rs
+++ b/crates/cashu/src/nuts/nut02.rs
@@ -51,7 +51,6 @@ pub enum Error {
 
 /// Keyset version
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 pub enum KeySetVersion {
     /// Current Version 00
     Version00,
@@ -88,7 +87,6 @@ impl fmt::Display for KeySetVersion {
 /// which mint or keyset it was generated from.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(into = "String", try_from = "String")]
-#[cfg_attr(feature = "swagger", derive(utoipa::ToSchema), schema(as = String))]
 pub struct Id {
     version: KeySetVersion,
     id: [u8; Self::BYTELEN],
@@ -221,6 +219,7 @@ pub struct KeysetResponse {
 #[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 pub struct KeySet {
     /// Keyset [`Id`]
+    #[cfg_attr(feature = "swagger", schema(value_type = String))]
     pub id: Id,
     /// Keyset [`CurrencyUnit`]
     pub unit: CurrencyUnit,
@@ -257,6 +256,7 @@ impl From<MintKeySet> for KeySet {
 #[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 pub struct KeySetInfo {
     /// Keyset [`Id`]
+    #[cfg_attr(feature = "swagger", schema(value_type = String))]
     pub id: Id,
     /// Keyset [`CurrencyUnit`]
     pub unit: CurrencyUnit,

--- a/crates/cdk-axum/src/lib.rs
+++ b/crates/cdk-axum/src/lib.rs
@@ -24,7 +24,7 @@ mod swagger_imports {
         BlindSignature, BlindedMessage, CurrencyUnit, PaymentMethod, Proof, Witness,
     };
     pub use cdk::nuts::nut01::{Keys, KeysResponse, PublicKey, SecretKey};
-    pub use cdk::nuts::nut02::{Id, KeySet, KeySetInfo, KeySetVersion, KeysetResponse};
+    pub use cdk::nuts::nut02::{KeySet, KeySetInfo, KeysetResponse};
     pub use cdk::nuts::nut03::{SwapRequest, SwapResponse};
     pub use cdk::nuts::nut04::{
         MintBolt11Request, MintBolt11Response, MintMethodSettings, MintQuoteBolt11Request,
@@ -70,13 +70,11 @@ pub struct MintState {
         ErrorCode,
         ErrorResponse,
         HTLCWitness,
-        Id,
         Keys,
         KeysResponse,
         KeysetResponse,
         KeySet,
         KeySetInfo,
-        KeySetVersion,
         MeltBolt11Request<Uuid>,
         MeltQuoteBolt11Request,
         MeltQuoteBolt11Response<Uuid>,


### PR DESCRIPTION


### Description
The attribute `schema(as = String)` does not result in the expected behaviour.
It does not convert Id to being represented as a simple string, but rather simply rename the type `Id` to `String`.

Current openapi.json  file on master
```json
    "components": {
        "schemas": {
...
            "BlindedMessage": {
                "type": "object",
                "description": "Blinded Message (also called `output`)",
                "required": [
                    "amount",
                    "id",
                    "B_"
                ],
                "properties": {
                    "amount": {
                        "$ref": "#/components/schemas/Amount"
                    },
                    "id": {
                        "$ref": "#/components/schemas/Id"
                    },
                    "B_": {
                        "type": "string",
                        "description": "Blinded secret message (B_)\n\nThe blinded secret message generated by the sender."
                    },
                    "witness": {
                        "allOf": [
                            {
                                "$ref": "#/components/schemas/Witness"
                            }
                        ],
                        "nullable": true
                    }
                }
            },
...
            "String": {
                "type": "object",
                "description": "A keyset ID is an identifier for a specific keyset. It can be derived by\nanyone who knows the set of public keys of a mint. The keyset ID **CAN**\nbe stored in a Cashu token such that the token can be used to identify\nwhich mint or keyset it was generated from.",
                "required": [
                    "version",
                    "id"
                ],
                "properties": {
                    "version": {
                        "$ref": "#/components/schemas/KeySetVersion"
                    },
                    "id": {
                        "type": "string",
                        "format": "binary"
                    }
                }
            },
...

```
 openapi.json with this PR
 ```json
    "components": {
        "schemas": {
...
            "BlindedMessage": {
                "type": "object",
                "description": "Blinded Message (also called `output`)",
                "required": [
                    "amount",
                    "id",
                    "B_"
                ],
                "properties": {
                    "amount": {
                        "$ref": "#/components/schemas/Amount"
                    },
                    "id": {
                        "type": "string",
                        "description": "Keyset ID\n\nID from which we expect a signature."
                    },
                    "B_": {
                        "type": "string",
                        "description": "Blinded secret message (B_)\n\nThe blinded secret message generated by the sender."
                    },
                    "witness": {
                        "allOf": [
                            {
                                "$ref": "#/components/schemas/Witness"
                            }
                        ],
                        "nullable": true
                    }
                }
            },
```

The error can also be seen in browser when navigating to `/swagger-ui` and opening documentation for any endpoint that involves a message containing a keyset Id, like for instance `/v1/melt/quote/bolt11/{quote_id}`.
At the top of screen the error message `Could not resolve reference: Could not resolve pointer: /components/schemas/Id does not exist in document` appears.
