### PR TITLE
Use base trait in return type of Mint's `get_settings()`

### DIFF
--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -12,8 +12,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use cdk::amount::{to_unit, Amount};
 use cdk::cdk_payment::{
-    self, Bolt11Settings, CreateIncomingPaymentResponse, MakePaymentResponse, MintPayment,
-    PaymentQuoteResponse,
+    self, BaseMintSettings, Bolt11Settings, CreateIncomingPaymentResponse, MakePaymentResponse,
+    MintPayment, PaymentQuoteResponse,
 };
 use cdk::nuts::{CurrencyUnit, MeltOptions, MeltQuoteState, MintQuoteState};
 use cdk::types::FeeReserve;
@@ -29,7 +29,6 @@ use cln_rpc::model::responses::{
 use cln_rpc::primitives::{Amount as CLN_Amount, AmountOrAny};
 use error::Error;
 use futures::{Stream, StreamExt};
-use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -65,12 +64,12 @@ impl Cln {
 impl MintPayment for Cln {
     type Err = cdk_payment::Error;
 
-    async fn get_settings(&self) -> Result<Value, Self::Err> {
-        Ok(serde_json::to_value(Bolt11Settings {
+    async fn get_settings(&self) -> Result<Box<dyn BaseMintSettings>, Self::Err> {
+        Ok(Box::new(Bolt11Settings {
             mpp: true,
             unit: CurrencyUnit::Msat,
             invoice_description: true,
-        })?)
+        }))
     }
 
     /// Is wait invoice active

--- a/crates/cdk-fake-wallet/src/lib.rs
+++ b/crates/cdk-fake-wallet/src/lib.rs
@@ -17,8 +17,8 @@ use bitcoin::secp256k1::rand::{thread_rng, Rng};
 use bitcoin::secp256k1::{Secp256k1, SecretKey};
 use cdk::amount::{to_unit, Amount};
 use cdk::cdk_payment::{
-    self, Bolt11Settings, CreateIncomingPaymentResponse, MakePaymentResponse, MintPayment,
-    PaymentQuoteResponse,
+    self, BaseMintSettings, Bolt11Settings, CreateIncomingPaymentResponse, MakePaymentResponse,
+    MintPayment, PaymentQuoteResponse,
 };
 use cdk::nuts::{CurrencyUnit, MeltOptions, MeltQuoteState, MintQuoteState};
 use cdk::types::FeeReserve;
@@ -28,7 +28,6 @@ use futures::stream::StreamExt;
 use futures::Stream;
 use lightning_invoice::{Bolt11Invoice, Currency, InvoiceBuilder, PaymentSecret};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio::time;
 use tokio_stream::wrappers::ReceiverStream;
@@ -102,12 +101,12 @@ impl MintPayment for FakeWallet {
     type Err = cdk_payment::Error;
 
     #[instrument(skip_all)]
-    async fn get_settings(&self) -> Result<Value, Self::Err> {
-        Ok(serde_json::to_value(Bolt11Settings {
+    async fn get_settings(&self) -> Result<Box<dyn BaseMintSettings>, Self::Err> {
+        Ok(Box::new(Bolt11Settings {
             mpp: true,
             unit: CurrencyUnit::Msat,
             invoice_description: true,
-        })?)
+        }))
     }
 
     #[instrument(skip_all)]

--- a/crates/cdk-lnbits/src/lib.rs
+++ b/crates/cdk-lnbits/src/lib.rs
@@ -13,8 +13,8 @@ use async_trait::async_trait;
 use axum::Router;
 use cdk::amount::{to_unit, Amount, MSAT_IN_SAT};
 use cdk::cdk_payment::{
-    self, Bolt11Settings, CreateIncomingPaymentResponse, MakePaymentResponse, MintPayment,
-    PaymentQuoteResponse,
+    self, BaseMintSettings, Bolt11Settings, CreateIncomingPaymentResponse, MakePaymentResponse,
+    MintPayment, PaymentQuoteResponse,
 };
 use cdk::nuts::{CurrencyUnit, MeltOptions, MeltQuoteState, MintQuoteState};
 use cdk::types::FeeReserve;
@@ -25,7 +25,6 @@ use futures::stream::StreamExt;
 use futures::Stream;
 use lnbits_rs::api::invoice::CreateInvoiceRequest;
 use lnbits_rs::LNBitsClient;
-use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
@@ -76,8 +75,8 @@ impl LNbits {
 impl MintPayment for LNbits {
     type Err = cdk_payment::Error;
 
-    async fn get_settings(&self) -> Result<Value, Self::Err> {
-        Ok(serde_json::to_value(&self.settings)?)
+    async fn get_settings(&self) -> Result<Box<dyn BaseMintSettings>, Self::Err> {
+        Ok(Box::new(self.settings.clone()))
     }
 
     fn is_wait_invoice_active(&self) -> bool {

--- a/crates/cdk-lnd/src/lib.rs
+++ b/crates/cdk-lnd/src/lib.rs
@@ -15,8 +15,8 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use cdk::amount::{to_unit, Amount, MSAT_IN_SAT};
 use cdk::cdk_payment::{
-    self, Bolt11Settings, CreateIncomingPaymentResponse, MakePaymentResponse, MintPayment,
-    PaymentQuoteResponse,
+    self, BaseMintSettings, Bolt11Settings, CreateIncomingPaymentResponse, MakePaymentResponse,
+    MintPayment, PaymentQuoteResponse,
 };
 use cdk::nuts::{CurrencyUnit, MeltOptions, MeltQuoteState, MintQuoteState};
 use cdk::secp256k1::hashes::Hash;
@@ -112,8 +112,8 @@ impl MintPayment for Lnd {
     type Err = cdk_payment::Error;
 
     #[instrument(skip_all)]
-    async fn get_settings(&self) -> Result<serde_json::Value, Self::Err> {
-        Ok(serde_json::to_value(&self.settings)?)
+    async fn get_settings(&self) -> Result<Box<dyn BaseMintSettings>, Self::Err> {
+        Ok(Box::new(self.settings.clone()))
     }
 
     #[instrument(skip_all)]

--- a/crates/cdk-payment-processor/src/lib.rs
+++ b/crates/cdk-payment-processor/src/lib.rs
@@ -1,8 +1,16 @@
 pub mod error;
 pub mod proto;
 
+use std::any::Any;
+
 pub use proto::cdk_payment_processor_client::CdkPaymentProcessorClient;
 pub use proto::cdk_payment_processor_server::CdkPaymentProcessorServer;
 pub use proto::{PaymentProcessorClient, PaymentProcessorServer};
 #[doc(hidden)]
 pub use tonic;
+
+impl cdk_common::payment::BaseMintSettings for proto::SettingsResponse {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/cdk-redb/src/mint/mod.rs
+++ b/crates/cdk-redb/src/mint/mod.rs
@@ -965,7 +965,7 @@ mod tests {
         let proofs = vec![
             Proof {
                 amount: Amount::from(100),
-                keyset_id: keyset_id.clone(),
+                keyset_id,
                 secret: Secret::generate(),
                 c: SecretKey::generate().public_key(),
                 witness: None,
@@ -973,7 +973,7 @@ mod tests {
             },
             Proof {
                 amount: Amount::from(200),
-                keyset_id: keyset_id.clone(),
+                keyset_id,
                 secret: Secret::generate(),
                 c: SecretKey::generate().public_key(),
                 witness: None,
@@ -1026,7 +1026,7 @@ mod tests {
         let proofs = vec![
             Proof {
                 amount: Amount::from(100),
-                keyset_id: keyset_id.clone(),
+                keyset_id,
                 secret: Secret::generate(),
                 c: SecretKey::generate().public_key(),
                 witness: None,
@@ -1034,7 +1034,7 @@ mod tests {
             },
             Proof {
                 amount: Amount::from(200),
-                keyset_id: keyset_id.clone(),
+                keyset_id,
                 secret: Secret::generate(),
                 c: SecretKey::generate().public_key(),
                 witness: None,

--- a/crates/cdk-sqlite/src/mint/mod.rs
+++ b/crates/cdk-sqlite/src/mint/mod.rs
@@ -1748,7 +1748,7 @@ mod tests {
         // Create a keyset and add it to the database
         let keyset_id = Id::from_str("00916bbf7ef91a36").unwrap();
         let keyset_info = MintKeySetInfo {
-            id: keyset_id.clone(),
+            id: keyset_id,
             unit: CurrencyUnit::Sat,
             active: true,
             valid_from: 0,
@@ -1763,7 +1763,7 @@ mod tests {
         let proofs = vec![
             Proof {
                 amount: Amount::from(100),
-                keyset_id: keyset_id.clone(),
+                keyset_id,
                 secret: Secret::generate(),
                 c: SecretKey::generate().public_key(),
                 witness: None,
@@ -1771,7 +1771,7 @@ mod tests {
             },
             Proof {
                 amount: Amount::from(200),
-                keyset_id: keyset_id.clone(),
+                keyset_id,
                 secret: Secret::generate(),
                 c: SecretKey::generate().public_key(),
                 witness: None,
@@ -1816,7 +1816,7 @@ mod tests {
         // Create a keyset and add it to the database
         let keyset_id = Id::from_str("00916bbf7ef91a36").unwrap();
         let keyset_info = MintKeySetInfo {
-            id: keyset_id.clone(),
+            id: keyset_id,
             unit: CurrencyUnit::Sat,
             active: true,
             valid_from: 0,
@@ -1831,7 +1831,7 @@ mod tests {
         let proofs = vec![
             Proof {
                 amount: Amount::from(100),
-                keyset_id: keyset_id.clone(),
+                keyset_id,
                 secret: Secret::generate(),
                 c: SecretKey::generate().public_key(),
                 witness: None,
@@ -1839,7 +1839,7 @@ mod tests {
             },
             Proof {
                 amount: Amount::from(200),
-                keyset_id: keyset_id.clone(),
+                keyset_id,
                 secret: Secret::generate(),
                 c: SecretKey::generate().public_key(),
                 witness: None,

--- a/crates/cdk/src/mint/builder.rs
+++ b/crates/cdk/src/mint/builder.rs
@@ -143,9 +143,11 @@ impl MintBuilder {
 
         let mut ln = self.ln.unwrap_or_default();
 
-        let settings = ln_backend.get_settings().await?;
-
-        let settings: Bolt11Settings = settings.try_into()?;
+        let settings_trait_obj = ln_backend.get_settings().await?;
+        let settings: &Bolt11Settings = settings_trait_obj
+            .as_any()
+            .downcast_ref::<Bolt11Settings>()
+            .ok_or(Error::Internal)?;
 
         if settings.mpp {
             let mpp_settings = MppMethodSettings {

--- a/crates/cdk/src/mint/mint_nut04.rs
+++ b/crates/cdk/src/mint/mint_nut04.rs
@@ -79,8 +79,11 @@ impl Mint {
 
         let quote_expiry = unix_time() + mint_ttl;
 
-        let settings = ln.get_settings().await?;
-        let settings: Bolt11Settings = serde_json::from_value(settings)?;
+        let settings_trait_obj = ln.get_settings().await?;
+        let settings: &Bolt11Settings = settings_trait_obj
+            .as_any()
+            .downcast_ref::<Bolt11Settings>()
+            .ok_or(Error::Internal)?;
 
         if description.is_some() && !settings.invoice_description {
             tracing::error!("Backend does not support invoice description");


### PR DESCRIPTION
### Description

This PR replaces `serde_json::Value` with a custom base trait `BaseMintSettings` in the mint's `get_settings()` method.

This is now possible due to the recent bump in MSRV.

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
