### PR TITLE
Fix connection pool resource initialization and path validation

### DIFF
--- a/crates/cdk-sql-common/src/pool.rs
+++ b/crates/cdk-sql-common/src/pool.rs
@@ -208,14 +208,12 @@ where
 
             if self.in_use.load(Ordering::Relaxed) < self.max_size {
                 drop(resources);
-                self.increment_connection_counter();
                 let stale: Arc<AtomicBool> = Arc::new(false.into());
+                let new_resource = RM::new_resource(&self.config, stale.clone(), timeout)?;
+                self.increment_connection_counter();
 
                 return Ok(PooledResource {
-                    resource: Some((
-                        stale.clone(),
-                        RM::new_resource(&self.config, stale, timeout)?,
-                    )),
+                    resource: Some((stale, new_resource)),
                     pool: self.clone(),
                     #[cfg(feature = "prometheus")]
                     start_time: Instant::now(),

--- a/crates/cdk-sqlite/src/common.rs
+++ b/crates/cdk-sqlite/src/common.rs
@@ -50,7 +50,7 @@ impl DatabasePool for SqliteConnectionManager {
             // Check if parent directory exists before attempting to open database
             let path_buf = PathBuf::from(path);
             if let Some(parent) = path_buf.parent() {
-                if !parent.exists() {
+                if !parent.to_str().unwrap_or_default().is_empty() && !parent.exists() {
                     return Err(pool::Error::Resource(rusqlite::Error::InvalidPath(
                         path_buf.clone(),
                     )));

--- a/crates/cdk-sqlite/src/mint/mod.rs
+++ b/crates/cdk-sqlite/src/mint/mod.rs
@@ -32,6 +32,16 @@ mod test {
     mint_db_test!(provide_db);
 
     #[tokio::test]
+    async fn bug_opening_relative_path() {
+        let config: Config = "test.db".into();
+
+        let pool = Pool::<SqliteConnectionManager>::new(config);
+        let db = pool.get();
+        assert!(db.is_ok());
+        let _ = remove_file("test.db");
+    }
+
+    #[tokio::test]
     async fn open_legacy_and_migrate() {
         let file = format!(
             "{}/db.sqlite",


### PR DESCRIPTION


### Description

Fixes two issues in SQLite connection handling:

**Connection Pool Resource Initialization:**
- Move resource creation before incrementing connection counter in pool.rs
- Ensures counter is only incremented after successful resource creation
- Prevents counter increment on resource creation failure
- Fixes potential resource leak where counter could be incremented without a valid resource

**Path Validation:**
- Add empty string check before parent directory existence validation
- Allows relative paths like "test.db" to work correctly
- Prevents false negative errors for valid relative database paths
- Only validates parent directory existence for non-empty paths

**Test Coverage:**
- Add test case `bug_opening_relative_path()` to verify relative path handling
- Ensures databases can be created with simple filenames like "test.db"

These changes fix issues where:
1. Connection pool counter could become inconsistent with actual connections
2. Relative database paths were incorrectly rejected

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
