### PR TITLE
Make sqlite dependency optional for signatory

### DIFF
--- a/crates/cdk-signatory/Cargo.toml
+++ b/crates/cdk-signatory/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 description = "CDK signatory default implementation"
 
 [features]
-default = ["grpc"]
+default = ["grpc", "sqlite"]
+sqlite = ["cdk-sqlite"]
 sqlcipher = ["cdk-sqlite/sqlcipher"]
 redb = ["dep:cdk-redb"]
 grpc = ["dep:tonic", "tokio/full", "dep:prost", "dep:tonic-build"]
@@ -13,8 +14,9 @@ grpc = ["dep:tonic", "tokio/full", "dep:prost", "dep:tonic-build"]
 [dependencies]
 async-trait.workspace = true
 bitcoin.workspace = true
-cdk-common = { workspace = true, default-features=false, features = [
-    "mint", "auth",
+cdk-common = { workspace = true, default-features = false, features = [
+    "mint",
+    "auth",
 ] }
 tonic = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
@@ -23,7 +25,7 @@ tracing.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # main.rs dependencies
 anyhow.workspace = true
-cdk-sqlite = { workspace = true, features = ["mint", "auth"] }
+cdk-sqlite = { workspace = true, features = ["mint", "auth"], optional = true }
 cdk-redb = { workspace = true, features = ["mint", "auth"], optional = true }
 clap = { workspace = true }
 bip39.workspace = true

--- a/crates/cdk-signatory/src/bin/cli/mod.rs
+++ b/crates/cdk-signatory/src/bin/cli/mod.rs
@@ -16,6 +16,7 @@ use cdk_common::CurrencyUnit;
 #[cfg(feature = "redb")]
 use cdk_redb::MintRedbDatabase;
 use cdk_signatory::{db_signatory, grpc_server};
+#[cfg(feature = "sqlite")]
 use cdk_sqlite::MintSqliteDatabase;
 use clap::Parser;
 use tracing::Level;
@@ -101,18 +102,25 @@ pub async fn cli_main() -> Result<()> {
     let localstore: Arc<dyn MintKeysDatabase<Err = cdk_common::database::Error> + Send + Sync> =
         match args.engine.as_str() {
             "sqlite" => {
-                let sql_path = work_dir.join("cdk-cli.sqlite");
-                #[cfg(not(feature = "sqlcipher"))]
-                let db = MintSqliteDatabase::new(&sql_path).await?;
-                #[cfg(feature = "sqlcipher")]
-                let db = {
-                    match args.password {
-                        Some(pass) => MintSqliteDatabase::new(&sql_path, pass).await?,
-                        None => bail!("Missing database password"),
-                    }
-                };
+                #[cfg(feature = "sqlite")]
+                {
+                    let sql_path = work_dir.join("cdk-cli.sqlite");
+                    #[cfg(not(feature = "sqlcipher"))]
+                    let db = MintSqliteDatabase::new(&sql_path).await?;
+                    #[cfg(feature = "sqlcipher")]
+                    let db = {
+                        match args.password {
+                            Some(pass) => MintSqliteDatabase::new(&sql_path, pass).await?,
+                            None => bail!("Missing database password"),
+                        }
+                    };
 
-                Arc::new(db)
+                    Arc::new(db)
+                }
+                #[cfg(not(feature = "sqlite"))]
+                {
+                    bail!("sqlite feature not enabled");
+                }
             }
             "redb" => {
                 #[cfg(feature = "redb")]


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
The SQLite dependency is not strictly necessary for the signatory. 

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED
- Make the SQLite dependency optional for signatory

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
