### PR TITLE
Add explicit rollback.

### DIFF
--- a/crates/cdk/src/mint/melt.rs
+++ b/crates/cdk/src/mint/melt.rs
@@ -662,6 +662,7 @@ impl Mint {
                             "Lightning payment for quote {} failed.",
                             melt_request.quote()
                         );
+                        proof_writer.rollback().await?;
                         return Err(Error::PaymentFailed);
                     }
                     MeltQuoteState::Pending => {

--- a/crates/cdk/src/mint/proof_writer.rs
+++ b/crates/cdk/src/mint/proof_writer.rs
@@ -157,8 +157,8 @@ impl ProofWriter {
         };
 
         tracing::info!(
-            "Rollback proofs to their original states {:?} {:?}",
-            ys,
+            "Rollback {} proofs to their original states {:?}",
+            ys.len(),
             original_states
         );
 

--- a/crates/cdk/src/mint/proof_writer.rs
+++ b/crates/cdk/src/mint/proof_writer.rs
@@ -143,13 +143,28 @@ impl ProofWriter {
     }
 
     /// Rollback all changes in this ProofWriter consuming it.
-    pub async fn rollback(mut self, tx: &mut Tx<'_, '_>) -> Result<(), Error> {
+    pub async fn rollback(mut self) -> Result<(), Error> {
+        let db = if let Some(db) = self.db.take() {
+            db
+        } else {
+            return Ok(());
+        };
+        let mut tx = db.begin_transaction().await?;
         let (ys, original_states) = if let Some(proofs) = self.proof_original_states.take() {
             proofs.into_iter().unzip::<_, _, Vec<_>, Vec<_>>()
         } else {
             return Ok(());
         };
-        reset_proofs_to_original_state(tx, &ys, original_states).await?;
+
+        tracing::info!(
+            "Rollback proofs to their original states {:?} {:?}",
+            ys,
+            original_states
+        );
+
+        reset_proofs_to_original_state(&mut tx, &ys, original_states).await?;
+        tx.commit().await?;
+
         Ok(())
     }
 }


### PR DESCRIPTION

### Description

The proof_writer implicit rollback on Drop is too slow for our tests causing race conditions with Postgres.

This commit enhances the rollback logic and makes it explicit


-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
