### PR TITLE
Make Uniffi Records Codable in Swift

### DIFF
--- a/crates/cdk-ffi/uniffi.toml
+++ b/crates/cdk-ffi/uniffi.toml
@@ -8,3 +8,5 @@ cdylib_name = "cdk_ffi"
 [bindings.swift]
 module_name = "CashuDevKit"
 cdylib_name = "cdk_ffi"
+generate_codable_conformance = true
+generate_immutable_records = true


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

This will allow wallet developers to encode and decode the Uniffi Record structs in Swift.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

I tested building the Swift bindings locally and verified that the Records are now Codable.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED
- Make Uniffi Records Codable in Swift

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
