### PR TITLE
Remove stale crate references

### DIFF
--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -42,7 +42,7 @@ tti = 60
 # engine = "sqlite"
 
 [ln]
-# Required ln backend `cln`, `lnd`, `fakewallet`, 'lnbits', 'phoenixd'
+# Required ln backend `cln`, `lnd`, `fakewallet`, 'lnbits'
 ln_backend = "cln"
 # min_mint=1
 # max_mint=500000
@@ -61,13 +61,6 @@ reserve_fee_min = 4
 # invoice_api_key = ""
 # lnbits_api = ""
 # fee_percent=0.04
-# reserve_fee_min=4
-
-# [phoenixd]
-# For 'phoenixd' backend, also specify fee_percent (% fee of the ln payment that mint will put in the melt quote) and reserve_fee_min (absolute amount-higher of fee_percent or reserve_fee_min is the fee reserve). 
-# api_password = ""
-# api_url = ""
-# fee_percent=0.05
 # reserve_fee_min=4
 
 # [lnd]

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -42,7 +42,7 @@ tti = 60
 # engine = "sqlite"
 
 [ln]
-# Required ln backend `cln`, `lnd`, `strike`, `fakewallet`, 'lnbits', 'phoenixd'
+# Required ln backend `cln`, `lnd`, `fakewallet`, 'lnbits', 'phoenixd'
 ln_backend = "cln"
 # min_mint=1
 # max_mint=500000
@@ -55,14 +55,6 @@ cln_path = ""
 rpc_path = ""
 fee_percent = 0.04
 reserve_fee_min = 4
-
-# [strike]
-# For the Webhook subscription, the url under [info] must be a valid, absolute, non-local, https url 
-# api_key=""
-# Optional default sats
-# supported_units=[""]
-# fee_percent=0.04
-# reserve_fee_min=4
 
 # [lnbits]
 # admin_api_key = ""

--- a/flake.nix
+++ b/flake.nix
@@ -143,7 +143,6 @@
             (craneLib.fileset.commonCargoSources ./crates/cdk-lnd)
             (craneLib.fileset.commonCargoSources ./crates/cdk-fake-wallet)
             (craneLib.fileset.commonCargoSources ./crates/cdk-lnbits)
-            (craneLib.fileset.commonCargoSources ./crates/cdk-phoenixd)
             (craneLib.fileset.commonCargoSources ./crates/cdk-redb)
             (craneLib.fileset.commonCargoSources ./crates/cdk-sqlite)
             ./crates/cdk-sqlite/src/mint/migrations

--- a/flake.nix
+++ b/flake.nix
@@ -143,7 +143,6 @@
             (craneLib.fileset.commonCargoSources ./crates/cdk-lnd)
             (craneLib.fileset.commonCargoSources ./crates/cdk-fake-wallet)
             (craneLib.fileset.commonCargoSources ./crates/cdk-lnbits)
-            (craneLib.fileset.commonCargoSources ./crates/cdk-strike)
             (craneLib.fileset.commonCargoSources ./crates/cdk-phoenixd)
             (craneLib.fileset.commonCargoSources ./crates/cdk-redb)
             (craneLib.fileset.commonCargoSources ./crates/cdk-sqlite)

--- a/justfile
+++ b/justfile
@@ -171,7 +171,6 @@ check-docs:
     "-p cdk-rexie"
     "-p cdk-cln"
     "-p cdk-lnd"
-    "-p cdk-phoenixd"
     "-p cdk-lnbits"
     "-p cdk-fake-wallet"
     "-p cdk-mint-rpc"

--- a/justfile
+++ b/justfile
@@ -171,7 +171,6 @@ check-docs:
     "-p cdk-rexie"
     "-p cdk-cln"
     "-p cdk-lnd"
-    "-p cdk-strike"
     "-p cdk-phoenixd"
     "-p cdk-lnbits"
     "-p cdk-fake-wallet"

--- a/misc/justfile.custom.just
+++ b/misc/justfile.custom.just
@@ -49,7 +49,6 @@ clippy-each:
   "-p cdk-cln"
   "-p cdk-axum"
   "-p cdk-fake-wallet"
-  "-p cdk-strike"
   "-p cdk-lnd"
   "-p cdk-mint-rpc"
   "--bin cdk-cli"


### PR DESCRIPTION
### Description

This PR removes references to `cdk-strike` and `cdk-phoenixd`.

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
