### PR TITLE
chore: disabled mint_management_rpc. update ln_backend

### DIFF
--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -7,7 +7,7 @@ mnemonic = ""
 # enable_swagger_ui = false
 
 [mint_management_rpc]
-# enabled = false
+enabled = false
 # address = "127.0.0.1"
 # port = 8086
 
@@ -43,7 +43,7 @@ tti = 60
 
 [ln]
 # Required ln backend `cln`, `lnd`, `fakewallet`, 'lnbits'
-ln_backend = "cln"
+ln_backend = "fakewallet"
 # min_mint=1
 # max_mint=500000
 # min_melt=1


### PR DESCRIPTION
### Description

Updated the example configuration to disable mint_management_rpc by default. 

Additionally, updated the LN backend to use a fake wallet by default. 

This will make starting a mint with the example configuration a little bit easier

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
