### PR TITLE
Do not create the wallet struct directly; instead, call new.

### DIFF
--- a/crates/cdk-cli/src/main.rs
+++ b/crates/cdk-cli/src/main.rs
@@ -128,8 +128,6 @@ async fn main() -> Result<()> {
                     }
                 };
 
-                sql.migrate().await;
-
                 Arc::new(sql)
             }
             "redb" => {

--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -193,7 +193,6 @@ pub async fn create_and_start_test_mint() -> Result<Mint> {
                 let database = cdk_sqlite::MintSqliteDatabase::new(&path)
                     .await
                     .expect("Could not create sqlite db");
-                database.migrate().await;
                 Arc::new(database)
             }
             "redb" => {
@@ -206,7 +205,6 @@ pub async fn create_and_start_test_mint() -> Result<Mint> {
             }
             "memory" => {
                 let database = cdk_sqlite::mint::memory::empty().await?;
-                database.migrate().await;
                 Arc::new(database)
             }
             _ => {
@@ -289,7 +287,6 @@ pub async fn create_test_wallet_for_mint(mint: Mint) -> Result<Wallet> {
                 let database = cdk_sqlite::WalletSqliteDatabase::new(&path)
                     .await
                     .expect("Could not create sqlite db");
-                database.migrate().await;
                 Arc::new(database)
             }
             "redb" => {
@@ -302,7 +299,6 @@ pub async fn create_test_wallet_for_mint(mint: Mint) -> Result<Wallet> {
             }
             "memory" => {
                 let database = cdk_sqlite::wallet::memory::empty().await?;
-                database.migrate().await;
                 Arc::new(database)
             }
             _ => {

--- a/crates/cdk-integration-tests/tests/regtest.rs
+++ b/crates/cdk-integration-tests/tests/regtest.rs
@@ -199,7 +199,6 @@ async fn test_multimint_melt() -> Result<()> {
     )?;
 
     let db = Arc::new(memory::empty().await?);
-    db.migrate().await;
     let wallet2 = Wallet::new(
         &get_second_mint_url_from_env(),
         CurrencyUnit::Sat,

--- a/crates/cdk-mintd/src/main.rs
+++ b/crates/cdk-mintd/src/main.rs
@@ -130,8 +130,6 @@ async fn main() -> anyhow::Result<()> {
                 #[cfg(feature = "sqlcipher")]
                 let sqlite_db = MintSqliteDatabase::new(&sql_db_path, args.password).await?;
 
-                sqlite_db.migrate().await;
-
                 Arc::new(sqlite_db)
             }
             #[cfg(feature = "redb")]

--- a/crates/cdk-sqlite/src/mint/memory.rs
+++ b/crates/cdk-sqlite/src/mint/memory.rs
@@ -18,7 +18,6 @@ pub async fn empty() -> Result<MintSqliteDatabase, database::Error> {
     let db = MintSqliteDatabase::new(":memory:").await?;
     #[cfg(feature = "sqlcipher")]
     let db = MintSqliteDatabase::new(":memory:", "memory".to_string()).await?;
-    db.migrate().await;
     Ok(db)
 }
 

--- a/crates/cdk-sqlite/src/wallet/memory.rs
+++ b/crates/cdk-sqlite/src/wallet/memory.rs
@@ -6,11 +6,9 @@ use super::WalletSqliteDatabase;
 
 /// Creates a new in-memory [`WalletSqliteDatabase`] instance
 pub async fn empty() -> Result<WalletSqliteDatabase, Error> {
-    let db = WalletSqliteDatabase {
-        pool: sqlx::sqlite::SqlitePool::connect(":memory:")
-            .await
-            .map_err(|e| Error::Database(Box::new(e)))?,
-    };
-    db.migrate().await;
+    #[cfg(not(feature = "sqlcipher"))]
+    let db = WalletSqliteDatabase::new(":memory:").await?;
+    #[cfg(feature = "sqlcipher")]
+    let db = WalletSqliteDatabase::new(":memory:", "memory".to_owned()).await?;
     Ok(db)
 }


### PR DESCRIPTION

### Description

The bug comes with the SQLx-sqlite pool bug, where several connections are created by default, but the `new` function takes care of that, fixing that bug by making a single instance of the database.

If constructed directly, the pool would create several connections to the database, which in most instances is fine, but with SQLite :memory: each connection is entirely independent.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
