### PR TITLE
feat(cdk): add WebSocket authentication support

### DIFF
--- a/crates/cashu/src/nuts/auth/nut21.rs
+++ b/crates/cashu/src/nuts/auth/nut21.rs
@@ -161,6 +161,10 @@ pub enum RoutePath {
     /// Bolt12 Quote
     #[serde(rename = "/v1/melt/bolt12")]
     MeltBolt12,
+
+    /// WebSocket
+    #[serde(rename = "/v1/ws")]
+    Ws,
 }
 
 /// Returns [`RoutePath`]s that match regex

--- a/crates/cdk-integration-tests/src/bin/start_fake_auth_mint.rs
+++ b/crates/cdk-integration-tests/src/bin/start_fake_auth_mint.rs
@@ -85,6 +85,7 @@ async fn start_fake_auth_mint(
         swap: AuthType::Blind,
         restore: AuthType::Blind,
         check_proof_state: AuthType::Blind,
+        websocket_auth: AuthType::Blind,
     });
 
     // Set description for the mint

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -457,6 +457,9 @@ pub struct Auth {
     pub restore: AuthType,
     #[serde(default)]
     pub check_proof_state: AuthType,
+    /// Enable WebSocket authentication support
+    #[serde(default = "default_blind")]
+    pub websocket_auth: AuthType,
 }
 
 fn default_blind() -> AuthType {

--- a/crates/cdk-mintd/src/env_vars/auth.rs
+++ b/crates/cdk-mintd/src/env_vars/auth.rs
@@ -17,6 +17,10 @@ pub const ENV_AUTH_CHECK_MELT_QUOTE: &str = "CDK_MINTD_AUTH_CHECK_MELT_QUOTE";
 pub const ENV_AUTH_SWAP: &str = "CDK_MINTD_AUTH_SWAP";
 pub const ENV_AUTH_RESTORE: &str = "CDK_MINTD_AUTH_RESTORE";
 pub const ENV_AUTH_CHECK_PROOF_STATE: &str = "CDK_MINTD_AUTH_CHECK_PROOF_STATE";
+pub const ENV_AUTH_WEBSOCKET: &str = "CDK_MINTD_AUTH_WEBSOCKET";
+pub const ENV_AUTH_WS_MINT_QUOTE: &str = "CDK_MINTD_AUTH_WS_MINT_QUOTE";
+pub const ENV_AUTH_WS_MELT_QUOTE: &str = "CDK_MINTD_AUTH_WS_MELT_QUOTE";
+pub const ENV_AUTH_WS_PROOF_STATE: &str = "CDK_MINTD_AUTH_WS_PROOF_STATE";
 
 impl Auth {
     pub fn from_env(mut self) -> Self {
@@ -91,6 +95,12 @@ impl Auth {
         if let Ok(check_proof_state_str) = env::var(ENV_AUTH_CHECK_PROOF_STATE) {
             if let Ok(auth_type) = check_proof_state_str.parse() {
                 self.check_proof_state = auth_type;
+            }
+        }
+
+        if let Ok(ws_auth_str) = env::var(ENV_AUTH_WEBSOCKET) {
+            if let Ok(auth_type) = ws_auth_str.parse() {
+                self.websocket_auth = auth_type;
             }
         }
 

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -792,6 +792,12 @@ async fn setup_authentication(
             add_endpoint(state_protected_endpoint, &auth_settings.check_proof_state);
         }
 
+        // Ws endpoint
+        {
+            let ws_protected_endpoint = ProtectedEndpoint::new(Method::Get, RoutePath::Ws);
+            add_endpoint(ws_protected_endpoint, &auth_settings.websocket_auth);
+        }
+
         mint_builder = mint_builder.with_auth(
             auth_localstore.clone(),
             auth_settings.openid_discovery,

--- a/crates/cdk/src/wallet/mint_connector/http_client.rs
+++ b/crates/cdk/src/wallet/mint_connector/http_client.rs
@@ -71,7 +71,7 @@ where
     /// Get auth token for a protected endpoint
     #[cfg(feature = "auth")]
     #[instrument(skip(self))]
-    async fn get_auth_token(
+    pub async fn get_auth_token(
         &self,
         method: Method,
         path: RoutePath,

--- a/crates/cdk/src/wallet/subscription/ws.rs
+++ b/crates/cdk/src/wallet/subscription/ws.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use cdk_common::subscription::Params;
 use cdk_common::ws::{WsMessageOrResponse, WsMethodRequest, WsRequest, WsUnsubscribeRequest};
+#[cfg(feature = "auth")]
 use cdk_common::{Method, RoutePath};
 use futures::{SinkExt, StreamExt};
 use tokio::sync::{mpsc, RwLock};

--- a/crates/cdk/src/wallet/subscription/ws.rs
+++ b/crates/cdk/src/wallet/subscription/ws.rs
@@ -4,9 +4,11 @@ use std::sync::Arc;
 
 use cdk_common::subscription::Params;
 use cdk_common::ws::{WsMessageOrResponse, WsMethodRequest, WsRequest, WsUnsubscribeRequest};
+use cdk_common::{Method, RoutePath};
 use futures::{SinkExt, StreamExt};
 use tokio::sync::{mpsc, RwLock};
 use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message;
 
 use super::http::http_main;
@@ -37,14 +39,64 @@ pub async fn ws_main(
         url.set_scheme("ws").expect("Could not set scheme");
     }
 
-    let url = url.to_string();
+    let request = match url.to_string().into_client_request() {
+        Ok(req) => req,
+        Err(err) => {
+            tracing::error!("Failed to create client request: {:?}", err);
+            // Fallback to HTTP client if we can't create the WebSocket request
+            return http_main(
+                std::iter::empty(),
+                http_client,
+                subscriptions,
+                new_subscription_recv,
+                on_drop,
+                wallet,
+            )
+            .await;
+        }
+    };
 
     let mut active_subscriptions = HashMap::<SubId, mpsc::Sender<_>>::new();
     let mut failure_count = 0;
 
     loop {
+        let mut request_clone = request.clone();
+        #[cfg(feature = "auth")]
+        {
+            let auth_wallet = http_client.get_auth_wallet().await;
+            let token = match auth_wallet.as_ref() {
+                Some(auth_wallet) => {
+                    let endpoint = cdk_common::ProtectedEndpoint::new(Method::Get, RoutePath::Ws);
+                    match auth_wallet.get_auth_for_request(&endpoint).await {
+                        Ok(token) => token,
+                        Err(err) => {
+                            tracing::warn!("Failed to get auth token: {:?}", err);
+                            None
+                        }
+                    }
+                }
+                None => None,
+            };
+
+            if let Some(auth_token) = token {
+                let header_key = match &auth_token {
+                    cdk_common::AuthToken::ClearAuth(_) => "Clear-auth",
+                    cdk_common::AuthToken::BlindAuth(_) => "Blind-auth",
+                };
+
+                match auth_token.to_string().parse() {
+                    Ok(header_value) => {
+                        request_clone.headers_mut().insert(header_key, header_value);
+                    }
+                    Err(err) => {
+                        tracing::warn!("Failed to parse auth token as header value: {:?}", err);
+                    }
+                }
+            }
+        }
+
         tracing::debug!("Connecting to {}", url);
-        let ws_stream = match connect_async(&url).await {
+        let ws_stream = match connect_async(request_clone.clone()).await {
             Ok((ws_stream, _)) => ws_stream,
             Err(err) => {
                 failure_count += 1;


### PR DESCRIPTION
…nfiguration

- Add WebSocket auth token injection for client connections
- Implement server-side WebSocket authentication verification
- Add configuration options for per-endpoint WebSocket auth types
- Include comprehensive documentation and example configuration
- Support clear, blind, and no-auth modes for WebSocket endpoin

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
