### PR TITLE
fix: atomically increment keyset counter

### DIFF
--- a/crates/cdk-common/src/database/wallet.rs
+++ b/crates/cdk-common/src/database/wallet.rs
@@ -99,10 +99,8 @@ pub trait Database: Debug {
     /// Update proofs state in storage
     async fn update_proofs_state(&self, ys: Vec<PublicKey>, state: State) -> Result<(), Self::Err>;
 
-    /// Increment Keyset counter
-    async fn increment_keyset_counter(&self, keyset_id: &Id, count: u32) -> Result<(), Self::Err>;
-    /// Get current Keyset counter
-    async fn get_keyset_counter(&self, keyset_id: &Id) -> Result<Option<u32>, Self::Err>;
+    /// Increment Keyset counter and return new value
+    async fn increment_keyset_counter(&self, keyset_id: &Id, count: u32) -> Result<u32, Self::Err>;
 
     /// Add transaction to storage
     async fn add_transaction(&self, transaction: Transaction) -> Result<(), Self::Err>;


### PR DESCRIPTION
this prevents race conditions causing duplicate blind messages

remove get_keyset_counter() function
update increment_keyset_counter() to return the new count value
  - sqlite and redb implementations change all wallet operations to use the new atomic increment pattern
  - issue_bolt11.rs - Bolt11 invoice minting
  - issue_bolt12.rs - Bolt12 offer minting
  - melt_bolt11.rs - Melting with change proofs
  - swap.rs - Token swapping operations

### Description

https://github.com/cashubtc/cdk/issues/894

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
