### PR TITLE
fix(cdk): improve error handling when adding mint to MultiMintWallet

### DIFF
--- a/crates/cdk/src/wallet/multi_mint_wallet.rs
+++ b/crates/cdk/src/wallet/multi_mint_wallet.rs
@@ -242,7 +242,13 @@ impl MultiMintWallet {
             if mint_has_proofs_for_unit {
                 // Add mint to the MultiMintWallet if not already present
                 if !self.has_mint(&mint_url).await {
-                    self.add_mint(mint_url, None).await?;
+                    if let Err(err) = self.add_mint(mint_url.clone(), None).await {
+                        tracing::error!(
+                            "Could not add {} to wallet {}.",
+                            mint_url,
+                            err.to_string()
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
Add proper error handling and logging for add_mint operation instead of propagating errors, preventing wallet operations from failing completely when a mint cannot be added.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

for the mmw we don't want the wallet to fail if one mint cannot be reached. 

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
