### PR TITLE
feat(cdk): allow minting less than paid amount for non-bolt11 payments

### DIFF
--- a/crates/cdk/src/wallet/issue/issue_bolt12.rs
+++ b/crates/cdk/src/wallet/issue/issue_bolt12.rs
@@ -97,7 +97,7 @@ impl Wallet {
 
         let quote_info = if let Some(quote) = quote_info {
             if quote.expiry.le(&unix_time()) && quote.expiry.ne(&0) {
-                return Err(Error::ExpiredQuote(quote.expiry, unix_time()));
+                tracing::info!("Minting after expiry");
             }
 
             quote.clone()


### PR DESCRIPTION
For bolt11 payments, enforce exact amount matching between outputs and quote. For other payment methods, allow minting less than paid amount while preventing overspending.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
