### PR TITLE
Fix race condition

### DIFF
--- a/misc/nutshell_wallet_itest.sh
+++ b/misc/nutshell_wallet_itest.sh
@@ -156,8 +156,8 @@ export CDK_TEST_MINT_URL=${MINT_URL}
 
 # Run the integration test
 echo "Running integration test..."
-cargo test -p cdk-integration-tests --test nutshell_wallet
-cargo test -p cdk-integration-tests --test test_fees
+cargo test -p cdk-integration-tests --test nutshell_wallet -- --test-threads 1
+cargo test -p cdk-integration-tests --test test_fees -- --test-threads 1
 TEST_STATUS=$?
 
 # Exit with the test status


### PR DESCRIPTION

### Description

Because of the nature of Rust tests, the nutshell integration test has a race condition. Triggering the issue in the local environment was hard, but it happens more often in #509 because all the keys are read from memory without blocking the database.

The error happens because, by default, Rust tests run in parallel, and maybe by design or by mistake, the external wallet did not increase its counter until the completion of the minting. This led to some tests having the same blinded messages, and the fastest test would mint successfully. The slowest test would result in the CDK failing to sign duplicated blinded messages.

In any case, the fix is on the rust side, running the tests sequentially.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
