### PR TITLE
fix: include change in melt quote state updates

### DIFF
--- a/crates/cdk/src/mint/melt.rs
+++ b/crates/cdk/src/mint/melt.rs
@@ -755,13 +755,6 @@ impl Mint {
         )
         .await?;
 
-        self.pubsub_manager.melt_quote_status(
-            &quote,
-            payment_preimage.clone(),
-            None,
-            MeltQuoteState::Paid,
-        );
-
         let mut change = None;
 
         // Check if there is change to return
@@ -826,6 +819,13 @@ impl Mint {
                 change = Some(change_sigs);
             }
         }
+
+        self.pubsub_manager.melt_quote_status(
+            &quote,
+            payment_preimage.clone(),
+            change.clone(),
+            MeltQuoteState::Paid,
+        );
 
         proof_writer.commit();
         tx.commit().await?;


### PR DESCRIPTION
### Description

Change was not included in the melt quote state updates but change is included when making a regular GET request.  This PR makes sure we compute change before sending the ws update

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
