### PR TITLE
fix: reduce mmap_size to 5 MiB

### DIFF
--- a/crates/cdk-sqlite/src/common.rs
+++ b/crates/cdk-sqlite/src/common.rs
@@ -62,7 +62,7 @@ impl DatabasePool for SqliteConnectionManager {
             pragma journal_mode = WAL;
             pragma synchronous = normal;
             pragma temp_store = memory;
-            pragma mmap_size = 30000000000;
+            pragma mmap_size = 5242880;
             pragma cache = shared;
             "#,
         )?;


### PR DESCRIPTION
### Description

This fixes the sqlite memory exhaustion. 

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED
- reduced mmap_size to prevent memory exhaustion. 
----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
