### PR TITLE
Update README.md-name issue on crates.io for cdk-mint-rpc

### DIFF
--- a/crates/cdk-mint-rpc/README.md
+++ b/crates/cdk-mint-rpc/README.md
@@ -19,7 +19,7 @@ This crate includes:
 
 From crates.io:
 ```bash
-cargo install cdk-mint-cli
+cargo install cdk-mint-rpc
 ```
 
 As a library:


### PR DESCRIPTION

### Description

could not find "cdk-mint-cli" in crates.io.  Found "cdk-mint-rpc"

-----

### Notes to the reviewers


-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED  cdk-mint-cli to cdk-mint-rpc for crates.io install

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
