### PR TITLE
test: use `expect` / `unwrap` instead of  `anyhow`

### DIFF
--- a/crates/cdk-integration-tests/tests/nutshell_wallet.rs
+++ b/crates/cdk-integration-tests/tests/nutshell_wallet.rs
@@ -104,8 +104,6 @@ async fn get_wallet_balance(base_url: &str) -> u64 {
         .await
         .expect("Failed to parse balance response");
 
-    println!("Wallet balance: {:?}", balance);
-
     balance["balance"]
         .as_u64()
         .expect("Could not parse balance as u64")

--- a/crates/cdk-integration-tests/tests/test_fees.rs
+++ b/crates/cdk-integration-tests/tests/test_fees.rs
@@ -1,7 +1,6 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
-use anyhow::Result;
 use bip39::Mnemonic;
 use cashu::{Bolt11Invoice, ProofsMethods};
 use cdk::amount::{Amount, SplitTarget};
@@ -13,28 +12,31 @@ use cdk_integration_tests::{
 use cdk_sqlite::wallet::memory;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_swap() -> Result<()> {
-    let seed = Mnemonic::generate(12)?.to_seed_normalized("");
+async fn test_swap() {
+    let seed = Mnemonic::generate(12).unwrap().to_seed_normalized("");
     let wallet = Wallet::new(
         &get_mint_url_from_env(),
         CurrencyUnit::Sat,
-        Arc::new(memory::empty().await?),
+        Arc::new(memory::empty().await.unwrap()),
         &seed,
         None,
-    )?;
+    )
+    .expect("failed to create new wallet");
 
-    let mint_quote = wallet.mint_quote(100.into(), None).await?;
+    let mint_quote = wallet.mint_quote(100.into(), None).await.unwrap();
 
-    let invoice = Bolt11Invoice::from_str(&mint_quote.request)?;
-    pay_if_regtest(&invoice).await?;
+    let invoice = Bolt11Invoice::from_str(&mint_quote.request).unwrap();
+    pay_if_regtest(&invoice).await.unwrap();
 
     let _mint_amount = wallet
         .mint(&mint_quote.id, SplitTarget::default(), None)
-        .await?;
+        .await
+        .unwrap();
 
     let proofs: Vec<Amount> = wallet
         .get_unspent_proofs()
-        .await?
+        .await
+        .unwrap()
         .iter()
         .map(|p| p.amount)
         .collect();
@@ -49,65 +51,72 @@ async fn test_swap() -> Result<()> {
                 ..Default::default()
             },
         )
-        .await?;
+        .await
+        .unwrap();
 
     let proofs = send.proofs();
 
-    let fee = wallet.get_proofs_fee(&proofs).await?;
+    let fee = wallet.get_proofs_fee(&proofs).await.unwrap();
 
     assert_eq!(fee, 1.into());
 
-    let send = wallet.send(send, None).await?;
+    let send = wallet.send(send, None).await.unwrap();
 
     let rec_amount = wallet
         .receive(&send.to_string(), ReceiveOptions::default())
-        .await?;
+        .await
+        .unwrap();
 
     assert_eq!(rec_amount, 3.into());
 
-    let wallet_balance = wallet.total_balance().await?;
+    let wallet_balance = wallet.total_balance().await.unwrap();
 
     assert_eq!(wallet_balance, 99.into());
-
-    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_fake_melt_change_in_quote() -> Result<()> {
+async fn test_fake_melt_change_in_quote() {
     let wallet = Wallet::new(
         &get_mint_url_from_env(),
         CurrencyUnit::Sat,
-        Arc::new(memory::empty().await?),
-        &Mnemonic::generate(12)?.to_seed_normalized(""),
+        Arc::new(memory::empty().await.unwrap()),
+        &Mnemonic::generate(12).unwrap().to_seed_normalized(""),
         None,
-    )?;
+    )
+    .expect("failed to create new wallet");
 
-    let mint_quote = wallet.mint_quote(100.into(), None).await?;
+    let mint_quote = wallet.mint_quote(100.into(), None).await.unwrap();
 
-    let bolt11 = Bolt11Invoice::from_str(&mint_quote.request)?;
+    let bolt11 = Bolt11Invoice::from_str(&mint_quote.request).unwrap();
 
-    pay_if_regtest(&bolt11).await?;
+    pay_if_regtest(&bolt11).await.unwrap();
 
-    wait_for_mint_to_be_paid(&wallet, &mint_quote.id, 60).await?;
+    wait_for_mint_to_be_paid(&wallet, &mint_quote.id, 60)
+        .await
+        .unwrap();
 
     let _mint_amount = wallet
         .mint(&mint_quote.id, SplitTarget::default(), None)
-        .await?;
+        .await
+        .unwrap();
 
     let invoice_amount = 9;
 
-    let invoice = create_invoice_for_env(Some(invoice_amount)).await?;
+    let invoice = create_invoice_for_env(Some(invoice_amount)).await.unwrap();
 
-    let melt_quote = wallet.melt_quote(invoice.to_string(), None).await?;
+    let melt_quote = wallet.melt_quote(invoice.to_string(), None).await.unwrap();
 
-    let proofs = wallet.get_unspent_proofs().await?;
+    let proofs = wallet.get_unspent_proofs().await.unwrap();
 
     let proofs_total = proofs.total_amount().unwrap();
 
-    let fee = wallet.get_proofs_fee(&proofs).await?;
-    let melt = wallet.melt_proofs(&melt_quote.id, proofs.clone()).await?;
+    let fee = wallet.get_proofs_fee(&proofs).await.unwrap();
+    let melt = wallet
+        .melt_proofs(&melt_quote.id, proofs.clone())
+        .await
+        .unwrap();
     let change = melt.change.unwrap().total_amount().unwrap();
-    let idk = proofs.total_amount()? - Amount::from(invoice_amount) - change;
+    let idk = proofs.total_amount().unwrap() - Amount::from(invoice_amount) - change;
 
     println!("{}", idk);
     println!("{}", fee);
@@ -117,9 +126,7 @@ async fn test_fake_melt_change_in_quote() -> Result<()> {
     let ln_fee = 1;
 
     assert_eq!(
-        wallet.total_balance().await?,
+        wallet.total_balance().await.unwrap(),
         Amount::from(100 - invoice_amount - u64::from(fee) - ln_fee)
     );
-
-    Ok(())
 }

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -383,7 +383,7 @@ mod tests {
         };
 
         // Convert the Info struct to a debug string
-        let debug_output = format!("{:?}", info);
+        let debug_output = format!("{info:?}");
 
         // Verify the debug output contains expected fields
         assert!(debug_output.contains("url: \"http://example.com\""));

--- a/crates/cdk/src/fees.rs
+++ b/crates/cdk/src/fees.rs
@@ -42,7 +42,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_calc_fee() -> anyhow::Result<()> {
+    fn test_calc_fee() {
         let keyset_id = Id::from_str("001711afb1de20cb").unwrap();
 
         let fee = 2;
@@ -54,34 +54,32 @@ mod tests {
 
         proofs_count.insert(keyset_id, 1);
 
-        let sum_fee = calculate_fee(&proofs_count, &keyset_fees)?;
+        let sum_fee = calculate_fee(&proofs_count, &keyset_fees).unwrap();
 
         assert_eq!(sum_fee, 1.into());
 
         proofs_count.insert(keyset_id, 500);
 
-        let sum_fee = calculate_fee(&proofs_count, &keyset_fees)?;
+        let sum_fee = calculate_fee(&proofs_count, &keyset_fees).unwrap();
 
         assert_eq!(sum_fee, 1.into());
 
         proofs_count.insert(keyset_id, 1000);
 
-        let sum_fee = calculate_fee(&proofs_count, &keyset_fees)?;
+        let sum_fee = calculate_fee(&proofs_count, &keyset_fees).unwrap();
 
         assert_eq!(sum_fee, 2.into());
 
         proofs_count.insert(keyset_id, 2000);
-        let sum_fee = calculate_fee(&proofs_count, &keyset_fees)?;
+        let sum_fee = calculate_fee(&proofs_count, &keyset_fees).unwrap();
         assert_eq!(sum_fee, 4.into());
 
         proofs_count.insert(keyset_id, 3500);
-        let sum_fee = calculate_fee(&proofs_count, &keyset_fees)?;
+        let sum_fee = calculate_fee(&proofs_count, &keyset_fees).unwrap();
         assert_eq!(sum_fee, 7.into());
 
         proofs_count.insert(keyset_id, 3501);
-        let sum_fee = calculate_fee(&proofs_count, &keyset_fees)?;
+        let sum_fee = calculate_fee(&proofs_count, &keyset_fees).unwrap();
         assert_eq!(sum_fee, 8.into());
-
-        Ok(())
     }
 }

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -764,7 +764,7 @@ mod tests {
         melt_requests: Vec<(MeltBolt11Request<Uuid>, PaymentProcessorKey)>,
     }
 
-    async fn create_mint(config: MintConfig<'_>) -> Result<Mint, Error> {
+    async fn create_mint(config: MintConfig<'_>) -> Mint {
         let localstore = Arc::new(
             new_with_state(
                 config.active_keysets,
@@ -788,14 +788,15 @@ mod tests {
             HashMap::new(),
         )
         .await
+        .unwrap()
     }
 
     #[tokio::test]
-    async fn mint_mod_new_mint() -> Result<(), Error> {
+    async fn mint_mod_new_mint() {
         let config = MintConfig::<'_> {
             ..Default::default()
         };
-        let mint = create_mint(config).await?;
+        let mint = create_mint(config).await;
 
         assert_eq!(
             mint.pubkeys().await.unwrap(),
@@ -820,23 +821,22 @@ mod tests {
             mint.total_redeemed().await.unwrap(),
             HashMap::<nut02::Id, Amount>::new()
         );
-
-        Ok(())
     }
 
     #[tokio::test]
-    async fn mint_mod_rotate_keyset() -> Result<(), Error> {
+    async fn mint_mod_rotate_keyset() {
         let config = MintConfig::<'_> {
             ..Default::default()
         };
-        let mint = create_mint(config).await?;
+        let mint = create_mint(config).await;
 
         let keysets = mint.keysets().await.unwrap();
         assert!(keysets.keysets.is_empty());
 
         // generate the first keyset and set it to active
         mint.rotate_keyset(CurrencyUnit::default(), 0, 1, 1, &HashMap::new())
-            .await?;
+            .await
+            .unwrap();
 
         let keysets = mint.keysets().await.unwrap();
         assert!(keysets.keysets.len().eq(&1));
@@ -845,7 +845,8 @@ mod tests {
 
         // set the first keyset to inactive and generate a new keyset
         mint.rotate_keyset(CurrencyUnit::default(), 1, 1, 1, &HashMap::new())
-            .await?;
+            .await
+            .unwrap();
 
         let keysets = mint.keysets().await.unwrap();
 
@@ -857,34 +858,29 @@ mod tests {
                 assert!(keyset.active);
             }
         }
-
-        Ok(())
     }
 
     #[tokio::test]
-    async fn test_mint_keyset_gen() -> Result<(), Error> {
+    async fn test_mint_keyset_gen() {
         let seed = bip39::Mnemonic::from_str(
             "dismiss price public alone audit gallery ignore process swap dance crane furnace",
         )
         .unwrap();
 
-        println!("{}", seed);
-
         let config = MintConfig::<'_> {
             seed: &seed.to_seed_normalized(""),
             ..Default::default()
         };
-        let mint = create_mint(config).await?;
+        let mint = create_mint(config).await;
 
         mint.rotate_keyset(CurrencyUnit::default(), 0, 32, 1, &HashMap::new())
-            .await?;
+            .await
+            .unwrap();
 
         let keys = mint.keysets.read().await.clone();
 
         let expected_keys = r#"{"005f6e8c540c9e61":{"id":"005f6e8c540c9e61","unit":"sat","keys":{"1":{"public_key":"03e8aded7525acee36e3394e28f2dcbc012533ef2a2b085a55fc291d311afee3ef","secret_key":"32ee9fc0723772aed4c7b8ac0a02ffe390e54a4e0b037ec6035c2afa10ebd873"},"2":{"public_key":"02628c0919e5cb8ce9aed1f81ce313f40e1ab0b33439d5be2abc69d9bb574902e0","secret_key":"48384bf901bbe8f937d601001d067e73b28b435819c009589350c664f9ba872c"},"4":{"public_key":"039e7c7f274e1e8a90c61669e961c944944e6154c0794fccf8084af90252d2848f","secret_key":"1f039c1e54e9e65faae8ecf69492f810b4bb2292beb3734059f2bb4d564786d0"},"8":{"public_key":"02ca0e563ae941700aefcb16a7fb820afbb3258ae924ab520210cb730227a76ca3","secret_key":"ea3c2641d847c9b15c5f32c150b5c9c04d0666af0549e54f51f941cf584442be"},"16":{"public_key":"031dbab0e4f7fb4fb0030f0e1a1dc80668eadd0b1046df3337bb13a7b9c982d392","secret_key":"5b244f8552077e68b30b534e85bd0e8e29ae0108ff47f5cd92522aa524d3288f"},"32":{"public_key":"037241f7ad421374eb764a48e7769b5e2473582316844fda000d6eef28eea8ffb8","secret_key":"95608f61dd690aef34e6a2d4cbef3ad8fddb4537a14480a17512778058e4f5bd"},"64":{"public_key":"02bc9767b4abf88becdac47a59e67ee9a9a80b9864ef57d16084575273ac63c0e7","secret_key":"2e9cd067fafa342f3118bc1e62fbb8e53acdb0f96d51ce8a1e1037e43fad0dce"},"128":{"public_key":"0351e33a076f415c2cadc945bc9bcb75bf4a774b28df8a0605dea1557e5897fed8","secret_key":"7014f27be5e2b77e4951a81c18ae3585d0b037899d8a37b774970427b13d8f65"},"256":{"public_key":"0314b9f4300367c7e64fa85770da90839d2fc2f57d63660f08bb3ebbf90ed76840","secret_key":"1a545bd9c40fc6cf2ab281710e279967e9f4b86cd07761c741da94bc8042c8fb"},"512":{"public_key":"030d95abc7e881d173f4207a3349f4ee442b9e51cc461602d3eb9665b9237e8db3","secret_key":"622984ef16d1cb28e9adc7a7cfea1808d85b4bdabd015977f0320c9f573858b4"},"1024":{"public_key":"0351a68a667c5fc21d66c187baecefa1d65529d06b7ae13112d432b6bca16b0e8c","secret_key":"6a8badfa26129499b60edb96cda4cbcf08f8007589eb558a9d0307bdc56e0ff6"},"2048":{"public_key":"0376166d8dcf97d8b0e9f11867ff0dafd439c90255b36a25be01e37e14741b9c6a","secret_key":"48fe41181636716ce202b3a3303c2475e6d511991930868d907441e1bcbf8566"},"4096":{"public_key":"03d40f47b4e5c4d72f2a977fab5c66b54d945b2836eb888049b1dd9334d1d70304","secret_key":"66a25bf144a3b40c015dd1f630aa4ba81d2242f5aee845e4f378246777b21676"},"8192":{"public_key":"03be18afaf35a29d7bcd5dfd1936d82c1c14691a63f8aa6ece258e16b0c043049b","secret_key":"4ddac662e82f6028888c11bdefd07229d7c1b56987395f106cc9ea5b301695f6"},"16384":{"public_key":"028e9c6ce70f34cd29aad48656bf8345bb5ba2cb4f31fdd978686c37c93f0ab411","secret_key":"83676bd7d047655476baecad2864519f0ffd8e60f779956d2faebcc727caa7bd"},"32768":{"public_key":"0253e34bab4eec93e235c33994e01bf851d5caca4559f07d37b5a5c266de7cf840","secret_key":"d5be522906223f5d92975e2a77f7e166aa121bf93d5fe442d6d132bf67166b04"},"65536":{"public_key":"02684ede207f9ace309b796b5259fc81ef0d4492b4fb5d66cf866b0b4a6f27bec9","secret_key":"20d859b7052d768e007bf285ee11dc0b98a4abfe272a551852b0cce9fb6d5ad4"},"131072":{"public_key":"027cdf7be8b20a49ac7f2f065f7c53764c8926799877858c6b00b888a8aa6741a5","secret_key":"f6eef28183344b32fc0a1fba00cd6cf967614e51d1c990f0bfce8f67c6d9746a"},"262144":{"public_key":"026939b8f766c3ebaf26408e7e54fc833805563e2ef14c8ee4d0435808b005ec4c","secret_key":"690f23e4eaa250c652afeac24d4efb583095a66abf6b87a7f3d17b1f42c5f896"},"524288":{"public_key":"03772542057493a46eed6513b40386e766eedada16560ffde2f776b65794e9f004","secret_key":"fe36e61bea74665f8796b4b62f9501ae6e0d5b16733d2c05c146cd39f89475a0"},"1048576":{"public_key":"02b016346e5a322d371c6e6164b28b31b4d93a51572351ca2f26cdc12e916d9ac3","secret_key":"b9269779e057ce715964caa6d6b5b65672f255e86746e994b6b8c4780cb9d728"},"2097152":{"public_key":"028f25283e36a11df7713934a5287267381f8304aca3c1eb1b89fddce973ef1436","secret_key":"41aec998b9624ddcff97eb7341daa6385b2a8714ed3f12969ef39649f4d641ab"},"4194304":{"public_key":"03e5841d310819a49ec42dfb24839c61f68bbfc93ac68f6dad37fd5b2d204cc535","secret_key":"e5aef2509c56236f004e2df4343beab6406816fb187c3532d4340a9674857c64"},"8388608":{"public_key":"0307ebfeb87b7bca9baa03fad00499e5cc999fa5179ef0b7ad4f555568bcb946f5","secret_key":"369e8dcabcc69a2eabb7363beb66178cafc29e53b02c46cd15374028c3110541"},"16777216":{"public_key":"02f2508e7df981c32f7b0008a273e2a1f19c23bb60a1561dba6b2a95ed1251eb90","secret_key":"f93965b96ed5428bcacd684eff2f43a9777d03adfde867fa0c6efb39c46a7550"},"33554432":{"public_key":"0381883a1517f8c9979a84fcd5f18437b1a2b0020376ecdd2e515dc8d5a157a318","secret_key":"7f5e77c7ed04dff952a7c15564ab551c769243eb65423adfebf46bf54360cd64"},"67108864":{"public_key":"02aa648d39c9a725ef5927db15af6895f0d43c17f0a31faff4406314fc80180086","secret_key":"d34eda86679bf872dfb6faa6449285741bba6c6d582cd9fe5a9152d5752596cc"},"134217728":{"public_key":"0380658e5163fcf274e1ace6c696d1feef4c6068e0d03083d676dc5ef21804f22d","secret_key":"3ad22e92d497309c5b08b2dc01cb5180de3e00d3d703229914906bc847183987"},"268435456":{"public_key":"031526f03de945c638acccb879de837ac3fabff8590057cfb8552ebcf51215f3aa","secret_key":"3a740771e29119b171ab8e79e97499771439e0ab6a082ec96e43baf06a546372"},"536870912":{"public_key":"035eb3e7262e126c5503e1b402db05f87de6556773ae709cb7aa1c3b0986b87566","secret_key":"9b77ee8cd879128c0ea6952dd188e63617fbaa9e66a3bca0244bcceb9b1f7f48"},"1073741824":{"public_key":"03f12e6a0903ed0db87485a296b1dca9d953a8a6919ff88732238fbc672d6bd125","secret_key":"f3947bca4df0f024eade569c81c5c53e167476e074eb81fa6b289e5e10dd4e42"},"2147483648":{"public_key":"02cece3fb38a54581e0646db4b29242b6d78e49313dda46764094f9d128c1059c1","secret_key":"582d54a894cd41441157849e0d16750e5349bd9310776306e7313b255866950b"}}}}"#;
 
         assert_eq!(expected_keys, serde_json::to_string(&keys.clone()).unwrap());
-
-        Ok(())
     }
 }

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -507,9 +507,9 @@ mod tests {
             Wallet::select_proofs(1024.into(), proofs, &vec![id()], &HashMap::new(), false)
                 .unwrap();
         assert_eq!(selected_proofs.len(), 1024);
-        for i in 0..1024 {
-            assert_eq!(selected_proofs[i].amount, 1.into());
-        }
+        selected_proofs
+            .iter()
+            .for_each(|proof| assert_eq!(proof.amount, Amount::ONE));
     }
 
     #[test]
@@ -527,9 +527,11 @@ mod tests {
         .unwrap();
         selected_proofs.sort();
         assert_eq!(selected_proofs.len(), 32);
-        for i in 0..32 {
-            assert_eq!(selected_proofs[i].amount, (1 << i).into());
-        }
+
+        selected_proofs
+            .iter()
+            .enumerate()
+            .for_each(|(i, proof)| assert_eq!(proof.amount, (1 << i).into()));
     }
 
     #[test]


### PR DESCRIPTION
### Description

fix #528

-----

### Notes to the reviewers

- I have not removed `anyhow` from `cdk-integration-test/src` as these helper functions are used in the tests -> so IMO, it's better to propagate the error from these helper functions and `panic` in the tests..
- Though I also agree for directly unwraping in those helper functions that would make the code  a bit simpler..

 -----




#### REMOVED
- usage of `anyhow` from tests..



----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
