### PR TITLE
feat(cdk-payment-processor): add currency unit parameter to make_payment

### DIFF
--- a/crates/cdk-payment-processor/src/proto/client.rs
+++ b/crates/cdk-payment-processor/src/proto/client.rs
@@ -195,7 +195,7 @@ impl MintPayment for PaymentProcessorClient {
 
     async fn make_payment(
         &self,
-        _unit: &cdk_common::CurrencyUnit,
+        unit: &cdk_common::CurrencyUnit,
         options: cdk_common::payment::OutgoingPaymentOptions,
     ) -> Result<CdkMakePaymentResponse, Self::Err> {
         let mut inner = self.inner.clone();
@@ -232,6 +232,7 @@ impl MintPayment for PaymentProcessorClient {
                 payment_options: Some(payment_options),
                 partial_amount: None,
                 max_fee_amount: None,
+                unit: unit.to_string(),
             }))
             .await
             .map_err(|err| {

--- a/crates/cdk-payment-processor/src/proto/payment_processor.proto
+++ b/crates/cdk-payment-processor/src/proto/payment_processor.proto
@@ -145,6 +145,7 @@ message MakePaymentRequest {
   OutgoingPaymentVariant payment_options = 1;
   optional uint64 partial_amount = 2;
   optional uint64 max_fee_amount = 3;
+  string unit = 4;
 }
 
 message MakePaymentResponse {

--- a/crates/cdk-payment-processor/src/proto/server.rs
+++ b/crates/cdk-payment-processor/src/proto/server.rs
@@ -274,11 +274,14 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
     ) -> Result<Response<MakePaymentResponse>, Status> {
         let request = request.into_inner();
 
+        let unit = CurrencyUnit::from_str(&request.unit)
+            .map_err(|_| Status::invalid_argument("Invalid currency unit"))?;
+
         let options = request
             .payment_options
             .ok_or_else(|| Status::invalid_argument("Missing payment options"))?;
 
-        let (unit, payment_options) = match options
+        let payment_options = match options
             .options
             .ok_or_else(|| Status::invalid_argument("Missing options"))?
         {
@@ -286,32 +289,28 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
                 let bolt11: cdk_common::Bolt11Invoice =
                     opts.bolt11.parse().map_err(Error::Invoice)?;
 
-                let payment_options = cdk_common::payment::OutgoingPaymentOptions::Bolt11(
-                    Box::new(cdk_common::payment::Bolt11OutgoingPaymentOptions {
+                cdk_common::payment::OutgoingPaymentOptions::Bolt11(Box::new(
+                    cdk_common::payment::Bolt11OutgoingPaymentOptions {
                         bolt11,
                         max_fee_amount: opts.max_fee_amount.map(Into::into),
                         timeout_secs: opts.timeout_secs,
                         melt_options: opts.melt_options.map(Into::into),
-                    }),
-                );
-
-                (CurrencyUnit::Msat, payment_options)
+                    },
+                ))
             }
             outgoing_payment_variant::Options::Bolt12(opts) => {
                 let offer = Offer::from_str(&opts.offer)
                     .map_err(|_| Error::Bolt12Parse)
                     .unwrap();
 
-                let payment_options = cdk_common::payment::OutgoingPaymentOptions::Bolt12(
-                    Box::new(cdk_common::payment::Bolt12OutgoingPaymentOptions {
+                cdk_common::payment::OutgoingPaymentOptions::Bolt12(Box::new(
+                    cdk_common::payment::Bolt12OutgoingPaymentOptions {
                         offer,
                         max_fee_amount: opts.max_fee_amount.map(Into::into),
                         timeout_secs: opts.timeout_secs,
                         melt_options: opts.melt_options.map(Into::into),
-                    }),
-                );
-
-                (CurrencyUnit::Msat, payment_options)
+                    },
+                ))
             }
         };
 


### PR DESCRIPTION
Add unit field to MakePaymentRequest proto message and pass currency unit through payment processing flow instead of hardcoding CurrencyUnit::Msat

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
