### PR TITLE
fix(build): use OUT_DIR for migration files

### DIFF
--- a/crates/cdk-sql-common/src/mint/auth/mod.rs
+++ b/crates/cdk-sql-common/src/mint/auth/mod.rs
@@ -54,8 +54,9 @@ where
 }
 
 #[rustfmt::skip]
-mod migrations;
-
+mod migrations {
+    include!(concat!(env!("OUT_DIR"), "/migrations_mint_auth.rs"));
+}
 
 #[async_trait]
 impl<RM> MintAuthTransaction<database::Error> for SQLTransaction<RM>

--- a/crates/cdk-sql-common/src/mint/mod.rs
+++ b/crates/cdk-sql-common/src/mint/mod.rs
@@ -52,8 +52,9 @@ use crate::{
 mod auth;
 
 #[rustfmt::skip]
-mod migrations;
-
+mod migrations {
+    include!(concat!(env!("OUT_DIR"), "/migrations_mint.rs"));
+}
 
 #[cfg(feature = "auth")]
 pub use auth::SQLMintAuthDatabase;

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -28,7 +28,9 @@ use crate::{
 };
 
 #[rustfmt::skip]
-mod migrations;
+mod migrations {
+    include!(concat!(env!("OUT_DIR"), "/migrations_wallet.rs"));
+}
 
 /// Wallet SQLite Database
 #[derive(Debug, Clone)]


### PR DESCRIPTION
- write generated migration files to OUT_DIR instead of source directory
- copy migration SQL files to OUT_DIR for inclusion in build artifacts
- use absolute paths from OUT_DIR in include_str! macros
- update consumer modules to include from OUT_DIR using concat! macro

these changes enable cdk to support nix sandbox builds

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
