### PR TITLE
fix: only settle same unit quote internally

### DIFF
--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -887,9 +887,9 @@ impl Mint {
             .get_mint_quote_by_request(&melt_quote.request.to_string())
             .await
         {
-            Ok(Some(mint_quote)) => mint_quote,
-            // Not an internal melt -> mint
-            Ok(None) => return Ok(None),
+            Ok(Some(mint_quote)) if mint_quote.unit == melt_quote.unit => mint_quote,
+            // Not an internal melt -> mint or unit mismatch
+            Ok(_) => return Ok(None),
             Err(err) => {
                 tracing::debug!("Error attempting to get mint quote: {}", err);
                 return Err(Error::Internal);


### PR DESCRIPTION
### Description

Internal settlement should only occur if within the same unit, otherwise settle externally.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
