### PR TITLE
refactor(cdk-lnbits): migrate to LNbits v1 websocket API and remove w…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The project is split up into several crates in the `crates/` directory:
     * [**cdk-axum**](./crates/cdk-axum/): Axum webserver for mint.
     * [**cdk-cln**](./crates/cdk-cln/): CLN Lightning backend for mint.
     * [**cdk-lnd**](./crates/cdk-lnd/): Lnd Lightning backend for mint.
-    * [**cdk-lnbits**](./crates/cdk-lnbits/): [LNbits](https://lnbits.com/) Lightning backend for mint.
+    * [**cdk-lnbits**](./crates/cdk-lnbits/): [LNbits](https://lnbits.com/) Lightning backend for mint. **Note: Only LNBits v1 API is supported.**
     * [**cdk-fake-wallet**](./crates/cdk-fake-wallet/): Fake Lightning backend for mint. To be used only for testing, quotes are automatically filled.
     * [**cdk-mint-rpc**](./crates/cdk-mint-rpc/): Mint management gRPC server and cli.
 * Binaries:

--- a/crates/cdk-lnbits/Cargo.toml
+++ b/crates/cdk-lnbits/Cargo.toml
@@ -20,8 +20,6 @@ tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
-# lnbits-rs = "0.6.0"
-# lnbits-rs = { path = "../../../../lnbits-rs" }
-lnbits-rs = { git = "https://github.com/thesimplekid/lnbits-rs", branch = "v1_only"}
+lnbits-rs = "0.8.0"
 serde_json.workspace = true
 rustls.workspace = true

--- a/crates/cdk-lnbits/Cargo.toml
+++ b/crates/cdk-lnbits/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 [dependencies]
 async-trait.workspace = true
 anyhow.workspace = true
-axum.workspace = true
 bitcoin.workspace = true
 cdk-common = { workspace = true, features = ["mint"] }
 futures.workspace = true
@@ -21,6 +20,8 @@ tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
-lnbits-rs = "0.6.0"
+# lnbits-rs = "0.6.0"
+# lnbits-rs = { path = "../../../../lnbits-rs" }
+lnbits-rs = { git = "https://github.com/thesimplekid/lnbits-rs", branch = "v1_only"}
 serde_json.workspace = true
 rustls.workspace = true

--- a/crates/cdk-lnbits/README.md
+++ b/crates/cdk-lnbits/README.md
@@ -8,6 +8,8 @@
 
 LNBits backend implementation for the Cashu Development Kit (CDK). This provides integration with [LNBits](https://lnbits.com/) for Lightning Network functionality.
 
+**Note: Only LNBits v1 API is supported.** This backend uses the websocket-based v1 API for real-time payment notifications.
+
 ## Installation
 
 Add this to your `Cargo.toml`:

--- a/crates/cdk-lnbits/src/lib.rs
+++ b/crates/cdk-lnbits/src/lib.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
-use axum::Router;
 use cdk_common::amount::{to_unit, Amount, MSAT_IN_SAT};
 use cdk_common::common::FeeReserve;
 use cdk_common::nuts::{CurrencyUnit, MeltOptions, MeltQuoteState};
@@ -36,7 +35,6 @@ pub mod error;
 pub struct LNbits {
     lnbits_api: LNBitsClient,
     fee_reserve: FeeReserve,
-    webhook_url: Option<String>,
     wait_invoice_cancel_token: CancellationToken,
     wait_invoice_is_active: Arc<AtomicBool>,
     settings: Bolt11Settings,
@@ -50,14 +48,12 @@ impl LNbits {
         invoice_api_key: String,
         api_url: String,
         fee_reserve: FeeReserve,
-        webhook_url: Option<String>,
     ) -> Result<Self, Error> {
         let lnbits_api = LNBitsClient::new("", &admin_api_key, &invoice_api_key, &api_url, None)?;
 
         Ok(Self {
             lnbits_api,
             fee_reserve,
-            webhook_url,
             wait_invoice_cancel_token: CancellationToken::new(),
             wait_invoice_is_active: Arc::new(AtomicBool::new(false)),
             settings: Bolt11Settings {
@@ -134,9 +130,15 @@ impl MintPayment for LNbits {
                                                 Ok(decoded) => {
                                                     match decoded.try_into() {
                                                         Ok(hash) => {
+                                                            let amount = payment.details.amount;
+
+                                                            if amount == i64::MIN {
+                                                                return None;
+                                                            }
+
                                                             let response = WaitPaymentResponse {
                                                                 payment_identifier: PaymentIdentifier::PaymentHash(hash),
-                                                                payment_amount: Amount::from(payment.details.amount as u64),
+                                                                payment_amount: Amount::from(amount.unsigned_abs()),
                                                                 unit: CurrencyUnit::Msat,
                                                                 payment_id: msg.clone()
                                                             };
@@ -306,7 +308,6 @@ impl MintPayment for LNbits {
                     memo: Some(description),
                     unit: unit.to_string(),
                     expiry,
-                    webhook: self.webhook_url.clone(),
                     internal: None,
                     out: false,
                 };
@@ -321,10 +322,8 @@ impl MintPayment for LNbits {
                         Self::Err::Anyhow(anyhow!("Could not create invoice"))
                     })?;
 
-                let request: Bolt11Invoice = create_invoice_response
-                    .bolt11()
-                    .ok_or_else(|| Self::Err::Anyhow(anyhow!("Missing bolt11 invoice")))?
-                    .parse()?;
+                let request: Bolt11Invoice = create_invoice_response.bolt11().parse()?;
+
                 let expiry = request.expires_at().map(|t| t.as_secs());
 
                 Ok(CreateIncomingPaymentResponse {
@@ -389,7 +388,7 @@ impl MintPayment for LNbits {
         let pay_response = MakePaymentResponse {
             payment_lookup_id: payment_identifier.clone(),
             payment_proof: payment.preimage,
-            status: lnbits_to_melt_status(&payment.details.status, payment.details.pending),
+            status: lnbits_to_melt_status(&payment.details.status),
             total_spent: Amount::from(
                 payment.details.amount.unsigned_abs() + payment.details.fee.unsigned_abs(),
             ),
@@ -400,27 +399,11 @@ impl MintPayment for LNbits {
     }
 }
 
-fn lnbits_to_melt_status(status: &str, pending: Option<bool>) -> MeltQuoteState {
-    if pending.unwrap_or_default() {
-        return MeltQuoteState::Pending;
-    }
-
+fn lnbits_to_melt_status(status: &str) -> MeltQuoteState {
     match status {
         "success" => MeltQuoteState::Paid,
         "failed" => MeltQuoteState::Unpaid,
         "pending" => MeltQuoteState::Pending,
         _ => MeltQuoteState::Unknown,
-    }
-}
-
-impl LNbits {
-    /// Create invoice webhook
-    pub async fn create_invoice_webhook_router(
-        &self,
-        webhook_endpoint: &str,
-    ) -> anyhow::Result<Router> {
-        self.lnbits_api
-            .create_invoice_webhook_router(webhook_endpoint)
-            .await
     }
 }

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -80,8 +80,7 @@ reserve_fee_min = 4
 # admin_api_key = ""
 # invoice_api_key = ""
 # lnbits_api = ""
-# To be set true to support pre v1 lnbits api
-# retro_api=false
+# Note: Only LNBits v1 API is supported (websocket-based)
 
 # [lnd]
 # address = "https://domain:port"

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -161,7 +161,6 @@ pub struct LNbits {
     pub lnbits_api: String,
     pub fee_percent: f32,
     pub reserve_fee_min: Amount,
-    pub retro_api: bool,
 }
 
 #[cfg(feature = "cln")]

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -103,7 +103,7 @@ pub fn setup_tracing(
     logging_config: &config::LoggingConfig,
 ) -> Result<Option<tracing_appender::non_blocking::WorkerGuard>> {
     let default_filter = "debug";
-    let hyper_filter = "hyper=warn";
+    let hyper_filter = "hyper=warn,rustls=warn,reqwest=warn";
     let h2_filter = "h2=warn";
     let tower_http = "tower_http=warn";
 

--- a/crates/cdk/src/wallet/auth/auth_wallet.rs
+++ b/crates/cdk/src/wallet/auth/auth_wallet.rs
@@ -23,7 +23,7 @@ use crate::{Amount, Error, OidcClient};
 
 /// JWT Claims structure for decoding tokens
 #[derive(Debug, Serialize, Deserialize)]
-struct Claims {
+struct _Claims {
     /// Subject
     sub: Option<String>,
     /// Expiration time (as UTC timestamp)


### PR DESCRIPTION
…ebhook support

- Remove webhook-based payment notifications in favor of v1 websocket API
- Add explicit documentation that only LNbits v1 API is supported
- Remove webhook_url parameter and related router setup code
- Simplify payment status handling by removing pending status logic
- Switch to local lnbits-rs dependency for development
- Remove unused axum dependency and clean up imports
- Update configuration documentation and examples

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
