### PR TITLE
chore: pin base64ct as newer version is unsuported on stable

### DIFF
--- a/crates/cdk-cli/Cargo.toml
+++ b/crates/cdk-cli/Cargo.toml
@@ -36,3 +36,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "socks",
 ]}
 url = "2.3"
+
+# Indirect dep
+base64ct = "=1.6.0"
+


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
