### PR TITLE
fix: install CryptoProvider when starting RPC server

### DIFF
--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -76,6 +76,11 @@ impl MintRPCServer {
     pub async fn start(&mut self, tls_dir: Option<PathBuf>) -> Result<(), Error> {
         tracing::info!("Starting RPC server {}", self.socket_addr);
 
+        #[cfg(not(target_arch = "wasm32"))]
+        if rustls::crypto::CryptoProvider::get_default().is_none() {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        }
+
         let server = match tls_dir {
             Some(tls_dir) => {
                 tracing::info!("TLS configuration found, starting secure server");


### PR DESCRIPTION
### Description

I was getting this error when I would run cdk-mintd with the management-rpc feature:

![image](https://github.com/user-attachments/assets/6aa67fca-6825-49cf-ad17-85985fb78662)
-----

### Notes to the reviewers

I'm not sure if `#[cfg(not(target_arch = "wasm32"))]` is needed. I see this same `rustls::crypto::ring::default_provider().install_default();` throughout the repo and sometimes the check for wasm32 is there and sometimes it is not. 

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED
 
ensure default crypto provider is present on RPC server startup

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
