### PR TITLE
Perform a swap before melting by default.

### DIFF
--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -570,6 +570,20 @@ mod tests {
     }
 
     #[test]
+    fn test_select_proof_change() {
+        let proofs = vec![proof(64), proof(4), proof(32)];
+        let (selected_proofs, exchange) =
+            Wallet::select_exact_proofs(97.into(), proofs, &vec![id()], &HashMap::new(), false)
+                .unwrap();
+        assert!(exchange.is_some());
+        let (proof_to_exchange, amount) = exchange.unwrap();
+
+        assert_eq!(selected_proofs.len(), 2);
+        assert_eq!(proof_to_exchange.amount, 64.into());
+        assert_eq!(amount, 61.into());
+    }
+
+    #[test]
     fn test_select_proofs_huge_proofs() {
         let proofs = (0..32)
             .flat_map(|i| (0..5).map(|_| proof(1 << i)).collect::<Vec<_>>())


### PR DESCRIPTION

### Description

Fixes #465

This PR modifies the default `melt` operation, performing a swap to melt exact amounts instead of overpaying and getting the exchange token.

Although this may end up costing more in fees, it is more efficient sometimes since the overpaid amount is not unusable until the melt is finalized.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
