### PR TITLE
feat: Add secret length validation

### DIFF
--- a/crates/cashu/src/nuts/nut00/mod.rs
+++ b/crates/cashu/src/nuts/nut00/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! <https://github.com/cashubtc/nuts/blob/main/00.md>
 
-/// Maximum length of a secret in characters
+/// Maximum length of a secret in UTF-8 characters
 pub const MAX_SECRET_LENGTH: usize = 512;
 
 use std::cmp::Ordering;

--- a/crates/cashu/src/nuts/nut00/mod.rs
+++ b/crates/cashu/src/nuts/nut00/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! <https://github.com/cashubtc/nuts/blob/main/00.md>
 
-/// Maximum length of a secret in bytes
+/// Maximum length of a secret in characters
 pub const MAX_SECRET_LENGTH: usize = 512;
 
 use std::cmp::Ordering;

--- a/crates/cashu/src/nuts/nut00/mod.rs
+++ b/crates/cashu/src/nuts/nut00/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! <https://github.com/cashubtc/nuts/blob/main/00.md>
 
+/// Maximum length of a secret in bytes
+pub const MAX_SECRET_LENGTH: usize = 512;
+
 use std::cmp::Ordering;
 use std::fmt;
 use std::hash::{Hash, Hasher};

--- a/crates/cashu/src/nuts/nut13.rs
+++ b/crates/cashu/src/nuts/nut13.rs
@@ -30,6 +30,9 @@ pub enum Error {
     /// NUT02 Error
     #[error(transparent)]
     NUT02(#[from] crate::nuts::nut02::Error),
+    /// Secret Error
+    #[error(transparent)]
+    Secret(#[from] crate::secret::Error),
     /// Bip32 Error
     #[error(transparent)]
     Bip32(#[from] bitcoin::bip32::Error),
@@ -45,7 +48,7 @@ impl Secret {
 
         Ok(Self::new(hex::encode(
             derived_xpriv.private_key.secret_bytes(),
-        )))
+        ))?)
     }
 }
 

--- a/crates/cashu/src/secret.rs
+++ b/crates/cashu/src/secret.rs
@@ -36,7 +36,7 @@ pub enum Error {
     #[error("Invalid secret length: `{0}`")]
     InvalidLength(u64),
     /// Invalid Secret
-    #[error("Secret exceeds maximum allowed length")]
+    #[error("Secret exceeds maximum allowed char length")]
     InvalidSecret,
     /// Hex Error
     #[error(transparent)]

--- a/crates/cashu/src/secret.rs
+++ b/crates/cashu/src/secret.rs
@@ -195,7 +195,7 @@ mod tests {
             Err(e) => panic!("Unexpected error type: {:?}", e),
             Ok(_) => panic!("Expected an error for too long secret"),
         }
-        
+
         // Test with multi-byte characters (emoji)
         let emoji_string = "😀".repeat(crate::nuts::nut00::MAX_SECRET_LENGTH);
         let secret_result = Secret::from_str(&emoji_string);
@@ -203,7 +203,7 @@ mod tests {
             secret_result.is_ok(),
             "Secret with max length of emoji characters should be valid"
         );
-        
+
         let too_long_emoji = "😀".repeat(crate::nuts::nut00::MAX_SECRET_LENGTH + 1);
         let secret_result = Secret::from_str(&too_long_emoji);
         assert!(
@@ -231,7 +231,7 @@ mod tests {
             secret_result.is_err(),
             "Secret exceeding max length should fail deserialization"
         );
-        
+
         // Test with multi-byte characters (emoji)
         let emoji_string = "😀".repeat(crate::nuts::nut00::MAX_SECRET_LENGTH);
         let json = format!("\"{}\"", emoji_string);
@@ -240,7 +240,7 @@ mod tests {
             secret_result.is_ok(),
             "Secret with max length of emoji characters should deserialize correctly"
         );
-        
+
         let too_long_emoji = "😀".repeat(crate::nuts::nut00::MAX_SECRET_LENGTH + 1);
         let json = format!("\"{}\"", too_long_emoji);
         let secret_result: Result<Secret, _> = serde_json::from_str(&json);

--- a/crates/cashu/src/secret.rs
+++ b/crates/cashu/src/secret.rs
@@ -156,4 +156,23 @@ mod tests {
 
         assert_eq!(secret_n, secret)
     }
+
+    #[test]
+    fn test_secret_length_validation() {
+        // Create a string that is exactly MAX_SECRET_LENGTH bytes
+        let max_length_string = "a".repeat(crate::nuts::nut00::MAX_SECRET_LENGTH);
+        let secret_result = Secret::from_str(&max_length_string);
+        assert!(secret_result.is_ok(), "Secret with max length should be valid");
+
+        // Create a string that is MAX_SECRET_LENGTH + 1 bytes
+        let too_long_string = "a".repeat(crate::nuts::nut00::MAX_SECRET_LENGTH + 1);
+        let secret_result = Secret::from_str(&too_long_string);
+        assert!(secret_result.is_err(), "Secret exceeding max length should be rejected");
+        
+        match secret_result {
+            Err(Error::InvalidSecret) => {}, // Expected error
+            Err(e) => panic!("Unexpected error type: {:?}", e),
+            Ok(_) => panic!("Expected an error for too long secret"),
+        }
+    }
 }

--- a/crates/cashu/src/secret.rs
+++ b/crates/cashu/src/secret.rs
@@ -175,4 +175,19 @@ mod tests {
             Ok(_) => panic!("Expected an error for too long secret"),
         }
     }
+
+    #[test]
+    fn test_secret_serde_deserialization_validation() {
+        // Create a string that is exactly MAX_SECRET_LENGTH bytes
+        let max_length_string = "a".repeat(crate::nuts::nut00::MAX_SECRET_LENGTH);
+        let json = format!("\"{}\"", max_length_string);
+        let secret_result: Result<Secret, _> = serde_json::from_str(&json);
+        assert!(secret_result.is_ok(), "Secret with max length should deserialize correctly");
+
+        // Create a string that is MAX_SECRET_LENGTH + 1 bytes
+        let too_long_string = "a".repeat(crate::nuts::nut00::MAX_SECRET_LENGTH + 1);
+        let json = format!("\"{}\"", too_long_string);
+        let secret_result: Result<Secret, _> = serde_json::from_str(&json);
+        assert!(secret_result.is_err(), "Secret exceeding max length should fail deserialization");
+    }
 }

--- a/crates/cashu/src/secret.rs
+++ b/crates/cashu/src/secret.rs
@@ -20,6 +20,7 @@ impl<'de> Deserialize<'de> for Secret {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
+        // Rust Strings can only contain UTF-8 chars. In case of a non-UTF-8 char, String instantiation above would error out.
         if s.chars().count() > crate::nuts::nut00::MAX_SECRET_LENGTH {
             return Err(serde::de::Error::custom(
                 "Secret exceeds maximum allowed length",

--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -59,7 +59,7 @@ pub enum Error {
     #[error("Multi-Part payment is not supported for unit `{0}` and method `{1}`")]
     MppUnitMethodNotSupported(CurrencyUnit, PaymentMethod),
     /// Invalid secret must be less then 512
-    #[error("Invalid secret must be less then 512")]
+    #[error("Invalid secret: must be at most 512 UTF-8 chars")]
     InvalidSecret,
 
     // Mint Errors

--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -58,6 +58,9 @@ pub enum Error {
     /// Multi-Part Payment not supported for unit and method
     #[error("Multi-Part payment is not supported for unit `{0}` and method `{1}`")]
     MppUnitMethodNotSupported(CurrencyUnit, PaymentMethod),
+    /// Invalid secret must be less then 512
+    #[error("Invalid secret must be less then 512")]
+    InvalidSecret,
 
     // Mint Errors
     /// Minting is disabled

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -268,6 +268,12 @@ impl Mint {
     /// Verify [`Proof`] meets conditions and is signed
     #[instrument(skip_all)]
     pub async fn verify_proof(&self, proof: &Proof) -> Result<(), Error> {
+        // Check that the secret length is not greater than MAX_SECRET_LENGTH bytes
+        ensure_cdk!(
+            proof.secret.as_bytes().len() <= cdk_common::nuts::nut00::MAX_SECRET_LENGTH,
+            Error::InvalidSecret
+        );
+
         // Check if secret is a nut10 secret with conditions
         if let Ok(secret) =
             <&crate::secret::Secret as TryInto<crate::nuts::nut10::Secret>>::try_into(&proof.secret)

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -268,9 +268,9 @@ impl Mint {
     /// Verify [`Proof`] meets conditions and is signed
     #[instrument(skip_all)]
     pub async fn verify_proof(&self, proof: &Proof) -> Result<(), Error> {
-        // Check that the secret length is not greater than MAX_SECRET_LENGTH bytes
+        // Check that the secret length is not greater than MAX_SECRET_LENGTH characters
         ensure_cdk!(
-            proof.secret.as_bytes().len() <= cdk_common::nuts::nut00::MAX_SECRET_LENGTH,
+            proof.secret.to_string().chars().count() <= cdk_common::nuts::nut00::MAX_SECRET_LENGTH,
             Error::InvalidSecret
         );
 


### PR DESCRIPTION
feat: Add secret length validation with 512-byte limit

feat: Add MAX_SECRET_LENGTH constant for secret length validation

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

https://github.com/cashubtc/nuts/pull/234

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
