### PR TITLE
Update example.config.toml

### DIFF
--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -62,7 +62,7 @@ reserve_fee_min = 4
 # reserve_fee_min=4
 
 # [lnd]
-# address = ""
+# address = "https://domain:port"
 # macaroon_file = ""
 # cert_file = ""
 # fee_percent=0.04


### PR DESCRIPTION
add example domain to lnd address in example config

### Description

Add an example domain in the example config, showing the expected format for the address
