### PR TITLE
Add MultiMintWallet function to check proofs state

### DIFF
--- a/crates/cdk-ffi/src/multi_mint_wallet.rs
+++ b/crates/cdk-ffi/src/multi_mint_wallet.rs
@@ -248,6 +248,25 @@ impl MultiMintWallet {
         Ok(proofs_by_mint)
     }
 
+    /// Check the state of proofs at a specific mint
+    pub async fn check_proofs_state(
+        &self,
+        mint_url: MintUrl,
+        proofs: Proofs,
+    ) -> Result<Vec<ProofState>, FfiError> {
+        let cdk_mint_url: cdk::mint_url::MintUrl = mint_url.try_into()?;
+        let cdk_proofs: Result<Vec<cdk::nuts::Proof>, _> =
+            proofs.into_iter().map(|p| p.try_into()).collect();
+        let cdk_proofs = cdk_proofs?;
+
+        let states = self
+            .inner
+            .check_proofs_state(&cdk_mint_url, cdk_proofs)
+            .await?;
+
+        Ok(states.into_iter().map(|s| s.into()).collect())
+    }
+
     /// Receive token
     pub async fn receive(
         &self,


### PR DESCRIPTION
### Description

Add `check_proofs_state` method to MultiMintWallet for checking proof states via NUT-07.

-----

### Notes to the reviewers

Delegates to the existing `Wallet::check_proofs_spent` method and extracts the state from each response.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

#### ADDED

- `MultiMintWallet::check_proofs_state` - check proof states at a specific mint (core returns `Vec<State>`, FFI returns `Vec<ProofState>`)

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing