### PR TITLE
Split the database trait into read and transactions.

### DIFF
--- a/crates/cdk-cli/src/sub_commands/check_pending.rs
+++ b/crates/cdk-cli/src/sub_commands/check_pending.rs
@@ -26,7 +26,7 @@ pub async fn check_pending(multi_mint_wallet: &MultiMintWallet) -> Result<()> {
         // Try to reclaim any proofs that are no longer pending
         match wallet.reclaim_unspent(pending_proofs).await {
             Ok(()) => println!("Successfully reclaimed pending proofs"),
-            Err(e) => println!("Error reclaimed pending proofs: {}", e),
+            Err(e) => println!("Error reclaimed pending proofs: {e}"),
         }
     }
     Ok(())

--- a/crates/cdk-common/src/database/mint/auth/mod.rs
+++ b/crates/cdk-common/src/database/mint/auth/mod.rs
@@ -5,61 +5,79 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use cashu::{AuthRequired, ProtectedEndpoint};
 
+use super::DbTransactionFinalizer;
 use crate::database::Error;
 use crate::mint::MintKeySetInfo;
 use crate::nuts::nut07::State;
 use crate::nuts::{AuthProof, BlindSignature, Id, PublicKey};
+
+/// Mint Database transaction
+#[async_trait]
+pub trait MintAuthTransaction<Error>: DbTransactionFinalizer<Err = Error> {
+    /// Add Active Keyset
+    async fn set_active_keyset(&mut self, id: Id) -> Result<(), Error>;
+
+    /// Add [`MintKeySetInfo`]
+    async fn add_keyset_info(&mut self, keyset: MintKeySetInfo) -> Result<(), Error>;
+
+    /// Add spent [`AuthProof`]
+    async fn add_proof(&mut self, proof: AuthProof) -> Result<(), Error>;
+
+    /// Update [`AuthProof`]s state
+    async fn update_proof_state(
+        &mut self,
+        y: &PublicKey,
+        proofs_state: State,
+    ) -> Result<Option<State>, Error>;
+
+    /// Add [`BlindSignature`]
+    async fn add_blind_signatures(
+        &mut self,
+        blinded_messages: &[PublicKey],
+        blind_signatures: &[BlindSignature],
+    ) -> Result<(), Error>;
+
+    /// Add protected endpoints
+    async fn add_protected_endpoints(
+        &mut self,
+        protected_endpoints: HashMap<ProtectedEndpoint, AuthRequired>,
+    ) -> Result<(), Error>;
+
+    /// Removed Protected endpoints
+    async fn remove_protected_endpoints(
+        &mut self,
+        protected_endpoints: Vec<ProtectedEndpoint>,
+    ) -> Result<(), Error>;
+}
 
 /// Mint Database trait
 #[async_trait]
 pub trait MintAuthDatabase {
     /// Mint Database Error
     type Err: Into<Error> + From<Error>;
-    /// Add Active Keyset
-    async fn set_active_keyset(&self, id: Id) -> Result<(), Self::Err>;
+
+    /// Begins a transaction
+    async fn begin_transaction<'a>(
+        &'a self,
+    ) -> Result<Box<dyn MintAuthTransaction<Self::Err> + Send + Sync + 'a>, Self::Err>;
+
     /// Get Active Keyset
     async fn get_active_keyset_id(&self) -> Result<Option<Id>, Self::Err>;
 
-    /// Add [`MintKeySetInfo`]
-    async fn add_keyset_info(&self, keyset: MintKeySetInfo) -> Result<(), Self::Err>;
     /// Get [`MintKeySetInfo`]
     async fn get_keyset_info(&self, id: &Id) -> Result<Option<MintKeySetInfo>, Self::Err>;
     /// Get [`MintKeySetInfo`]s
     async fn get_keyset_infos(&self) -> Result<Vec<MintKeySetInfo>, Self::Err>;
 
-    /// Add spent [`AuthProof`]
-    async fn add_proof(&self, proof: AuthProof) -> Result<(), Self::Err>;
     /// Get [`AuthProof`] state
     async fn get_proofs_states(&self, ys: &[PublicKey]) -> Result<Vec<Option<State>>, Self::Err>;
-    /// Update [`AuthProof`]s state
-    async fn update_proof_state(
-        &self,
-        y: &PublicKey,
-        proofs_state: State,
-    ) -> Result<Option<State>, Self::Err>;
 
-    /// Add [`BlindSignature`]
-    async fn add_blind_signatures(
-        &self,
-        blinded_messages: &[PublicKey],
-        blind_signatures: &[BlindSignature],
-    ) -> Result<(), Self::Err>;
     /// Get [`BlindSignature`]s
     async fn get_blind_signatures(
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err>;
 
-    /// Add protected endpoints
-    async fn add_protected_endpoints(
-        &self,
-        protected_endpoints: HashMap<ProtectedEndpoint, AuthRequired>,
-    ) -> Result<(), Self::Err>;
-    /// Removed Protected endpoints
-    async fn remove_protected_endpoints(
-        &self,
-        protected_endpoints: Vec<ProtectedEndpoint>,
-    ) -> Result<(), Self::Err>;
     /// Get auth for protected_endpoint
     async fn get_auth_for_endpoint(
         &self,

--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -21,7 +21,7 @@ mod auth;
 pub mod test;
 
 #[cfg(feature = "auth")]
-pub use auth::MintAuthDatabase;
+pub use auth::{MintAuthDatabase, MintAuthTransaction};
 
 /// KeysDatabaseWriter
 #[async_trait]

--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -83,6 +83,14 @@ pub trait QuotesTransaction<'a> {
     ) -> Result<Option<mint::MeltQuote>, Self::Err>;
     /// Add [`mint::MeltQuote`]
     async fn add_melt_quote(&mut self, quote: mint::MeltQuote) -> Result<(), Self::Err>;
+
+    /// Updates the request lookup id for a melt quote
+    async fn update_melt_quote_request_lookup_id(
+        &mut self,
+        quote_id: &Uuid,
+        new_request_lookup_id: &str,
+    ) -> Result<(), Self::Err>;
+
     /// Update [`mint::MeltQuote`] state
     ///
     /// It is expected for this function to fail if the state is already set to the new state

--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -149,6 +149,13 @@ pub trait ProofsTransaction<'a> {
         ys: &[PublicKey],
         proofs_state: State,
     ) -> Result<Vec<Option<State>>, Self::Err>;
+
+    /// Remove [`Proofs`]
+    async fn remove_proofs(
+        &mut self,
+        ys: &[PublicKey],
+        quote_id: Option<Uuid>,
+    ) -> Result<(), Self::Err>;
 }
 
 /// Mint Proof Database trait

--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -67,7 +67,7 @@ pub trait QuotesTransaction<'a> {
     async fn get_mint_quote(&mut self, quote_id: &Uuid)
         -> Result<Option<MintMintQuote>, Self::Err>;
     /// Add [`MintMintQuote`]
-    async fn add_mint_quote(&mut self, quote: MintMintQuote) -> Result<(), Self::Err>;
+    async fn add_or_replace_mint_quote(&mut self, quote: MintMintQuote) -> Result<(), Self::Err>;
     /// Update state of [`MintMintQuote`]
     async fn update_mint_quote_state(
         &mut self,

--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -23,24 +23,81 @@ pub mod test;
 #[cfg(feature = "auth")]
 pub use auth::MintAuthDatabase;
 
+/// KeysDatabaseWriter
+#[async_trait]
+pub trait KeysDatabaseTransaction<'a, Error>: DbTransactionFinalizer<Err = Error> {
+    /// Add Active Keyset
+    async fn set_active_keyset(&mut self, unit: CurrencyUnit, id: Id) -> Result<(), Error>;
+
+    /// Add [`MintKeySetInfo`]
+    async fn add_keyset_info(&mut self, keyset: MintKeySetInfo) -> Result<(), Error>;
+}
+
 /// Mint Keys Database trait
 #[async_trait]
 pub trait KeysDatabase {
     /// Mint Keys Database Error
     type Err: Into<Error> + From<Error>;
 
-    /// Add Active Keyset
-    async fn set_active_keyset(&self, unit: CurrencyUnit, id: Id) -> Result<(), Self::Err>;
+    /// Beings a transaction
+    async fn begin_transaction<'a>(
+        &'a self,
+    ) -> Result<Box<dyn KeysDatabaseTransaction<'a, Self::Err> + Send + Sync + 'a>, Error>;
+
     /// Get Active Keyset
     async fn get_active_keyset_id(&self, unit: &CurrencyUnit) -> Result<Option<Id>, Self::Err>;
+
     /// Get all Active Keyset
     async fn get_active_keysets(&self) -> Result<HashMap<CurrencyUnit, Id>, Self::Err>;
-    /// Add [`MintKeySetInfo`]
-    async fn add_keyset_info(&self, keyset: MintKeySetInfo) -> Result<(), Self::Err>;
+
     /// Get [`MintKeySetInfo`]
     async fn get_keyset_info(&self, id: &Id) -> Result<Option<MintKeySetInfo>, Self::Err>;
+
     /// Get [`MintKeySetInfo`]s
     async fn get_keyset_infos(&self) -> Result<Vec<MintKeySetInfo>, Self::Err>;
+}
+
+/// Mint Quote Database writer trait
+#[async_trait]
+pub trait QuotesTransaction<'a> {
+    /// Mint Quotes Database Error
+    type Err: Into<Error> + From<Error>;
+
+    /// Get [`MintMintQuote`] and lock it for update in this transaction
+    async fn get_mint_quote(&mut self, quote_id: &Uuid)
+        -> Result<Option<MintMintQuote>, Self::Err>;
+    /// Add [`MintMintQuote`]
+    async fn add_mint_quote(&mut self, quote: MintMintQuote) -> Result<(), Self::Err>;
+    /// Update state of [`MintMintQuote`]
+    async fn update_mint_quote_state(
+        &mut self,
+        quote_id: &Uuid,
+        state: MintQuoteState,
+    ) -> Result<MintQuoteState, Self::Err>;
+    /// Remove [`MintMintQuote`]
+    async fn remove_mint_quote(&mut self, quote_id: &Uuid) -> Result<(), Self::Err>;
+    /// Get [`mint::MeltQuote`] and lock it for update in this transaction
+    async fn get_melt_quote(
+        &mut self,
+        quote_id: &Uuid,
+    ) -> Result<Option<mint::MeltQuote>, Self::Err>;
+    /// Add [`mint::MeltQuote`]
+    async fn add_melt_quote(&mut self, quote: mint::MeltQuote) -> Result<(), Self::Err>;
+    /// Update [`mint::MeltQuote`] state
+    ///
+    /// It is expected for this function to fail if the state is already set to the new state
+    async fn update_melt_quote_state(
+        &mut self,
+        quote_id: &Uuid,
+        new_state: MeltQuoteState,
+    ) -> Result<(MeltQuoteState, mint::MeltQuote), Self::Err>;
+    /// Remove [`mint::MeltQuote`]
+    async fn remove_melt_quote(&mut self, quote_id: &Uuid) -> Result<(), Self::Err>;
+    /// Get all [`MintMintQuote`]s and lock it for update in this transaction
+    async fn get_mint_quote_by_request(
+        &mut self,
+        request: &str,
+    ) -> Result<Option<MintMintQuote>, Self::Err>;
 }
 
 /// Mint Quote Database trait
@@ -49,16 +106,9 @@ pub trait QuotesDatabase {
     /// Mint Quotes Database Error
     type Err: Into<Error> + From<Error>;
 
-    /// Add [`MintMintQuote`]
-    async fn add_mint_quote(&self, quote: MintMintQuote) -> Result<(), Self::Err>;
     /// Get [`MintMintQuote`]
     async fn get_mint_quote(&self, quote_id: &Uuid) -> Result<Option<MintMintQuote>, Self::Err>;
-    /// Update state of [`MintMintQuote`]
-    async fn update_mint_quote_state(
-        &self,
-        quote_id: &Uuid,
-        state: MintQuoteState,
-    ) -> Result<MintQuoteState, Self::Err>;
+
     /// Get all [`MintMintQuote`]s
     async fn get_mint_quote_by_request(
         &self,
@@ -76,25 +126,29 @@ pub trait QuotesDatabase {
         &self,
         state: MintQuoteState,
     ) -> Result<Vec<MintMintQuote>, Self::Err>;
-    /// Remove [`MintMintQuote`]
-    async fn remove_mint_quote(&self, quote_id: &Uuid) -> Result<(), Self::Err>;
-
-    /// Add [`mint::MeltQuote`]
-    async fn add_melt_quote(&self, quote: mint::MeltQuote) -> Result<(), Self::Err>;
     /// Get [`mint::MeltQuote`]
     async fn get_melt_quote(&self, quote_id: &Uuid) -> Result<Option<mint::MeltQuote>, Self::Err>;
-    /// Update [`mint::MeltQuote`] state
-    ///
-    /// It is expected for this function to fail if the state is already set to the new state
-    async fn update_melt_quote_state(
-        &self,
-        quote_id: &Uuid,
-        new_state: MeltQuoteState,
-    ) -> Result<(MeltQuoteState, mint::MeltQuote), Self::Err>;
     /// Get all [`mint::MeltQuote`]s
     async fn get_melt_quotes(&self) -> Result<Vec<mint::MeltQuote>, Self::Err>;
-    /// Remove [`mint::MeltQuote`]
-    async fn remove_melt_quote(&self, quote_id: &Uuid) -> Result<(), Self::Err>;
+}
+
+/// Mint Proof Transaction trait
+#[async_trait]
+pub trait ProofsTransaction<'a> {
+    /// Mint Proof Database Error
+    type Err: Into<Error> + From<Error>;
+
+    /// Add  [`Proofs`]
+    ///
+    /// Adds proofs to the database. The database should error if the proof already exits, with a
+    /// `AttemptUpdateSpentProof` if the proof is already spent or a `Duplicate` error otherwise.
+    async fn add_proofs(&mut self, proof: Proofs, quote_id: Option<Uuid>) -> Result<(), Self::Err>;
+    /// Updates the proofs to a given states and return the previous states
+    async fn update_proofs_states(
+        &mut self,
+        ys: &[PublicKey],
+        proofs_state: State,
+    ) -> Result<Vec<Option<State>>, Self::Err>;
 }
 
 /// Mint Proof Database trait
@@ -103,11 +157,6 @@ pub trait ProofsDatabase {
     /// Mint Proof Database Error
     type Err: Into<Error> + From<Error>;
 
-    /// Add  [`Proofs`]
-    ///
-    /// Adds proofs to the database. The database should error if the proof already exits, with a
-    /// `AttemptUpdateSpentProof` if the proof is already spent or a `Duplicate` error otherwise.
-    async fn add_proofs(&self, proof: Proofs, quote_id: Option<Uuid>) -> Result<(), Self::Err>;
     /// Remove [`Proofs`]
     async fn remove_proofs(
         &self,
@@ -120,12 +169,6 @@ pub trait ProofsDatabase {
     async fn get_proof_ys_by_quote_id(&self, quote_id: &Uuid) -> Result<Vec<PublicKey>, Self::Err>;
     /// Get [`Proofs`] state
     async fn get_proofs_states(&self, ys: &[PublicKey]) -> Result<Vec<Option<State>>, Self::Err>;
-    /// Get [`Proofs`] state
-    async fn update_proofs_states(
-        &self,
-        ys: &[PublicKey],
-        proofs_state: State,
-    ) -> Result<Vec<Option<State>>, Self::Err>;
     /// Get [`Proofs`] by state
     async fn get_proofs_by_keyset_id(
         &self,
@@ -134,18 +177,32 @@ pub trait ProofsDatabase {
 }
 
 #[async_trait]
-/// Mint Signatures Database trait
-pub trait SignaturesDatabase {
+/// Mint Signatures Transaction trait
+pub trait SignaturesTransaction<'a> {
     /// Mint Signature Database Error
     type Err: Into<Error> + From<Error>;
 
     /// Add [`BlindSignature`]
     async fn add_blind_signatures(
-        &self,
+        &mut self,
         blinded_messages: &[PublicKey],
         blind_signatures: &[BlindSignature],
         quote_id: Option<Uuid>,
     ) -> Result<(), Self::Err>;
+
+    /// Get [`BlindSignature`]s
+    async fn get_blind_signatures(
+        &mut self,
+        blinded_messages: &[PublicKey],
+    ) -> Result<Vec<Option<BlindSignature>>, Self::Err>;
+}
+
+#[async_trait]
+/// Mint Signatures Database trait
+pub trait SignaturesDatabase {
+    /// Mint Signature Database Error
+    type Err: Into<Error> + From<Error>;
+
     /// Get [`BlindSignature`]s
     async fn get_blind_signatures(
         &self,
@@ -163,13 +220,42 @@ pub trait SignaturesDatabase {
     ) -> Result<Vec<BlindSignature>, Self::Err>;
 }
 
+#[async_trait]
+/// Commit and Rollback
+pub trait DbTransactionFinalizer {
+    /// Mint Signature Database Error
+    type Err: Into<Error> + From<Error>;
+
+    /// Commits all the changes into the database
+    async fn commit(self: Box<Self>) -> Result<(), Self::Err>;
+
+    /// Rollbacks the write transaction
+    async fn rollback(self: Box<Self>) -> Result<(), Self::Err>;
+}
+
+/// Base database writer
+#[async_trait]
+pub trait Transaction<'a, Error>:
+    DbTransactionFinalizer<Err = Error>
+    + QuotesTransaction<'a, Err = Error>
+    + SignaturesTransaction<'a, Err = Error>
+    + ProofsTransaction<'a, Err = Error>
+{
+}
+
 /// Mint Database trait
 #[async_trait]
 pub trait Database<Error>:
     QuotesDatabase<Err = Error> + ProofsDatabase<Err = Error> + SignaturesDatabase<Err = Error>
 {
+    /// Beings a transaction
+    async fn begin_transaction<'a>(
+        &'a self,
+    ) -> Result<Box<dyn Transaction<'a, Error> + Send + Sync + 'a>, Error>;
+
     /// Set [`MintInfo`]
     async fn set_mint_info(&self, mint_info: MintInfo) -> Result<(), Error>;
+
     /// Get [`MintInfo`]
     async fn get_mint_info(&self) -> Result<MintInfo, Error>;
 

--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -157,12 +157,6 @@ pub trait ProofsDatabase {
     /// Mint Proof Database Error
     type Err: Into<Error> + From<Error>;
 
-    /// Remove [`Proofs`]
-    async fn remove_proofs(
-        &self,
-        ys: &[PublicKey],
-        quote_id: Option<Uuid>,
-    ) -> Result<(), Self::Err>;
     /// Get [`Proofs`] by ys
     async fn get_proofs_by_ys(&self, ys: &[PublicKey]) -> Result<Vec<Option<Proof>>, Self::Err>;
     /// Get ys by quote id
@@ -241,6 +235,11 @@ pub trait Transaction<'a, Error>:
     + SignaturesTransaction<'a, Err = Error>
     + ProofsTransaction<'a, Err = Error>
 {
+    /// Set [`QuoteTTL`]
+    async fn set_quote_ttl(&mut self, quote_ttl: QuoteTTL) -> Result<(), Error>;
+
+    /// Set [`MintInfo`]
+    async fn set_mint_info(&mut self, mint_info: MintInfo) -> Result<(), Error>;
 }
 
 /// Mint Database trait
@@ -253,14 +252,9 @@ pub trait Database<Error>:
         &'a self,
     ) -> Result<Box<dyn Transaction<'a, Error> + Send + Sync + 'a>, Error>;
 
-    /// Set [`MintInfo`]
-    async fn set_mint_info(&self, mint_info: MintInfo) -> Result<(), Error>;
-
     /// Get [`MintInfo`]
     async fn get_mint_info(&self) -> Result<MintInfo, Error>;
 
-    /// Set [`QuoteTTL`]
-    async fn set_quote_ttl(&self, quote_ttl: QuoteTTL) -> Result<(), Error>;
     /// Get [`QuoteTTL`]
     async fn get_quote_ttl(&self) -> Result<QuoteTTL, Error>;
 }

--- a/crates/cdk-common/src/database/mint/test.rs
+++ b/crates/cdk-common/src/database/mint/test.rs
@@ -2,17 +2,20 @@
 //!
 //! This set is generic and checks the default and expected behaviour for a mint database
 //! implementation
-use std::fmt::Debug;
 use std::str::FromStr;
 
 use cashu::secret::Secret;
 use cashu::{Amount, CurrencyUnit, SecretKey};
 
 use super::*;
+use crate::database;
 use crate::mint::MintKeySetInfo;
 
 #[inline]
-async fn setup_keyset<E: Debug, DB: Database<E> + KeysDatabase<Err = E>>(db: &DB) -> Id {
+async fn setup_keyset<DB>(db: &DB) -> Id
+where
+    DB: KeysDatabase<Err = database::Error>,
+{
     let keyset_id = Id::from_str("00916bbf7ef91a36").unwrap();
     let keyset_info = MintKeySetInfo {
         id: keyset_id,
@@ -25,12 +28,17 @@ async fn setup_keyset<E: Debug, DB: Database<E> + KeysDatabase<Err = E>>(db: &DB
         max_order: 32,
         input_fee_ppk: 0,
     };
-    db.add_keyset_info(keyset_info).await.unwrap();
+    let mut writer = db.begin_transaction().await.expect("db.begin()");
+    writer.add_keyset_info(keyset_info).await.unwrap();
+    writer.commit().await.expect("commit()");
     keyset_id
 }
 
 /// State transition test
-pub async fn state_transition<E: Debug, DB: Database<E> + KeysDatabase<Err = E>>(db: DB) {
+pub async fn state_transition<DB>(db: DB)
+where
+    DB: Database<database::Error> + KeysDatabase<Err = database::Error>,
+{
     let keyset_id = setup_keyset(&db).await;
 
     let proofs = vec![
@@ -53,19 +61,21 @@ pub async fn state_transition<E: Debug, DB: Database<E> + KeysDatabase<Err = E>>
     ];
 
     // Add proofs to database
-    db.add_proofs(proofs.clone(), None).await.unwrap();
+    let mut tx = Database::begin_transaction(&db).await.unwrap();
+    tx.add_proofs(proofs.clone(), None).await.unwrap();
 
     // Mark one proof as `pending`
-    assert!(db
+    assert!(tx
         .update_proofs_states(&[proofs[0].y().unwrap()], State::Pending)
         .await
         .is_ok());
 
     // Attempt to select the `pending` proof, as `pending` again (which should fail)
-    assert!(db
+    assert!(tx
         .update_proofs_states(&[proofs[0].y().unwrap()], State::Pending)
         .await
         .is_err());
+    tx.commit().await.unwrap();
 }
 
 /// Unit test that is expected to be passed for a correct database implementation

--- a/crates/cdk-common/src/database/mod.rs
+++ b/crates/cdk-common/src/database/mod.rs
@@ -9,9 +9,12 @@ mod wallet;
 pub use mint::MintAuthDatabase;
 #[cfg(feature = "mint")]
 pub use mint::{
-    Database as MintDatabase, KeysDatabase as MintKeysDatabase,
-    ProofsDatabase as MintProofsDatabase, QuotesDatabase as MintQuotesDatabase,
+    Database as MintDatabase, DbTransactionFinalizer as MintDbWriterFinalizer,
+    KeysDatabase as MintKeysDatabase, KeysDatabaseTransaction as MintKeyDatabaseTransaction,
+    ProofsDatabase as MintProofsDatabase, ProofsTransaction as MintProofsTransaction,
+    QuotesDatabase as MintQuotesDatabase, QuotesTransaction as MintQuotesTransaction,
     SignaturesDatabase as MintSignaturesDatabase,
+    SignaturesTransaction as MintSignatureTransaction, Transaction as MintTransaction,
 };
 #[cfg(feature = "wallet")]
 pub use wallet::Database as WalletDatabase;

--- a/crates/cdk-common/src/database/mod.rs
+++ b/crates/cdk-common/src/database/mod.rs
@@ -5,8 +5,6 @@ pub mod mint;
 #[cfg(feature = "wallet")]
 mod wallet;
 
-#[cfg(all(feature = "mint", feature = "auth"))]
-pub use mint::MintAuthDatabase;
 #[cfg(feature = "mint")]
 pub use mint::{
     Database as MintDatabase, DbTransactionFinalizer as MintDbWriterFinalizer,
@@ -16,6 +14,8 @@ pub use mint::{
     SignaturesDatabase as MintSignaturesDatabase,
     SignaturesTransaction as MintSignatureTransaction, Transaction as MintTransaction,
 };
+#[cfg(all(feature = "mint", feature = "auth"))]
+pub use mint::{MintAuthDatabase, MintAuthTransaction};
 #[cfg(feature = "wallet")]
 pub use wallet::Database as WalletDatabase;
 

--- a/crates/cdk-integration-tests/src/init_auth_mint.rs
+++ b/crates/cdk-integration-tests/src/init_auth_mint.rs
@@ -71,9 +71,9 @@ where
                 acc
             });
 
-    auth_database
-        .add_protected_endpoints(blind_auth_endpoints)
-        .await?;
+    let mut tx = auth_database.begin_transaction().await?;
+
+    tx.add_protected_endpoints(blind_auth_endpoints).await?;
 
     let mut clear_auth_endpoint = HashMap::new();
     clear_auth_endpoint.insert(
@@ -81,9 +81,9 @@ where
         AuthRequired::Clear,
     );
 
-    auth_database
-        .add_protected_endpoints(clear_auth_endpoint)
-        .await?;
+    tx.add_protected_endpoints(clear_auth_endpoint).await?;
+
+    tx.commit().await?;
 
     mint_builder = mint_builder.with_auth_localstore(Arc::new(auth_database));
 

--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -227,11 +227,12 @@ pub async fn create_and_start_test_mint() -> Result<Mint> {
         .map(|x| x.clone())
         .expect("localstore");
 
-    localstore
-        .set_mint_info(mint_builder.mint_info.clone())
-        .await?;
+    let mut tx = localstore.begin_transaction().await?;
+    tx.set_mint_info(mint_builder.mint_info.clone()).await?;
+
     let quote_ttl = QuoteTTL::new(10000, 10000);
-    localstore.set_quote_ttl(quote_ttl).await?;
+    tx.set_quote_ttl(quote_ttl).await?;
+    tx.commit().await?;
 
     let mint = mint_builder.build().await?;
 

--- a/crates/cdk-integration-tests/tests/happy_path_mint_wallet.rs
+++ b/crates/cdk-integration-tests/tests/happy_path_mint_wallet.rs
@@ -425,9 +425,7 @@ async fn test_pay_invoice_twice() {
 
     let melt = wallet.melt(&melt_quote.id).await.unwrap();
 
-    let melt_two = wallet.melt_quote(invoice, None).await.unwrap();
-
-    let melt_two = wallet.melt(&melt_two.id).await;
+    let melt_two = wallet.melt_quote(invoice, None).await;
 
     match melt_two {
         Err(err) => match err {

--- a/crates/cdk-integration-tests/tests/mint.rs
+++ b/crates/cdk-integration-tests/tests/mint.rs
@@ -51,13 +51,15 @@ async fn test_correct_keyset() {
         .with_seed(mnemonic.to_seed_normalized("").to_vec());
 
     let mint = mint_builder.build().await.unwrap();
+    let mut tx = localstore.begin_transaction().await.unwrap();
 
-    localstore
-        .set_mint_info(mint_builder.mint_info.clone())
+    tx.set_mint_info(mint_builder.mint_info.clone())
         .await
         .unwrap();
     let quote_ttl = QuoteTTL::new(10000, 10000);
-    localstore.set_quote_ttl(quote_ttl).await.unwrap();
+    tx.set_quote_ttl(quote_ttl).await.unwrap();
+
+    tx.commit().await.unwrap();
 
     let active = mint.get_active_keysets();
 

--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -655,8 +655,16 @@ impl CdkMint for MintRPCServer {
 
                 mint_quote.state = state;
 
-                self.mint
-                    .update_mint_quote(mint_quote)
+                let mut tx = self
+                    .mint
+                    .localstore
+                    .begin_transaction()
+                    .await
+                    .map_err(|_| Status::internal("Could not update quote".to_string()))?;
+                tx.add_or_replace_mint_quote(mint_quote)
+                    .await
+                    .map_err(|_| Status::internal("Could not update quote".to_string()))?;
+                tx.commit()
                     .await
                     .map_err(|_| Status::internal("Could not update quote".to_string()))?;
             }

--- a/crates/cdk-mintd/src/main.rs
+++ b/crates/cdk-mintd/src/main.rs
@@ -526,12 +526,11 @@ async fn main() -> anyhow::Result<()> {
 
         mint_builder = mint_builder.set_blind_auth_settings(auth_settings.mint_max_bat);
 
-        auth_localstore
-            .remove_protected_endpoints(unprotected_endpoints)
-            .await?;
-        auth_localstore
-            .add_protected_endpoints(protected_endpoints)
-            .await?;
+        let mut tx = auth_localstore.begin_transaction().await?;
+
+        tx.remove_protected_endpoints(unprotected_endpoints).await?;
+        tx.add_protected_endpoints(protected_endpoints).await?;
+        tx.commit().await?;
     }
 
     let mint = mint_builder.build().await?;

--- a/crates/cdk-signatory/src/common.rs
+++ b/crates/cdk-signatory/src/common.rs
@@ -25,7 +25,7 @@ pub async fn init_keysets(
     // Get keysets info from DB
     let keysets_infos = localstore.get_keyset_infos().await?;
 
-    let mut tx = localstore.begin_transaction().await.expect("begin");
+    let mut tx = localstore.begin_transaction().await?;
     if !keysets_infos.is_empty() {
         tracing::debug!("Setting all saved keysets to inactive");
         for keyset in keysets_infos.clone() {
@@ -114,7 +114,7 @@ pub async fn init_keysets(
         }
     }
 
-    tx.commit().await.expect("commit");
+    tx.commit().await?;
 
     Ok((active_keysets, active_keyset_units))
 }

--- a/crates/cdk-signatory/src/common.rs
+++ b/crates/cdk-signatory/src/common.rs
@@ -25,13 +25,14 @@ pub async fn init_keysets(
     // Get keysets info from DB
     let keysets_infos = localstore.get_keyset_infos().await?;
 
+    let mut tx = localstore.begin_transaction().await.expect("begin");
     if !keysets_infos.is_empty() {
         tracing::debug!("Setting all saved keysets to inactive");
         for keyset in keysets_infos.clone() {
             // Set all to in active
             let mut keyset = keyset;
             keyset.active = false;
-            localstore.add_keyset_info(keyset).await?;
+            tx.add_keyset_info(keyset).await?;
         }
 
         let keysets_by_unit: HashMap<CurrencyUnit, Vec<MintKeySetInfo>> =
@@ -74,9 +75,9 @@ pub async fn init_keysets(
                     active_keysets.insert(id, keyset);
                     let mut keyset_info = highest_index_keyset;
                     keyset_info.active = true;
-                    localstore.add_keyset_info(keyset_info).await?;
+                    tx.add_keyset_info(keyset_info).await?;
                     active_keyset_units.push(unit.clone());
-                    localstore.set_active_keyset(unit, id).await?;
+                    tx.set_active_keyset(unit, id).await?;
                 } else {
                     // Check to see if there are not keysets by this unit
                     let derivation_path_index = if keysets.is_empty() {
@@ -104,14 +105,16 @@ pub async fn init_keysets(
                     );
 
                     let id = keyset_info.id;
-                    localstore.add_keyset_info(keyset_info).await?;
-                    localstore.set_active_keyset(unit.clone(), id).await?;
+                    tx.add_keyset_info(keyset_info).await?;
+                    tx.set_active_keyset(unit.clone(), id).await?;
                     active_keysets.insert(id, keyset);
                     active_keyset_units.push(unit.clone());
                 };
             }
         }
     }
+
+    tx.commit().await.expect("commit");
 
     Ok((active_keysets, active_keyset_units))
 }

--- a/crates/cdk-sqlite/src/mint/auth/mod.rs
+++ b/crates/cdk-sqlite/src/mint/auth/mod.rs
@@ -6,14 +6,14 @@ use std::path::Path;
 use std::str::FromStr;
 
 use async_trait::async_trait;
-use cdk_common::database::{self, MintAuthDatabase};
+use cdk_common::database::{self, MintAuthDatabase, MintAuthTransaction};
 use cdk_common::mint::MintKeySetInfo;
 use cdk_common::nuts::{AuthProof, BlindSignature, Id, PublicKey, State};
 use cdk_common::{AuthRequired, ProtectedEndpoint};
 use tracing::instrument;
 
 use super::async_rusqlite::AsyncRusqlite;
-use super::{sqlite_row_to_blind_signature, sqlite_row_to_keyset_info};
+use super::{sqlite_row_to_blind_signature, sqlite_row_to_keyset_info, SqliteTransaction};
 use crate::column_as_string;
 use crate::common::{create_sqlite_pool, migrate};
 use crate::mint::async_rusqlite::query;
@@ -56,11 +56,9 @@ impl MintSqliteAuthDatabase {
 }
 
 #[async_trait]
-impl MintAuthDatabase for MintSqliteAuthDatabase {
-    type Err = database::Error;
-
+impl MintAuthTransaction<database::Error> for SqliteTransaction<'_> {
     #[instrument(skip(self))]
-    async fn set_active_keyset(&self, id: Id) -> Result<(), Self::Err> {
+    async fn set_active_keyset(&mut self, id: Id) -> Result<(), database::Error> {
         tracing::info!("Setting auth keyset {id} active");
         query(
             r#"
@@ -72,30 +70,13 @@ impl MintAuthDatabase for MintSqliteAuthDatabase {
             "#,
         )
         .bind(":id", id.to_string())
-        .execute(&self.pool)
+        .execute(&self.transaction)
         .await?;
 
         Ok(())
     }
 
-    async fn get_active_keyset_id(&self) -> Result<Option<Id>, Self::Err> {
-        Ok(query(
-            r#"
-            SELECT
-                id
-            FROM
-                keyset
-            WHERE
-                active = 1;
-            "#,
-        )
-        .pluck(&self.pool)
-        .await?
-        .map(|id| Ok::<_, Error>(column_as_string!(id, Id::from_str, Id::from_bytes)))
-        .transpose()?)
-    }
-
-    async fn add_keyset_info(&self, keyset: MintKeySetInfo) -> Result<(), Self::Err> {
+    async fn add_keyset_info(&mut self, keyset: MintKeySetInfo) -> Result<(), database::Error> {
         query(
             r#"
         INSERT INTO
@@ -125,10 +106,157 @@ impl MintAuthDatabase for MintSqliteAuthDatabase {
         .bind(":derivation_path", keyset.derivation_path.to_string())
         .bind(":max_order", keyset.max_order)
         .bind(":derivation_path_index", keyset.derivation_path_index)
-        .execute(&self.pool)
+        .execute(&self.transaction)
         .await?;
 
         Ok(())
+    }
+
+    async fn add_proof(&mut self, proof: AuthProof) -> Result<(), database::Error> {
+        if let Err(err) = query(
+            r#"
+                INSERT INTO proof
+                (y, keyset_id, secret, c, state)
+                VALUES
+                (:y, :keyset_id, :secret, :c, :state)
+                "#,
+        )
+        .bind(":y", proof.y()?.to_bytes().to_vec())
+        .bind(":keyset_id", proof.keyset_id.to_string())
+        .bind(":secret", proof.secret.to_string())
+        .bind(":c", proof.c.to_bytes().to_vec())
+        .bind(":state", "UNSPENT".to_string())
+        .execute(&self.transaction)
+        .await
+        {
+            tracing::debug!("Attempting to add known proof. Skipping.... {:?}", err);
+        }
+        Ok(())
+    }
+
+    async fn update_proof_state(
+        &mut self,
+        y: &PublicKey,
+        proofs_state: State,
+    ) -> Result<Option<State>, Self::Err> {
+        let current_state = query(r#"SELECT state FROM proof WHERE y = :y"#)
+            .bind(":y", y.to_bytes().to_vec())
+            .pluck(&self.transaction)
+            .await?
+            .map(|state| Ok::<_, Error>(column_as_string!(state, State::from_str)))
+            .transpose()?;
+
+        query(r#"UPDATE proof SET state = :new_state WHERE state = :state AND y = :y"#)
+            .bind(":y", y.to_bytes().to_vec())
+            .bind(
+                ":state",
+                current_state.as_ref().map(|state| state.to_string()),
+            )
+            .bind(":new_state", proofs_state.to_string())
+            .execute(&self.transaction)
+            .await?;
+
+        Ok(current_state)
+    }
+
+    async fn add_blind_signatures(
+        &mut self,
+        blinded_messages: &[PublicKey],
+        blind_signatures: &[BlindSignature],
+    ) -> Result<(), database::Error> {
+        for (message, signature) in blinded_messages.iter().zip(blind_signatures) {
+            query(
+                r#"
+                       INSERT
+                       INTO blind_signature
+                       (y, amount, keyset_id, c)
+                       VALUES
+                       (:y, :amount, :keyset_id, :c)
+                   "#,
+            )
+            .bind(":y", message.to_bytes().to_vec())
+            .bind(":amount", u64::from(signature.amount) as i64)
+            .bind(":keyset_id", signature.keyset_id.to_string())
+            .bind(":c", signature.c.to_bytes().to_vec())
+            .execute(&self.transaction)
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn add_protected_endpoints(
+        &mut self,
+        protected_endpoints: HashMap<ProtectedEndpoint, AuthRequired>,
+    ) -> Result<(), database::Error> {
+        for (endpoint, auth) in protected_endpoints.iter() {
+            if let Err(err) = query(
+                r#"
+                 INSERT OR REPLACE INTO protected_endpoints
+                 (endpoint, auth)
+                 VALUES (:endpoint, :auth);
+                 "#,
+            )
+            .bind(":endpoint", serde_json::to_string(endpoint)?)
+            .bind(":auth", serde_json::to_string(auth)?)
+            .execute(&self.transaction)
+            .await
+            {
+                tracing::debug!(
+                    "Attempting to add protected endpoint. Skipping.... {:?}",
+                    err
+                );
+            }
+        }
+
+        Ok(())
+    }
+    async fn remove_protected_endpoints(
+        &mut self,
+        protected_endpoints: Vec<ProtectedEndpoint>,
+    ) -> Result<(), database::Error> {
+        query(r#"DELETE FROM protected_endpoints WHERE endpoint IN (:endpoints)"#)
+            .bind_vec(
+                ":endpoints",
+                protected_endpoints
+                    .iter()
+                    .map(serde_json::to_string)
+                    .collect::<Result<_, _>>()?,
+            )
+            .execute(&self.transaction)
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl MintAuthDatabase for MintSqliteAuthDatabase {
+    type Err = database::Error;
+
+    async fn begin_transaction<'a>(
+        &'a self,
+    ) -> Result<Box<dyn MintAuthTransaction<database::Error> + Send + Sync + 'a>, database::Error>
+    {
+        Ok(Box::new(SqliteTransaction {
+            transaction: self.pool.begin().await?,
+        }))
+    }
+
+    async fn get_active_keyset_id(&self) -> Result<Option<Id>, Self::Err> {
+        Ok(query(
+            r#"
+            SELECT
+                id
+            FROM
+                keyset
+            WHERE
+                active = 1;
+            "#,
+        )
+        .pluck(&self.pool)
+        .await?
+        .map(|id| Ok::<_, Error>(column_as_string!(id, Id::from_str, Id::from_bytes)))
+        .transpose()?)
     }
 
     async fn get_keyset_info(&self, id: &Id) -> Result<Option<MintKeySetInfo>, Self::Err> {
@@ -177,28 +305,6 @@ impl MintAuthDatabase for MintSqliteAuthDatabase {
         .collect::<Result<Vec<_>, _>>()?)
     }
 
-    async fn add_proof(&self, proof: AuthProof) -> Result<(), Self::Err> {
-        if let Err(err) = query(
-            r#"
-            INSERT INTO proof
-            (y, keyset_id, secret, c, state)
-            VALUES
-            (:y, :keyset_id, :secret, :c, :state)
-            "#,
-        )
-        .bind(":y", proof.y()?.to_bytes().to_vec())
-        .bind(":keyset_id", proof.keyset_id.to_string())
-        .bind(":secret", proof.secret.to_string())
-        .bind(":c", proof.c.to_bytes().to_vec())
-        .bind(":state", "UNSPENT".to_string())
-        .execute(&self.pool)
-        .await
-        {
-            tracing::debug!("Attempting to add known proof. Skipping.... {:?}", err);
-        }
-        Ok(())
-    }
-
     async fn get_proofs_states(&self, ys: &[PublicKey]) -> Result<Vec<Option<State>>, Self::Err> {
         let mut current_states = query(r#"SELECT y, state FROM proof WHERE y IN (:ys)"#)
             .bind_vec(":ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
@@ -214,65 +320,6 @@ impl MintAuthDatabase for MintSqliteAuthDatabase {
             .collect::<Result<HashMap<_, _>, Error>>()?;
 
         Ok(ys.iter().map(|y| current_states.remove(y)).collect())
-    }
-
-    async fn update_proof_state(
-        &self,
-        y: &PublicKey,
-        proofs_state: State,
-    ) -> Result<Option<State>, Self::Err> {
-        let transaction = self.pool.begin().await?;
-
-        let current_state = query(r#"SELECT state FROM proof WHERE y = :y"#)
-            .bind(":y", y.to_bytes().to_vec())
-            .pluck(&transaction)
-            .await?
-            .map(|state| Ok::<_, Error>(column_as_string!(state, State::from_str)))
-            .transpose()?;
-
-        query(r#"UPDATE proof SET state = :new_state WHERE state = :state AND y = :y"#)
-            .bind(":y", y.to_bytes().to_vec())
-            .bind(
-                ":state",
-                current_state.as_ref().map(|state| state.to_string()),
-            )
-            .bind(":new_state", proofs_state.to_string())
-            .execute(&transaction)
-            .await?;
-
-        transaction.commit().await?;
-
-        Ok(current_state)
-    }
-
-    async fn add_blind_signatures(
-        &self,
-        blinded_messages: &[PublicKey],
-        blind_signatures: &[BlindSignature],
-    ) -> Result<(), Self::Err> {
-        let transaction = self.pool.begin().await?;
-
-        for (message, signature) in blinded_messages.iter().zip(blind_signatures) {
-            query(
-                r#"
-                    INSERT
-                    INTO blind_signature
-                    (y, amount, keyset_id, c)
-                    VALUES
-                    (:y, :amount, :keyset_id, :c)
-                "#,
-            )
-            .bind(":y", message.to_bytes().to_vec())
-            .bind(":amount", u64::from(signature.amount) as i64)
-            .bind(":keyset_id", signature.keyset_id.to_string())
-            .bind(":c", signature.c.to_bytes().to_vec())
-            .execute(&transaction)
-            .await?;
-        }
-
-        transaction.commit().await?;
-
-        Ok(())
     }
 
     async fn get_blind_signatures(
@@ -317,53 +364,6 @@ impl MintAuthDatabase for MintSqliteAuthDatabase {
             .iter()
             .map(|y| blinded_signatures.remove(y))
             .collect())
-    }
-
-    async fn add_protected_endpoints(
-        &self,
-        protected_endpoints: HashMap<ProtectedEndpoint, AuthRequired>,
-    ) -> Result<(), Self::Err> {
-        let transaction = self.pool.begin().await?;
-
-        for (endpoint, auth) in protected_endpoints.iter() {
-            if let Err(err) = query(
-                r#"
-                INSERT OR REPLACE INTO protected_endpoints
-                (endpoint, auth)
-                VALUES (:endpoint, :auth);
-                "#,
-            )
-            .bind(":endpoint", serde_json::to_string(endpoint)?)
-            .bind(":auth", serde_json::to_string(auth)?)
-            .execute(&transaction)
-            .await
-            {
-                tracing::debug!(
-                    "Attempting to add protected endpoint. Skipping.... {:?}",
-                    err
-                );
-            }
-        }
-
-        transaction.commit().await?;
-
-        Ok(())
-    }
-    async fn remove_protected_endpoints(
-        &self,
-        protected_endpoints: Vec<ProtectedEndpoint>,
-    ) -> Result<(), Self::Err> {
-        query(r#"DELETE FROM protected_endpoints WHERE endpoint IN (:endpoints)"#)
-            .bind_vec(
-                ":endpoints",
-                protected_endpoints
-                    .iter()
-                    .map(serde_json::to_string)
-                    .collect::<Result<_, _>>()?,
-            )
-            .execute(&self.pool)
-            .await?;
-        Ok(())
     }
 
     async fn get_auth_for_endpoint(

--- a/crates/cdk-sqlite/src/mint/memory.rs
+++ b/crates/cdk-sqlite/src/mint/memory.rs
@@ -1,9 +1,7 @@
 //! In-memory database that is provided by the `cdk-sqlite` crate, mainly for testing purposes.
 use std::collections::HashMap;
 
-use cdk_common::database::{
-    self, MintDatabase, MintKeysDatabase, MintProofsDatabase, MintQuotesDatabase,
-};
+use cdk_common::database::{self, MintDatabase, MintKeysDatabase};
 use cdk_common::mint::{self, MintKeySetInfo, MintQuote};
 use cdk_common::nuts::{CurrencyUnit, Id, Proofs};
 use cdk_common::MintInfo;
@@ -31,26 +29,31 @@ pub async fn new_with_state(
     mint_info: MintInfo,
 ) -> Result<MintSqliteDatabase, database::Error> {
     let db = empty().await?;
+    let mut tx = MintKeysDatabase::begin_transaction(&db).await?;
 
     for active_keyset in active_keysets {
-        db.set_active_keyset(active_keyset.0, active_keyset.1)
+        tx.set_active_keyset(active_keyset.0, active_keyset.1)
             .await?;
     }
 
     for keyset in keysets {
-        db.add_keyset_info(keyset).await?;
+        tx.add_keyset_info(keyset).await?;
     }
+    tx.commit().await?;
+
+    let mut tx = MintDatabase::begin_transaction(&db).await?;
 
     for quote in mint_quotes {
-        db.add_mint_quote(quote).await?;
+        tx.add_mint_quote(quote).await?;
     }
 
     for quote in melt_quotes {
-        db.add_melt_quote(quote).await?;
+        tx.add_melt_quote(quote).await?;
     }
 
-    db.add_proofs(pending_proofs, None).await?;
-    db.add_proofs(spent_proofs, None).await?;
+    tx.add_proofs(pending_proofs, None).await?;
+    tx.add_proofs(spent_proofs, None).await?;
+    tx.commit().await?;
 
     db.set_mint_info(mint_info).await?;
 

--- a/crates/cdk-sqlite/src/mint/memory.rs
+++ b/crates/cdk-sqlite/src/mint/memory.rs
@@ -44,7 +44,7 @@ pub async fn new_with_state(
     let mut tx = MintDatabase::begin_transaction(&db).await?;
 
     for quote in mint_quotes {
-        tx.add_mint_quote(quote).await?;
+        tx.add_or_replace_mint_quote(quote).await?;
     }
 
     for quote in melt_quotes {

--- a/crates/cdk-sqlite/src/mint/memory.rs
+++ b/crates/cdk-sqlite/src/mint/memory.rs
@@ -53,9 +53,8 @@ pub async fn new_with_state(
 
     tx.add_proofs(pending_proofs, None).await?;
     tx.add_proofs(spent_proofs, None).await?;
+    tx.set_mint_info(mint_info).await?;
     tx.commit().await?;
-
-    db.set_mint_info(mint_info).await?;
 
     Ok(db)
 }

--- a/crates/cdk-sqlite/src/mint/mod.rs
+++ b/crates/cdk-sqlite/src/mint/mod.rs
@@ -311,7 +311,7 @@ impl MintKeysDatabase for MintSqliteDatabase {
 impl<'a> MintQuotesTransaction<'a> for SqliteTransaction<'a> {
     type Err = database::Error;
 
-    async fn add_mint_quote(&mut self, quote: MintQuote) -> Result<(), Self::Err> {
+    async fn add_or_replace_mint_quote(&mut self, quote: MintQuote) -> Result<(), Self::Err> {
         query(
             r#"
                 INSERT OR REPLACE INTO mint_quote (

--- a/crates/cdk-sqlite/src/mint/mod.rs
+++ b/crates/cdk-sqlite/src/mint/mod.rs
@@ -366,7 +366,7 @@ impl<'a> MintQuotesTransaction<'a> for SqliteTransaction<'a> {
     async fn add_melt_quote(&mut self, quote: mint::MeltQuote) -> Result<(), Self::Err> {
         query(
             r#"
-            INSERT INTO melt_quote
+            INSERT OR REPLACE INTO melt_quote
             (
                 id, unit, amount, request, fee_reserve, state,
                 expiry, payment_preimage, request_lookup_id, msat_to_pay,
@@ -378,29 +378,6 @@ impl<'a> MintQuotesTransaction<'a> for SqliteTransaction<'a> {
                 :expiry, :payment_preimage, :request_lookup_id, :msat_to_pay,
                 :created_time, :paid_time
             )
-            ON CONFLICT(id) DO UPDATE SET
-                unit = excluded.unit,
-                amount = excluded.amount,
-                request = excluded.request,
-                fee_reserve = excluded.fee_reserve,
-                state = excluded.state,
-                expiry = excluded.expiry,
-                payment_preimage = excluded.payment_preimage,
-                request_lookup_id = excluded.request_lookup_id,
-                msat_to_pay = excluded.msat_to_pay,
-                created_time = excluded.created_time,
-                paid_time = excluded.paid_time
-            ON CONFLICT(request_lookup_id) DO UPDATE SET
-                unit = excluded.unit,
-                amount = excluded.amount,
-                request = excluded.request,
-                fee_reserve = excluded.fee_reserve,
-                state = excluded.state,
-                expiry = excluded.expiry,
-                payment_preimage = excluded.payment_preimage,
-                id = excluded.id,
-                created_time = excluded.created_time,
-                paid_time = excluded.paid_time;
         "#,
         )
         .bind(":id", quote.id.to_string())

--- a/crates/cdk-sqlite/src/mint/mod.rs
+++ b/crates/cdk-sqlite/src/mint/mod.rs
@@ -5,13 +5,14 @@ use std::ops::DerefMut;
 use std::path::Path;
 use std::str::FromStr;
 
-use async_rusqlite::{query, DatabaseExecutor};
+use async_rusqlite::{query, DatabaseExecutor, Transaction};
 use async_trait::async_trait;
 use bitcoin::bip32::DerivationPath;
 use cdk_common::common::QuoteTTL;
 use cdk_common::database::{
-    self, MintDatabase, MintKeysDatabase, MintProofsDatabase, MintQuotesDatabase,
-    MintSignaturesDatabase,
+    self, MintDatabase, MintDbWriterFinalizer, MintKeyDatabaseTransaction, MintKeysDatabase,
+    MintProofsDatabase, MintProofsTransaction, MintQuotesDatabase, MintQuotesTransaction,
+    MintSignatureTransaction, MintSignaturesDatabase,
 };
 use cdk_common::mint::{self, MintKeySetInfo, MintQuote};
 use cdk_common::nut00::ProofsMethods;
@@ -52,6 +53,28 @@ pub struct MintSqliteDatabase {
     pool: async_rusqlite::AsyncRusqlite,
 }
 
+#[inline(always)]
+async fn get_current_states<C>(
+    conn: &C,
+    ys: &[PublicKey],
+) -> Result<HashMap<PublicKey, State>, Error>
+where
+    C: DatabaseExecutor + Send + Sync,
+{
+    query(r#"SELECT y, state FROM proof WHERE y IN (:ys)"#)
+        .bind_vec(":ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
+        .fetch_all(conn)
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok((
+                column_as_string!(&row[0], PublicKey::from_hex, PublicKey::from_slice),
+                column_as_string!(&row[1], State::from_str),
+            ))
+        })
+        .collect::<Result<HashMap<_, _>, _>>()
+}
+
 impl MintSqliteDatabase {
     /// Create new [`MintSqliteDatabase`]
     #[cfg(not(feature = "sqlcipher"))]
@@ -76,29 +99,6 @@ impl MintSqliteDatabase {
         Ok(Self {
             pool: async_rusqlite::AsyncRusqlite::new(pool),
         })
-    }
-
-    #[inline(always)]
-    async fn get_current_states<C>(
-        &self,
-        conn: &C,
-        ys: &[PublicKey],
-    ) -> Result<HashMap<PublicKey, State>, Error>
-    where
-        C: DatabaseExecutor + Send + Sync,
-    {
-        query(r#"SELECT y, state FROM proof WHERE y IN (:ys)"#)
-            .bind_vec(":ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
-            .fetch_all(conn)
-            .await?
-            .into_iter()
-            .map(|row| {
-                Ok((
-                    column_as_string!(&row[0], PublicKey::from_hex, PublicKey::from_slice),
-                    column_as_string!(&row[1], State::from_str),
-                ))
-            })
-            .collect::<Result<HashMap<_, _>, _>>()
     }
 
     #[inline(always)]
@@ -135,59 +135,30 @@ impl MintSqliteDatabase {
     }
 }
 
+/// Sqlite Writer
+pub struct SqliteTransaction<'a> {
+    transaction: Transaction<'a>,
+}
+
 #[async_trait]
-impl MintKeysDatabase for MintSqliteDatabase {
+impl<'a> database::MintTransaction<'a, database::Error> for SqliteTransaction<'a> {}
+
+#[async_trait]
+impl MintDbWriterFinalizer for SqliteTransaction<'_> {
     type Err = database::Error;
 
-    async fn set_active_keyset(&self, unit: CurrencyUnit, id: Id) -> Result<(), Self::Err> {
-        let transaction = self.pool.begin().await?;
-
-        query(r#"UPDATE keyset SET active=FALSE WHERE unit IS :unit"#)
-            .bind(":unit", unit.to_string())
-            .execute(&transaction)
-            .await?;
-
-        query(r#"UPDATE keyset SET active=TRUE WHERE unit IS :unit AND id IS :id"#)
-            .bind(":unit", unit.to_string())
-            .bind(":id", id.to_string())
-            .execute(&transaction)
-            .await?;
-
-        transaction.commit().await?;
-
-        Ok(())
+    async fn commit(self: Box<Self>) -> Result<(), database::Error> {
+        Ok(self.transaction.commit().await?)
     }
 
-    async fn get_active_keyset_id(&self, unit: &CurrencyUnit) -> Result<Option<Id>, Self::Err> {
-        Ok(
-            query(r#" SELECT id FROM keyset WHERE active = 1 AND unit IS :unit"#)
-                .bind(":unit", unit.to_string())
-                .pluck(&self.pool)
-                .await?
-                .map(|id| match id {
-                    Column::Text(text) => Ok(Id::from_str(&text)?),
-                    Column::Blob(id) => Ok(Id::from_bytes(&id)?),
-                    _ => Err(Error::InvalidKeysetId),
-                })
-                .transpose()?,
-        )
+    async fn rollback(self: Box<Self>) -> Result<(), database::Error> {
+        Ok(self.transaction.rollback().await?)
     }
+}
 
-    async fn get_active_keysets(&self) -> Result<HashMap<CurrencyUnit, Id>, Self::Err> {
-        Ok(query(r#"SELECT id, unit FROM keyset WHERE active = 1"#)
-            .fetch_all(&self.pool)
-            .await?
-            .into_iter()
-            .map(|row| {
-                Ok((
-                    column_as_string!(&row[1], CurrencyUnit::from_str),
-                    column_as_string!(&row[0], Id::from_str, Id::from_bytes),
-                ))
-            })
-            .collect::<Result<HashMap<_, _>, Error>>()?)
-    }
-
-    async fn add_keyset_info(&self, keyset: MintKeySetInfo) -> Result<(), Self::Err> {
+#[async_trait]
+impl<'a> MintKeyDatabaseTransaction<'a, database::Error> for SqliteTransaction<'a> {
+    async fn add_keyset_info(&mut self, keyset: MintKeySetInfo) -> Result<(), database::Error> {
         query(
             r#"
         INSERT INTO
@@ -219,10 +190,74 @@ impl MintKeysDatabase for MintSqliteDatabase {
         .bind(":max_order", keyset.max_order)
         .bind(":input_fee_ppk", keyset.input_fee_ppk as i64)
         .bind(":derivation_path_index", keyset.derivation_path_index)
-        .execute(&self.pool)
+        .execute(&self.transaction)
         .await?;
 
         Ok(())
+    }
+
+    async fn set_active_keyset(
+        &mut self,
+        unit: CurrencyUnit,
+        id: Id,
+    ) -> Result<(), database::Error> {
+        query(r#"UPDATE keyset SET active=FALSE WHERE unit IS :unit"#)
+            .bind(":unit", unit.to_string())
+            .execute(&self.transaction)
+            .await?;
+
+        query(r#"UPDATE keyset SET active=TRUE WHERE unit IS :unit AND id IS :id"#)
+            .bind(":unit", unit.to_string())
+            .bind(":id", id.to_string())
+            .execute(&self.transaction)
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl MintKeysDatabase for MintSqliteDatabase {
+    type Err = database::Error;
+
+    async fn begin_transaction<'a>(
+        &'a self,
+    ) -> Result<
+        Box<dyn MintKeyDatabaseTransaction<'a, database::Error> + Send + Sync + 'a>,
+        database::Error,
+    > {
+        Ok(Box::new(SqliteTransaction {
+            transaction: self.pool.begin().await?,
+        }))
+    }
+
+    async fn get_active_keyset_id(&self, unit: &CurrencyUnit) -> Result<Option<Id>, Self::Err> {
+        Ok(
+            query(r#" SELECT id FROM keyset WHERE active = 1 AND unit IS :unit"#)
+                .bind(":unit", unit.to_string())
+                .pluck(&self.pool)
+                .await?
+                .map(|id| match id {
+                    Column::Text(text) => Ok(Id::from_str(&text)?),
+                    Column::Blob(id) => Ok(Id::from_bytes(&id)?),
+                    _ => Err(Error::InvalidKeysetId),
+                })
+                .transpose()?,
+        )
+    }
+
+    async fn get_active_keysets(&self) -> Result<HashMap<CurrencyUnit, Id>, Self::Err> {
+        Ok(query(r#"SELECT id, unit FROM keyset WHERE active = 1"#)
+            .fetch_all(&self.pool)
+            .await?
+            .into_iter()
+            .map(|row| {
+                Ok((
+                    column_as_string!(&row[1], CurrencyUnit::from_str),
+                    column_as_string!(&row[0], Id::from_str, Id::from_bytes),
+                ))
+            })
+            .collect::<Result<HashMap<_, _>, Error>>()?)
     }
 
     async fn get_keyset_info(&self, id: &Id) -> Result<Option<MintKeySetInfo>, Self::Err> {
@@ -273,10 +308,10 @@ impl MintKeysDatabase for MintSqliteDatabase {
 }
 
 #[async_trait]
-impl MintQuotesDatabase for MintSqliteDatabase {
+impl<'a> MintQuotesTransaction<'a> for SqliteTransaction<'a> {
     type Err = database::Error;
 
-    async fn add_mint_quote(&self, quote: MintQuote) -> Result<(), Self::Err> {
+    async fn add_mint_quote(&mut self, quote: MintQuote) -> Result<(), Self::Err> {
         query(
             r#"
                 INSERT OR REPLACE INTO mint_quote (
@@ -300,11 +335,321 @@ impl MintQuotesDatabase for MintSqliteDatabase {
         .bind(":created_time", quote.created_time as i64)
         .bind(":paid_time", quote.paid_time.map(|t| t as i64))
         .bind(":issued_time", quote.issued_time.map(|t| t as i64))
-        .execute(&self.pool)
+        .execute(&self.transaction)
         .await?;
 
         Ok(())
     }
+
+    async fn remove_mint_quote(&mut self, quote_id: &Uuid) -> Result<(), Self::Err> {
+        query(
+            r#"
+            DELETE FROM mint_quote
+            WHERE id=?
+            "#,
+        )
+        .bind(":id", quote_id.as_hyphenated().to_string())
+        .execute(&self.transaction)
+        .await?;
+        Ok(())
+    }
+
+    async fn add_melt_quote(&mut self, quote: mint::MeltQuote) -> Result<(), Self::Err> {
+        query(
+            r#"
+            INSERT INTO melt_quote
+            (
+                id, unit, amount, request, fee_reserve, state,
+                expiry, payment_preimage, request_lookup_id, msat_to_pay,
+                created_time, paid_time
+            )
+            VALUES
+            (
+                :id, :unit, :amount, :request, :fee_reserve, :state,
+                :expiry, :payment_preimage, :request_lookup_id, :msat_to_pay,
+                :created_time, :paid_time
+            )
+            ON CONFLICT(id) DO UPDATE SET
+                unit = excluded.unit,
+                amount = excluded.amount,
+                request = excluded.request,
+                fee_reserve = excluded.fee_reserve,
+                state = excluded.state,
+                expiry = excluded.expiry,
+                payment_preimage = excluded.payment_preimage,
+                request_lookup_id = excluded.request_lookup_id,
+                msat_to_pay = excluded.msat_to_pay,
+                created_time = excluded.created_time,
+                paid_time = excluded.paid_time
+            ON CONFLICT(request_lookup_id) DO UPDATE SET
+                unit = excluded.unit,
+                amount = excluded.amount,
+                request = excluded.request,
+                fee_reserve = excluded.fee_reserve,
+                state = excluded.state,
+                expiry = excluded.expiry,
+                payment_preimage = excluded.payment_preimage,
+                id = excluded.id,
+                created_time = excluded.created_time,
+                paid_time = excluded.paid_time;
+        "#,
+        )
+        .bind(":id", quote.id.to_string())
+        .bind(":unit", quote.unit.to_string())
+        .bind(":amount", u64::from(quote.amount) as i64)
+        .bind(":request", quote.request)
+        .bind(":fee_reserve", u64::from(quote.fee_reserve) as i64)
+        .bind(":state", quote.state.to_string())
+        .bind(":expiry", quote.expiry as i64)
+        .bind(":payment_preimage", quote.payment_preimage)
+        .bind(":request_lookup_id", quote.request_lookup_id)
+        .bind(
+            ":msat_to_pay",
+            quote.msat_to_pay.map(|a| u64::from(a) as i64),
+        )
+        .bind(":created_time", quote.created_time as i64)
+        .bind(":paid_time", quote.paid_time.map(|t| t as i64))
+        .execute(&self.transaction)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn update_melt_quote_state(
+        &mut self,
+        quote_id: &Uuid,
+        state: MeltQuoteState,
+    ) -> Result<(MeltQuoteState, mint::MeltQuote), Self::Err> {
+        let mut quote = query(
+            r#"
+            SELECT
+                id,
+                unit,
+                amount,
+                request,
+                fee_reserve,
+                state,
+                expiry,
+                payment_preimage,
+                request_lookup_id,
+                msat_to_pay,
+                created_time,
+                paid_time
+            FROM
+                melt_quote
+            WHERE
+                id=:id
+                AND state != :state
+            "#,
+        )
+        .bind(":id", quote_id.as_hyphenated().to_string())
+        .bind(":state", state.to_string())
+        .fetch_one(&self.transaction)
+        .await?
+        .map(sqlite_row_to_melt_quote)
+        .transpose()?
+        .ok_or(Error::QuoteNotFound)?;
+
+        let rec = if state == MeltQuoteState::Paid {
+            let current_time = unix_time();
+            query(r#"UPDATE melt_quote SET state = :state, paid_time = :paid_time WHERE id = :id"#)
+                .bind(":state", state.to_string())
+                .bind(":paid_time", current_time as i64)
+                .bind(":id", quote_id.as_hyphenated().to_string())
+                .execute(&self.transaction)
+                .await
+        } else {
+            query(r#"UPDATE melt_quote SET state = :state WHERE id = :id"#)
+                .bind(":state", state.to_string())
+                .bind(":id", quote_id.as_hyphenated().to_string())
+                .execute(&self.transaction)
+                .await
+        };
+
+        match rec {
+            Ok(_) => {}
+            Err(err) => {
+                tracing::error!("SQLite Could not update melt quote");
+                return Err(err.into());
+            }
+        };
+
+        let old_state = quote.state;
+        quote.state = state;
+
+        Ok((old_state, quote))
+    }
+
+    async fn remove_melt_quote(&mut self, quote_id: &Uuid) -> Result<(), Self::Err> {
+        query(
+            r#"
+            DELETE FROM melt_quote
+            WHERE id=?
+            "#,
+        )
+        .bind(":id", quote_id.as_hyphenated().to_string())
+        .execute(&self.transaction)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn update_mint_quote_state(
+        &mut self,
+        quote_id: &Uuid,
+        state: MintQuoteState,
+    ) -> Result<MintQuoteState, Self::Err> {
+        let quote = query(
+            r#"
+            SELECT
+                id,
+                amount,
+                unit,
+                request,
+                state,
+                expiry,
+                request_lookup_id,
+                pubkey,
+                created_time,
+                paid_time,
+                issued_time
+            FROM
+                mint_quote
+            WHERE id = :id"#,
+        )
+        .bind(":id", quote_id.as_hyphenated().to_string())
+        .fetch_one(&self.transaction)
+        .await?
+        .map(sqlite_row_to_mint_quote)
+        .ok_or(Error::QuoteNotFound)??;
+
+        let update_query = match state {
+            MintQuoteState::Paid => {
+                r#"UPDATE mint_quote SET state = :state, paid_time = :current_time WHERE id = :quote_id"#
+            }
+            MintQuoteState::Issued => {
+                r#"UPDATE mint_quote SET state = :state, issued_time = :current_time WHERE id = :quote_id"#
+            }
+            _ => r#"UPDATE mint_quote SET state = :state WHERE id = :quote_id"#,
+        };
+
+        let current_time = unix_time();
+
+        let update = match state {
+            MintQuoteState::Paid => query(update_query)
+                .bind(":state", state.to_string())
+                .bind(":current_time", current_time as i64)
+                .bind(":quote_id", quote_id.as_hyphenated().to_string()),
+            MintQuoteState::Issued => query(update_query)
+                .bind(":state", state.to_string())
+                .bind(":current_time", current_time as i64)
+                .bind(":quote_id", quote_id.as_hyphenated().to_string()),
+            _ => query(update_query)
+                .bind(":state", state.to_string())
+                .bind(":quote_id", quote_id.as_hyphenated().to_string()),
+        };
+
+        match update.execute(&self.transaction).await {
+            Ok(_) => Ok(quote.state),
+            Err(err) => {
+                tracing::error!("SQLite Could not update keyset: {:?}", err);
+
+                return Err(err.into());
+            }
+        }
+    }
+
+    async fn get_mint_quote(&mut self, quote_id: &Uuid) -> Result<Option<MintQuote>, Self::Err> {
+        Ok(query(
+            r#"
+            SELECT
+                id,
+                amount,
+                unit,
+                request,
+                state,
+                expiry,
+                request_lookup_id,
+                pubkey,
+                created_time,
+                paid_time,
+                issued_time
+            FROM
+                mint_quote
+            WHERE id = :id"#,
+        )
+        .bind(":id", quote_id.as_hyphenated().to_string())
+        .fetch_one(&self.transaction)
+        .await?
+        .map(sqlite_row_to_mint_quote)
+        .transpose()?)
+    }
+
+    async fn get_melt_quote(
+        &mut self,
+        quote_id: &Uuid,
+    ) -> Result<Option<mint::MeltQuote>, Self::Err> {
+        Ok(query(
+            r#"
+            SELECT
+                id,
+                unit,
+                amount,
+                request,
+                fee_reserve,
+                state,
+                expiry,
+                payment_preimage,
+                request_lookup_id,
+                msat_to_pay,
+                created_time,
+                paid_time
+            FROM
+                melt_quote
+            WHERE
+                id=:id
+            "#,
+        )
+        .bind(":id", quote_id.as_hyphenated().to_string())
+        .fetch_one(&self.transaction)
+        .await?
+        .map(sqlite_row_to_melt_quote)
+        .transpose()?)
+    }
+
+    async fn get_mint_quote_by_request(
+        &mut self,
+        request: &str,
+    ) -> Result<Option<MintQuote>, Self::Err> {
+        Ok(query(
+            r#"
+            SELECT
+                id,
+                amount,
+                unit,
+                request,
+                state,
+                expiry,
+                request_lookup_id,
+                pubkey,
+                created_time,
+                paid_time,
+                issued_time
+            FROM
+                mint_quote
+            WHERE request = :request"#,
+        )
+        .bind(":request", request.to_owned())
+        .fetch_one(&self.transaction)
+        .await?
+        .map(sqlite_row_to_mint_quote)
+        .transpose()?)
+    }
+}
+
+#[async_trait]
+impl MintQuotesDatabase for MintSqliteDatabase {
+    type Err = database::Error;
 
     async fn get_mint_quote(&self, quote_id: &Uuid) -> Result<Option<MintQuote>, Self::Err> {
         Ok(query(
@@ -390,79 +735,6 @@ impl MintQuotesDatabase for MintSqliteDatabase {
         .transpose()?)
     }
 
-    async fn update_mint_quote_state(
-        &self,
-        quote_id: &Uuid,
-        state: MintQuoteState,
-    ) -> Result<MintQuoteState, Self::Err> {
-        let transaction = self.pool.begin().await?;
-
-        let quote = query(
-            r#"
-            SELECT
-                id,
-                amount,
-                unit,
-                request,
-                state,
-                expiry,
-                request_lookup_id,
-                pubkey,
-                created_time,
-                paid_time,
-                issued_time
-            FROM
-                mint_quote
-            WHERE id = :id"#,
-        )
-        .bind(":id", quote_id.as_hyphenated().to_string())
-        .fetch_one(&transaction)
-        .await?
-        .map(sqlite_row_to_mint_quote)
-        .ok_or(Error::QuoteNotFound)??;
-
-        let update_query = match state {
-            MintQuoteState::Paid => {
-                r#"UPDATE mint_quote SET state = :state, paid_time = :current_time WHERE id = :quote_id"#
-            }
-            MintQuoteState::Issued => {
-                r#"UPDATE mint_quote SET state = :state, issued_time = :current_time WHERE id = :quote_id"#
-            }
-            _ => r#"UPDATE mint_quote SET state = :state WHERE id = :quote_id"#,
-        };
-
-        let current_time = unix_time();
-
-        let update = match state {
-            MintQuoteState::Paid => query(update_query)
-                .bind(":state", state.to_string())
-                .bind(":current_time", current_time as i64)
-                .bind(":quote_id", quote_id.as_hyphenated().to_string()),
-            MintQuoteState::Issued => query(update_query)
-                .bind(":state", state.to_string())
-                .bind(":current_time", current_time as i64)
-                .bind(":quote_id", quote_id.as_hyphenated().to_string()),
-            _ => query(update_query)
-                .bind(":state", state.to_string())
-                .bind(":quote_id", quote_id.as_hyphenated().to_string()),
-        };
-
-        match update.execute(&transaction).await {
-            Ok(_) => {
-                transaction.commit().await?;
-                Ok(quote.state)
-            }
-            Err(err) => {
-                tracing::error!("SQLite Could not update keyset: {:?}", err);
-                if let Err(err) = transaction.rollback().await {
-                    tracing::error!("Could not rollback sql transaction: {}", err);
-                }
-
-                return Err(err.into());
-            }
-        }
-    }
-
     async fn get_mint_quotes(&self) -> Result<Vec<MintQuote>, Self::Err> {
         Ok(query(
             r#"
@@ -521,79 +793,6 @@ impl MintQuotesDatabase for MintSqliteDatabase {
         .collect::<Result<Vec<_>, _>>()?)
     }
 
-    async fn remove_mint_quote(&self, quote_id: &Uuid) -> Result<(), Self::Err> {
-        query(
-            r#"
-            DELETE FROM mint_quote
-            WHERE id=?
-            "#,
-        )
-        .bind(":id", quote_id.as_hyphenated().to_string())
-        .execute(&self.pool)
-        .await?;
-        Ok(())
-    }
-
-    async fn add_melt_quote(&self, quote: mint::MeltQuote) -> Result<(), Self::Err> {
-        query(
-            r#"
-            INSERT INTO melt_quote
-            (
-                id, unit, amount, request, fee_reserve, state,
-                expiry, payment_preimage, request_lookup_id, msat_to_pay,
-                created_time, paid_time
-            )
-            VALUES
-            (
-                :id, :unit, :amount, :request, :fee_reserve, :state,
-                :expiry, :payment_preimage, :request_lookup_id, :msat_to_pay,
-                :created_time, :paid_time
-            )
-            ON CONFLICT(id) DO UPDATE SET
-                unit = excluded.unit,
-                amount = excluded.amount,
-                request = excluded.request,
-                fee_reserve = excluded.fee_reserve,
-                state = excluded.state,
-                expiry = excluded.expiry,
-                payment_preimage = excluded.payment_preimage,
-                request_lookup_id = excluded.request_lookup_id,
-                msat_to_pay = excluded.msat_to_pay,
-                created_time = excluded.created_time,
-                paid_time = excluded.paid_time
-            ON CONFLICT(request_lookup_id) DO UPDATE SET
-                unit = excluded.unit,
-                amount = excluded.amount,
-                request = excluded.request,
-                fee_reserve = excluded.fee_reserve,
-                state = excluded.state,
-                expiry = excluded.expiry,
-                payment_preimage = excluded.payment_preimage,
-                id = excluded.id,
-                created_time = excluded.created_time,
-                paid_time = excluded.paid_time;
-        "#,
-        )
-        .bind(":id", quote.id.to_string())
-        .bind(":unit", quote.unit.to_string())
-        .bind(":amount", u64::from(quote.amount) as i64)
-        .bind(":request", quote.request)
-        .bind(":fee_reserve", u64::from(quote.fee_reserve) as i64)
-        .bind(":state", quote.state.to_string())
-        .bind(":expiry", quote.expiry as i64)
-        .bind(":payment_preimage", quote.payment_preimage)
-        .bind(":request_lookup_id", quote.request_lookup_id)
-        .bind(
-            ":msat_to_pay",
-            quote.msat_to_pay.map(|a| u64::from(a) as i64),
-        )
-        .bind(":created_time", quote.created_time as i64)
-        .bind(":paid_time", quote.paid_time.map(|t| t as i64))
-        .execute(&self.pool)
-        .await?;
-
-        Ok(())
-    }
     async fn get_melt_quote(&self, quote_id: &Uuid) -> Result<Option<mint::MeltQuote>, Self::Err> {
         Ok(query(
             r#"
@@ -649,99 +848,17 @@ impl MintQuotesDatabase for MintSqliteDatabase {
         .map(sqlite_row_to_melt_quote)
         .collect::<Result<Vec<_>, _>>()?)
     }
-
-    async fn update_melt_quote_state(
-        &self,
-        quote_id: &Uuid,
-        state: MeltQuoteState,
-    ) -> Result<(MeltQuoteState, mint::MeltQuote), Self::Err> {
-        let transaction = self.pool.begin().await?;
-
-        let mut quote = query(
-            r#"
-            SELECT
-                id,
-                unit,
-                amount,
-                request,
-                fee_reserve,
-                state,
-                expiry,
-                payment_preimage,
-                request_lookup_id,
-                msat_to_pay,
-                created_time,
-                paid_time
-            FROM
-                melt_quote
-            WHERE
-                id=:id
-                AND state != :state
-            "#,
-        )
-        .bind(":id", quote_id.as_hyphenated().to_string())
-        .bind(":state", state.to_string())
-        .fetch_one(&transaction)
-        .await?
-        .map(sqlite_row_to_melt_quote)
-        .transpose()?
-        .ok_or(Error::QuoteNotFound)?;
-
-        let rec = if state == MeltQuoteState::Paid {
-            let current_time = unix_time();
-            query(r#"UPDATE melt_quote SET state = :state, paid_time = :paid_time WHERE id = :id"#)
-                .bind(":state", state.to_string())
-                .bind(":paid_time", current_time as i64)
-                .bind(":id", quote_id.as_hyphenated().to_string())
-                .execute(&transaction)
-                .await
-        } else {
-            query(r#"UPDATE melt_quote SET state = :state WHERE id = :id"#)
-                .bind(":state", state.to_string())
-                .bind(":id", quote_id.as_hyphenated().to_string())
-                .execute(&transaction)
-                .await
-        };
-
-        match rec {
-            Ok(_) => {
-                transaction.commit().await?;
-            }
-            Err(err) => {
-                tracing::error!("SQLite Could not update melt quote");
-                transaction.rollback().await?;
-                return Err(err.into());
-            }
-        };
-
-        let old_state = quote.state;
-        quote.state = state;
-
-        Ok((old_state, quote))
-    }
-
-    async fn remove_melt_quote(&self, quote_id: &Uuid) -> Result<(), Self::Err> {
-        query(
-            r#"
-            DELETE FROM melt_quote
-            WHERE id=?
-            "#,
-        )
-        .bind(":id", quote_id.as_hyphenated().to_string())
-        .execute(&self.pool)
-        .await?;
-
-        Ok(())
-    }
 }
 
 #[async_trait]
-impl MintProofsDatabase for MintSqliteDatabase {
+impl<'a> MintProofsTransaction<'a> for SqliteTransaction<'a> {
     type Err = database::Error;
 
-    async fn add_proofs(&self, proofs: Proofs, quote_id: Option<Uuid>) -> Result<(), Self::Err> {
-        let transaction = self.pool.begin().await?;
-
+    async fn add_proofs(
+        &mut self,
+        proofs: Proofs,
+        quote_id: Option<Uuid>,
+    ) -> Result<(), Self::Err> {
         let current_time = unix_time();
 
         // Check any previous proof, this query should return None in order to proceed storing
@@ -754,7 +871,7 @@ impl MintProofsDatabase for MintSqliteDatabase {
                     .map(|y| y.y().map(|y| y.to_bytes().to_vec()))
                     .collect::<Result<_, _>>()?,
             )
-            .pluck(&transaction)
+            .pluck(&self.transaction)
             .await?
             .map(|state| Ok::<_, Error>(column_as_string!(&state, State::from_str)))
             .transpose()?
@@ -767,11 +884,11 @@ impl MintProofsDatabase for MintSqliteDatabase {
         for proof in proofs {
             query(
                 r#"
-                INSERT INTO proof
-                (y, amount, keyset_id, secret, c, witness, state, quote_id, created_time)
-                VALUES
-                (:y, :amount, :keyset_id, :secret, :c, :witness, :state, :quote_id, :created_time)
-                "#,
+                  INSERT INTO proof
+                  (y, amount, keyset_id, secret, c, witness, state, quote_id, created_time)
+                  VALUES
+                  (:y, :amount, :keyset_id, :secret, :c, :witness, :state, :quote_id, :created_time)
+                  "#,
             )
             .bind(":y", proof.y()?.to_bytes().to_vec())
             .bind(":amount", u64::from(proof.amount) as i64)
@@ -785,14 +902,46 @@ impl MintProofsDatabase for MintSqliteDatabase {
             .bind(":state", "UNSPENT".to_string())
             .bind(":quote_id", quote_id.map(|q| q.hyphenated().to_string()))
             .bind(":created_time", current_time as i64)
-            .execute(&transaction)
+            .execute(&self.transaction)
             .await?;
         }
 
-        transaction.commit().await?;
-
         Ok(())
     }
+
+    async fn update_proofs_states(
+        &mut self,
+        ys: &[PublicKey],
+        new_state: State,
+    ) -> Result<Vec<Option<State>>, Self::Err> {
+        let mut current_states = get_current_states(&self.transaction, ys).await?;
+
+        if current_states.len() != ys.len() {
+            tracing::warn!(
+                "Attempted to update state of non-existent proof {} {}",
+                current_states.len(),
+                ys.len()
+            );
+            return Err(database::Error::ProofNotFound);
+        }
+
+        for state in current_states.values() {
+            check_state_transition(*state, new_state)?;
+        }
+
+        query(r#"UPDATE proof SET state = :new_state WHERE y IN (:ys)"#)
+            .bind(":new_state", new_state.to_string())
+            .bind_vec(":ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
+            .execute(&self.transaction)
+            .await?;
+
+        Ok(ys.iter().map(|y| current_states.remove(y)).collect())
+    }
+}
+
+#[async_trait]
+impl MintProofsDatabase for MintSqliteDatabase {
+    type Err = database::Error;
 
     async fn remove_proofs(
         &self,
@@ -881,7 +1030,7 @@ impl MintProofsDatabase for MintSqliteDatabase {
     }
 
     async fn get_proofs_states(&self, ys: &[PublicKey]) -> Result<Vec<Option<State>>, Self::Err> {
-        let mut current_states = self.get_current_states(&self.pool, ys).await?;
+        let mut current_states = get_current_states(&self.pool, ys).await?;
 
         Ok(ys.iter().map(|y| current_states.remove(y)).collect())
     }
@@ -914,54 +1063,18 @@ impl MintProofsDatabase for MintSqliteDatabase {
         .into_iter()
         .unzip())
     }
-
-    async fn update_proofs_states(
-        &self,
-        ys: &[PublicKey],
-        new_state: State,
-    ) -> Result<Vec<Option<State>>, Self::Err> {
-        let transaction = self.pool.begin().await?;
-
-        let mut current_states = self.get_current_states(&transaction, ys).await?;
-
-        if current_states.len() != ys.len() {
-            transaction.rollback().await?;
-            tracing::warn!(
-                "Attempted to update state of non-existent proof {} {}",
-                current_states.len(),
-                ys.len()
-            );
-            return Err(database::Error::ProofNotFound);
-        }
-
-        for state in current_states.values() {
-            check_state_transition(*state, new_state)?;
-        }
-
-        query(r#"UPDATE proof SET state = :new_state WHERE y IN (:ys)"#)
-            .bind(":new_state", new_state.to_string())
-            .bind_vec(":ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
-            .execute(&transaction)
-            .await?;
-
-        transaction.commit().await?;
-
-        Ok(ys.iter().map(|y| current_states.remove(y)).collect())
-    }
 }
 
 #[async_trait]
-impl MintSignaturesDatabase for MintSqliteDatabase {
+impl<'a> MintSignatureTransaction<'a> for SqliteTransaction<'a> {
     type Err = database::Error;
 
     async fn add_blind_signatures(
-        &self,
+        &mut self,
         blinded_messages: &[PublicKey],
         blind_signatures: &[BlindSignature],
         quote_id: Option<Uuid>,
     ) -> Result<(), Self::Err> {
-        let transaction = self.pool.begin().await?;
-
         let current_time = unix_time();
 
         for (message, signature) in blinded_messages.iter().zip(blind_signatures) {
@@ -987,14 +1100,61 @@ impl MintSignaturesDatabase for MintSqliteDatabase {
                 signature.dleq.as_ref().map(|dleq| dleq.s.to_secret_hex()),
             )
             .bind(":created_time", current_time as i64)
-            .execute(&transaction)
+            .execute(&self.transaction)
             .await?;
         }
 
-        transaction.commit().await?;
-
         Ok(())
     }
+
+    async fn get_blind_signatures(
+        &mut self,
+        blinded_messages: &[PublicKey],
+    ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
+        let mut blinded_signatures = query(
+            r#"SELECT
+                keyset_id,
+                amount,
+                c,
+                dleq_e,
+                dleq_s,
+                y
+            FROM
+                blind_signature
+            WHERE y IN (:y)
+            "#,
+        )
+        .bind_vec(
+            ":y",
+            blinded_messages
+                .iter()
+                .map(|y| y.to_bytes().to_vec())
+                .collect(),
+        )
+        .fetch_all(&self.transaction)
+        .await?
+        .into_iter()
+        .map(|mut row| {
+            Ok((
+                column_as_string!(
+                    &row.pop().ok_or(Error::InvalidDbResponse)?,
+                    PublicKey::from_hex,
+                    PublicKey::from_slice
+                ),
+                sqlite_row_to_blind_signature(row)?,
+            ))
+        })
+        .collect::<Result<HashMap<_, _>, Error>>()?;
+        Ok(blinded_messages
+            .iter()
+            .map(|y| blinded_signatures.remove(y))
+            .collect())
+    }
+}
+
+#[async_trait]
+impl MintSignaturesDatabase for MintSqliteDatabase {
+    type Err = database::Error;
 
     async fn get_blind_signatures(
         &self,
@@ -1096,6 +1256,17 @@ impl MintSignaturesDatabase for MintSqliteDatabase {
 
 #[async_trait]
 impl MintDatabase<database::Error> for MintSqliteDatabase {
+    async fn begin_transaction<'a>(
+        &'a self,
+    ) -> Result<
+        Box<dyn database::MintTransaction<'a, database::Error> + Send + Sync + 'a>,
+        database::Error,
+    > {
+        Ok(Box::new(SqliteTransaction {
+            transaction: self.pool.begin().await?,
+        }))
+    }
+
     async fn set_mint_info(&self, mint_info: MintInfo) -> Result<(), database::Error> {
         Ok(self.set_to_config("mint_info", &mint_info).await?)
     }
@@ -1324,7 +1495,9 @@ mod tests {
             input_fee_ppk: 0,
             final_expiry: None,
         };
-        db.add_keyset_info(keyset_info).await.unwrap();
+        let mut tx = MintKeysDatabase::begin_transaction(&db).await.unwrap();
+        tx.add_keyset_info(keyset_info).await.unwrap();
+        tx.commit().await.unwrap();
 
         let proofs = vec![
             Proof {
@@ -1346,12 +1519,15 @@ mod tests {
         ];
 
         // Add proofs to database
-        db.add_proofs(proofs.clone(), None).await.unwrap();
+        let mut tx = MintDatabase::begin_transaction(&db).await.unwrap();
+        tx.add_proofs(proofs.clone(), None).await.unwrap();
 
         // Mark one proof as spent
-        db.update_proofs_states(&[proofs[0].y().unwrap()], State::Spent)
+        tx.update_proofs_states(&[proofs[0].y().unwrap()], State::Spent)
             .await
             .unwrap();
+
+        tx.commit().await.unwrap();
 
         // Try to remove both proofs - should fail because one is spent
         let result = db
@@ -1392,7 +1568,11 @@ mod tests {
             input_fee_ppk: 0,
             final_expiry: None,
         };
-        db.add_keyset_info(keyset_info).await.unwrap();
+        let mut tx = MintKeysDatabase::begin_transaction(&db)
+            .await
+            .expect("begin");
+        tx.add_keyset_info(keyset_info).await.unwrap();
+        tx.commit().await.expect("commit");
 
         let proofs = vec![
             Proof {
@@ -1414,17 +1594,20 @@ mod tests {
         ];
 
         // Add proofs to database
-        db.add_proofs(proofs.clone(), None).await.unwrap();
+        let mut tx = MintDatabase::begin_transaction(&db).await.unwrap();
+        tx.add_proofs(proofs.clone(), None).await.unwrap();
 
         // Mark one proof as spent
-        db.update_proofs_states(&[proofs[0].y().unwrap()], State::Spent)
+        tx.update_proofs_states(&[proofs[0].y().unwrap()], State::Spent)
             .await
             .unwrap();
 
         // Try to update both proofs - should fail because one is spent
-        let result = db
+        let result = tx
             .update_proofs_states(&[proofs[0].y().unwrap()], State::Unspent)
             .await;
+
+        tx.commit().await.unwrap();
 
         assert!(result.is_err());
         assert!(matches!(

--- a/crates/cdk-sqlite/src/mint/mod.rs
+++ b/crates/cdk-sqlite/src/mint/mod.rs
@@ -361,7 +361,7 @@ impl<'a> MintQuotesTransaction<'a> for SqliteTransaction<'a> {
     async fn add_melt_quote(&mut self, quote: mint::MeltQuote) -> Result<(), Self::Err> {
         query(
             r#"
-            INSERT OR REPLACE INTO melt_quote
+            INSERT INTO melt_quote
             (
                 id, unit, amount, request, fee_reserve, state,
                 expiry, payment_preimage, request_lookup_id, msat_to_pay,
@@ -393,6 +393,19 @@ impl<'a> MintQuotesTransaction<'a> for SqliteTransaction<'a> {
         .execute(&self.inner)
         .await?;
 
+        Ok(())
+    }
+
+    async fn update_melt_quote_request_lookup_id(
+        &mut self,
+        quote_id: &Uuid,
+        new_request_lookup_id: &str,
+    ) -> Result<(), Self::Err> {
+        query(r#"UPDATE melt_quote SET request_lookup_id = :new_req_id WHERE id = :id"#)
+            .bind(":new_req_id", new_request_lookup_id.to_owned())
+            .bind(":id", quote_id.as_hyphenated().to_string())
+            .execute(&self.inner)
+            .await?;
         Ok(())
     }
 

--- a/crates/cdk/src/lib.rs
+++ b/crates/cdk/src/lib.rs
@@ -13,7 +13,7 @@ pub mod cdk_database {
     #[cfg(feature = "mint")]
     pub use cdk_common::database::{
         MintDatabase, MintKeysDatabase, MintProofsDatabase, MintQuotesDatabase,
-        MintSignaturesDatabase,
+        MintSignaturesDatabase, MintTransaction,
     };
 }
 

--- a/crates/cdk/src/mint/check_spendable.rs
+++ b/crates/cdk/src/mint/check_spendable.rs
@@ -1,41 +1,10 @@
-use std::collections::{HashMap, HashSet};
-
 use futures::future::try_join_all;
 use tracing::instrument;
 
-use super::{CheckStateRequest, CheckStateResponse, Mint, ProofState, PublicKey, State};
-use crate::{cdk_database, Error};
+use super::{CheckStateRequest, CheckStateResponse, Mint, ProofState, State};
+use crate::Error;
 
 impl Mint {
-    /// Helper function to reset proofs to their original state, skipping spent proofs
-    async fn reset_proofs_to_original_state(
-        &self,
-        ys: &[PublicKey],
-        original_states: Vec<Option<State>>,
-    ) -> Result<(), Error> {
-        let mut ys_by_state = HashMap::new();
-        let mut unknown_proofs = Vec::new();
-        for (y, state) in ys.iter().zip(original_states) {
-            if let Some(state) = state {
-                // Skip attempting to update proofs that were originally spent
-                if state != State::Spent {
-                    ys_by_state.entry(state).or_insert_with(Vec::new).push(*y);
-                }
-            } else {
-                unknown_proofs.push(*y);
-            }
-        }
-
-        let mut tx = self.localstore.begin_transaction().await?;
-        for (state, ys) in ys_by_state {
-            tx.update_proofs_states(&ys, state).await?;
-        }
-
-        tx.commit().await?;
-
-        Ok(())
-    }
-
     /// Check state
     #[instrument(skip_all)]
     pub async fn check_state(
@@ -70,51 +39,5 @@ impl Mint {
         Ok(CheckStateResponse {
             states: proof_states,
         })
-    }
-
-    /// Check Tokens are not spent or pending
-    #[instrument(skip_all)]
-    pub async fn check_ys_spendable(
-        &self,
-        tx: &mut Box<dyn cdk_database::MintTransaction<'_, cdk_database::Error> + Send + Sync + '_>,
-        ys: &[PublicKey],
-        proof_state: State,
-    ) -> Result<(), Error> {
-        let original_proofs_state = match tx.update_proofs_states(ys, proof_state).await {
-            Ok(states) => states,
-            Err(cdk_database::Error::AttemptUpdateSpentProof)
-            | Err(cdk_database::Error::AttemptRemoveSpentProof) => {
-                return Err(Error::TokenAlreadySpent)
-            }
-            Err(err) => return Err(err.into()),
-        };
-
-        assert!(ys.len() == original_proofs_state.len());
-
-        let proofs_state = original_proofs_state
-            .iter()
-            .flatten()
-            .collect::<HashSet<&State>>();
-
-        if proofs_state.contains(&State::Pending) {
-            // Reset states before returning error
-            self.reset_proofs_to_original_state(ys, original_proofs_state)
-                .await?;
-            return Err(Error::TokenPending);
-        }
-
-        if proofs_state.contains(&State::Spent) {
-            // Reset states before returning error
-            self.reset_proofs_to_original_state(ys, original_proofs_state)
-                .await?;
-            return Err(Error::TokenAlreadySpent);
-        }
-
-        for public_key in ys {
-            tracing::trace!("proof: {} set to {}", public_key.to_hex(), proof_state);
-            self.pubsub_manager.proof_state((*public_key, proof_state));
-        }
-
-        Ok(())
     }
 }

--- a/crates/cdk/src/mint/check_spendable.rs
+++ b/crates/cdk/src/mint/check_spendable.rs
@@ -33,8 +33,6 @@ impl Mint {
 
         tx.commit().await?;
 
-        self.localstore.remove_proofs(&unknown_proofs, None).await?;
-
         Ok(())
     }
 

--- a/crates/cdk/src/mint/issue/issue_nut04.rs
+++ b/crates/cdk/src/mint/issue/issue_nut04.rs
@@ -106,7 +106,7 @@ impl Mint {
         );
 
         let mut tx = self.localstore.begin_transaction().await?;
-        tx.add_mint_quote(quote.clone()).await?;
+        tx.add_or_replace_mint_quote(quote.clone()).await?;
         tx.commit().await?;
 
         let quote: MintQuoteBolt11Response<Uuid> = quote.into();
@@ -146,15 +146,6 @@ impl Mint {
             amount: Some(mint_quote.amount),
             unit: Some(mint_quote.unit.clone()),
         })
-    }
-
-    /// Update mint quote
-    #[instrument(skip_all)]
-    pub async fn update_mint_quote(&self, quote: MintQuote) -> Result<(), Error> {
-        let mut tx = self.localstore.begin_transaction().await?;
-        tx.add_mint_quote(quote).await?;
-        tx.commit().await?;
-        Ok(())
     }
 
     /// Get mint quotes

--- a/crates/cdk/src/mint/issue/issue_nut04.rs
+++ b/crates/cdk/src/mint/issue/issue_nut04.rs
@@ -105,7 +105,9 @@ impl Mint {
             create_invoice_response.request_lookup_id,
         );
 
-        self.localstore.add_mint_quote(quote.clone()).await?;
+        let mut tx = self.localstore.begin_transaction().await?;
+        tx.add_mint_quote(quote.clone()).await?;
+        tx.commit().await?;
 
         let quote: MintQuoteBolt11Response<Uuid> = quote.into();
 
@@ -121,8 +123,8 @@ impl Mint {
         &self,
         quote_id: &Uuid,
     ) -> Result<MintQuoteBolt11Response<Uuid>, Error> {
-        let quote = self
-            .localstore
+        let mut tx = self.localstore.begin_transaction().await?;
+        let mut mint_quote = tx
             .get_mint_quote(quote_id)
             .await?
             .ok_or(Error::UnknownQuote)?;
@@ -130,27 +132,28 @@ impl Mint {
         // Since the pending state is not part of the NUT it should not be part of the
         // response. In practice the wallet should not be checking the state of
         // a quote while waiting for the mint response.
-        let state = match quote.state {
-            MintQuoteState::Pending => MintQuoteState::Paid,
-            MintQuoteState::Unpaid => self.check_mint_quote_paid(quote_id).await?,
-            s => s,
-        };
+        if mint_quote.state == MintQuoteState::Unpaid {
+            self.check_mint_quote_paid(&mut tx, &mut mint_quote).await?;
+            tx.commit().await?;
+        }
 
         Ok(MintQuoteBolt11Response {
-            quote: quote.id,
-            request: quote.request,
-            state,
-            expiry: Some(quote.expiry),
-            pubkey: quote.pubkey,
-            amount: Some(quote.amount),
-            unit: Some(quote.unit.clone()),
+            quote: mint_quote.id,
+            request: mint_quote.request,
+            state: mint_quote.state,
+            expiry: Some(mint_quote.expiry),
+            pubkey: mint_quote.pubkey,
+            amount: Some(mint_quote.amount),
+            unit: Some(mint_quote.unit.clone()),
         })
     }
 
     /// Update mint quote
     #[instrument(skip_all)]
     pub async fn update_mint_quote(&self, quote: MintQuote) -> Result<(), Error> {
-        self.localstore.add_mint_quote(quote).await?;
+        let mut tx = self.localstore.begin_transaction().await?;
+        tx.add_mint_quote(quote).await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -186,7 +189,9 @@ impl Mint {
     /// Remove mint quote
     #[instrument(skip_all)]
     pub async fn remove_mint_quote(&self, quote_id: &Uuid) -> Result<(), Error> {
-        self.localstore.remove_mint_quote(quote_id).await?;
+        let mut tx = self.localstore.begin_transaction().await?;
+        tx.remove_mint_quote(quote_id).await?;
+        tx.commit().await?;
 
         Ok(())
     }
@@ -215,9 +220,10 @@ impl Mint {
             mint_quote.id
         );
         if mint_quote.state != MintQuoteState::Issued && mint_quote.state != MintQuoteState::Paid {
-            self.localstore
-                .update_mint_quote_state(&mint_quote.id, MintQuoteState::Paid)
+            let mut tx = self.localstore.begin_transaction().await?;
+            tx.update_mint_quote_state(&mint_quote.id, MintQuoteState::Paid)
                 .await?;
+            tx.commit().await?;
         } else {
             tracing::debug!(
                 "{} Quote already {} continuing",
@@ -238,39 +244,25 @@ impl Mint {
         &self,
         mint_request: MintRequest<Uuid>,
     ) -> Result<MintResponse, Error> {
-        let mint_quote = self
-            .localstore
+        let mut tx = self.localstore.begin_transaction().await?;
+
+        let mut mint_quote = tx
             .get_mint_quote(&mint_request.quote)
             .await?
             .ok_or(Error::UnknownQuote)?;
 
-        let state = self
-            .localstore
-            .update_mint_quote_state(&mint_request.quote, MintQuoteState::Pending)
-            .await?;
+        if mint_quote.state == MintQuoteState::Unpaid {
+            self.check_mint_quote_paid(&mut tx, &mut mint_quote).await?
+        }
 
-        let state = if state == MintQuoteState::Unpaid {
-            self.check_mint_quote_paid(&mint_quote.id).await?
-        } else {
-            state
-        };
-
-        match state {
+        match mint_quote.state {
             MintQuoteState::Unpaid => {
-                let _state = self
-                    .localstore
-                    .update_mint_quote_state(&mint_request.quote, MintQuoteState::Unpaid)
-                    .await?;
                 return Err(Error::UnpaidQuote);
             }
             MintQuoteState::Pending => {
                 return Err(Error::PendingQuote);
             }
             MintQuoteState::Issued => {
-                let _state = self
-                    .localstore
-                    .update_mint_quote_state(&mint_request.quote, MintQuoteState::Issued)
-                    .await?;
                 return Err(Error::IssuedQuote);
             }
             MintQuoteState::Paid => (),
@@ -282,17 +274,14 @@ impl Mint {
             mint_request.verify_signature(pubkey)?;
         }
 
-        let Verification { amount, unit } = match self.verify_outputs(&mint_request.outputs).await {
-            Ok(verification) => verification,
-            Err(err) => {
-                tracing::debug!("Could not verify mint outputs");
-                self.localstore
-                    .update_mint_quote_state(&mint_request.quote, MintQuoteState::Paid)
-                    .await?;
-
-                return Err(err);
-            }
-        };
+        let Verification { amount, unit } =
+            match self.verify_outputs(&mut tx, &mint_request.outputs).await {
+                Ok(verification) => verification,
+                Err(err) => {
+                    tracing::debug!("Could not verify mint outputs");
+                    return Err(err);
+                }
+            };
 
         // We check the total value of blinded messages == mint quote
         if amount != mint_quote.amount {
@@ -313,21 +302,21 @@ impl Mint {
             blind_signatures.push(blind_signature);
         }
 
-        self.localstore
-            .add_blind_signatures(
-                &mint_request
-                    .outputs
-                    .iter()
-                    .map(|p| p.blinded_secret)
-                    .collect::<Vec<PublicKey>>(),
-                &blind_signatures,
-                Some(mint_request.quote),
-            )
+        tx.add_blind_signatures(
+            &mint_request
+                .outputs
+                .iter()
+                .map(|p| p.blinded_secret)
+                .collect::<Vec<PublicKey>>(),
+            &blind_signatures,
+            Some(mint_request.quote),
+        )
+        .await?;
+
+        tx.update_mint_quote_state(&mint_request.quote, MintQuoteState::Issued)
             .await?;
 
-        self.localstore
-            .update_mint_quote_state(&mint_request.quote, MintQuoteState::Issued)
-            .await?;
+        tx.commit().await?;
 
         self.pubsub_manager
             .mint_quote_bolt11_status(mint_quote, MintQuoteState::Issued);

--- a/crates/cdk/src/mint/issue/issue_nut04.rs
+++ b/crates/cdk/src/mint/issue/issue_nut04.rs
@@ -133,8 +133,10 @@ impl Mint {
         // response. In practice the wallet should not be checking the state of
         // a quote while waiting for the mint response.
         if mint_quote.state == MintQuoteState::Unpaid {
-            self.check_mint_quote_paid(&mut tx, &mut mint_quote).await?;
-            tx.commit().await?;
+            self.check_mint_quote_paid(tx, &mut mint_quote)
+                .await?
+                .commit()
+                .await?;
         }
 
         Ok(MintQuoteBolt11Response {
@@ -242,9 +244,11 @@ impl Mint {
             .await?
             .ok_or(Error::UnknownQuote)?;
 
-        if mint_quote.state == MintQuoteState::Unpaid {
-            self.check_mint_quote_paid(&mut tx, &mut mint_quote).await?
-        }
+        let mut tx = if mint_quote.state == MintQuoteState::Unpaid {
+            self.check_mint_quote_paid(tx, &mut mint_quote).await?
+        } else {
+            tx
+        };
 
         match mint_quote.state {
             MintQuoteState::Unpaid => {

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -36,6 +36,7 @@ mod issue;
 mod keysets;
 mod ln;
 mod melt;
+mod proof_writer;
 mod start_up_check;
 pub mod subscription;
 mod swap;

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -225,7 +225,9 @@ impl Mint {
     /// Set mint info
     #[instrument(skip_all)]
     pub async fn set_mint_info(&self, mint_info: MintInfo) -> Result<(), Error> {
-        Ok(self.localstore.set_mint_info(mint_info).await?)
+        let mut tx = self.localstore.begin_transaction().await?;
+        tx.set_mint_info(mint_info).await?;
+        Ok(tx.commit().await?)
     }
 
     /// Get quote ttl
@@ -237,7 +239,9 @@ impl Mint {
     /// Set quote ttl
     #[instrument(skip_all)]
     pub async fn set_quote_ttl(&self, quote_ttl: QuoteTTL) -> Result<(), Error> {
-        Ok(self.localstore.set_quote_ttl(quote_ttl).await?)
+        let mut tx = self.localstore.begin_transaction().await?;
+        tx.set_quote_ttl(quote_ttl).await?;
+        Ok(tx.commit().await?)
     }
 
     /// Wait for any invoice to be paid

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -420,6 +420,7 @@ impl Mint {
                 return Err(Error::Internal);
             }
         };
+        tracing::error!("internal stuff");
 
         // Mint quote has already been settled, proofs should not be burned or held.
         if mint_quote.state == MintQuoteState::Issued || mint_quote.state == MintQuoteState::Paid {
@@ -446,7 +447,7 @@ impl Mint {
 
         let amount = melt_quote.amount;
 
-        self.update_mint_quote(mint_quote).await?;
+        tx.add_or_replace_mint_quote(mint_quote).await?;
 
         Ok(Some(amount))
     }

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -7,7 +7,7 @@ use arc_swap::ArcSwap;
 use cdk_common::common::{PaymentProcessorKey, QuoteTTL};
 #[cfg(feature = "auth")]
 use cdk_common::database::MintAuthDatabase;
-use cdk_common::database::{self, MintDatabase};
+use cdk_common::database::{self, MintDatabase, MintTransaction};
 use cdk_common::nuts::{self, BlindSignature, BlindedMessage, CurrencyUnit, Id, Kind};
 use cdk_common::secret;
 use cdk_signatory::signatory::{Signatory, SignatoryKeySet};
@@ -24,9 +24,9 @@ use crate::cdk_payment::{self, MintPayment};
 use crate::error::Error;
 use crate::fees::calculate_fee;
 use crate::nuts::*;
-use crate::Amount;
 #[cfg(feature = "auth")]
 use crate::OidcClient;
+use crate::{cdk_database, Amount};
 
 #[cfg(feature = "auth")]
 pub(crate) mod auth;
@@ -407,14 +407,11 @@ impl Mint {
     #[instrument(skip_all)]
     pub async fn handle_internal_melt_mint(
         &self,
+        tx: &mut Box<dyn MintTransaction<'_, cdk_database::Error> + Send + Sync + '_>,
         melt_quote: &MeltQuote,
         melt_request: &MeltRequest<Uuid>,
     ) -> Result<Option<Amount>, Error> {
-        let mint_quote = match self
-            .localstore
-            .get_mint_quote_by_request(&melt_quote.request)
-            .await
-        {
+        let mint_quote = match tx.get_mint_quote_by_request(&melt_quote.request).await {
             Ok(Some(mint_quote)) => mint_quote,
             // Not an internal melt -> mint
             Ok(None) => return Ok(None),

--- a/crates/cdk/src/mint/proof_writer.rs
+++ b/crates/cdk/src/mint/proof_writer.rs
@@ -1,0 +1,214 @@
+//! Proof writer
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use cdk_common::database::{self, MintDatabase, MintTransaction};
+use cdk_common::{Error, Proofs, ProofsMethods, PublicKey, State};
+
+use super::subscription::PubSubManager;
+
+type Db = Arc<dyn MintDatabase<database::Error> + Send + Sync>;
+type Tx<'a, 'b> = Box<dyn MintTransaction<'a, database::Error> + Send + Sync + 'b>;
+
+/// Proof writer
+///
+/// This is a proof writer that emulates a database transaction but without holding the transaction
+/// alive while waiting for external events to be fully committed to the database; instead, it
+/// maintains a `pending` state.
+///
+/// This struct allows for premature exit on error, enabling it to remove proofs or reset their
+/// status.
+///
+/// This struct is not fully ACID. If the process exits due to a panic, and the `Drop` function
+/// cannot be run, the reset process should reset the state.
+pub struct ProofWriter {
+    db: Option<Db>,
+    pubsub_manager: Arc<PubSubManager>,
+    proof_original_states: Option<HashMap<PublicKey, Option<State>>>,
+}
+
+impl ProofWriter {
+    /// Creates a new ProofWriter on top of the database
+    pub fn new(db: Db, pubsub_manager: Arc<PubSubManager>) -> Self {
+        Self {
+            db: Some(db),
+            pubsub_manager,
+            proof_original_states: Some(Default::default()),
+        }
+    }
+
+    /// The changes are permanent, consume the struct removing the database, so the Drop does
+    /// nothing
+    pub fn commit(mut self) {
+        self.db.take();
+        self.proof_original_states.take();
+    }
+
+    /// Add proofs
+    pub async fn add_proofs(
+        &mut self,
+        tx: &mut Tx<'_, '_>,
+        proofs: &Proofs,
+    ) -> Result<Vec<PublicKey>, Error> {
+        let proof_states = if let Some(proofs) = self.proof_original_states.as_mut() {
+            proofs
+        } else {
+            return Err(Error::Internal);
+        };
+
+        if let Some(err) = tx.add_proofs(proofs.clone(), None).await.err() {
+            return match err {
+                cdk_common::database::Error::Duplicate => Err(Error::TokenPending),
+                cdk_common::database::Error::AttemptUpdateSpentProof => {
+                    Err(Error::TokenAlreadySpent)
+                }
+                err => Err(Error::Database(err)),
+            };
+        }
+
+        let ys = proofs.ys()?;
+
+        for pk in ys.iter() {
+            proof_states.insert(*pk, None);
+        }
+
+        self.update_proofs_states(tx, &ys, State::Pending).await?;
+
+        Ok(ys)
+    }
+
+    /// Update proof status
+    pub async fn update_proofs_states(
+        &mut self,
+        tx: &mut Tx<'_, '_>,
+        ys: &[PublicKey],
+        new_proof_state: State,
+    ) -> Result<(), Error> {
+        let proof_states = if let Some(proofs) = self.proof_original_states.as_mut() {
+            proofs
+        } else {
+            return Err(Error::Internal);
+        };
+
+        let original_proofs_state = match tx.update_proofs_states(ys, new_proof_state).await {
+            Ok(states) => states,
+            Err(database::Error::AttemptUpdateSpentProof)
+            | Err(database::Error::AttemptRemoveSpentProof) => {
+                return Err(Error::TokenAlreadySpent)
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+        if ys.len() != original_proofs_state.len() {
+            return Err(Error::Internal);
+        }
+
+        let proofs_state = original_proofs_state
+            .iter()
+            .flatten()
+            .map(|x| x.to_owned())
+            .collect::<HashSet<State>>();
+
+        let forbidden_states = if new_proof_state == State::Pending {
+            // If the new state is `State::Pending` it cannot be pending already
+            vec![State::Pending, State::Spent]
+        } else {
+            // For other state it cannot be spent
+            vec![State::Spent]
+        };
+
+        for forbidden_state in forbidden_states.iter() {
+            if proofs_state.contains(forbidden_state) {
+                reset_proofs_to_original_state(tx, ys, original_proofs_state).await?;
+
+                return Err(if proofs_state.contains(&State::Pending) {
+                    Error::TokenPending
+                } else {
+                    Error::TokenAlreadySpent
+                });
+            }
+        }
+
+        for (idx, ys) in ys.iter().enumerate() {
+            proof_states
+                .entry(*ys)
+                .or_insert(original_proofs_state[idx]);
+        }
+
+        for pk in ys {
+            self.pubsub_manager.proof_state((*pk, new_proof_state));
+        }
+
+        Ok(())
+    }
+
+    /// Rollback all changes in this ProofWriter consuming it.
+    pub async fn rollback(mut self, tx: &mut Tx<'_, '_>) -> Result<(), Error> {
+        let (ys, original_states) = if let Some(proofs) = self.proof_original_states.take() {
+            proofs.into_iter().unzip::<_, _, Vec<_>, Vec<_>>()
+        } else {
+            return Ok(());
+        };
+        reset_proofs_to_original_state(tx, &ys, original_states).await?;
+        Ok(())
+    }
+}
+
+/// Resets proofs to their original states or removes them
+#[inline(always)]
+async fn reset_proofs_to_original_state(
+    tx: &mut Tx<'_, '_>,
+    ys: &[PublicKey],
+    original_states: Vec<Option<State>>,
+) -> Result<(), Error> {
+    let mut ys_by_state = HashMap::new();
+    let mut unknown_proofs = Vec::new();
+    for (y, state) in ys.iter().zip(original_states) {
+        if let Some(state) = state {
+            // Skip attempting to update proofs that were originally spent
+            if state != State::Spent {
+                ys_by_state.entry(state).or_insert_with(Vec::new).push(*y);
+            }
+        } else {
+            unknown_proofs.push(*y);
+        }
+    }
+
+    for (state, ys) in ys_by_state {
+        tx.update_proofs_states(&ys, state).await?;
+    }
+
+    tx.remove_proofs(&unknown_proofs, None).await?;
+
+    Ok(())
+}
+
+#[inline(always)]
+async fn rollback(
+    db: Arc<dyn MintDatabase<database::Error> + Send + Sync>,
+    ys: Vec<PublicKey>,
+    original_states: Vec<Option<State>>,
+) -> Result<(), Error> {
+    let mut tx = db.begin_transaction().await?;
+    reset_proofs_to_original_state(&mut tx, &ys, original_states).await?;
+    tx.commit().await?;
+
+    Ok(())
+}
+
+impl Drop for ProofWriter {
+    fn drop(&mut self) {
+        let db = if let Some(db) = self.db.take() {
+            db
+        } else {
+            return;
+        };
+        let (ys, states) = if let Some(proofs) = self.proof_original_states.take() {
+            proofs.into_iter().unzip()
+        } else {
+            return;
+        };
+
+        tokio::spawn(rollback(db, ys, states));
+    }
+}

--- a/misc/itests.sh
+++ b/misc/itests.sh
@@ -210,7 +210,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Running happy_path_mint_wallet test with CLN mint"
-cargo test -p cdk-integration-tests --test happy_path_mint_wallet test_happy_mint_melt_round_trip
+cargo test -p cdk-integration-tests --test happy_path_mint_wallet
 if [ $? -ne 0 ]; then
     echo "happy_path_mint_wallet test failed, exiting"
     exit 1


### PR DESCRIPTION
### Description

The transaction traits will encapsulate all database changes and also expect READ-and-lock operations to read and lock records from the database for exclusive access, thereby avoiding race conditions.

The Transaction trait expects a `rollback` operation on Drop unless the transaction has been committed. 

This PR also includes work to remove redb #787 

TODO:
 - [ ] Add a set of tests for the database operations
 - [x] Move all INSERT, UPDATE and DELETE to their transaction traits
 - [x] Implement Rollback on `DROP`, although that should be already supported by  our rusqlite wrapper
-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
