### PR TITLE
refactor Nut10SecretRequest and add tests with provided test vectors

### DIFF
--- a/crates/cashu/src/nuts/nut18/mod.rs
+++ b/crates/cashu/src/nuts/nut18/mod.rs
@@ -7,5 +7,5 @@ pub mod transport;
 
 pub use error::Error;
 pub use payment_request::{PaymentRequest, PaymentRequestBuilder, PaymentRequestPayload};
-pub use secret::{Nut10SecretRequest, SecretDataRequest};
+pub use secret::Nut10SecretRequest;
 pub use transport::{Transport, TransportBuilder, TransportType};

--- a/crates/cashu/src/nuts/nut18/payment_request.rs
+++ b/crates/cashu/src/nuts/nut18/payment_request.rs
@@ -358,14 +358,8 @@ mod tests {
 
         // Check round-trip conversion
         assert_eq!(converted_back.kind, secret_request.kind);
-        assert_eq!(
-            converted_back.secret_data.data,
-            secret_request.secret_data.data
-        );
-        assert_eq!(
-            converted_back.secret_data.tags,
-            secret_request.secret_data.tags
-        );
+        assert_eq!(converted_back.data, secret_request.data);
+        assert_eq!(converted_back.tags, secret_request.tags);
 
         // Test in PaymentRequest builder
         let payment_request = PaymentRequest::builder()
@@ -458,7 +452,7 @@ mod tests {
         // Verify the P2PK data was preserved correctly
         if let Some(nut10_secret) = decoded_request.nut10 {
             assert_eq!(nut10_secret.kind, Kind::P2PK);
-            assert_eq!(nut10_secret.secret_data.data, pubkey_hex);
+            assert_eq!(nut10_secret.data, pubkey_hex);
         } else {
             panic!("NUT10 secret data missing in decoded payment request");
         }


### PR DESCRIPTION
### Description

Makes the NUT10 secret inside a payment request conformant to [the latest changes](https://github.com/cashubtc/nuts/pull/274)

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
