### PR TITLE
feat(cli): enhance check-pending to reclaim proofs

### DIFF
--- a/crates/cdk-cli/src/main.rs
+++ b/crates/cdk-cli/src/main.rs
@@ -67,6 +67,8 @@ enum Commands {
     Send(sub_commands::send::SendSubCommand),
     /// Check if wallet balance is spendable
     CheckSpendable,
+    /// Reclaim pending proofs that are no longer pending
+    CheckPending,
     /// View mint info
     MintInfo(sub_commands::mint_info::MintInfoSubcommand),
     /// Mint proofs via bolt11
@@ -217,6 +219,9 @@ async fn main() -> Result<()> {
         }
         Commands::CheckSpendable => {
             sub_commands::check_spent::check_spent(&multi_mint_wallet).await
+        }
+        Commands::CheckPending => {
+            sub_commands::check_pending::check_pending(&multi_mint_wallet).await
         }
         Commands::MintInfo(sub_command_args) => {
             sub_commands::mint_info::mint_info(args.proxy, sub_command_args).await

--- a/crates/cdk-cli/src/sub_commands/check_pending.rs
+++ b/crates/cdk-cli/src/sub_commands/check_pending.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use cdk::nuts::nut00::ProofsMethods;
+use cdk::wallet::multi_mint_wallet::MultiMintWallet;
+
+pub async fn check_pending(multi_mint_wallet: &MultiMintWallet) -> Result<()> {
+    let wallets = multi_mint_wallet.get_wallets().await;
+
+    for (i, wallet) in wallets.iter().enumerate() {
+        let mint_url = wallet.mint_url.clone();
+        println!("{i}: {mint_url}");
+
+        // Get all pending proofs
+        let pending_proofs = wallet.get_pending_proofs().await?;
+        if pending_proofs.is_empty() {
+            println!("No pending proofs found");
+            continue;
+        }
+
+        println!(
+            "Found {} pending proofs with {} {}",
+            pending_proofs.len(),
+            pending_proofs.total_amount()?,
+            wallet.unit
+        );
+
+        // Try to reclaim any proofs that are no longer pending
+        match wallet.reclaim_unspent(pending_proofs).await {
+            Ok(()) => println!("Successfully reclaimed pending proofs"),
+            Err(e) => println!("Error reclaimed pending proofs: {}", e),
+        }
+    }
+    Ok(())
+}

--- a/crates/cdk-cli/src/sub_commands/mod.rs
+++ b/crates/cdk-cli/src/sub_commands/mod.rs
@@ -2,6 +2,7 @@ pub mod balance;
 pub mod burn;
 pub mod cat_device_login;
 pub mod cat_login;
+pub mod check_pending;
 pub mod check_spent;
 pub mod create_request;
 pub mod decode_request;


### PR DESCRIPTION
The check-pending command now directly attempts to reclaim proofs that are no longer pending, replacing the previous check-only behavior.

Changes:
- Replace check_all_pending_proofs with reclaim_unspent functionality
- Add more detailed feedback about pending proof status
- Update command description to reflect new reclaim behavior
- Improve error handling and status reporting

This change makes the command more useful by actively reclaiming proofs rather than just checking their status.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
