### PR TITLE
feat: optimize SQL balance calculation

### DIFF
--- a/crates/cdk-common/src/database/wallet.rs
+++ b/crates/cdk-common/src/database/wallet.rs
@@ -96,6 +96,13 @@ pub trait Database: Debug {
         state: Option<Vec<State>>,
         spending_conditions: Option<Vec<SpendingConditions>>,
     ) -> Result<Vec<ProofInfo>, Self::Err>;
+    /// Get balance efficiently using SQL aggregation
+    async fn get_balance(
+        &self,
+        mint_url: Option<MintUrl>,
+        unit: Option<CurrencyUnit>,
+        state: Option<Vec<State>>,
+    ) -> Result<u64, Self::Err>;
     /// Update proofs state in storage
     async fn update_proofs_state(&self, ys: Vec<PublicKey>, state: State) -> Result<(), Self::Err>;
 

--- a/crates/cdk-common/src/database/wallet.rs
+++ b/crates/cdk-common/src/database/wallet.rs
@@ -96,7 +96,7 @@ pub trait Database: Debug {
         state: Option<Vec<State>>,
         spending_conditions: Option<Vec<SpendingConditions>>,
     ) -> Result<Vec<ProofInfo>, Self::Err>;
-    /// Get balance efficiently using SQL aggregation
+    /// Get balance
     async fn get_balance(
         &self,
         mint_url: Option<MintUrl>,

--- a/crates/cdk-ffi/src/database.rs
+++ b/crates/cdk-ffi/src/database.rs
@@ -108,6 +108,14 @@ pub trait WalletDatabase: Send + Sync {
         spending_conditions: Option<Vec<SpendingConditions>>,
     ) -> Result<Vec<ProofInfo>, FfiError>;
 
+    /// Get balance efficiently using SQL aggregation
+    async fn get_balance(
+        &self,
+        mint_url: Option<MintUrl>,
+        unit: Option<CurrencyUnit>,
+        state: Option<Vec<ProofState>>,
+    ) -> Result<u64, FfiError>;
+
     /// Update proofs state in storage
     async fn update_proofs_state(
         &self,
@@ -463,6 +471,22 @@ impl CdkWalletDatabase for WalletDatabaseBridge {
             .collect();
 
         cdk_result
+    }
+
+    async fn get_balance(
+        &self,
+        mint_url: Option<cdk::mint_url::MintUrl>,
+        unit: Option<cdk::nuts::CurrencyUnit>,
+        state: Option<Vec<cdk::nuts::State>>,
+    ) -> Result<u64, Self::Err> {
+        let ffi_mint_url = mint_url.map(Into::into);
+        let ffi_unit = unit.map(Into::into);
+        let ffi_state = state.map(|s| s.into_iter().map(Into::into).collect());
+
+        self.ffi_db
+            .get_balance(ffi_mint_url, ffi_unit, ffi_state)
+            .await
+            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
     }
 
     async fn update_proofs_state(
@@ -868,6 +892,22 @@ impl WalletDatabase for WalletSqliteDatabase {
             .map_err(|e| FfiError::Database { msg: e.to_string() })?;
 
         Ok(result.into_iter().map(Into::into).collect())
+    }
+
+    async fn get_balance(
+        &self,
+        mint_url: Option<MintUrl>,
+        unit: Option<CurrencyUnit>,
+        state: Option<Vec<ProofState>>,
+    ) -> Result<u64, FfiError> {
+        let cdk_mint_url = mint_url.map(|u| u.try_into()).transpose()?;
+        let cdk_unit = unit.map(Into::into);
+        let cdk_state = state.map(|s| s.into_iter().map(Into::into).collect());
+
+        self.inner
+            .get_balance(cdk_mint_url, cdk_unit, cdk_state)
+            .await
+            .map_err(|e| FfiError::Database { msg: e.to_string() })
     }
 
     async fn update_proofs_state(

--- a/crates/cdk-redb/src/wallet/mod.rs
+++ b/crates/cdk-redb/src/wallet/mod.rs
@@ -721,6 +721,18 @@ impl WalletDatabase for WalletRedbDatabase {
         Ok(proofs)
     }
 
+    async fn get_balance(
+        &self,
+        mint_url: Option<MintUrl>,
+        unit: Option<CurrencyUnit>,
+        state: Option<Vec<State>>,
+    ) -> Result<u64, database::Error> {
+        // For redb, we still need to fetch all proofs and sum them
+        // since redb doesn't have SQL aggregation
+        let proofs = self.get_proofs(mint_url, unit, state, None).await?;
+        Ok(proofs.iter().map(|p| u64::from(p.proof.amount)).sum())
+    }
+
     async fn update_proofs_state(
         &self,
         ys: Vec<PublicKey>,

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -836,6 +836,75 @@ ON CONFLICT(id) DO UPDATE SET
         .collect::<Vec<_>>())
     }
 
+    async fn get_balance(
+        &self,
+        mint_url: Option<MintUrl>,
+        unit: Option<CurrencyUnit>,
+        state: Option<Vec<State>>,
+    ) -> Result<u64, Self::Err> {
+        let start_time = std::time::Instant::now();
+        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+
+        let mut query_str = "SELECT COALESCE(SUM(amount), 0) as total FROM proof".to_string();
+        let mut where_clauses = Vec::new();
+
+        if mint_url.is_some() {
+            where_clauses.push("mint_url = :mint_url");
+        }
+        if unit.is_some() {
+            where_clauses.push("unit = :unit");
+        }
+        if let Some(ref states) = state {
+            if !states.is_empty() {
+                where_clauses.push("state IN (:states)");
+            }
+        }
+
+        if !where_clauses.is_empty() {
+            query_str.push_str(" WHERE ");
+            query_str.push_str(&where_clauses.join(" AND "));
+        }
+
+        let mut q = query(&query_str)?;
+
+        if let Some(ref mint_url) = mint_url {
+            q = q.bind("mint_url", mint_url.to_string());
+        }
+        if let Some(ref unit) = unit {
+            q = q.bind("unit", unit.to_string());
+        }
+        if let Some(ref states) = state {
+            if !states.is_empty() {
+                q = q.bind_vec("states", states.iter().map(|s| s.to_string()).collect());
+            }
+        }
+
+        let balance = q
+            .pluck(&*conn)
+            .await?
+            .map(|n| {
+                // SQLite SUM returns INTEGER which we need to convert to u64
+                match n {
+                    crate::stmt::Column::Integer(i) => Ok(i as u64),
+                    crate::stmt::Column::Real(f) => Ok(f as u64),
+                    _ => Err(Error::Database(Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "Invalid balance type",
+                    )))),
+                }
+            })
+            .transpose()?
+            .unwrap_or(0);
+
+        let elapsed = start_time.elapsed();
+        tracing::debug!(
+            "Balance query completed in {:.2}ms: {}",
+            elapsed.as_secs_f64() * 1000.0,
+            balance
+        );
+        Ok(balance)
+    }
+
     async fn update_proofs_state(&self, ys: Vec<PublicKey>, state: State) -> Result<(), Self::Err> {
         let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
         query("UPDATE proof SET state = :state WHERE y IN (:ys)")?

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -897,11 +897,6 @@ ON CONFLICT(id) DO UPDATE SET
             .unwrap_or(0);
 
         let elapsed = start_time.elapsed();
-        tracing::debug!(
-            "Balance query completed in {:.2}ms: {}",
-            elapsed.as_secs_f64() * 1000.0,
-            balance
-        );
         Ok(balance)
     }
 

--- a/crates/cdk/src/wallet/balance.rs
+++ b/crates/cdk/src/wallet/balance.rs
@@ -1,6 +1,7 @@
 use tracing::instrument;
 
-use crate::nuts::{nut00::ProofsMethods, State};
+use crate::nuts::nut00::ProofsMethods;
+use crate::nuts::State;
 use crate::{Amount, Error, Wallet};
 
 impl Wallet {


### PR DESCRIPTION
replace proof-fetching approach with SUM aggregation

- add get_balance() method to Database trait
- implement SQL SUM aggregation in cdk-sql-common
- update total_balance() to use get_balance() instead of get_unspent_proofs()
- redb impl maintains existing behavior

### Description

Hashpool produces and consumes mint quotes at a rapid pace. I recently implemented a dashboard that queries for the wallet balance every three seconds. I noticed this message in the logs:
```
WARN 
  total_balance:get_unspent_proofs:get_proofs{mint_url=Some(MintUrl("http://localhost:3338")) unit=Some(Hash)}: cdk_sql_common::common: 
  [SLOW QUERY] Took 21 ms: SELECT
                  amount,
                  unit,
                  keyset_id,
                  secret,
                  c,
                  witness,
                  dleq_e,
                  dleq_s,
                  dleq_r,
                  y,
                  mint_url,
                  state,
                  spending_condition
              FROM proof
```

This query, which scans the entire proof table, was being called every time the wallet balance was requested. This PR speeds up this process by performing the sum operation in db logic instead of application logic.

Here are some log messages demonstrating the 100x speedup of the balance query:
```
2025-09-23T21:17:49.992802Z  INFO translator_sv2::lib: 🕐 Proof sweeper loop #8 starting
2025-09-23T21:17:49.994467Z  INFO total_balance: cdk_sql_common::wallet: Balance query completed in 0.18ms: 9561
2025-09-23T21:17:49.994486Z  INFO translator_sv2::lib: 💰 Current wallet balance: 9561 diff
2025-09-23T21:17:49.994516Z  INFO translator_sv2::lib: 📋 Found 16 quotes in Paid state with mintable amount
2025-09-23T21:17:50.055000Z  INFO translator_sv2::lib: Minted 452 ehash from 16 quotes
2025-09-23T21:17:50.055115Z  INFO total_balance: cdk_sql_common::wallet: Balance query completed in 0.10ms: 10013
2025-09-23T21:17:50.055122Z  INFO translator_sv2::lib: 💰 Wallet balance after sweep: 10013 diff
```

-----

### Notes to the reviewers

No test changes were needed because integration tests already cover balance calculations.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing

BTW final check is broken because it depends on a running postgres db, which leads `just final-check` to return false negative results for the following tests:
```
failures:
    test::add_and_find_proofs
    test::add_duplicate_proofs
    test::add_mint_quote
    test::add_mint_quote_only_once
    test::get_proofs_by_keyset_id
    test::kvstore_functionality
    test::read_mint_from_db_and_tx
    test::register_payments
    test::reject_duplicate_payments_diff_tx
    test::reject_duplicate_payments_same_tx
    test::reject_over_issue_different_tx
    test::reject_over_issue_same_tx
    test::reject_over_issue_with_payment
    test::reject_over_issue_with_payment_different_tx
    test::state_transition
```
