### PR TITLE
fix GLIBC compatibility issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY crates ./crates
 RUN nix develop --extra-experimental-features nix-command --extra-experimental-features flakes --command cargo build --release --bin cdk-mintd --features redis
 
 # Create a runtime stage
-FROM debian:bookworm-slim
+FROM debian:sid-slim
 
 # Set the working directory
 WORKDIR /usr/src/app

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -16,7 +16,7 @@ RUN echo 'filter-syscalls = false' > /etc/nix/nix.conf
 RUN nix develop --extra-platforms aarch64-linux --extra-experimental-features nix-command --extra-experimental-features flakes --command cargo build --release --bin cdk-mintd --features redis
 
 # Create a runtime stage
-FROM debian:bookworm-slim
+FROM debian:sid-slim
 
 # Set the working directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
### Description
I'm getting `cdk-mintd: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.38 not found (required by cdk-mintd)` when running mintd 0.11.0 in docker environment
It turns out latest NixOS ships with glibc 2.38 while bookworm debian still uses glibc 2.36.
The next debian release trixie should come out soon meanwhile we may have to rely on sid version which has compatible glibc already

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [X] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [X] I ran `just final-check` before committing
