### PR TITLE
Add `ensure_cdk` macro for validation checks

### DIFF
--- a/crates/cashu/src/lib.rs
+++ b/crates/cashu/src/lib.rs
@@ -15,3 +15,13 @@ pub use lightning_invoice::{self, Bolt11Invoice};
 pub use self::amount::Amount;
 pub use self::nuts::*;
 pub use self::util::SECP256K1;
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! ensure_cdk {
+    ($cond:expr, $err:expr) => {
+        if !$cond {
+            return Err($err);
+        }
+    };
+}

--- a/crates/cashu/src/mint_url.rs
+++ b/crates/cashu/src/mint_url.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::{ParseError, Url};
 
+use crate::ensure_cdk;
+
 /// Url Error
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum Error {
@@ -27,9 +29,8 @@ pub struct MintUrl(String);
 
 impl MintUrl {
     fn format_url(url: &str) -> Result<String, Error> {
-        if url.is_empty() {
-            return Err(Error::InvalidUrl);
-        }
+        ensure_cdk!(!url.is_empty(), Error::InvalidUrl);
+
         let url = url.trim_end_matches('/');
         // https://URL.com/path/TO/resource -> https://url.com/path/TO/resource
         let protocol = url

--- a/crates/cashu/src/nuts/nut02.rs
+++ b/crates/cashu/src/nuts/nut02.rs
@@ -25,7 +25,7 @@ use super::nut01::Keys;
 use super::nut01::{MintKeyPair, MintKeys};
 use crate::nuts::nut00::CurrencyUnit;
 use crate::util::hex;
-use crate::Amount;
+use crate::{ensure_cdk, Amount};
 
 /// NUT02 Error
 #[derive(Debug, Error)]
@@ -144,9 +144,7 @@ impl TryFrom<String> for Id {
     type Error = Error;
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
-        if s.len() != 16 {
-            return Err(Error::Length);
-        }
+        ensure_cdk!(s.len() == 16, Error::Length);
 
         Ok(Self {
             version: KeySetVersion::from_byte(&hex::decode(&s[..2])?[0])?,
@@ -230,9 +228,7 @@ impl KeySet {
     pub fn verify_id(&self) -> Result<(), Error> {
         let keys_id: Id = (&self.keys).into();
 
-        if keys_id != self.id {
-            return Err(Error::IncorrectKeysetId);
-        }
+        ensure_cdk!(keys_id == self.id, Error::IncorrectKeysetId);
 
         Ok(())
     }

--- a/crates/cashu/src/nuts/nut14/mod.rs
+++ b/crates/cashu/src/nuts/nut14/mod.rs
@@ -14,6 +14,7 @@ use super::nut00::Witness;
 use super::nut10::Secret;
 use super::nut11::valid_signatures;
 use super::{Conditions, Proof};
+use crate::ensure_cdk;
 use crate::util::unix_time;
 
 pub mod serde_htlc_witness;
@@ -112,9 +113,8 @@ impl Proof {
                     .map(|s| Signature::from_str(s))
                     .collect::<Result<Vec<Signature>, _>>()?;
 
-                if valid_signatures(self.secret.as_bytes(), &pubkey, &signatures).lt(&req_sigs) {
-                    return Err(Error::IncorrectSecretKind);
-                }
+                let valid_sigs = valid_signatures(self.secret.as_bytes(), &pubkey, &signatures);
+                ensure_cdk!(valid_sigs >= req_sigs, Error::IncorrectSecretKind);
             }
         }
 

--- a/crates/cashu/src/util/hex.rs
+++ b/crates/cashu/src/util/hex.rs
@@ -5,6 +5,8 @@
 
 use core::fmt;
 
+use crate::ensure_cdk;
+
 /// Hex error
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
@@ -76,9 +78,7 @@ where
     let hex = hex.as_ref();
     let len = hex.len();
 
-    if len % 2 != 0 {
-        return Err(Error::OddLength);
-    }
+    ensure_cdk!(len % 2 == 0, Error::OddLength);
 
     let mut bytes: Vec<u8> = Vec::with_capacity(len / 2);
 

--- a/crates/cdk-common/src/lib.rs
+++ b/crates/cdk-common/src/lib.rs
@@ -24,4 +24,4 @@ pub use cashu::mint;
 pub use cashu::nuts::{self, *};
 #[cfg(feature = "wallet")]
 pub use cashu::wallet;
-pub use cashu::{dhke, mint_url, secret, util, SECP256K1};
+pub use cashu::{dhke, ensure_cdk, mint_url, secret, util, SECP256K1};

--- a/crates/cdk-fake-wallet/src/lib.rs
+++ b/crates/cdk-fake-wallet/src/lib.rs
@@ -19,10 +19,10 @@ use cdk::amount::{Amount, MSAT_IN_SAT};
 use cdk::cdk_lightning::{
     self, CreateInvoiceResponse, MintLightning, PayInvoiceResponse, PaymentQuoteResponse, Settings,
 };
-use cdk::mint;
 use cdk::mint::FeeReserve;
 use cdk::nuts::{CurrencyUnit, MeltQuoteBolt11Request, MeltQuoteState, MintQuoteState};
 use cdk::util::unix_time;
+use cdk::{ensure_cdk, mint};
 use error::Error;
 use futures::stream::StreamExt;
 use futures::Stream;
@@ -182,9 +182,7 @@ impl MintLightning for FakeWallet {
                 fail.insert(payment_hash.clone());
             }
 
-            if description.pay_err {
-                return Err(Error::UnknownInvoice.into());
-            }
+            ensure_cdk!(!description.pay_err, Error::UnknownInvoice.into());
         }
 
         Ok(PayInvoiceResponse {

--- a/crates/cdk/src/lib.rs
+++ b/crates/cdk/src/lib.rs
@@ -22,7 +22,7 @@ pub mod pub_sub;
 /// Re-export amount type
 #[doc(hidden)]
 pub use cdk_common::{
-    amount, common as types, dhke,
+    amount, common as types, dhke, ensure_cdk,
     error::{self, Error},
     lightning_invoice, mint_url, nuts, secret, util, ws, Amount, Bolt11Invoice,
 };

--- a/crates/cdk/src/mint/mint_nut04.rs
+++ b/crates/cdk/src/mint/mint_nut04.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::nuts::MintQuoteState;
 use crate::types::LnKey;
 use crate::util::unix_time;
-use crate::{Amount, Error};
+use crate::{ensure_cdk, Amount, Error};
 
 impl Mint {
     /// Checks that minting is enabled, request is supported unit and within range
@@ -21,38 +21,28 @@ impl Mint {
         let mint_info = self.localstore.get_mint_info().await?;
         let nut04 = &mint_info.nuts.nut04;
 
-        if nut04.disabled {
-            return Err(Error::MintingDisabled);
-        }
+        ensure_cdk!(!nut04.disabled, Error::MintingDisabled);
 
-        match nut04.get_settings(unit, &PaymentMethod::Bolt11) {
-            Some(settings) => {
-                if settings
-                    .max_amount
-                    .map_or(false, |max_amount| amount > max_amount)
-                {
-                    return Err(Error::AmountOutofLimitRange(
-                        settings.min_amount.unwrap_or_default(),
-                        settings.max_amount.unwrap_or_default(),
-                        amount,
-                    ));
-                }
+        let settings = nut04
+            .get_settings(unit, &PaymentMethod::Bolt11)
+            .ok_or(Error::UnsupportedUnit)?;
 
-                if settings
-                    .min_amount
-                    .map_or(false, |min_amount| amount < min_amount)
-                {
-                    return Err(Error::AmountOutofLimitRange(
-                        settings.min_amount.unwrap_or_default(),
-                        settings.max_amount.unwrap_or_default(),
-                        amount,
-                    ));
-                }
-            }
-            None => {
-                return Err(Error::UnsupportedUnit);
-            }
-        }
+        let is_above_max = settings
+            .max_amount
+            .map_or(false, |max_amount| amount > max_amount);
+        let is_below_min = settings
+            .min_amount
+            .map_or(false, |min_amount| amount < min_amount);
+        let is_out_of_range = is_above_max || is_below_min;
+
+        ensure_cdk!(
+            !is_out_of_range,
+            Error::AmountOutofLimitRange(
+                settings.min_amount.unwrap_or_default(),
+                settings.max_amount.unwrap_or_default(),
+                amount,
+            )
+        );
 
         Ok(())
     }
@@ -263,12 +253,11 @@ impl Mint {
         &self,
         mint_request: nut04::MintBolt11Request<Uuid>,
     ) -> Result<nut04::MintBolt11Response, Error> {
-        let mint_quote =
-            if let Some(mint_quote) = self.localstore.get_mint_quote(&mint_request.quote).await? {
-                mint_quote
-            } else {
-                return Err(Error::UnknownQuote);
-            };
+        let mint_quote = self
+            .localstore
+            .get_mint_quote(&mint_request.quote)
+            .await?
+            .ok_or(Error::UnknownQuote)?;
 
         let state = self
             .localstore
@@ -329,9 +318,7 @@ impl Mint {
             ));
         }
 
-        if unit != mint_quote.unit {
-            return Err(Error::UnsupportedUnit);
-        }
+        ensure_cdk!(unit == mint_quote.unit, Error::UnsupportedUnit);
 
         let mut blind_signatures = Vec::with_capacity(mint_request.outputs.len());
 

--- a/crates/cdk/src/wallet/multi_mint_wallet.rs
+++ b/crates/cdk/src/wallet/multi_mint_wallet.rs
@@ -18,7 +18,7 @@ use crate::mint_url::MintUrl;
 use crate::nuts::{CurrencyUnit, MeltOptions, Proof, Proofs, SecretKey, SpendingConditions, Token};
 use crate::types::Melted;
 use crate::wallet::types::MintQuote;
-use crate::{Amount, Wallet};
+use crate::{ensure_cdk, Amount, Wallet};
 
 /// Multi Mint Wallet
 #[derive(Debug, Clone)]
@@ -271,9 +271,7 @@ impl MultiMintWallet {
 
         let quote = wallet.melt_quote(bolt11.to_string(), options).await?;
         if let Some(max_fee) = max_fee {
-            if quote.fee_reserve > max_fee {
-                return Err(Error::MaxFeeExceeded);
-            }
+            ensure_cdk!(quote.fee_reserve <= max_fee, Error::MaxFeeExceeded);
         }
 
         wallet.melt(&quote.id).await

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -8,7 +8,7 @@ use crate::nuts::{
     CheckStateRequest, Proof, ProofState, Proofs, PublicKey, SpendingConditions, State,
 };
 use crate::types::ProofInfo;
-use crate::{Amount, Error, Wallet};
+use crate::{ensure_cdk, Amount, Error, Wallet};
 
 impl Wallet {
     /// Get unspent proofs for mint
@@ -166,9 +166,7 @@ impl Wallet {
             amount,
             proofs.total_amount()?
         );
-        if proofs.total_amount()? < amount {
-            return Err(Error::InsufficientFunds);
-        }
+        ensure_cdk!(proofs.total_amount()? >= amount, Error::InsufficientFunds);
 
         let (mut proofs_larger, mut proofs_smaller): (Proofs, Proofs) =
             proofs.into_iter().partition(|p| p.amount > amount);

--- a/crates/cdk/src/wallet/swap.rs
+++ b/crates/cdk/src/wallet/swap.rs
@@ -7,7 +7,7 @@ use crate::nuts::{
     nut10, PreMintSecrets, PreSwap, Proofs, PublicKey, SpendingConditions, State, SwapRequest,
 };
 use crate::types::ProofInfo;
-use crate::{Amount, Error, Wallet};
+use crate::{ensure_cdk, Amount, Error, Wallet};
 
 impl Wallet {
     /// Swap
@@ -161,9 +161,7 @@ impl Wallet {
             },
         );
 
-        if proofs_sum < amount {
-            return Err(Error::InsufficientFunds);
-        }
+        ensure_cdk!(proofs_sum >= amount, Error::InsufficientFunds);
 
         let proofs = self.select_proofs_to_swap(amount, available_proofs).await?;
 


### PR DESCRIPTION
### Description

This PR brings the `ensure_cdk` macro, which is similar to `anyhow::ensure`.

It lets us replace validation steps like

```rust
if !flag {
  return Err(CustomError::Type);
}
```

with

```rust
ensure_cdk!(flag, CustomError::Type);
```

which helps make with code more readable and maintainable.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

* Improve code readability: introduce `ensure_cdk`

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
