### PR TITLE
Configure internal Wallets of a MultiMintWallet

### DIFF
--- a/crates/cdk-cli/src/sub_commands/cat_device_login.rs
+++ b/crates/cdk-cli/src/sub_commands/cat_device_login.rs
@@ -29,19 +29,13 @@ pub async fn cat_device_login(
 ) -> Result<()> {
     let mint_url = sub_command_args.mint_url.clone();
 
-    let wallet = match multi_mint_wallet.get_wallet(&mint_url).await {
-        Some(wallet) => wallet.clone(),
-        None => {
-            multi_mint_wallet.add_mint(mint_url.clone(), None).await?;
-            multi_mint_wallet
-                .get_wallet(&mint_url)
-                .await
-                .expect("Wallet should exist after adding mint")
-        }
-    };
+    // Ensure the mint exists
+    if !multi_mint_wallet.has_mint(&mint_url).await {
+        multi_mint_wallet.add_mint(mint_url.clone()).await?;
+    }
 
-    let mint_info = wallet
-        .fetch_mint_info()
+    let mint_info = multi_mint_wallet
+        .fetch_mint_info(&mint_url)
         .await?
         .ok_or(anyhow!("Mint info not found"))?;
 

--- a/crates/cdk-cli/src/sub_commands/cat_login.rs
+++ b/crates/cdk-cli/src/sub_commands/cat_login.rs
@@ -31,20 +31,13 @@ pub async fn cat_login(
 ) -> Result<()> {
     let mint_url = sub_command_args.mint_url.clone();
 
-    let wallet = match multi_mint_wallet.get_wallet(&mint_url).await {
-        Some(wallet) => wallet.clone(),
-        None => {
-            multi_mint_wallet.add_mint(mint_url.clone(), None).await?;
-            multi_mint_wallet
-                .get_wallet(&mint_url)
-                .await
-                .expect("Wallet should exist after adding mint")
-                .clone()
-        }
-    };
+    // Ensure the mint exists
+    if !multi_mint_wallet.has_mint(&mint_url).await {
+        multi_mint_wallet.add_mint(mint_url.clone()).await?;
+    }
 
-    let mint_info = wallet
-        .fetch_mint_info()
+    let mint_info = multi_mint_wallet
+        .fetch_mint_info(&mint_url)
         .await?
         .ok_or(anyhow!("Mint info not found"))?;
 

--- a/crates/cdk-cli/src/sub_commands/restore.rs
+++ b/crates/cdk-cli/src/sub_commands/restore.rs
@@ -18,7 +18,7 @@ pub async fn restore(
     let wallet = match multi_mint_wallet.get_wallet(&mint_url).await {
         Some(wallet) => wallet.clone(),
         None => {
-            multi_mint_wallet.add_mint(mint_url.clone(), None).await?;
+            multi_mint_wallet.add_mint(mint_url.clone()).await?;
             multi_mint_wallet
                 .get_wallet(&mint_url)
                 .await

--- a/crates/cdk-cli/src/utils.rs
+++ b/crates/cdk-cli/src/utils.rs
@@ -34,7 +34,7 @@ pub async fn get_or_create_wallet(
         Some(wallet) => Ok(wallet.clone()),
         None => {
             tracing::debug!("Wallet does not exist creating..");
-            multi_mint_wallet.add_mint(mint_url.clone(), None).await?;
+            multi_mint_wallet.add_mint(mint_url.clone()).await?;
             Ok(multi_mint_wallet
                 .get_wallet(mint_url)
                 .await

--- a/crates/cdk-ffi/src/multi_mint_wallet.rs
+++ b/crates/cdk-ffi/src/multi_mint_wallet.rs
@@ -118,9 +118,16 @@ impl MultiMintWallet {
         target_proof_count: Option<u32>,
     ) -> Result<(), FfiError> {
         let cdk_mint_url: cdk::mint_url::MintUrl = mint_url.try_into()?;
-        self.inner
-            .add_mint(cdk_mint_url, target_proof_count.map(|c| c as usize))
-            .await?;
+
+        if let Some(count) = target_proof_count {
+            let config = cdk::wallet::multi_mint_wallet::WalletConfig::new()
+                .with_target_proof_count(count as usize);
+            self.inner
+                .add_mint_with_config(cdk_mint_url, config)
+                .await?;
+        } else {
+            self.inner.add_mint(cdk_mint_url).await?;
+        }
         Ok(())
     }
 
@@ -379,6 +386,68 @@ impl MultiMintWallet {
         let cdk_token = token.inner.clone();
         self.inner.verify_token_dleq(&cdk_token).await?;
         Ok(())
+    }
+
+    /// Query mint for current mint information
+    pub async fn fetch_mint_info(&self, mint_url: MintUrl) -> Result<Option<MintInfo>, FfiError> {
+        let cdk_mint_url: cdk::mint_url::MintUrl = mint_url.try_into()?;
+        let mint_info = self.inner.fetch_mint_info(&cdk_mint_url).await?;
+        Ok(mint_info.map(Into::into))
+    }
+}
+
+/// Auth methods for MultiMintWallet
+#[uniffi::export(async_runtime = "tokio")]
+impl MultiMintWallet {
+    /// Set Clear Auth Token (CAT) for a specific mint
+    pub async fn set_cat(&self, mint_url: MintUrl, cat: String) -> Result<(), FfiError> {
+        let cdk_mint_url: cdk::mint_url::MintUrl = mint_url.try_into()?;
+        self.inner.set_cat(&cdk_mint_url, cat).await?;
+        Ok(())
+    }
+
+    /// Set refresh token for a specific mint
+    pub async fn set_refresh_token(
+        &self,
+        mint_url: MintUrl,
+        refresh_token: String,
+    ) -> Result<(), FfiError> {
+        let cdk_mint_url: cdk::mint_url::MintUrl = mint_url.try_into()?;
+        self.inner
+            .set_refresh_token(&cdk_mint_url, refresh_token)
+            .await?;
+        Ok(())
+    }
+
+    /// Refresh access token for a specific mint using the stored refresh token
+    pub async fn refresh_access_token(&self, mint_url: MintUrl) -> Result<(), FfiError> {
+        let cdk_mint_url: cdk::mint_url::MintUrl = mint_url.try_into()?;
+        self.inner.refresh_access_token(&cdk_mint_url).await?;
+        Ok(())
+    }
+
+    /// Mint blind auth tokens at a specific mint
+    pub async fn mint_blind_auth(
+        &self,
+        mint_url: MintUrl,
+        amount: Amount,
+    ) -> Result<Proofs, FfiError> {
+        let cdk_mint_url: cdk::mint_url::MintUrl = mint_url.try_into()?;
+        let proofs = self
+            .inner
+            .mint_blind_auth(&cdk_mint_url, amount.into())
+            .await?;
+        Ok(proofs.into_iter().map(|p| Arc::new(p.into())).collect())
+    }
+
+    /// Get unspent auth proofs for a specific mint
+    pub async fn get_unspent_auth_proofs(
+        &self,
+        mint_url: MintUrl,
+    ) -> Result<Vec<AuthProof>, FfiError> {
+        let cdk_mint_url: cdk::mint_url::MintUrl = mint_url.try_into()?;
+        let auth_proofs = self.inner.get_unspent_auth_proofs(&cdk_mint_url).await?;
+        Ok(auth_proofs.into_iter().map(Into::into).collect())
     }
 }
 

--- a/crates/cdk/src/wallet/auth/mod.rs
+++ b/crates/cdk/src/wallet/auth/mod.rs
@@ -65,4 +65,17 @@ impl Wallet {
         }
         Ok(())
     }
+
+    /// Set the auth client (AuthWallet) for this wallet
+    ///
+    /// This allows updating the auth wallet without recreating the wallet.
+    /// Also updates the client's auth wallet to keep them in sync.
+    #[instrument(skip_all)]
+    pub async fn set_auth_client(&self, auth_wallet: Option<AuthWallet>) {
+        let mut auth_wallet_guard = self.auth_wallet.write().await;
+        *auth_wallet_guard = auth_wallet.clone();
+
+        // Also update the client's auth wallet to keep them in sync
+        self.client.set_auth_wallet(auth_wallet).await;
+    }
 }

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -673,6 +673,20 @@ impl Wallet {
 
         Ok(())
     }
+
+    /// Set the client (MintConnector) for this wallet
+    ///
+    /// This allows updating the connector without recreating the wallet.
+    pub fn set_client(&mut self, client: Arc<dyn MintConnector + Send + Sync>) {
+        self.client = client;
+    }
+
+    /// Set the target proof count for this wallet
+    ///
+    /// This controls how many proofs of each denomination the wallet tries to maintain.
+    pub fn set_target_proof_count(&mut self, count: usize) {
+        self.target_proof_count = count;
+    }
 }
 
 impl Drop for Wallet {


### PR DESCRIPTION
### Description

This PR adds the ability to configure individual wallets within a `MultiMintWallet` with custom settings. Previously, all internal wallets shared the same global configuration. Now each mint can have its own configuration, including custom connectors and target proof counts.

The main additions:
- New `WalletConfig` struct to specify per-wallet settings (connectors, target proof count)
- New `add_mint_with_config()` method to add mints with custom configuration
- Setter methods on `Wallet` to update connectors and target proof count
- FFI bindings expose auth methods (`set_cat`, `set_refresh_token`, `refresh_access_token`, `mint_blind_auth`, `get_unspent_auth_proofs`) for individual mints
- CLI commands updated to use the new configuration API

-----

### Notes to the reviewers

The original `add_mint()` method maintains backward compatibility by using default settings.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

- `MultiMintWallet::add_mint()` now has a simpler signature (removed `target_proof_count` parameter)

#### ADDED

- `WalletConfig` for configuring individual wallets within `MultiMintWallet`
- `MultiMintWallet::add_mint_with_config()` to add mints with custom configuration
- `Wallet::set_client()` and `Wallet::set_target_proof_count()` setter methods
- `Wallet::set_auth_client()` for updating auth wallet
- FFI methods for per-mint auth operations: `set_cat`, `set_refresh_token`, `refresh_access_token`, `mint_blind_auth`, `get_unspent_auth_proofs`, `fetch_mint_info`

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing