### PR TITLE
fix: return actual error from get_payment_quote

### DIFF
--- a/crates/cdk/src/mint/melt/mod.rs
+++ b/crates/cdk/src/mint/melt/mod.rs
@@ -179,7 +179,7 @@ impl Mint {
                     METRICS.record_mint_operation("get_melt_bolt11_quote", false);
                     METRICS.record_error();
                 }
-                Error::UnsupportedUnit
+                err
             })?;
 
         if &payment_quote.unit != unit {
@@ -285,7 +285,7 @@ impl Mint {
                     err
                 );
 
-                Error::UnsupportedUnit
+                err
             })?;
 
         if &payment_quote.unit != unit {


### PR DESCRIPTION
### Description

fixes #1271 so that if `get_payment_quote` returns an error then getting the melt quote returns that same payment error directly from the processor

-----

### Notes to the reviewers


-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
