### PR TITLE
Remove redundant filter during restoration

### DIFF
--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -419,11 +419,6 @@ impl Wallet {
                     .filter(|p| response.outputs.contains(&p.blinded_message))
                     .collect();
 
-                let premint_secrets: Vec<_> = premint_secrets
-                    .iter()
-                    .filter(|p| response.outputs.contains(&p.blinded_message))
-                    .collect();
-
                 // the response outputs and premint secrets should be the same after filtering
                 // blinded messages the mint did not have signatures for
                 assert_eq!(response.outputs.len(), premint_secrets.len());


### PR DESCRIPTION
### Description

Small change to remove redundant filtering of blinded messages during restore, as we already filtered for them in the code above

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
