### PR TITLE
Make "just format" use the nightly toolchain

### DIFF
--- a/justfile
+++ b/justfile
@@ -35,7 +35,7 @@ format:
   if [ ! -f Cargo.toml ]; then
     cd {{invocation_directory()}}
   fi
-  cargo fmt --all
+  cargo +nightly fmt --all
   nixpkgs-fmt $(echo **.nix)
 
 # run tests


### PR DESCRIPTION
This PR enforces the nightly toolchain when calling `just format`.