### PR TITLE
Add `expect_wallet()`

### DIFF
--- a/crates/cdk-cli/src/sub_commands/burn.rs
+++ b/crates/cdk-cli/src/sub_commands/burn.rs
@@ -27,9 +27,8 @@ pub async fn burn(
     match &sub_command_args.mint_url {
         Some(mint_url) => {
             let wallet = multi_mint_wallet
-                .get_wallet(&WalletKey::new(mint_url.clone(), unit))
-                .await
-                .unwrap();
+                .expect_wallet(&WalletKey::new(mint_url.clone(), unit))
+                .await?;
             total_burnt = wallet.check_all_pending_proofs().await?;
         }
         None => {

--- a/crates/cdk-cli/src/sub_commands/melt.rs
+++ b/crates/cdk-cli/src/sub_commands/melt.rs
@@ -45,9 +45,8 @@ pub async fn pay(
     let mint_url = mints_amounts[mint_number].0.clone();
 
     let wallet = multi_mint_wallet
-        .get_wallet(&WalletKey::new(mint_url, unit))
-        .await
-        .expect("Known wallet");
+        .expect_wallet(&WalletKey::new(mint_url, unit))
+        .await?;
 
     println!("Enter bolt11 invoice request");
 

--- a/crates/cdk-cli/src/sub_commands/melt.rs
+++ b/crates/cdk-cli/src/sub_commands/melt.rs
@@ -42,10 +42,10 @@ pub async fn pay(
         bail!("Invalid mint number");
     }
 
-    let wallet = mints_amounts[mint_number].0.clone();
+    let mint_url = mints_amounts[mint_number].0.clone();
 
     let wallet = multi_mint_wallet
-        .get_wallet(&WalletKey::new(wallet, unit))
+        .get_wallet(&WalletKey::new(mint_url, unit))
         .await
         .expect("Known wallet");
 

--- a/crates/cdk-cli/src/sub_commands/send.rs
+++ b/crates/cdk-cli/src/sub_commands/send.rs
@@ -156,11 +156,10 @@ pub async fn send(
         },
     };
 
-    let wallet = mints_amounts[mint_number].0.clone();
+    let mint_url = mints_amounts[mint_number].0.clone();
     let wallet = multi_mint_wallet
-        .get_wallet(&WalletKey::new(wallet, unit))
-        .await
-        .expect("Known wallet");
+        .expect_wallet(&WalletKey::new(mint_url, unit))
+        .await?;
 
     let send_kind = match (sub_command_args.offline, sub_command_args.tolerance) {
         (true, Some(amount)) => SendKind::OfflineTolerance(Amount::from(amount)),


### PR DESCRIPTION
### Description

This PR adds `MultiMintWallet::expect_wallet(wallet_key)`, which throws `Error::UnknownWallet` if no wallet is found.

This is for workflows where callers expect there to be a wallet and are just trying to get it.

-----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
