### PR TITLE
Make sorting Transactions a stable sort

### DIFF
--- a/crates/cdk-common/src/wallet.rs
+++ b/crates/cdk-common/src/wallet.rs
@@ -246,7 +246,10 @@ impl PartialOrd for Transaction {
 
 impl Ord for Transaction {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.timestamp.cmp(&other.timestamp).reverse()
+        self.timestamp
+            .cmp(&other.timestamp)
+            .reverse()
+            .then_with(|| self.id().cmp(&other.id()))
     }
 }
 


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

If you had 2 Transactions that had the same timestamp the sort could be unstable and could cause annoying issues. Now it will compare the ids if they are equal and should always have a stable sorting implementation now.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

Sorting `Transaction`s is now more stable

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
