### PR TITLE
Fix SQLite race condition

### DIFF
--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -84,10 +84,12 @@ pub trait QuotesDatabase {
     /// Get [`mint::MeltQuote`]
     async fn get_melt_quote(&self, quote_id: &Uuid) -> Result<Option<mint::MeltQuote>, Self::Err>;
     /// Update [`mint::MeltQuote`] state
+    ///
+    /// It is expected for this function to fail if the state is already set to the new state
     async fn update_melt_quote_state(
         &self,
         quote_id: &Uuid,
-        state: MeltQuoteState,
+        new_state: MeltQuoteState,
     ) -> Result<(MeltQuoteState, mint::MeltQuote), Self::Err>;
     /// Get all [`mint::MeltQuote`]s
     async fn get_melt_quotes(&self) -> Result<Vec<mint::MeltQuote>, Self::Err>;

--- a/crates/cdk-sqlite/src/mint/mod.rs
+++ b/crates/cdk-sqlite/src/mint/mod.rs
@@ -696,9 +696,11 @@ ON CONFLICT(request_lookup_id) DO UPDATE SET
                 melt_quote
             WHERE
                 id=:id
+                AND state != :state
             "#,
         )
         .bind(":id", quote_id.as_hyphenated().to_string())
+        .bind(":state", state.to_string())
         .fetch_one(&transaction)
         .await?
         .map(sqlite_row_to_melt_quote)


### PR DESCRIPTION

### Description

Bug: https://github.com/crodas/cdk/actions/runs/15732950296/job/44339804072#step:5:1853

Reason: When melting in parallel, many update the melt status and attempt to add proofs and they fail when adding the proof and the rollback code kicks in. The loser process removes all the proofs, and the winner process has no proof later on.

Fix: Modify `update_melt_quote_state` requirements and implementation to allow only one winner.

This will be solved by design with a transaction writer trait

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
