### PR TITLE
feat(cdk): add payment request and proof to transaction records

### DIFF
--- a/crates/cdk-common/src/wallet.rs
+++ b/crates/cdk-common/src/wallet.rs
@@ -204,6 +204,10 @@ pub struct Transaction {
     pub metadata: HashMap<String, String>,
     /// Quote ID if this is a mint or melt transaction
     pub quote_id: Option<String>,
+    /// Payment request (e.g., BOLT11 invoice, BOLT12 offer)
+    pub payment_request: Option<String>,
+    /// Payment proof (e.g., preimage for Lightning melt transactions)
+    pub payment_proof: Option<String>,
 }
 
 impl Transaction {

--- a/crates/cdk-ffi/src/types/transaction.rs
+++ b/crates/cdk-ffi/src/types/transaction.rs
@@ -35,6 +35,10 @@ pub struct Transaction {
     pub metadata: HashMap<String, String>,
     /// Quote ID if this is a mint or melt transaction
     pub quote_id: Option<String>,
+    /// Payment request (e.g., BOLT11 invoice, BOLT12 offer)
+    pub payment_request: Option<String>,
+    /// Payment proof (e.g., preimage for Lightning melt transactions)
+    pub payment_proof: Option<String>,
 }
 
 impl From<cdk::wallet::types::Transaction> for Transaction {
@@ -51,6 +55,8 @@ impl From<cdk::wallet::types::Transaction> for Transaction {
             memo: tx.memo,
             metadata: tx.metadata,
             quote_id: tx.quote_id,
+            payment_request: tx.payment_request,
+            payment_proof: tx.payment_proof,
         }
     }
 }
@@ -75,6 +81,8 @@ impl TryFrom<Transaction> for cdk::wallet::types::Transaction {
             memo: tx.memo,
             metadata: tx.metadata,
             quote_id: tx.quote_id,
+            payment_request: tx.payment_request,
+            payment_proof: tx.payment_proof,
         })
     }
 }

--- a/crates/cdk-sql-common/src/wallet/migrations/postgres/20251005120000_add_payment_info_to_transactions.sql
+++ b/crates/cdk-sql-common/src/wallet/migrations/postgres/20251005120000_add_payment_info_to_transactions.sql
@@ -1,0 +1,3 @@
+-- Add payment_request and payment_proof to transactions table
+ALTER TABLE transactions ADD COLUMN payment_request TEXT;
+ALTER TABLE transactions ADD COLUMN payment_proof TEXT;

--- a/crates/cdk-sql-common/src/wallet/migrations/sqlite/20251005120000_add_payment_info_to_transactions.sql
+++ b/crates/cdk-sql-common/src/wallet/migrations/sqlite/20251005120000_add_payment_info_to_transactions.sql
@@ -1,0 +1,3 @@
+-- Add payment_request and payment_proof to transactions table
+ALTER TABLE transactions ADD COLUMN payment_request TEXT;
+ALTER TABLE transactions ADD COLUMN payment_proof TEXT;

--- a/crates/cdk/src/wallet/issue/issue_bolt11.rs
+++ b/crates/cdk/src/wallet/issue/issue_bolt11.rs
@@ -329,6 +329,8 @@ impl Wallet {
                 memo: None,
                 metadata: HashMap::new(),
                 quote_id: Some(quote_id.to_string()),
+                payment_request: Some(quote_info.request),
+                payment_proof: None,
             })
             .await?;
 

--- a/crates/cdk/src/wallet/issue/issue_bolt12.rs
+++ b/crates/cdk/src/wallet/issue/issue_bolt12.rs
@@ -232,6 +232,8 @@ impl Wallet {
                 memo: None,
                 metadata: HashMap::new(),
                 quote_id: Some(quote_id.to_string()),
+                payment_request: Some(quote_info.request),
+                payment_proof: None,
             })
             .await?;
 

--- a/crates/cdk/src/wallet/melt/melt_bolt11.rs
+++ b/crates/cdk/src/wallet/melt/melt_bolt11.rs
@@ -54,7 +54,7 @@ impl Wallet {
         let invoice = Bolt11Invoice::from_str(&request)?;
 
         let quote_request = MeltQuoteBolt11Request {
-            request: Bolt11Invoice::from_str(&request)?,
+            request: invoice.clone(),
             unit: self.unit.clone(),
             options,
         };
@@ -248,6 +248,8 @@ impl Wallet {
             None => None,
         };
 
+        let payment_preimage = melt_response.payment_preimage.clone();
+
         let melted = Melted::from_proofs(
             melt_response.state,
             melt_response.payment_preimage,
@@ -298,6 +300,8 @@ impl Wallet {
                 memo: None,
                 metadata,
                 quote_id: Some(quote_id.to_string()),
+                payment_request: Some(quote_info.request),
+                payment_proof: payment_preimage,
             })
             .await?;
 

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -60,6 +60,7 @@ impl Wallet {
                 let pending_proofs = self.get_pending_proofs().await?;
                 let proofs_total = pending_proofs.total_amount().unwrap_or_default();
                 let change_total = response.change_amount().unwrap_or_default();
+
                 self.localstore
                     .add_transaction(Transaction {
                         mint_url: self.mint_url.clone(),
@@ -75,6 +76,8 @@ impl Wallet {
                         memo: None,
                         metadata: HashMap::new(),
                         quote_id: Some(quote.id.clone()),
+                        payment_request: Some(quote.request.clone()),
+                        payment_proof: response.payment_preimage.clone(),
                     })
                     .await?;
             }

--- a/crates/cdk/src/wallet/receive.rs
+++ b/crates/cdk/src/wallet/receive.rs
@@ -167,7 +167,9 @@ impl Wallet {
                 timestamp: unix_time(),
                 memo,
                 metadata: opts.metadata,
-                quote_id: None, // Receive transactions don't have a quote_id
+                quote_id: None,
+                payment_request: None,
+                payment_proof: None,
             })
             .await?;
 

--- a/crates/cdk/src/wallet/send.rs
+++ b/crates/cdk/src/wallet/send.rs
@@ -350,7 +350,9 @@ impl PreparedSend {
                 timestamp: unix_time(),
                 memo: memo.clone(),
                 metadata: self.options.metadata,
-                quote_id: None, // Send transactions don't have a quote_id
+                quote_id: None,
+                payment_request: None,
+                payment_proof: None,
             })
             .await?;
 

--- a/crates/cdk/src/wallet/subscription/mod.rs
+++ b/crates/cdk/src/wallet/subscription/mod.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 use cdk_common::subscription::Params;
 use tokio::sync::{mpsc, RwLock};
 use tokio::task::JoinHandle;
-use tracing::error;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_futures;
 


### PR DESCRIPTION
Add payment_request and payment_proof fields to Transaction model to store Lightning invoice details and payment preimages. Update database migrations and all transaction creation points across wallet operations (mint, melt, send, receive) to populate these fields.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

closes https://github.com/cashubtc/cdk/issues/1151

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
