### PR TITLE
refactor: update send functionality across wallet components

### DIFF
--- a/crates/cdk-cli/src/sub_commands/pay_request.rs
+++ b/crates/cdk-cli/src/sub_commands/pay_request.rs
@@ -92,7 +92,7 @@ pub async fn pay_request(
         )
         .await?;
 
-    let token = matching_wallet.send(prepared_send, None).await?;
+    let token = prepared_send.confirm(None).await?;
 
     // We need the keysets information to properly convert from token proof to proof
     let keysets_info = match matching_wallet

--- a/crates/cdk-cli/src/sub_commands/send.rs
+++ b/crates/cdk-cli/src/sub_commands/send.rs
@@ -221,7 +221,7 @@ pub async fn send(
             },
         )
         .await?;
-    let token = wallet.send(prepared_send, None).await?;
+    let token = prepared_send.confirm(None).await?;
 
     match sub_command_args.v3 {
         true => {

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -70,11 +70,8 @@ async fn test_swap_to_send() {
                 .expect("Failed to get ys")
         )
     );
-    let token = wallet_alice
-        .send(
-            prepared_send,
-            Some(SendMemo::for_token("test_swapt_to_send")),
-        )
+    let token = prepared_send
+        .confirm(Some(SendMemo::for_token("test_swapt_to_send")))
         .await
         .expect("Failed to send token");
     let keysets_info = wallet_alice.get_mint_keysets().await.unwrap();

--- a/crates/cdk-integration-tests/tests/test_fees.rs
+++ b/crates/cdk-integration-tests/tests/test_fees.rs
@@ -64,7 +64,7 @@ async fn test_swap() {
 
     assert_eq!(fee, 1.into());
 
-    let send = wallet.send(send, None).await.unwrap();
+    let send = send.confirm(None).await.unwrap();
 
     let rec_amount = wallet
         .receive(&send.to_string(), ReceiveOptions::default())

--- a/crates/cdk/README.md
+++ b/crates/cdk/README.md
@@ -101,7 +101,7 @@ async fn main() {
 
         // Send the token
         let prepared_send = wallet.prepare_send(Amount::ONE, SendOptions::default()).await.unwrap();
-        let token = wallet.send(prepared_send, None).await.unwrap();
+        let token = prepared_send.confirm(None).await.unwrap();
 
         println!("{}", token);
     }

--- a/crates/cdk/examples/auth_wallet.rs
+++ b/crates/cdk/examples/auth_wallet.rs
@@ -88,7 +88,7 @@ async fn main() -> Result<(), Error> {
     let prepared_send = wallet
         .prepare_send(10.into(), SendOptions::default())
         .await?;
-    let token = wallet.send(prepared_send, None).await?;
+    let token = prepared_send.confirm(None).await?;
 
     println!("Created token: {}", token);
 

--- a/crates/cdk/examples/mint-token.rs
+++ b/crates/cdk/examples/mint-token.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Error> {
 
     // Send a token with the specified amount
     let prepared_send = wallet.prepare_send(amount, SendOptions::default()).await?;
-    let token = wallet.send(prepared_send, None).await?;
+    let token = prepared_send.confirm(None).await?;
     println!("Token:");
     println!("{}", token);
 

--- a/crates/cdk/examples/p2pk.rs
+++ b/crates/cdk/examples/p2pk.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Error> {
         )
         .await?;
     println!("Fee: {}", prepared_send.fee());
-    let token = wallet.send(prepared_send, None).await?;
+    let token = prepared_send.confirm(None).await?;
 
     println!("Created token locked to pubkey: {}", secret.public_key());
     println!("{}", token);

--- a/crates/cdk/examples/wallet.rs
+++ b/crates/cdk/examples/wallet.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Send the token
     let prepared_send = wallet.prepare_send(amount, SendOptions::default()).await?;
-    let token = wallet.send(prepared_send, None).await?;
+    let token = prepared_send.confirm(None).await?;
 
     println!("{}", token);
 

--- a/crates/cdk/src/wallet/multi_mint_wallet.rs
+++ b/crates/cdk/src/wallet/multi_mint_wallet.rs
@@ -185,12 +185,7 @@ impl MultiMintWallet {
         send: PreparedSend,
         memo: Option<SendMemo>,
     ) -> Result<Token, Error> {
-        let wallets = self.wallets.read().await;
-        let wallet = wallets
-            .get(wallet_key)
-            .ok_or(Error::UnknownWallet(wallet_key.clone()))?;
-
-        wallet.send(send, memo).await
+        send.confirm(memo).await
     }
 
     /// Mint quote for wallet

--- a/crates/cdk/src/wallet/multi_mint_wallet.rs
+++ b/crates/cdk/src/wallet/multi_mint_wallet.rs
@@ -15,7 +15,7 @@ use tokio::sync::RwLock;
 use tracing::instrument;
 
 use super::receive::ReceiveOptions;
-use super::send::{PreparedSend, SendMemo, SendOptions};
+use super::send::{PreparedSend, SendOptions};
 use super::Error;
 use crate::amount::SplitTarget;
 use crate::mint_url::MintUrl;
@@ -175,17 +175,6 @@ impl MultiMintWallet {
             .ok_or(Error::UnknownWallet(wallet_key.clone()))?;
 
         wallet.prepare_send(amount, opts).await
-    }
-
-    /// Create cashu token
-    #[instrument(skip(self))]
-    pub async fn send(
-        &self,
-        wallet_key: &WalletKey,
-        send: PreparedSend,
-        memo: Option<SendMemo>,
-    ) -> Result<Token, Error> {
-        send.confirm(memo).await
     }
 
     /// Mint quote for wallet


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
Use `Wallet` instance in `PreparedSend` to confirm or cancel the send.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED
- Moved the logic to confirm or cancel a send from the `Wallet` to the `PreparedSend`.

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
