### PR TITLE
refactor(cdk/wallet): extract keyset key loading into helper method

### DIFF
--- a/crates/cdk/src/wallet/melt/melt_bolt11.rs
+++ b/crates/cdk/src/wallet/melt/melt_bolt11.rs
@@ -215,17 +215,7 @@ impl Wallet {
             }
         };
 
-        let active_keys = self
-            .metadata_cache
-            .load(&self.localstore, &self.client, {
-                let ttl = self.metadata_cache_ttl.read();
-                *ttl
-            })
-            .await?
-            .keys
-            .get(&active_keyset_id)
-            .ok_or(Error::NoActiveKeyset)?
-            .clone();
+        let active_keys = self.load_keyset_keys(active_keyset_id).await?;
 
         let change_proofs = match melt_response.change {
             Some(change) => {

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -346,6 +346,26 @@ impl Wallet {
         Ok(Some(mint_info))
     }
 
+    /// Load mint info from cache
+    ///
+    /// This is a helper function that loads the mint info from the metadata cache
+    /// using the configured TTL. Unlike `fetch_mint_info()`, this does not make
+    /// a network call if the cache is fresh.
+    #[instrument(skip(self))]
+    pub async fn load_mint_info(&self) -> Result<MintInfo, Error> {
+        let mint_info = self
+            .metadata_cache
+            .load(&self.localstore, &self.client, {
+                let ttl = self.metadata_cache_ttl.read();
+                *ttl
+            })
+            .await?
+            .mint_info
+            .clone();
+
+        Ok(mint_info)
+    }
+
     /// Get amounts needed to refill proof state
     #[instrument(skip(self))]
     pub async fn amounts_needed_for_state_target(

--- a/crates/cdk/src/wallet/swap.rs
+++ b/crates/cdk/src/wallet/swap.rs
@@ -47,17 +47,7 @@ impl Wallet {
             .get_keyset_fees_and_amounts_by_id(active_keyset_id)
             .await?;
 
-        let active_keys = self
-            .metadata_cache
-            .load(&self.localstore, &self.client, {
-                let ttl = self.metadata_cache_ttl.read();
-                *ttl
-            })
-            .await?
-            .keys
-            .get(&active_keyset_id)
-            .ok_or(Error::UnknownKeySet)?
-            .clone();
+        let active_keys = self.load_keyset_keys(active_keyset_id).await?;
 
         let post_swap_proofs = construct_proofs(
             swap_response.signatures,


### PR DESCRIPTION
Consolidate duplicate keyset key loading logic from melt_bolt11 and swap modules into reusable load_keyset_keys() helper method. Also add load_mint_info() helper for consistent metadata cache access.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
