### PR TITLE
Simplify `process_swap_request`

### DIFF
--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -157,9 +157,7 @@ pub async fn create_and_start_test_mint() -> anyhow::Result<Arc<Mint>> {
 
     let mut mint_builder = MintBuilder::new();
 
-    let database = cdk_sqlite::mint::memory::empty()
-        .await
-        .expect("valid db instance");
+    let database = cdk_sqlite::mint::memory::empty().await?;
 
     let localstore = Arc::new(database);
     mint_builder = mint_builder.with_localstore(localstore.clone());
@@ -216,9 +214,7 @@ pub async fn create_test_wallet_for_mint(mint: Arc<Mint>) -> anyhow::Result<Arc<
     let seed = Mnemonic::generate(12)?.to_seed_normalized("");
     let mint_url = "http://aa".to_string();
     let unit = CurrencyUnit::Sat;
-    let localstore = cdk_sqlite::wallet::memory::empty()
-        .await
-        .expect("valid db instance");
+    let localstore = cdk_sqlite::wallet::memory::empty().await?;
     let mut wallet = Wallet::new(&mint_url, unit, Arc::new(localstore), &seed, None)?;
 
     wallet.set_client(connector);

--- a/crates/cdk-integration-tests/tests/fake_wallet.rs
+++ b/crates/cdk-integration-tests/tests/fake_wallet.rs
@@ -996,17 +996,10 @@ async fn test_fake_mint_swap_spend_after_fail() -> Result<()> {
 
     match response {
         Err(err) => match err {
-            cdk::Error::TokenAlreadySpent => (),
-            err => {
-                bail!(
-                    "Wrong mint error returned expected already spent: {}",
-                    err.to_string()
-                );
-            }
+            cdk::Error::TransactionUnbalanced(_, _, _) => (),
+            err => bail!("Wrong mint error returned expected TransactionUnbalanced, got: {err}"),
         },
-        Ok(_) => {
-            bail!("Should not have allowed swap with unbalanced");
-        }
+        Ok(_) => bail!("Should not have allowed swap with unbalanced"),
     }
 
     let pre_mint = PreMintSecrets::random(active_keyset_id, 100.into(), &SplitTarget::None)?;
@@ -1076,14 +1069,10 @@ async fn test_fake_mint_melt_spend_after_fail() -> Result<()> {
 
     match response {
         Err(err) => match err {
-            cdk::Error::TokenAlreadySpent => (),
-            err => {
-                bail!("Wrong mint error returned: {}", err.to_string());
-            }
+            cdk::Error::TransactionUnbalanced(_, _, _) => (),
+            err => bail!("Wrong mint error returned expected TransactionUnbalanced, got: {err}"),
         },
-        Ok(_) => {
-            bail!("Should not have allowed to mint with multiple units");
-        }
+        Ok(_) => bail!("Should not have allowed swap with unbalanced"),
     }
 
     let input_amount: u64 = proofs.total_amount()?.into();

--- a/crates/cdk-sqlite/src/wallet/memory.rs
+++ b/crates/cdk-sqlite/src/wallet/memory.rs
@@ -6,7 +6,11 @@ use super::WalletSqliteDatabase;
 
 /// Creates a new in-memory [`WalletSqliteDatabase`] instance
 pub async fn empty() -> Result<WalletSqliteDatabase, Error> {
-    let db = WalletSqliteDatabase::new(":memory:").await?;
+    let db = WalletSqliteDatabase {
+        pool: sqlx::sqlite::SqlitePool::connect(":memory:")
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?,
+    };
     db.migrate().await;
     Ok(db)
 }

--- a/crates/cdk/src/mint/swap.rs
+++ b/crates/cdk/src/mint/swap.rs
@@ -12,8 +12,6 @@ impl Mint {
         &self,
         swap_request: SwapRequest,
     ) -> Result<SwapResponse, Error> {
-        let input_ys = swap_request.inputs.ys()?;
-
         if let Err(err) = self
             .verify_transaction_balanced(&swap_request.inputs, &swap_request.outputs)
             .await
@@ -22,27 +20,14 @@ impl Mint {
             return Err(err);
         };
 
+        self.validate_sig_flag(&swap_request).await?;
+
+        // After swap request is fully validated, add the new proofs to DB
+        let input_ys = swap_request.inputs.ys()?;
         self.localstore
             .add_proofs(swap_request.inputs.clone(), None)
             .await?;
         self.check_ys_spendable(&input_ys, State::Pending).await?;
-
-        let EnforceSigFlag {
-            sig_flag,
-            pubkeys,
-            sigs_required,
-        } = enforce_sig_flag(swap_request.inputs.clone());
-
-        if sig_flag.eq(&SigFlag::SigAll) {
-            let pubkeys = pubkeys.into_iter().collect();
-            for blinded_message in &swap_request.outputs {
-                if let Err(err) = blinded_message.verify_p2pk(&pubkeys, sigs_required) {
-                    tracing::info!("Could not verify p2pk in swap request");
-                    self.localstore.remove_proofs(&input_ys, None).await?;
-                    return Err(err.into());
-                }
-            }
-        }
 
         let mut promises = Vec::with_capacity(swap_request.outputs.len());
 
@@ -72,5 +57,25 @@ impl Mint {
             .await?;
 
         Ok(SwapResponse::new(promises))
+    }
+
+    async fn validate_sig_flag(&self, swap_request: &SwapRequest) -> Result<(), Error> {
+        let EnforceSigFlag {
+            sig_flag,
+            pubkeys,
+            sigs_required,
+        } = enforce_sig_flag(swap_request.inputs.clone());
+
+        if sig_flag.eq(&SigFlag::SigAll) {
+            let pubkeys = pubkeys.into_iter().collect();
+            for blinded_message in &swap_request.outputs {
+                if let Err(err) = blinded_message.verify_p2pk(&pubkeys, sigs_required) {
+                    tracing::info!("Could not verify p2pk in swap request");
+                    return Err(err.into());
+                }
+            }
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
### Description

This PR slightly changes the `process_swap_request` implementation: it validates if the tx is balanced _before_ storing the new proofs in the DB. By doing this, we avoid having to later remove these proofs in case the tx is not balanced.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

* NUT-17: Removed superfluous proof state notification

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
