### PR TITLE
added missing env params in docker-compose.ldk-node.yaml

### DIFF
--- a/docker-compose.ldk-node.yaml
+++ b/docker-compose.ldk-node.yaml
@@ -70,7 +70,7 @@ services:
       - CDK_MINTD_LDK_NODE_NETWORK=testnet
       - CDK_MINTD_LDK_NODE_ESPLORA_URL=https://blockstream.info/testnet/api
       - CDK_MINTD_LDK_NODE_LISTENING_ADDRESSES=0.0.0.0:9735
-      # LDK Admin dashboard config
+      # LDK admin dashboard config
       - CDK_MINTD_LDK_NODE_WEBSERVER_HOST=0.0.0.0
       # - CDK_MINTD_LDK_NODE_WEBSERVER_PORT=
     volumes:


### PR DESCRIPTION
### Description

Added missing LDK env variables in `docker-compose.ldk-node.yaml`

### Notes to the reviewers

-

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

-

#### ADDED

Env variables in docker-compose
- CDK_MINTD_LDK_NODE_WEBSERVER_HOST
- CDK_MINTD_LDK_NODE_WEBSERVER_PORT

Port mapping exposing web interface 

#### REMOVED

-

#### FIXED

-

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing

