### PR TITLE
Drop `nostr_last_checked` table, remove references

### DIFF
--- a/crates/cdk-redb/src/wallet/mod.rs
+++ b/crates/cdk-redb/src/wallet/mod.rs
@@ -40,7 +40,6 @@ const MINT_KEYS_TABLE: TableDefinition<&str, &str> = TableDefinition::new("mint_
 const PROOFS_TABLE: TableDefinition<&[u8], &str> = TableDefinition::new("proofs");
 const CONFIG_TABLE: TableDefinition<&str, &str> = TableDefinition::new("config");
 const KEYSET_COUNTER: TableDefinition<&str, u32> = TableDefinition::new("keyset_counter");
-const NOSTR_LAST_CHECKED: TableDefinition<&str, u32> = TableDefinition::new("keyset_counter");
 
 const DATABASE_VERSION: u32 = 2;
 
@@ -133,7 +132,6 @@ impl WalletRedbDatabase {
                         let _ = write_txn.open_table(MINT_KEYS_TABLE)?;
                         let _ = write_txn.open_table(PROOFS_TABLE)?;
                         let _ = write_txn.open_table(KEYSET_COUNTER)?;
-                        let _ = write_txn.open_table(NOSTR_LAST_CHECKED)?;
                         table.insert("db_version", DATABASE_VERSION.to_string().as_str())?;
                     }
 

--- a/crates/cdk-rexie/src/wallet.rs
+++ b/crates/cdk-rexie/src/wallet.rs
@@ -27,9 +27,8 @@ const MELT_QUOTES: &str = "melt_quotes";
 const PROOFS: &str = "proofs";
 const CONFIG: &str = "config";
 const KEYSET_COUNTER: &str = "keyset_counter";
-const NOSTR_LAST_CHECKED: &str = "nostr_last_check";
 
-const DATABASE_VERSION: u32 = 3;
+const DATABASE_VERSION: u32 = 4;
 
 /// Rexie Database Error
 #[derive(Debug, Error)]
@@ -98,7 +97,6 @@ impl WalletRexieDatabase {
             .add_object_store(ObjectStore::new(MELT_QUOTES))
             .add_object_store(ObjectStore::new(CONFIG))
             .add_object_store(ObjectStore::new(KEYSET_COUNTER))
-            .add_object_store(ObjectStore::new(NOSTR_LAST_CHECKED))
             // Build the database
             .build()
             .await
@@ -746,55 +744,5 @@ impl WalletDatabase for WalletRexieDatabase {
             .and_then(|c| serde_wasm_bindgen::from_value(c).ok());
 
         Ok(current_count)
-    }
-
-    async fn add_nostr_last_checked(
-        &self,
-        verifying_key: PublicKey,
-        last_checked: u32,
-    ) -> Result<(), Self::Err> {
-        let rexie = self.db.lock().await;
-
-        let transaction = rexie
-            .transaction(&[NOSTR_LAST_CHECKED], TransactionMode::ReadWrite)
-            .map_err(Error::from)?;
-
-        let counter_store = transaction.store(NOSTR_LAST_CHECKED).map_err(Error::from)?;
-
-        let verifying_key = serde_wasm_bindgen::to_value(&verifying_key).map_err(Error::from)?;
-
-        let last_checked = serde_wasm_bindgen::to_value(&last_checked).map_err(Error::from)?;
-
-        counter_store
-            .put(&last_checked, Some(&verifying_key))
-            .await
-            .map_err(Error::from)?;
-
-        transaction.done().await.map_err(Error::from)?;
-
-        Ok(())
-    }
-
-    async fn get_nostr_last_checked(
-        &self,
-        verifying_key: &PublicKey,
-    ) -> Result<Option<u32>, Self::Err> {
-        let rexie = self.db.lock().await;
-
-        let transaction = rexie
-            .transaction(&[NOSTR_LAST_CHECKED], TransactionMode::ReadOnly)
-            .map_err(Error::from)?;
-
-        let nostr_last_check_store = transaction.store(NOSTR_LAST_CHECKED).map_err(Error::from)?;
-
-        let verifying_key = serde_wasm_bindgen::to_value(verifying_key).map_err(Error::from)?;
-
-        let last_checked = nostr_last_check_store
-            .get(verifying_key)
-            .await
-            .map_err(Error::from)?
-            .and_then(|l| serde_wasm_bindgen::from_value(l).ok());
-
-        Ok(last_checked)
     }
 }

--- a/crates/cdk-sqlite/src/wallet/migrations/20250310111513_drop_nostr_last_checked.sql
+++ b/crates/cdk-sqlite/src/wallet/migrations/20250310111513_drop_nostr_last_checked.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS nostr_last_checked;


### PR DESCRIPTION
### Description

#645 removed `nostr_last_checked` references from the mint storage, but the table schema and data remain.

This PR drops the table from the various storage backends:
- `cdk-sqlite`: added a migration to drop the table
- `cdk-redb`: due to a typo, the `NOSTR_LAST_CHECKED` key was pointing to the `keyset_counter` table, so no `nostr_last_checked` was ever created. Here, this PR simply removes redb references to `NOSTR_LAST_CHECKED`.
- `cdk-rexie`: bump the DB version and do not add the `NOSTR_LAST_CHECKED` object store.

-----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
