### PR TITLE
fix: add missing comma in get_mint_quotes

### DIFF
--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -553,7 +553,7 @@ ON CONFLICT(id) DO UPDATE SET
                 request,
                 state,
                 expiry,
-                secret_key
+                secret_key,
                 payment_method,
                 amount_issued,
                 amount_paid


### PR DESCRIPTION
add missing comma in get_mint_quotes