### PR TITLE
refactor(ci): move flake check from CI to separate daily workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  self-care:
-    name: Flake self-check
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check Nix flake inputs
-        uses: DeterminateSystems/flake-checker-action@v9
-        with:
-          fail-mode: true
-
   pre-commit-checks:
     name: "Cargo fmt, typos"
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-flake-check.yml
+++ b/.github/workflows/daily-flake-check.yml
@@ -1,0 +1,20 @@
+name: Daily Flake Check
+
+on:
+  schedule:
+    # Run daily at 6 AM UTC
+    - cron: '0 6 * * *'
+  # Allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  flake-check:
+    name: Daily Nix Flake Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Nix flake inputs
+        uses: DeterminateSystems/flake-checker-action@v9
+        with:
+          fail-mode: true


### PR DESCRIPTION
Move Nix flake input checking from the main CI pipeline to a dedicated daily scheduled workflow to reduce CI build time while maintaining regular dependency monitoring.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
