### PR TITLE
Make PreparedSend cloneable

### DIFF
--- a/crates/cdk/src/wallet/send.rs
+++ b/crates/cdk/src/wallet/send.rs
@@ -306,6 +306,7 @@ impl Wallet {
 }
 
 /// Prepared send
+#[derive(Clone)]
 pub struct PreparedSend {
     amount: Amount,
     options: SendOptions,


### PR DESCRIPTION
### Description

This PR makes `PreparedSend` cloneable. This is useful for callers when handling the send cancellation, which may happen in a context that only has a `&PreparedSend`.

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
