### PR TITLE
mintd: remove non-existent stdout logging from docs

### DIFF
--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -14,8 +14,7 @@ melt_ttl = 120
 
 
 [info.logging]
-# Where to output logs: "stdout", "file", or "both" (default: "both")
-# Note: "stdout" actually outputs to stderr (standard error stream)
+# Where to output logs: "stderr" (standard error stream), "file", or "both" (default: "both")
 # output = "both"
 # Log level for console output (default: "info")
 # console_level = "info"  


### PR DESCRIPTION
The rust struct for this has only stderr and expects stderr in deserialization aswell. Setting logging output to stdout leads to mintd erroring on deserialization and eventually using the default settings and complaining about not setting a ln backend which makes finding this mistake a hassle.
