### PR TITLE
Wallet DB trait: add default impl for common proof state changes

### DIFF
--- a/crates/cdk-common/src/database/wallet.rs
+++ b/crates/cdk-common/src/database/wallet.rs
@@ -77,6 +77,21 @@ pub trait Database: Debug {
     /// Remove [`Keys`] from storage
     async fn remove_keys(&self, id: &Id) -> Result<(), Self::Err>;
 
+    /// Set proofs as pending in storage. Proofs are identified by their Y
+    /// value.
+    async fn set_pending_proofs(&self, ys: Vec<PublicKey>) -> Result<(), Self::Err> {
+        self.update_proofs_state(ys, State::Pending).await
+    }
+    /// Reserve proofs in storage. Proofs are identified by their Y value.
+    async fn reserve_proofs(&self, ys: Vec<PublicKey>) -> Result<(), Self::Err> {
+        self.update_proofs_state(ys, State::Reserved).await
+    }
+    /// Set proofs as unspent in storage. Proofs are identified by their Y
+    /// value.
+    async fn set_unspent_proofs(&self, ys: Vec<PublicKey>) -> Result<(), Self::Err> {
+        self.update_proofs_state(ys, State::Unspent).await
+    }
+
     /// Update the proofs in storage by adding new proofs or removing proofs by
     /// their Y value.
     async fn update_proofs(

--- a/crates/cdk-rexie/src/wallet.rs
+++ b/crates/cdk-rexie/src/wallet.rs
@@ -637,18 +637,6 @@ impl WalletDatabase for WalletRexieDatabase {
         Ok(())
     }
 
-    async fn set_pending_proofs(&self, ys: Vec<PublicKey>) -> Result<(), Self::Err> {
-        self.set_proof_states(ys, State::Pending).await
-    }
-
-    async fn reserve_proofs(&self, ys: Vec<PublicKey>) -> Result<(), Self::Err> {
-        self.set_proof_states(ys, State::Reserved).await
-    }
-
-    async fn set_unspent_proofs(&self, ys: Vec<PublicKey>) -> Result<(), Self::Err> {
-        self.set_proof_states(ys, State::Unspent).await
-    }
-
     async fn get_proofs(
         &self,
         mint_url: Option<MintUrl>,

--- a/crates/cdk/src/wallet/melt.rs
+++ b/crates/cdk/src/wallet/melt.rs
@@ -129,10 +129,7 @@ impl Wallet {
             return Err(Error::InsufficientFunds);
         }
 
-        let ys = proofs.ys()?;
-        self.localstore
-            .update_proofs_state(ys, State::Pending)
-            .await?;
+        self.localstore.set_pending_proofs(proofs.ys()?).await?;
 
         let active_keyset_id = self.get_active_mint_keyset().await?.id;
 

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -62,10 +62,7 @@ impl Wallet {
     /// Return proofs to unspent allowing them to be selected and spent
     #[instrument(skip(self))]
     pub async fn unreserve_proofs(&self, ys: Vec<PublicKey>) -> Result<(), Error> {
-        Ok(self
-            .localstore
-            .update_proofs_state(ys, State::Unspent)
-            .await?)
+        Ok(self.localstore.set_unspent_proofs(ys).await?)
     }
 
     /// Reclaim unspent proofs

--- a/crates/cdk/src/wallet/send.rs
+++ b/crates/cdk/src/wallet/send.rs
@@ -149,9 +149,7 @@ impl Wallet {
         tracing::debug!("Send fee: {:?}", send_fee);
 
         // Reserve proofs
-        self.localstore
-            .update_proofs_state(proofs.ys()?, State::Reserved)
-            .await?;
+        self.localstore.reserve_proofs(proofs.ys()?).await?;
 
         // Check if proofs are exact send amount
         let proofs_exact_amount = proofs.total_amount()? == amount + send_fee;
@@ -298,7 +296,7 @@ impl Wallet {
         }
 
         self.localstore
-            .update_proofs_state(send.proofs().ys()?, State::Unspent)
+            .set_unspent_proofs(send.proofs().ys()?)
             .await?;
 
         Ok(())

--- a/crates/cdk/src/wallet/swap.rs
+++ b/crates/cdk/src/wallet/swap.rs
@@ -208,10 +208,7 @@ impl Wallet {
         // Desired amount is either amount passed or value of all proof
         let proofs_total = proofs.total_amount()?;
 
-        let ys: Vec<PublicKey> = proofs.ys()?;
-        self.localstore
-            .update_proofs_state(ys, State::Reserved)
-            .await?;
+        self.localstore.reserve_proofs(proofs.ys()?).await?;
 
         let fee = self.get_proofs_fee(&proofs).await?;
 


### PR DESCRIPTION
### Description

This PR adds a change suggested but not addressed in an earlier PR: https://github.com/cashubtc/cdk/pull/596/files#r1968068766

More specifically, it adds default implementations of `set_pending_proofs`, `reserve_proofs` and `set_unspent_proofs` in the wallet `Database` trait. This has a few benefits:
- it simplifies the caller semantics: these methods are clearer than relying on `update_proofs_state`
- it spares all current and future wallet `Database` implementations from having to implement them

-----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
