### PR TITLE
feat: add nightly flag

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ check *ARGS="--workspace --all-targets":
   if [ ! -f Cargo.toml ]; then
     cd {{invocation_directory()}}
   fi
-  cargo check {{ARGS}}
+  cargo +nightly check {{ARGS}}
 
 # run code formatters
 format:
@@ -49,7 +49,7 @@ format:
   if [ ! -f Cargo.toml ]; then
     cd {{invocation_directory()}}
   fi
-  cargo fmt --all
+  cargo +nightly fmt --all
   nixpkgs-fmt $(echo **.nix)
 
 # run doc tests
@@ -155,12 +155,12 @@ test-nutshell:
     
 
 # run `cargo clippy` on everything
-clippy *ARGS="--workspace --all-targets":
-  cargo clippy {{ARGS}} -- -D warnings
+clippy *ARGS="--locked --offline --workspace --all-targets":
+  cargo +nightly clippy {{ARGS}} -- -D warnings
 
 # run `cargo clippy --fix` on everything
-clippy-fix *ARGS="--workspace --all-targets":
-  cargo clippy {{ARGS}} --fix
+clippy-fix *ARGS="--locked --offline --workspace --all-targets":
+  cargo +nightly clippy {{ARGS}} --fix
 
 typos: 
   typos


### PR DESCRIPTION
### Description

Some times when running `just format` or `just clippy` you will get alerts about not using nightly on your toolchain. Setting the flag directly in the command avoids confusion. 

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED
Justfile
#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
