### PR TITLE
fix: remove try_proof_operation_or_reclaim from receive ops

### DIFF
--- a/crates/cdk/src/wallet/receive.rs
+++ b/crates/cdk/src/wallet/receive.rs
@@ -145,14 +145,17 @@ impl Wallet {
             }
         }
 
-        // Note: We do NOT use try_proof_operation_or_reclaim here because these are
-        // external proofs from a received token, not our own proofs. If the swap fails,
-        // we should simply log the error and keep the pending proofs we added.
         let swap_response = match self.client.post_swap(pre_swap.swap_request).await {
             Ok(response) => response,
             Err(err) => {
-                // log the error. We don't clean up the pending proofs we added.
                 tracing::error!("Failed to post swap request: {}", err);
+
+                // Remove the pending proofs we added since the swap failed
+                let mut tx = self.localstore.begin_db_transaction().await?;
+                tx.update_proofs(vec![], proofs_info.into_iter().map(|p| p.y).collect())
+                    .await?;
+                tx.commit().await?;
+
                 return Err(err);
             }
         };


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
