### PR TITLE
fix: handle fiat melt amount conversions

### DIFF
--- a/crates/cdk/src/mint/melt.rs
+++ b/crates/cdk/src/mint/melt.rs
@@ -183,6 +183,10 @@ impl Mint {
                 Error::UnsupportedUnit
             })?;
 
+        if &payment_quote.unit != unit {
+            return Err(Error::UnitMismatch);
+        }
+
         // Validate using processor quote amount for currency conversion
         self.check_melt_request_acceptable(
             payment_quote.amount,
@@ -284,6 +288,10 @@ impl Mint {
 
                 Error::UnsupportedUnit
             })?;
+
+        if &payment_quote.unit != unit {
+            return Err(Error::UnitMismatch);
+        }
 
         // Validate using processor quote amount for currency conversion
         self.check_melt_request_acceptable(
@@ -504,8 +512,6 @@ impl Mint {
             unit: input_unit,
         } = input_verification;
 
-        ensure_cdk!(input_unit.is_some(), Error::UnsupportedUnit);
-
         let mut proof_writer =
             ProofWriter::new(self.localstore.clone(), self.pubsub_manager.clone());
 
@@ -521,6 +527,10 @@ impl Mint {
         let (state, quote) = tx
             .update_melt_quote_state(melt_request.quote(), MeltQuoteState::Pending, None)
             .await?;
+
+        if input_unit != Some(quote.unit.clone()) {
+            return Err(Error::UnitMismatch);
+        }
 
         match state {
             MeltQuoteState::Unpaid | MeltQuoteState::Failed => Ok(()),


### PR DESCRIPTION
### Description

Allows the payment processor to do currency conversion when getting the melt quote. Before, if a melt request was in a fiat unit, the `Amount::to_unit` would fail. This change moves `check_melt_request_acceptable` to after the the payment processor can tell us the amount in the requested unit.

I also added currency conversion to fake wallet using mempool's price api (https://mempool.space/api/v1/prices)

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
