### PR TITLE
Remove "mint" from default features of common crates

### DIFF
--- a/crates/cashu/Cargo.toml
+++ b/crates/cashu/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 readme = "README.md"
 
 [features]
-default = ["mint", "wallet", "auth"]
+default = ["wallet", "auth"]
 swagger = ["dep:utoipa"]
 mint = ["dep:uuid"]
 wallet = []

--- a/crates/cdk-integration-tests/Cargo.toml
+++ b/crates/cdk-integration-tests/Cargo.toml
@@ -24,8 +24,8 @@ cdk = { workspace = true, features = ["mint", "wallet", "auth"] }
 cdk-cln = { workspace = true }
 cdk-lnd = { workspace = true }
 cdk-axum = { workspace = true }
-cdk-sqlite = { workspace = true }
-cdk-redb = { workspace = true }
+cdk-sqlite = { workspace = true, features = ["mint", "wallet"] }
+cdk-redb = { workspace = true , features = ["mint", "wallet"] }
 cdk-fake-wallet = { workspace = true }
 futures = { workspace = true, default-features = false, features = [
     "executor",

--- a/crates/cdk-redb/Cargo.toml
+++ b/crates/cdk-redb/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["mint", "wallet", "auth"]
+default = ["wallet", "auth"]
 mint = ["cdk-common/mint"]
 wallet = ["cdk-common/wallet"]
 auth = ["cdk-common/auth"]

--- a/crates/cdk-sqlite/Cargo.toml
+++ b/crates/cdk-sqlite/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["mint", "wallet", "auth"]
+default = ["wallet", "auth"]
 mint = ["cdk-common/mint"]
 wallet = ["cdk-common/wallet"]
 auth = ["cdk-common/auth"]

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 
 
 [features]
-default = ["mint", "wallet", "auth"]
+default = ["wallet", "auth"]
 wallet = ["dep:reqwest", "cdk-common/wallet"]
 mint = ["dep:futures", "dep:reqwest", "cdk-common/mint"]
 auth = ["dep:jsonwebtoken", "cdk-common/auth", "cdk-common/auth"]


### PR DESCRIPTION
### Description

This PR removes `mint` from the default features of `cashu`, `cdk`, `cdk-sqlite` and `cdk-redb`.

This is because these libraries, in their default state (i.e. as published to crates.io), are typically used in apps integrating the CDK Wallet. Having both `mint` and `wallet` features enabled by default can lead to confusion when callers try to resolve imports, for example

```rust
use cdk::wallet::MintQuote;
use cdk_common::mint::MintQuote;
```

especially since some words are ambiguous: `mint` can mean the act of minting, or the mint as the counterparty.

By removing `mint` and keeping `wallet` in the default feature list, this PR removes this possible source of confusion for integrating apps.

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
