### PR TITLE
feat: zeroize cryptographic secrets on drop

### DIFF
--- a/crates/cashu/Cargo.toml
+++ b/crates/cashu/Cargo.toml
@@ -36,6 +36,7 @@ serde_with.workspace = true
 regex = { workspace = true, optional = true }
 strum = { workspace = true, optional = true }
 strum_macros = { workspace = true, optional = true }
+zeroize = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { workspace = true, features = ["wasm-bindgen", "inaccurate"] }

--- a/crates/cashu/src/secret.rs
+++ b/crates/cashu/src/secret.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use bitcoin::secp256k1::rand::{self, RngCore};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use zeroize::Zeroize;
 
 use crate::util::hex;
 
@@ -118,6 +119,12 @@ impl TryFrom<Secret> for crate::nuts::nut10::Secret {
 
     fn try_from(unchecked_secret: Secret) -> Result<crate::nuts::nut10::Secret, Self::Error> {
         serde_json::from_str(&unchecked_secret.0)
+    }
+}
+
+impl Drop for Secret {
+    fn drop(&mut self) {
+        self.0.zeroize();
     }
 }
 

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -47,6 +47,7 @@ jsonwebtoken = { workspace = true, optional = true }
 sync_wrapper = "0.1.2"
 bech32 = "0.9.1"
 arc-swap = "1.7.1"
+zeroize = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = [

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -11,6 +11,7 @@ use subscription::{ActiveSubscription, SubscriptionManager};
 #[cfg(feature = "auth")]
 use tokio::sync::RwLock;
 use tracing::instrument;
+use zeroize::Zeroize;
 
 use crate::amount::SplitTarget;
 use crate::dhke::construct_proofs;
@@ -655,5 +656,11 @@ impl Wallet {
         }
 
         Ok(())
+    }
+}
+
+impl Drop for Wallet {
+    fn drop(&mut self) {
+        self.seed.zeroize();
     }
 }

--- a/crates/cdk/src/wallet/multi_mint_wallet.rs
+++ b/crates/cdk/src/wallet/multi_mint_wallet.rs
@@ -13,6 +13,7 @@ use cdk_common::database::WalletDatabase;
 use cdk_common::wallet::{Transaction, TransactionDirection, WalletKey};
 use tokio::sync::RwLock;
 use tracing::instrument;
+use zeroize::Zeroize;
 
 use super::receive::ReceiveOptions;
 use super::send::{PreparedSend, SendOptions};
@@ -366,5 +367,11 @@ impl MultiMintWallet {
             .ok_or(Error::UnknownWallet(wallet_key.clone()))?;
 
         wallet.verify_token_dleq(token).await
+    }
+}
+
+impl Drop for MultiMintWallet {
+    fn drop(&mut self) {
+        self.seed.zeroize();
     }
 }


### PR DESCRIPTION
implement zeroize on Drop for Secret, Wallet, and MultiMintWallet
this erases sensitive memory addresses before deallocation

### Description

Minor security improvement that prevents a memory dump, swap file, or process memory inspection attack from exposing secrets left in deallocated memory addresses.

This is good hygiene and could be useful as part of a defense in depth strategy. Currently, it doesn't accomplish much because the master seed is kept in Wallet memory for the duration of the process.

A more meaningful security improvement would be to encrypt the seed on disk and load it into memory only when actively deriving keys. This would have a high performance impact due to the high frequency of ecash operations. Perhaps a better approach would be to focus on device architectures with a secure computing environment such as a secure enclave on a mobile phone and using something like [VLS](https://github.com/lightning-signer) on mint servers.

In any case this PR has very low performance impact and it's better than nothing.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
