### PR TITLE
fix: also check UNPAID mint quotes on startup

### DIFF
--- a/crates/cdk/src/mint/start_up_check.rs
+++ b/crates/cdk/src/mint/start_up_check.rs
@@ -8,13 +8,20 @@ use crate::mint::{MeltQuote, MeltQuoteState, PaymentMethod};
 use crate::types::PaymentProcessorKey;
 
 impl Mint {
-    /// Check the status of all pending mint quotes in the mint db
+    /// Check the status of all pending and unpaid mint quotes in the mint db
     /// with all the lighting backends. This check that any payments
     /// received while the mint was offline are accounted for, and the wallet can mint associated ecash
     pub async fn check_pending_mint_quotes(&self) -> Result<(), Error> {
         let pending_quotes = self.get_pending_mint_quotes().await?;
-        tracing::info!("There are {} pending mint quotes.", pending_quotes.len());
-        for quote in pending_quotes.iter() {
+        let unpaid_quotes = self.get_unpaid_mint_quotes().await?;
+
+        let all_quotes = vec![pending_quotes, unpaid_quotes].concat();
+
+        tracing::info!(
+            "There are {} pending and unpaid mint quotes.",
+            all_quotes.len()
+        );
+        for quote in all_quotes.iter() {
             tracing::debug!("Checking status of mint quote: {}", quote.id);
             if let Err(err) = self.check_mint_quote_paid(&quote.id).await {
                 tracing::error!("Could not check status of {}, {}", quote.id, err);


### PR DESCRIPTION
### Description

closes https://github.com/cashubtc/cdk/issues/843

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

When the mint starts up, check the payment status of mint quotes that are UNPAID and PENDING instead of just PENDING quotes.

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
