### PR TITLE
feat: enhance auth config

### DIFF
--- a/crates/cdk-integration-tests/src/bin/start_fake_auth_mint.rs
+++ b/crates/cdk-integration-tests/src/bin/start_fake_auth_mint.rs
@@ -17,6 +17,7 @@ use anyhow::Result;
 use bip39::Mnemonic;
 use cdk_integration_tests::cli::CommonArgs;
 use cdk_integration_tests::shared;
+use cdk_mintd::config::AuthType;
 use clap::Parser;
 use tokio::sync::Notify;
 
@@ -71,13 +72,15 @@ async fn start_fake_auth_mint(
         openid_discovery,
         openid_client_id: "cashu-client".to_string(),
         mint_max_bat: 50,
-        enabled_mint: true,
-        enabled_melt: true,
-        enabled_swap: true,
-        enabled_check_mint_quote: true,
-        enabled_check_melt_quote: true,
-        enabled_restore: true,
-        enabled_check_proof_state: true,
+        mint: AuthType::Blind,
+        get_mint_quote: AuthType::Blind,
+        check_mint_quote: AuthType::Blind,
+        melt: AuthType::Blind,
+        get_melt_quote: AuthType::Blind,
+        check_melt_quote: AuthType::Blind,
+        swap: AuthType::Blind,
+        restore: AuthType::Blind,
+        check_proof_state: AuthType::Blind,
     });
 
     // Set description for the mint

--- a/crates/cdk-integration-tests/src/bin/start_fake_auth_mint.rs
+++ b/crates/cdk-integration-tests/src/bin/start_fake_auth_mint.rs
@@ -69,6 +69,7 @@ async fn start_fake_auth_mint(
 
     // Enable authentication
     settings.auth = Some(cdk_mintd::config::Auth {
+        auth_enabled: true,
         openid_discovery,
         openid_client_id: "cashu-client".to_string(),
         mint_max_bat: 50,

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -86,10 +86,18 @@ reserve_fee_min = 4
 # openid_discovery = "http://127.0.0.1:8080/realms/cdk-test-realm/.well-known/openid-configuration"
 # openid_client_id = "cashu-client"
 # mint_max_bat=50
-# enabled_mint=true
-# enabled_melt=true
-# enabled_swap=true
-# enabled_check_mint_quote=true
-# enabled_check_melt_quote=true
-# enabled_restore=true
-# enabled_check_proof_state=true
+
+# Authentication settings for endpoints
+# Options: "clear", "blind", "none" (none = disabled)
+
+# mint = "blind"
+# get_mint_quote = "none"  
+# check_mint_quote = "none"
+
+# melt = "none"
+# get_melt_quote = "none"
+# check_melt_quote = "none"
+
+# swap = "blind"
+# restore = "blind"
+# check_proof_state = "none"

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -83,6 +83,8 @@ reserve_fee_min = 4
 # tls_dir = "/path/to/tls"
 
 # [auth]
+# Set to true to enable authentication features (defaults to false)
+# auth_enabled = false
 # openid_discovery = "http://127.0.0.1:8080/realms/cdk-test-realm/.well-known/openid-configuration"
 # openid_client_id = "cashu-client"
 # mint_max_bat=50

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -232,6 +232,8 @@ impl std::str::FromStr for AuthType {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Auth {
+    #[serde(default)]
+    pub auth_enabled: bool,
     pub openid_discovery: String,
     pub openid_client_id: String,
     pub mint_max_bat: u64,

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -208,30 +208,57 @@ pub struct Database {
     pub engine: DatabaseEngine,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthType {
+    Clear,
+    Blind,
+    #[default]
+    None,
+}
+
+impl std::str::FromStr for AuthType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "clear" => Ok(AuthType::Clear),
+            "blind" => Ok(AuthType::Blind),
+            "none" => Ok(AuthType::None),
+            _ => Err(format!("Unknown auth type: {s}")),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Auth {
     pub openid_discovery: String,
     pub openid_client_id: String,
     pub mint_max_bat: u64,
-    #[serde(default = "default_true")]
-    pub enabled_mint: bool,
-    #[serde(default = "default_true")]
-    pub enabled_melt: bool,
-    #[serde(default = "default_true")]
-    pub enabled_swap: bool,
-    #[serde(default = "default_true")]
-    pub enabled_check_mint_quote: bool,
-    #[serde(default = "default_true")]
-    pub enabled_check_melt_quote: bool,
-    #[serde(default = "default_true")]
-    pub enabled_restore: bool,
-    #[serde(default = "default_true")]
-    pub enabled_check_proof_state: bool,
+    #[serde(default = "default_blind")]
+    pub mint: AuthType,
+    #[serde(default)]
+    pub get_mint_quote: AuthType,
+    #[serde(default)]
+    pub check_mint_quote: AuthType,
+    #[serde(default)]
+    pub melt: AuthType,
+    #[serde(default)]
+    pub get_melt_quote: AuthType,
+    #[serde(default)]
+    pub check_melt_quote: AuthType,
+    #[serde(default = "default_blind")]
+    pub swap: AuthType,
+    #[serde(default = "default_blind")]
+    pub restore: AuthType,
+    #[serde(default)]
+    pub check_proof_state: AuthType,
 }
 
-fn default_true() -> bool {
-    true
+fn default_blind() -> AuthType {
+    AuthType::Blind
 }
+
 /// CDK settings, derived from `config.toml`
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Settings {

--- a/crates/cdk-mintd/src/env_vars/auth.rs
+++ b/crates/cdk-mintd/src/env_vars/auth.rs
@@ -7,13 +7,15 @@ use crate::config::Auth;
 pub const ENV_AUTH_OPENID_DISCOVERY: &str = "CDK_MINTD_AUTH_OPENID_DISCOVERY";
 pub const ENV_AUTH_OPENID_CLIENT_ID: &str = "CDK_MINTD_AUTH_OPENID_CLIENT_ID";
 pub const ENV_AUTH_MINT_MAX_BAT: &str = "CDK_MINTD_AUTH_MINT_MAX_BAT";
-pub const ENV_AUTH_ENABLED_MINT: &str = "CDK_MINTD_AUTH_ENABLED_MINT";
-pub const ENV_AUTH_ENABLED_MELT: &str = "CDK_MINTD_AUTH_ENABLED_MELT";
-pub const ENV_AUTH_ENABLED_SWAP: &str = "CDK_MINTD_AUTH_ENABLED_SWAP";
-pub const ENV_AUTH_ENABLED_CHECK_MINT_QUOTE: &str = "CDK_MINTD_AUTH_ENABLED_CHECK_MINT_QUOTE";
-pub const ENV_AUTH_ENABLED_CHECK_MELT_QUOTE: &str = "CDK_MINTD_AUTH_ENABLED_CHECK_MELT_QUOTE";
-pub const ENV_AUTH_ENABLED_RESTORE: &str = "CDK_MINTD_AUTH_ENABLED_RESTORE";
-pub const ENV_AUTH_ENABLED_CHECK_PROOF_STATE: &str = "CDK_MINTD_AUTH_ENABLED_CHECK_PROOF_STATE";
+pub const ENV_AUTH_MINT: &str = "CDK_MINTD_AUTH_MINT";
+pub const ENV_AUTH_GET_MINT_QUOTE: &str = "CDK_MINTD_AUTH_GET_MINT_QUOTE";
+pub const ENV_AUTH_CHECK_MINT_QUOTE: &str = "CDK_MINTD_AUTH_CHECK_MINT_QUOTE";
+pub const ENV_AUTH_MELT: &str = "CDK_MINTD_AUTH_MELT";
+pub const ENV_AUTH_GET_MELT_QUOTE: &str = "CDK_MINTD_AUTH_GET_MELT_QUOTE";
+pub const ENV_AUTH_CHECK_MELT_QUOTE: &str = "CDK_MINTD_AUTH_CHECK_MELT_QUOTE";
+pub const ENV_AUTH_SWAP: &str = "CDK_MINTD_AUTH_SWAP";
+pub const ENV_AUTH_RESTORE: &str = "CDK_MINTD_AUTH_RESTORE";
+pub const ENV_AUTH_CHECK_PROOF_STATE: &str = "CDK_MINTD_AUTH_CHECK_PROOF_STATE";
 
 impl Auth {
     pub fn from_env(mut self) -> Self {
@@ -31,45 +33,57 @@ impl Auth {
             }
         }
 
-        if let Ok(enabled_mint_str) = env::var(ENV_AUTH_ENABLED_MINT) {
-            if let Ok(enabled) = enabled_mint_str.parse() {
-                self.enabled_mint = enabled;
+        if let Ok(mint_str) = env::var(ENV_AUTH_MINT) {
+            if let Ok(auth_type) = mint_str.parse() {
+                self.mint = auth_type;
             }
         }
 
-        if let Ok(enabled_melt_str) = env::var(ENV_AUTH_ENABLED_MELT) {
-            if let Ok(enabled) = enabled_melt_str.parse() {
-                self.enabled_melt = enabled;
+        if let Ok(get_mint_quote_str) = env::var(ENV_AUTH_GET_MINT_QUOTE) {
+            if let Ok(auth_type) = get_mint_quote_str.parse() {
+                self.get_mint_quote = auth_type;
             }
         }
 
-        if let Ok(enabled_swap_str) = env::var(ENV_AUTH_ENABLED_SWAP) {
-            if let Ok(enabled) = enabled_swap_str.parse() {
-                self.enabled_swap = enabled;
+        if let Ok(check_mint_quote_str) = env::var(ENV_AUTH_CHECK_MINT_QUOTE) {
+            if let Ok(auth_type) = check_mint_quote_str.parse() {
+                self.check_mint_quote = auth_type;
             }
         }
 
-        if let Ok(enabled_check_mint_str) = env::var(ENV_AUTH_ENABLED_CHECK_MINT_QUOTE) {
-            if let Ok(enabled) = enabled_check_mint_str.parse() {
-                self.enabled_check_mint_quote = enabled;
+        if let Ok(melt_str) = env::var(ENV_AUTH_MELT) {
+            if let Ok(auth_type) = melt_str.parse() {
+                self.melt = auth_type;
             }
         }
 
-        if let Ok(enabled_check_melt_str) = env::var(ENV_AUTH_ENABLED_CHECK_MELT_QUOTE) {
-            if let Ok(enabled) = enabled_check_melt_str.parse() {
-                self.enabled_check_melt_quote = enabled;
+        if let Ok(get_melt_quote_str) = env::var(ENV_AUTH_GET_MELT_QUOTE) {
+            if let Ok(auth_type) = get_melt_quote_str.parse() {
+                self.get_melt_quote = auth_type;
             }
         }
 
-        if let Ok(enabled_restore_str) = env::var(ENV_AUTH_ENABLED_RESTORE) {
-            if let Ok(enabled) = enabled_restore_str.parse() {
-                self.enabled_restore = enabled;
+        if let Ok(check_melt_quote_str) = env::var(ENV_AUTH_CHECK_MELT_QUOTE) {
+            if let Ok(auth_type) = check_melt_quote_str.parse() {
+                self.check_melt_quote = auth_type;
             }
         }
 
-        if let Ok(enabled_check_proof_str) = env::var(ENV_AUTH_ENABLED_CHECK_PROOF_STATE) {
-            if let Ok(enabled) = enabled_check_proof_str.parse() {
-                self.enabled_check_proof_state = enabled;
+        if let Ok(swap_str) = env::var(ENV_AUTH_SWAP) {
+            if let Ok(auth_type) = swap_str.parse() {
+                self.swap = auth_type;
+            }
+        }
+
+        if let Ok(restore_str) = env::var(ENV_AUTH_RESTORE) {
+            if let Ok(auth_type) = restore_str.parse() {
+                self.restore = auth_type;
+            }
+        }
+
+        if let Ok(check_proof_state_str) = env::var(ENV_AUTH_CHECK_PROOF_STATE) {
+            if let Ok(auth_type) = check_proof_state_str.parse() {
+                self.check_proof_state = auth_type;
             }
         }
 

--- a/crates/cdk-mintd/src/env_vars/auth.rs
+++ b/crates/cdk-mintd/src/env_vars/auth.rs
@@ -4,6 +4,7 @@ use std::env;
 
 use crate::config::Auth;
 
+pub const ENV_AUTH_ENABLED: &str = "CDK_MINTD_AUTH_ENABLED";
 pub const ENV_AUTH_OPENID_DISCOVERY: &str = "CDK_MINTD_AUTH_OPENID_DISCOVERY";
 pub const ENV_AUTH_OPENID_CLIENT_ID: &str = "CDK_MINTD_AUTH_OPENID_CLIENT_ID";
 pub const ENV_AUTH_MINT_MAX_BAT: &str = "CDK_MINTD_AUTH_MINT_MAX_BAT";
@@ -19,6 +20,12 @@ pub const ENV_AUTH_CHECK_PROOF_STATE: &str = "CDK_MINTD_AUTH_CHECK_PROOF_STATE";
 
 impl Auth {
     pub fn from_env(mut self) -> Self {
+        if let Ok(enabled_str) = env::var(ENV_AUTH_ENABLED) {
+            if let Ok(enabled) = enabled_str.parse() {
+                self.auth_enabled = enabled;
+            }
+        }
+
         if let Ok(discovery) = env::var(ENV_AUTH_OPENID_DISCOVERY) {
             self.openid_discovery = discovery;
         }

--- a/crates/cdk-mintd/src/env_vars/mod.rs
+++ b/crates/cdk-mintd/src/env_vars/mod.rs
@@ -60,6 +60,8 @@ impl Settings {
 
         #[cfg(feature = "auth")]
         {
+            use crate::config::AuthType;
+
             // Check env vars for auth config even if None
             let auth = self.auth.clone().unwrap_or_default().from_env();
 
@@ -67,9 +69,15 @@ impl Settings {
             if auth.openid_discovery != String::default()
                 || auth.openid_client_id != String::default()
                 || auth.mint_max_bat != 0
-                || auth.enabled_mint
-                || auth.enabled_melt
-                || auth.enabled_swap
+                || auth.mint != AuthType::Blind
+                || auth.get_mint_quote != AuthType::None
+                || auth.check_mint_quote != AuthType::None
+                || auth.melt != AuthType::None
+                || auth.get_melt_quote != AuthType::None
+                || auth.check_melt_quote != AuthType::None
+                || auth.swap != AuthType::Blind
+                || auth.restore != AuthType::Blind
+                || auth.check_proof_state != AuthType::None
             {
                 self.auth = Some(auth);
             } else {

--- a/crates/cdk-mintd/src/env_vars/mod.rs
+++ b/crates/cdk-mintd/src/env_vars/mod.rs
@@ -60,25 +60,11 @@ impl Settings {
 
         #[cfg(feature = "auth")]
         {
-            use crate::config::AuthType;
-
             // Check env vars for auth config even if None
             let auth = self.auth.clone().unwrap_or_default().from_env();
 
-            // Only set auth if env vars are present and have non-default values
-            if auth.openid_discovery != String::default()
-                || auth.openid_client_id != String::default()
-                || auth.mint_max_bat != 0
-                || auth.mint != AuthType::Blind
-                || auth.get_mint_quote != AuthType::None
-                || auth.check_mint_quote != AuthType::None
-                || auth.melt != AuthType::None
-                || auth.get_melt_quote != AuthType::None
-                || auth.check_melt_quote != AuthType::None
-                || auth.swap != AuthType::Blind
-                || auth.restore != AuthType::Blind
-                || auth.check_proof_state != AuthType::None
-            {
+            // Only set auth if auth_enabled flag is true
+            if auth.auth_enabled {
                 self.auth = Some(auth);
             } else {
                 self.auth = None;


### PR DESCRIPTION
### Description

Nuts 21 and 22 allow for any endpoint to be protected with clear or blind auth. This PR adds more fine grained configurations to allow users to enable/disable auth on every endpoint and configure the auth type as clear or blind. Minting blind auth tokens always requires clear auth.

-----

### Notes to the reviewers

#### Defaults 

I've chosen the defaults based on my experience with implementing auth in my wallet and trying to provide a smooth UX. Only minting, swapping, and restoring require blind auth. Everything else is unauthenticated. Of course, wallets should not assume these defaults, but it makes the wallet experience better if they are set in this way.

- **checkstate**: by default I do not require auth so that any wallet can easily input a token and check if its spent before prompting the user to authenticate
- **get/check mint quotes**: by default creating and checking mint quotes does not require auth which allows a server (ie. lnurl server) to generate mint quotes on behalf of a user. This one introduces the risk that a wallet which does not check auth requirements could create a mint quote but never be able to actually mint the ecash.
- **melting**: melting does not require auth by default because there is no good solution for sending ecash from an auth mint to a non-authenticated user. By disabling auth on melts anyone is able to withdraw from the mint

There is a reasonable argument to enable blind auth on everything by default.

#### Config names
I renamed some config options and changed their type from boolean to an enum of 'clear', 'blind', or 'none'. Is this acceptable? Or do we need to make this change more backwards compatible? 

I renamed them in this way because the other option I saw was to keep the old configs (ie `enabled_mint=true`) and introduce new configs to configure the auth type (ie. `mint_auth_type='clear'`). This is verbose and makes the config harder to read.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

changed auth configs to allow for fine grained control of protected endpoints

#### ADDED

added the following config options:

```toml
#Authentication settings for endpoints
# Options: "clear", "blind", "none" (none = disabled)

mint = "blind"
get_mint_quote = "none"  
check_mint_quote = "none"

melt = "none"
get_melt_quote = "none"
check_melt_quote = "none"

swap = "blind"
restore = "blind"
check_proof_state = "none"
```

#### REMOVED

removed the following config options:

```toml
enabled_mint=true
enabled_melt=true
enabled_swap=true
enabled_check_mint_quote=true
enabled_check_melt_quote=true
enabled_restore=true
enabled_check_proof_state=true
```

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
