### PR TITLE
Integration tests: fix `wait_for_mint_to_be_paid` loop

### DIFF
--- a/crates/cdk-integration-tests/src/lib.rs
+++ b/crates/cdk-integration-tests/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use cdk::amount::{Amount, SplitTarget};
 use cdk::nuts::nut00::ProofsMethods;
 use cdk::nuts::{MintQuoteState, NotificationPayload, State};
@@ -86,7 +86,7 @@ pub async fn wait_for_mint_to_be_paid(
                 }
             }
         }
-        Ok(())
+        Err(anyhow!("Subscription ended without quote being paid"))
     };
 
     let timeout_future = timeout(Duration::from_secs(timeout_secs), wait_future);
@@ -114,7 +114,7 @@ pub async fn wait_for_mint_to_be_paid(
         result = timeout_future => {
             match result {
                 Ok(payment_result) => payment_result,
-                Err(_) => Err(anyhow::anyhow!("Timeout waiting for mint quote to be paid")),
+                Err(_) => Err(anyhow!("Timeout waiting for mint quote to be paid")),
             }
         }
         result = periodic_task => {


### PR DESCRIPTION
### Description

Previously, the `wait_for_mint_to_be_paid` loop used in integration tests would successfully return (`Ok`) even when the subscription ended, but the quote was not paid.

This PR fixes this edge-case.

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
