### PR TITLE
Mint example config: remove stale `cln_path` reference

### DIFF
--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -50,8 +50,6 @@ ln_backend = "cln"
 # max_melt=500000
 
 [cln]
-#Required if using cln backend path to rpc
-cln_path = ""
 rpc_path = ""
 fee_percent = 0.04
 reserve_fee_min = 4


### PR DESCRIPTION
### Description

This PR removes an unused field in the `cln` section of the mint config.

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
