### PR TITLE
docs: Update cdk-mintd README to include prerequisites and system-wide install

### DIFF
--- a/crates/cdk-mintd/README.md
+++ b/crates/cdk-mintd/README.md
@@ -25,6 +25,23 @@ For detailed configuration of each Lightning backend, see:
 - **[CLN](../cdk-cln/README.md)** - Core Lightning
 - **[LNbits](../cdk-lnbits/README.md)** - LNbits API integration
 
+## Prerequisites
+
+### Ubuntu/Debian
+```bash
+# Install Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Install build dependencies
+sudo apt install pkg-config
+sudo apt-get install protobuf-compiler
+```
+
+### Other Linux Distributions
+- **Rust**: Install from [rustup.rs](https://rustup.rs/)
+- **pkg-config**: Usually available as `pkg-config` or `pkgconfig` package
+- **protobuf-compiler**: Usually available as `protobuf-compiler` or `protobuf` package
+
 ## Installation
 
 ### Option 1: Download Pre-built Binary
@@ -36,6 +53,12 @@ git clone https://github.com/cashubtc/cdk.git
 cd cdk
 cargo build --bin cdk-mintd --release
 # Binary will be at ./target/release/cdk-mintd
+
+# Install to ~/.cargo/bin (makes it available system-wide)
+cargo install --path crates/cdk-mintd
+
+# Verify installation
+cdk-mintd --version
 ```
 
 ## Configuration


### PR DESCRIPTION
### Description

Added prerequisites `Rust` and build dependencies `pkg-config`, `protobuf-compiler` to the cdk-mintd Readme

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

Minor Docs improvements

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
