### PR TITLE
feat(cdk): add melt quote state transition validation

### DIFF
--- a/crates/cdk-sql-common/src/mint/mod.rs
+++ b/crates/cdk-sql-common/src/mint/mod.rs
@@ -28,7 +28,7 @@ use cdk_common::nut00::ProofsMethods;
 use cdk_common::payment::PaymentIdentifier;
 use cdk_common::quote_id::QuoteId;
 use cdk_common::secret::Secret;
-use cdk_common::state::check_state_transition;
+use cdk_common::state::{check_melt_quote_state_transition, check_state_transition};
 use cdk_common::util::unix_time;
 use cdk_common::{
     Amount, BlindSignature, BlindSignatureDleq, BlindedMessage, CurrencyUnit, Id, MeltQuoteState,
@@ -1042,6 +1042,8 @@ VALUES (:quote_id, :amount, :timestamp);
         .map(sql_row_to_melt_quote)
         .transpose()?
         .ok_or(Error::QuoteNotFound)?;
+
+        check_melt_quote_state_transition(quote.state, state)?;
 
         let rec = if state == MeltQuoteState::Paid {
             let current_time = unix_time();


### PR DESCRIPTION
Add state machine validation for melt quote transitions to prevent invalid state changes. Includes new error types and validation logic for Unpaid, Pending, Paid, and Failed states.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

We already do this in the mint but as an extra check do it here for constancy with our proof check. 

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
