### PR TITLE
feat: redact secrets from Debug and Display impls

### DIFF
--- a/crates/cashu/src/nuts/nut01/secret_key.rs
+++ b/crates/cashu/src/nuts/nut01/secret_key.rs
@@ -15,7 +15,7 @@ use super::{Error, PublicKey};
 use crate::SECP256K1;
 
 /// SecretKey
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 pub struct SecretKey {
     #[cfg_attr(feature = "swagger", schema(value_type = String))]
@@ -38,7 +38,15 @@ impl From<secp256k1::SecretKey> for SecretKey {
 
 impl fmt::Display for SecretKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_secret_hex())
+        write!(f, "[REDACTED]")
+    }
+}
+
+impl fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecretKey")
+            .field("inner", &"[REDACTED]")
+            .finish()
     }
 }
 

--- a/crates/cashu/src/secret.rs
+++ b/crates/cashu/src/secret.rs
@@ -11,7 +11,7 @@ use zeroize::Zeroize;
 use crate::util::hex;
 
 /// The secret data that allows spending ecash
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Secret(String);
 
@@ -32,6 +32,18 @@ pub enum Error {
 impl Default for Secret {
     fn default() -> Self {
         Self::generate()
+    }
+}
+
+impl fmt::Debug for Secret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Secret").field(&"[REDACTED]").finish()
+    }
+}
+
+impl fmt::Display for Secret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[REDACTED]")
     }
 }
 

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -68,7 +68,7 @@ use crate::nuts::nut00::ProofsMethods;
 /// The CDK [`Wallet`] is a high level cashu wallet.
 ///
 /// A [`Wallet`] is for a single mint and single unit.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Wallet {
     /// Mint Url
     pub mint_url: MintUrl,
@@ -136,6 +136,26 @@ impl From<WalletSubscription> for Params {
                 id: id.into(),
             },
         }
+    }
+}
+
+impl fmt::Debug for Wallet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug_struct = f.debug_struct("Wallet");
+        debug_struct
+            .field("mint_url", &self.mint_url)
+            .field("unit", &self.unit)
+            .field("localstore", &self.localstore)
+            .field("target_proof_count", &self.target_proof_count);
+
+        #[cfg(feature = "auth")]
+        debug_struct.field("auth_wallet", &self.auth_wallet);
+
+        debug_struct
+            .field("seed", &"[REDACTED]")
+            .field("client", &self.client)
+            .field("subscription", &self.subscription)
+            .finish()
     }
 }
 

--- a/crates/cdk/src/wallet/multi_mint_wallet.rs
+++ b/crates/cdk/src/wallet/multi_mint_wallet.rs
@@ -4,6 +4,7 @@
 //! pairs
 
 use std::collections::{BTreeMap, HashMap};
+use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -26,13 +27,23 @@ use crate::wallet::types::MintQuote;
 use crate::{ensure_cdk, Amount, Wallet};
 
 /// Multi Mint Wallet
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct MultiMintWallet {
     /// Storage backend
     pub localstore: Arc<dyn WalletDatabase<Err = database::Error> + Send + Sync>,
     seed: [u8; 64],
     /// Wallets
     pub wallets: Arc<RwLock<BTreeMap<WalletKey, Wallet>>>,
+}
+
+impl fmt::Debug for MultiMintWallet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MultiMintWallet")
+            .field("localstore", &self.localstore)
+            .field("seed", &"[REDACTED]")
+            .field("wallets", &self.wallets)
+            .finish()
+    }
 }
 
 impl MultiMintWallet {


### PR DESCRIPTION
redact Debug impls for SecretKey, Secret, Wallet, and MultiMintWallet redact Display impls for SecretKey and Secret
wallet structs don't implement Display, so no issue there

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
