### PR TITLE
Add Amount::convert_unit convenience method

### DIFF
--- a/crates/cashu/src/amount.rs
+++ b/crates/cashu/src/amount.rs
@@ -172,6 +172,15 @@ impl Amount {
             acc.checked_add(x).ok_or(Error::AmountOverflow)
         })
     }
+
+    /// Convert unit
+    pub fn convert_unit(
+        &self,
+        current_unit: &CurrencyUnit,
+        target_unit: &CurrencyUnit,
+    ) -> Result<Amount, Error> {
+        to_unit(self.0, current_unit, target_unit)
+    }
 }
 
 impl Default for Amount {


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
Add a simple convenience method to avoid requiring the `to_unit` function import.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED
- Amount::convert_unit convenience method

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
