### PR TITLE
fix(cashu): skip serializing empty NUT15 settings in mint info

### DIFF
--- a/crates/cashu/src/nuts/nut15.rs
+++ b/crates/cashu/src/nuts/nut15.rs
@@ -34,6 +34,13 @@ pub struct Settings {
     pub methods: Vec<MppMethodSettings>,
 }
 
+impl Settings {
+    /// Check if methods is empty
+    pub fn is_empty(&self) -> bool {
+        self.methods.is_empty()
+    }
+}
+
 // Custom deserialization to handle both array and object formats
 impl<'de> Deserialize<'de> for Settings {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -88,5 +95,19 @@ mod tests {
 
         let json = serde_json::to_string(&settings).unwrap();
         assert_eq!(json, r#"{"methods":[{"method":"bolt11","unit":"sat"}]}"#);
+    }
+
+    #[test]
+    fn test_nut15_settings_empty() {
+        let settings = Settings { methods: vec![] };
+        assert!(settings.is_empty());
+
+        let settings_with_data = Settings {
+            methods: vec![MppMethodSettings {
+                method: PaymentMethod::Bolt11,
+                unit: CurrencyUnit::Sat,
+            }],
+        };
+        assert!(!settings_with_data.is_empty());
     }
 }


### PR DESCRIPTION
Add is_empty method to nut15::Settings and configure skip_serializing_if attribute to prevent empty NUT15 objects from appearing in serialized mint info responses.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

closes https://github.com/cashubtc/cdk/issues/1154

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
