### PR TITLE
fix(cdk-sqlite): reduce SQLite memory usage and optimize connection s…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Cargo.lock
 .aider*
 **/postgres_data/
 **/.env
+heaptrack*

--- a/crates/cdk-sqlite/src/common.rs
+++ b/crates/cdk-sqlite/src/common.rs
@@ -41,16 +41,17 @@ impl ResourceManager for SqliteConnectionManager {
 
         conn.execute_batch(
             r#"
-            pragma busy_timeout = 10000;
+            pragma busy_timeout = 5000;
             pragma journal_mode = WAL;
             pragma synchronous = normal;
             pragma temp_store = memory;
-            pragma mmap_size = 30000000000;
-            pragma cache = shared;
+            pragma mmap_size = 268435456;  -- 256MB instead of 30GB
+            pragma cache_size = 1000;
+            pragma page_size = 4096;
             "#,
         )?;
 
-        conn.busy_timeout(Duration::from_secs(10))?;
+        conn.busy_timeout(Duration::from_secs(5))?; // Match the pragma setting
 
         Ok(conn)
     }
@@ -76,11 +77,11 @@ pub fn create_sqlite_pool(
                 path: Some(path.to_owned()),
                 password,
             },
-            20,
+            5, // Reduced from 20 to 5 to minimize memory usage
         )
     };
 
-    Pool::new(config, max_size, Duration::from_secs(10))
+    Pool::new(config, max_size, Duration::from_secs(5)) // Reduced timeout
 }
 
 /// Convert cdk_sql_common::value::Value to rusqlite Value


### PR DESCRIPTION
…ettings

- Decreased busy timeout from 10s to 5s
- Reduced mmap_size from 30GB to 256MB
- Lowered cache size and set explicit page size
- Reduced connection pool max size from 20 to 5
- Decreased pool timeout from 10s to 5s
- Added heaptrack to gitignore for memory profilin

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
