### PR TITLE
Fix race conditions in minting tests

### DIFF
--- a/crates/cdk-integration-tests/src/init_auth_mint.rs
+++ b/crates/cdk-integration-tests/src/init_auth_mint.rs
@@ -33,7 +33,7 @@ where
         fee_reserve,
         HashMap::default(),
         HashSet::default(),
-        0,
+        2,
         CurrencyUnit::Sat,
     );
 

--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -247,7 +247,7 @@ pub async fn create_and_start_test_mint() -> Result<Mint> {
         fee_reserve.clone(),
         HashMap::default(),
         HashSet::default(),
-        0,
+        2,
         CurrencyUnit::Sat,
     );
 

--- a/crates/cdk-payment-processor/src/bin/payment_processor.rs
+++ b/crates/cdk-payment-processor/src/bin/payment_processor.rs
@@ -122,7 +122,7 @@ async fn main() -> anyhow::Result<()> {
                         fee_reserve,
                         HashMap::default(),
                         HashSet::default(),
-                        0,
+                        2,
                         cashu::CurrencyUnit::Sat,
                     );
 


### PR DESCRIPTION

### Description

There was a race condition between the database storing the mint quote and the fake wallet paying the invoice of a yet non-existent mint quote

The fix was quite simple, add a delay of seconds before paying all invoices

To recreate the slow conditions that would make our database slower than the external Fakewallet in Linux

```
sudo tc qdisc add dev lo root netem delay 200ms 50ms
ionice -c3  nix develop -i -L .#stable --command just itest-payment-processor FAKEWALLET
```

To reset

```
sudo tc qdisc del dev lo root

```


-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
