### PR TITLE
fix: return the correct error when fetching mint config values

### DIFF
--- a/crates/cdk-sqlite/src/mint/error.rs
+++ b/crates/cdk-sqlite/src/mint/error.rs
@@ -92,6 +92,9 @@ pub enum Error {
     /// Unknown quote TTL
     #[error("Unknown quote TTL")]
     UnknownQuoteTTL,
+    /// Unknown config key
+    #[error("Unknown config key: {0}")]
+    UnknownConfigKey(String),
     /// Proof not found
     #[error("Proof not found")]
     ProofNotFound,


### PR DESCRIPTION
do not always return UnknownQuoteTTL
return UnknownMintInfo when appropriate
add a new UnknownConfigKey for unknown key values
unit tests to cover this functionality

### Description

I encountered a misleading error message when trying to retrieve a MintInfo that did not exist from the database. I should have gotten `UnknownMintInfo` but got a `UnknownMintTTL` instead.

This PR is to fix the misleading error message.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
