### PR TITLE
token: add spending-condition inspection helpers and token_secrets()

### DIFF
--- a/crates/cashu/src/nuts/nut00/token.rs
+++ b/crates/cashu/src/nuts/nut00/token.rs
@@ -2,23 +2,21 @@
 //!
 //! <https://github.com/cashubtc/nuts/blob/main/00.md>
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt;
 use std::str::FromStr;
 
 use bitcoin::base64::engine::{general_purpose, GeneralPurpose};
 use bitcoin::base64::{alphabet, Engine as _};
+use bitcoin::hashes::sha256;
 use serde::{Deserialize, Serialize};
 
 use super::{Error, Proof, ProofV3, ProofV4, Proofs};
 use crate::mint_url::MintUrl;
 use crate::nut02::ShortKeysetId;
-use crate::nuts::{CurrencyUnit, Id};
-use crate::{ensure_cdk, Amount, KeySetInfo};
 use crate::nuts::nut11::SpendingConditions;
-use crate::nuts::{Kind, PublicKey};
-use std::collections::{HashSet, BTreeSet};
-use bitcoin::hashes::sha256;
+use crate::nuts::{CurrencyUnit, Id, Kind, PublicKey};
+use crate::{ensure_cdk, Amount, KeySetInfo};
 
 /// Token Enum
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -132,7 +130,7 @@ impl Token {
             Self::TokenV4(token) => token.to_raw_bytes(),
         }
     }
-    
+
     /// Return all proof secrets in this token without keyset-id mapping, across V3/V4
     /// This is intended for spending-condition inspection where only the secret matters.
     pub fn token_secrets(&self) -> Vec<&crate::secret::Secret> {
@@ -216,7 +214,6 @@ impl Token {
         }
         Ok(set)
     }
-
 }
 
 impl FromStr for Token {

--- a/crates/cashu/src/nuts/nut00/token.rs
+++ b/crates/cashu/src/nuts/nut00/token.rs
@@ -915,16 +915,6 @@ mod tests {
         let proofs1 = token1.unwrap().proofs(&keysets_info);
         assert!(proofs1.is_err());
     }
-}
-#[cfg(test)]
-mod token_spending_tests {
-    use bitcoin::hashes::sha256::Hash as Sha256Hash;
-    use bitcoin::hashes::Hash;
-
-    use super::*;
-    use crate::nuts::nut11::{Conditions, SigFlag, SpendingConditions};
-    use crate::secret::Secret;
-
     #[test]
     fn test_token_spending_condition_helpers_p2pk_htlc_v4() {
         let mint_url = MintUrl::from_str("https://example.com").unwrap();

--- a/crates/cashu/src/nuts/nut00/token.rs
+++ b/crates/cashu/src/nuts/nut00/token.rs
@@ -193,10 +193,10 @@ impl Token {
     pub fn htlc_hashes(&self) -> Result<HashSet<sha256::Hash>, Error> {
         let mut hashes: HashSet<sha256::Hash> = HashSet::new();
         for secret in self.token_secrets().into_iter() {
-            if let Ok(cond) = SpendingConditions::try_from(secret) {
-                if let SpendingConditions::HTLCConditions { data, .. } = cond {
-                    hashes.insert(data);
-                }
+            if let Ok(SpendingConditions::HTLCConditions { data, .. }) =
+                SpendingConditions::try_from(secret)
+            {
+                hashes.insert(data);
             }
         }
         Ok(hashes)

--- a/crates/cashu/src/nuts/nut00/token.rs
+++ b/crates/cashu/src/nuts/nut00/token.rs
@@ -148,7 +148,7 @@ impl Token {
         }
     }
 
-    /// Extract unique spending conditions across all proofs for downstream policy/UI
+    /// Extract unique spending conditions across all proofs
     pub fn spending_conditions(&self) -> Result<HashSet<SpendingConditions>, Error> {
         let mut set = HashSet::new();
         for secret in self.token_secrets().into_iter() {
@@ -159,7 +159,7 @@ impl Token {
         Ok(set)
     }
 
-    /// Collect pubkeys for P2PK-locked ecash to enable signer discovery and UX
+    /// Collect pubkeys for P2PK-locked ecash
     pub fn p2pk_pubkeys(&self) -> Result<HashSet<PublicKey>, Error> {
         let mut keys: HashSet<PublicKey> = HashSet::new();
         for secret in self.token_secrets().into_iter() {
@@ -174,7 +174,7 @@ impl Token {
         Ok(keys)
     }
 
-    /// Collect refund pubkeys from P2PK conditions for recovery/expiry flows
+    /// Collect refund pubkeys from P2PK conditions
     pub fn p2pk_refund_pubkeys(&self) -> Result<HashSet<PublicKey>, Error> {
         let mut keys: HashSet<PublicKey> = HashSet::new();
         for secret in self.token_secrets().into_iter() {
@@ -189,7 +189,7 @@ impl Token {
         Ok(keys)
     }
 
-    /// Collect HTLC hashes to support preimage tracking and monitoring
+    /// Collect HTLC hashes
     pub fn htlc_hashes(&self) -> Result<HashSet<sha256::Hash>, Error> {
         let mut hashes: HashSet<sha256::Hash> = HashSet::new();
         for secret in self.token_secrets().into_iter() {
@@ -202,7 +202,7 @@ impl Token {
         Ok(hashes)
     }
 
-    /// Collect unique locktimes from spending conditions for scheduling and warnings
+    /// Collect unique locktimes from spending conditions
     pub fn locktimes(&self) -> Result<BTreeSet<u64>, Error> {
         let mut set: BTreeSet<u64> = BTreeSet::new();
         for secret in self.token_secrets().into_iter() {

--- a/crates/cdk-ffi/src/lib.rs
+++ b/crates/cdk-ffi/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod database;
 pub mod error;
 pub mod multi_mint_wallet;
+pub mod token;
 pub mod types;
 pub mod wallet;
 

--- a/crates/cdk-ffi/src/multi_mint_wallet.rs
+++ b/crates/cdk-ffi/src/multi_mint_wallet.rs
@@ -12,6 +12,7 @@ use cdk::wallet::multi_mint_wallet::{
 };
 
 use crate::error::FfiError;
+use crate::token::Token;
 use crate::types::*;
 
 /// FFI-compatible MultiMintWallet

--- a/crates/cdk-ffi/src/token.rs
+++ b/crates/cdk-ffi/src/token.rs
@@ -1,5 +1,6 @@
 //! FFI token bindings
 
+use std::collections::BTreeSet;
 use std::str::FromStr;
 
 use crate::error::FfiError;
@@ -106,7 +107,6 @@ impl Token {
 
     /// Return all P2PK pubkeys referenced by this token's spending conditions
     pub fn p2pk_pubkeys(&self) -> Vec<String> {
-        use std::collections::BTreeSet;
         let set = self
             .inner
             .p2pk_pubkeys()
@@ -117,7 +117,6 @@ impl Token {
 
     /// Return all refund pubkeys from P2PK spending conditions
     pub fn p2pk_refund_pubkeys(&self) -> Vec<String> {
-        use std::collections::BTreeSet;
         let set = self
             .inner
             .p2pk_refund_pubkeys()
@@ -128,7 +127,6 @@ impl Token {
 
     /// Return all HTLC hashes from spending conditions
     pub fn htlc_hashes(&self) -> Vec<String> {
-        use std::collections::BTreeSet;
         let set = self
             .inner
             .htlc_hashes()

--- a/crates/cdk-ffi/src/token.rs
+++ b/crates/cdk-ffi/src/token.rs
@@ -110,7 +110,11 @@ impl Token {
         let set = self
             .inner
             .p2pk_pubkeys()
-            .map(|keys| keys.into_iter().map(|k| k.to_string()).collect::<BTreeSet<_>>())
+            .map(|keys| {
+                keys.into_iter()
+                    .map(|k| k.to_string())
+                    .collect::<BTreeSet<_>>()
+            })
             .unwrap_or_default();
         set.into_iter().collect()
     }
@@ -120,7 +124,11 @@ impl Token {
         let set = self
             .inner
             .p2pk_refund_pubkeys()
-            .map(|keys| keys.into_iter().map(|k| k.to_string()).collect::<BTreeSet<_>>())
+            .map(|keys| {
+                keys.into_iter()
+                    .map(|k| k.to_string())
+                    .collect::<BTreeSet<_>>()
+            })
             .unwrap_or_default();
         set.into_iter().collect()
     }
@@ -130,7 +138,12 @@ impl Token {
         let set = self
             .inner
             .htlc_hashes()
-            .map(|hashes| hashes.into_iter().map(|h| h.to_string()).collect::<BTreeSet<_>>())
+            .map(|hashes| {
+                hashes
+                    .into_iter()
+                    .map(|h| h.to_string())
+                    .collect::<BTreeSet<_>>()
+            })
             .unwrap_or_default();
         set.into_iter().collect()
     }

--- a/crates/cdk-ffi/src/token.rs
+++ b/crates/cdk-ffi/src/token.rs
@@ -1,0 +1,98 @@
+//! FFI token bindings
+
+use std::str::FromStr;
+
+use crate::error::FfiError;
+use crate::{Amount, CurrencyUnit, MintUrl, Proofs};
+
+/// FFI-compatible Token
+#[derive(Debug, uniffi::Object)]
+pub struct Token {
+    pub(crate) inner: cdk::nuts::Token,
+}
+
+impl std::fmt::Display for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl FromStr for Token {
+    type Err = FfiError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let token = cdk::nuts::Token::from_str(s)
+            .map_err(|e| FfiError::InvalidToken { msg: e.to_string() })?;
+        Ok(Token { inner: token })
+    }
+}
+
+impl From<cdk::nuts::Token> for Token {
+    fn from(token: cdk::nuts::Token) -> Self {
+        Self { inner: token }
+    }
+}
+
+impl From<Token> for cdk::nuts::Token {
+    fn from(token: Token) -> Self {
+        token.inner
+    }
+}
+
+#[uniffi::export]
+impl Token {
+    /// Create a new Token from string
+    #[uniffi::constructor]
+    pub fn from_string(encoded_token: String) -> Result<Token, FfiError> {
+        let token = cdk::nuts::Token::from_str(&encoded_token)
+            .map_err(|e| FfiError::InvalidToken { msg: e.to_string() })?;
+        Ok(Token { inner: token })
+    }
+
+    /// Get the total value of the token
+    pub fn value(&self) -> Result<Amount, FfiError> {
+        Ok(self.inner.value()?.into())
+    }
+
+    /// Get the memo from the token
+    pub fn memo(&self) -> Option<String> {
+        self.inner.memo().clone()
+    }
+
+    /// Get the currency unit
+    pub fn unit(&self) -> Option<CurrencyUnit> {
+        self.inner.unit().map(Into::into)
+    }
+
+    /// Get the mint URL
+    pub fn mint_url(&self) -> Result<MintUrl, FfiError> {
+        Ok(self.inner.mint_url()?.into())
+    }
+
+    /// Get proofs from the token (simplified - no keyset filtering for now)
+    pub fn proofs_simple(&self) -> Result<Proofs, FfiError> {
+        // For now, return empty keysets to get all proofs
+        let empty_keysets = vec![];
+        let proofs = self.inner.proofs(&empty_keysets)?;
+        Ok(proofs
+            .into_iter()
+            .map(|p| std::sync::Arc::new(p.into()))
+            .collect())
+    }
+
+    /// Convert token to raw bytes
+    pub fn to_raw_bytes(&self) -> Result<Vec<u8>, FfiError> {
+        Ok(self.inner.to_raw_bytes()?)
+    }
+
+    /// Encode token to string representation
+    pub fn encode(&self) -> String {
+        self.to_string()
+    }
+
+    /// Decode token from string representation
+    #[uniffi::constructor]
+    pub fn decode(encoded_token: String) -> Result<Token, FfiError> {
+        encoded_token.parse()
+    }
+}

--- a/crates/cdk-ffi/src/token.rs
+++ b/crates/cdk-ffi/src/token.rs
@@ -95,4 +95,53 @@ impl Token {
     pub fn decode(encoded_token: String) -> Result<Token, FfiError> {
         encoded_token.parse()
     }
+
+    /// Return unique spending conditions across all proofs in this token
+    pub fn spending_conditions(&self) -> Vec<crate::types::SpendingConditions> {
+        self.inner
+            .spending_conditions()
+            .map(|set| set.into_iter().map(Into::into).collect())
+            .unwrap_or_default()
+    }
+
+    /// Return all P2PK pubkeys referenced by this token's spending conditions
+    pub fn p2pk_pubkeys(&self) -> Vec<String> {
+        use std::collections::BTreeSet;
+        let set = self
+            .inner
+            .p2pk_pubkeys()
+            .map(|keys| keys.into_iter().map(|k| k.to_string()).collect::<BTreeSet<_>>())
+            .unwrap_or_default();
+        set.into_iter().collect()
+    }
+
+    /// Return all refund pubkeys from P2PK spending conditions
+    pub fn p2pk_refund_pubkeys(&self) -> Vec<String> {
+        use std::collections::BTreeSet;
+        let set = self
+            .inner
+            .p2pk_refund_pubkeys()
+            .map(|keys| keys.into_iter().map(|k| k.to_string()).collect::<BTreeSet<_>>())
+            .unwrap_or_default();
+        set.into_iter().collect()
+    }
+
+    /// Return all HTLC hashes from spending conditions
+    pub fn htlc_hashes(&self) -> Vec<String> {
+        use std::collections::BTreeSet;
+        let set = self
+            .inner
+            .htlc_hashes()
+            .map(|hashes| hashes.into_iter().map(|h| h.to_string()).collect::<BTreeSet<_>>())
+            .unwrap_or_default();
+        set.into_iter().collect()
+    }
+
+    /// Return all locktimes from spending conditions (sorted ascending)
+    pub fn locktimes(&self) -> Vec<u64> {
+        self.inner
+            .locktimes()
+            .map(|s| s.into_iter().collect())
+            .unwrap_or_default()
+    }
 }

--- a/crates/cdk-ffi/src/types.rs
+++ b/crates/cdk-ffi/src/types.rs
@@ -10,6 +10,7 @@ use cdk::Amount as CdkAmount;
 use serde::{Deserialize, Serialize};
 
 use crate::error::FfiError;
+use crate::token::Token;
 
 /// FFI-compatible Amount type
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
@@ -197,98 +198,6 @@ impl From<ProofState> for CdkState {
             ProofState::Reserved => CdkState::Reserved,
             ProofState::PendingSpent => CdkState::PendingSpent,
         }
-    }
-}
-
-/// FFI-compatible Token
-#[derive(Debug, uniffi::Object)]
-pub struct Token {
-    pub(crate) inner: cdk::nuts::Token,
-}
-
-impl std::fmt::Display for Token {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.inner)
-    }
-}
-
-impl FromStr for Token {
-    type Err = FfiError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let token = cdk::nuts::Token::from_str(s)
-            .map_err(|e| FfiError::InvalidToken { msg: e.to_string() })?;
-        Ok(Token { inner: token })
-    }
-}
-
-impl From<cdk::nuts::Token> for Token {
-    fn from(token: cdk::nuts::Token) -> Self {
-        Self { inner: token }
-    }
-}
-
-impl From<Token> for cdk::nuts::Token {
-    fn from(token: Token) -> Self {
-        token.inner
-    }
-}
-
-#[uniffi::export]
-impl Token {
-    /// Create a new Token from string
-    #[uniffi::constructor]
-    pub fn from_string(encoded_token: String) -> Result<Token, FfiError> {
-        let token = cdk::nuts::Token::from_str(&encoded_token)
-            .map_err(|e| FfiError::InvalidToken { msg: e.to_string() })?;
-        Ok(Token { inner: token })
-    }
-
-    /// Get the total value of the token
-    pub fn value(&self) -> Result<Amount, FfiError> {
-        Ok(self.inner.value()?.into())
-    }
-
-    /// Get the memo from the token
-    pub fn memo(&self) -> Option<String> {
-        self.inner.memo().clone()
-    }
-
-    /// Get the currency unit
-    pub fn unit(&self) -> Option<CurrencyUnit> {
-        self.inner.unit().map(Into::into)
-    }
-
-    /// Get the mint URL
-    pub fn mint_url(&self) -> Result<MintUrl, FfiError> {
-        Ok(self.inner.mint_url()?.into())
-    }
-
-    /// Get proofs from the token (simplified - no keyset filtering for now)
-    pub fn proofs_simple(&self) -> Result<Proofs, FfiError> {
-        // For now, return empty keysets to get all proofs
-        let empty_keysets = vec![];
-        let proofs = self.inner.proofs(&empty_keysets)?;
-        Ok(proofs
-            .into_iter()
-            .map(|p| std::sync::Arc::new(p.into()))
-            .collect())
-    }
-
-    /// Convert token to raw bytes
-    pub fn to_raw_bytes(&self) -> Result<Vec<u8>, FfiError> {
-        Ok(self.inner.to_raw_bytes()?)
-    }
-
-    /// Encode token to string representation
-    pub fn encode(&self) -> String {
-        self.to_string()
-    }
-
-    /// Decode token from string representation
-    #[uniffi::constructor]
-    pub fn decode(encoded_token: String) -> Result<Token, FfiError> {
-        encoded_token.parse()
     }
 }
 

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -7,6 +7,7 @@ use bip39::Mnemonic;
 use cdk::wallet::{Wallet as CdkWallet, WalletBuilder as CdkWalletBuilder};
 
 use crate::error::FfiError;
+use crate::token::Token;
 use crate::types::*;
 
 /// FFI-compatible Wallet

--- a/crates/cdk-integration-tests/tests/ffi_minting_integration.rs
+++ b/crates/cdk-integration-tests/tests/ffi_minting_integration.rs
@@ -214,7 +214,7 @@ async fn test_ffi_mint_quote_creation() {
         let quote = wallet
             .mint_quote(amount, Some(description.clone()))
             .await
-            .expect(&format!("Failed to create quote for {} sats", amount_value));
+            .unwrap_or_else(|_| panic!("Failed to create quote for {} sats", amount_value));
 
         // Verify quote properties
         assert_eq!(quote.amount, Some(amount));

--- a/crates/cdk-postgres/src/lib.rs
+++ b/crates/cdk-postgres/src/lib.rs
@@ -335,10 +335,9 @@ mod test {
 
         let db_url = format!("{db_url} schema={test_id}");
 
-        let db = MintPgDatabase::new(db_url.as_str())
+        MintPgDatabase::new(db_url.as_str())
             .await
-            .expect("database");
-        db
+            .expect("database")
     }
 
     mint_db_test!(provide_db);


### PR DESCRIPTION
### Description

This PR adds a lightweight API to inspect `SpendingConditions` directly from a `Token` and without requiring Mint keysets:

- New helpers on Token:
  - `spending_conditions`
  - `p2pk_pubkeys`
  - `p2pk_refund_pubkeys`
  - `htlc_hashes`
  - `locktimes`
- New token_secrets() unifies V3/V4 proof traversal and removes code duplication.
- Bypasses short→long keyset-id mapping since only Secret is needed for condition parsing.
- Improves DX: external users can extract P2PK and HTLC metadata without mint context.
