### PR TITLE
Reclaim unspent proofs by reverting transaction

### DIFF
--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -234,6 +234,9 @@ pub enum Error {
     /// Invalid transaction id
     #[error("Invalid transaction id")]
     InvalidTransactionId,
+    /// Transaction not found
+    #[error("Transaction not found")]
+    TransactionNotFound,
     /// Custom Error
     #[error("`{0}`")]
     Custom(String),


### PR DESCRIPTION
### Description

Allow a wallet user to reclaim unspent proofs by reverting a transaction. If the proofs are successfully reclaimed, the wallet will delete the transaction from the database.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED
- `Wallet::revert_transaction`: reclaim unspent proofs by reverting transaction

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
