### PR TITLE
 refactor: remove redundant input_ys and blinded_secrets from saga table

### DIFF
--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -235,6 +235,12 @@ pub trait ProofsTransaction {
         &self,
         quote_id: &QuoteId,
     ) -> Result<Vec<PublicKey>, Self::Err>;
+
+    /// Get proof ys by operation id
+    async fn get_proof_ys_by_operation_id(
+        &self,
+        operation_id: &uuid::Uuid,
+    ) -> Result<Vec<PublicKey>, Self::Err>;
 }
 
 /// Mint Proof Database trait
@@ -261,6 +267,12 @@ pub trait ProofsDatabase {
 
     /// Get total proofs redeemed by keyset id
     async fn get_total_redeemed(&self) -> Result<HashMap<Id, Amount>, Self::Err>;
+
+    /// Get proof ys by operation id
+    async fn get_proof_ys_by_operation_id(
+        &self,
+        operation_id: &uuid::Uuid,
+    ) -> Result<Vec<PublicKey>, Self::Err>;
 }
 
 #[async_trait]
@@ -310,6 +322,12 @@ pub trait SignaturesDatabase {
 
     /// Get total amount issued by keyset id
     async fn get_total_issued(&self) -> Result<HashMap<Id, Amount>, Self::Err>;
+
+    /// Get blinded secrets (B values) by operation id
+    async fn get_blinded_secrets_by_operation_id(
+        &self,
+        operation_id: &uuid::Uuid,
+    ) -> Result<Vec<PublicKey>, Self::Err>;
 }
 
 #[async_trait]

--- a/crates/cdk-common/src/database/mint/test/saga.rs
+++ b/crates/cdk-common/src/database/mint/test/saga.rs
@@ -1,7 +1,5 @@
 //! Saga database tests
 
-use cashu::SecretKey;
-
 use crate::database::mint::{Database, Error};
 use crate::mint::{MeltSagaState, OperationKind, Saga, SagaStateEnum, SwapSagaState};
 
@@ -15,14 +13,6 @@ where
         operation_id,
         operation_kind: OperationKind::Swap,
         state: SagaStateEnum::Swap(SwapSagaState::SetupComplete),
-        blinded_secrets: vec![
-            SecretKey::generate().public_key(),
-            SecretKey::generate().public_key(),
-        ],
-        input_ys: vec![
-            SecretKey::generate().public_key(),
-            SecretKey::generate().public_key(),
-        ],
         quote_id: None,
         created_at: 1234567890,
         updated_at: 1234567890,
@@ -41,8 +31,6 @@ where
     assert_eq!(retrieved.operation_id, saga.operation_id);
     assert_eq!(retrieved.operation_kind, saga.operation_kind);
     assert_eq!(retrieved.state, saga.state);
-    assert_eq!(retrieved.blinded_secrets, saga.blinded_secrets);
-    assert_eq!(retrieved.input_ys, saga.input_ys);
     assert_eq!(retrieved.quote_id, saga.quote_id);
     tx.commit().await.unwrap();
 }
@@ -57,8 +45,6 @@ where
         operation_id,
         operation_kind: OperationKind::Swap,
         state: SagaStateEnum::Swap(SwapSagaState::SetupComplete),
-        blinded_secrets: vec![SecretKey::generate().public_key()],
-        input_ys: vec![SecretKey::generate().public_key()],
         quote_id: None,
         created_at: 1234567890,
         updated_at: 1234567890,
@@ -86,8 +72,6 @@ where
         operation_id,
         operation_kind: OperationKind::Swap,
         state: SagaStateEnum::Swap(SwapSagaState::SetupComplete),
-        blinded_secrets: vec![SecretKey::generate().public_key()],
-        input_ys: vec![SecretKey::generate().public_key()],
         quote_id: None,
         created_at: 1234567890,
         updated_at: 1234567890,
@@ -125,8 +109,6 @@ where
         operation_id,
         operation_kind: OperationKind::Swap,
         state: SagaStateEnum::Swap(SwapSagaState::SetupComplete),
-        blinded_secrets: vec![SecretKey::generate().public_key()],
-        input_ys: vec![SecretKey::generate().public_key()],
         quote_id: None,
         created_at: 1234567890,
         updated_at: 1234567890,
@@ -164,8 +146,6 @@ where
         operation_id: uuid::Uuid::new_v4(),
         operation_kind: OperationKind::Swap,
         state: SagaStateEnum::Swap(SwapSagaState::SetupComplete),
-        blinded_secrets: vec![SecretKey::generate().public_key()],
-        input_ys: vec![SecretKey::generate().public_key()],
         quote_id: None,
         created_at: 1234567890,
         updated_at: 1234567890,
@@ -175,8 +155,6 @@ where
         operation_id: uuid::Uuid::new_v4(),
         operation_kind: OperationKind::Swap,
         state: SagaStateEnum::Swap(SwapSagaState::Signed),
-        blinded_secrets: vec![SecretKey::generate().public_key()],
-        input_ys: vec![SecretKey::generate().public_key()],
         quote_id: None,
         created_at: 1234567891,
         updated_at: 1234567891,
@@ -187,8 +165,6 @@ where
         operation_id: uuid::Uuid::new_v4(),
         operation_kind: OperationKind::Melt,
         state: SagaStateEnum::Melt(MeltSagaState::SetupComplete),
-        blinded_secrets: vec![SecretKey::generate().public_key()],
-        input_ys: vec![SecretKey::generate().public_key()],
         quote_id: Some("test_quote_id".to_string()),
         created_at: 1234567892,
         updated_at: 1234567892,
@@ -227,8 +203,6 @@ where
         operation_id: uuid::Uuid::new_v4(),
         operation_kind: OperationKind::Melt,
         state: SagaStateEnum::Melt(MeltSagaState::SetupComplete),
-        blinded_secrets: vec![SecretKey::generate().public_key()],
-        input_ys: vec![SecretKey::generate().public_key()],
         quote_id: Some("melt_quote_1".to_string()),
         created_at: 1234567890,
         updated_at: 1234567890,
@@ -238,8 +212,6 @@ where
         operation_id: uuid::Uuid::new_v4(),
         operation_kind: OperationKind::Melt,
         state: SagaStateEnum::Melt(MeltSagaState::PaymentAttempted),
-        blinded_secrets: vec![SecretKey::generate().public_key()],
-        input_ys: vec![SecretKey::generate().public_key()],
         quote_id: Some("melt_quote_2".to_string()),
         created_at: 1234567891,
         updated_at: 1234567891,
@@ -250,8 +222,6 @@ where
         operation_id: uuid::Uuid::new_v4(),
         operation_kind: OperationKind::Swap,
         state: SagaStateEnum::Swap(SwapSagaState::SetupComplete),
-        blinded_secrets: vec![SecretKey::generate().public_key()],
-        input_ys: vec![SecretKey::generate().public_key()],
         quote_id: None,
         created_at: 1234567892,
         updated_at: 1234567892,
@@ -344,8 +314,6 @@ where
         operation_id,
         operation_kind: OperationKind::Melt,
         state: SagaStateEnum::Melt(MeltSagaState::SetupComplete),
-        blinded_secrets: vec![SecretKey::generate().public_key()],
-        input_ys: vec![SecretKey::generate().public_key()],
         quote_id: Some(quote_id.to_string()),
         created_at: 1234567890,
         updated_at: 1234567890,
@@ -373,8 +341,6 @@ where
         operation_id,
         operation_kind: OperationKind::Swap,
         state: SagaStateEnum::Swap(SwapSagaState::SetupComplete),
-        blinded_secrets: vec![SecretKey::generate().public_key()],
-        input_ys: vec![SecretKey::generate().public_key()],
         quote_id: None,
         created_at: 1234567890,
         updated_at: 1234567890,
@@ -402,8 +368,6 @@ where
             operation_id: uuid::Uuid::new_v4(),
             operation_kind: OperationKind::Swap,
             state: SagaStateEnum::Swap(SwapSagaState::SetupComplete),
-            blinded_secrets: vec![SecretKey::generate().public_key()],
-            input_ys: vec![SecretKey::generate().public_key()],
             quote_id: None,
             created_at: 1234567890,
             updated_at: 1234567890,
@@ -412,8 +376,6 @@ where
             operation_id: uuid::Uuid::new_v4(),
             operation_kind: OperationKind::Swap,
             state: SagaStateEnum::Swap(SwapSagaState::Signed),
-            blinded_secrets: vec![SecretKey::generate().public_key()],
-            input_ys: vec![SecretKey::generate().public_key()],
             quote_id: None,
             created_at: 1234567891,
             updated_at: 1234567891,
@@ -422,8 +384,6 @@ where
             operation_id: uuid::Uuid::new_v4(),
             operation_kind: OperationKind::Melt,
             state: SagaStateEnum::Melt(MeltSagaState::SetupComplete),
-            blinded_secrets: vec![SecretKey::generate().public_key()],
-            input_ys: vec![SecretKey::generate().public_key()],
             quote_id: Some("quote1".to_string()),
             created_at: 1234567892,
             updated_at: 1234567892,
@@ -432,8 +392,6 @@ where
             operation_id: uuid::Uuid::new_v4(),
             operation_kind: OperationKind::Melt,
             state: SagaStateEnum::Melt(MeltSagaState::PaymentAttempted),
-            blinded_secrets: vec![SecretKey::generate().public_key()],
-            input_ys: vec![SecretKey::generate().public_key()],
             quote_id: Some("quote2".to_string()),
             created_at: 1234567893,
             updated_at: 1234567893,

--- a/crates/cdk-common/src/mint.rs
+++ b/crates/cdk-common/src/mint.rs
@@ -162,10 +162,6 @@ pub struct Saga {
     pub operation_kind: OperationKind,
     /// Current saga state (operation-specific)
     pub state: SagaStateEnum,
-    /// Blinded secrets (B values) from output blinded messages
-    pub blinded_secrets: Vec<PublicKey>,
-    /// Y values (public keys) from input proofs
-    pub input_ys: Vec<PublicKey>,
     /// Quote ID for melt operations (used for payment status lookup during recovery)
     /// None for swap operations
     pub quote_id: Option<String>,
@@ -177,19 +173,12 @@ pub struct Saga {
 
 impl Saga {
     /// Create new swap saga
-    pub fn new_swap(
-        operation_id: Uuid,
-        state: SwapSagaState,
-        blinded_secrets: Vec<PublicKey>,
-        input_ys: Vec<PublicKey>,
-    ) -> Self {
+    pub fn new_swap(operation_id: Uuid, state: SwapSagaState) -> Self {
         let now = unix_time();
         Self {
             operation_id,
             operation_kind: OperationKind::Swap,
             state: SagaStateEnum::Swap(state),
-            blinded_secrets,
-            input_ys,
             quote_id: None,
             created_at: now,
             updated_at: now,
@@ -203,20 +192,12 @@ impl Saga {
     }
 
     /// Create new melt saga
-    pub fn new_melt(
-        operation_id: Uuid,
-        state: MeltSagaState,
-        input_ys: Vec<PublicKey>,
-        blinded_secrets: Vec<PublicKey>,
-        quote_id: String,
-    ) -> Self {
+    pub fn new_melt(operation_id: Uuid, state: MeltSagaState, quote_id: String) -> Self {
         let now = unix_time();
         Self {
             operation_id,
             operation_kind: OperationKind::Melt,
             state: SagaStateEnum::Melt(state),
-            blinded_secrets,
-            input_ys,
             quote_id: Some(quote_id),
             created_at: now,
             updated_at: now,

--- a/crates/cdk-sql-common/src/mint/migrations/postgres/20251223000000_remove_saga_redundant_columns.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/postgres/20251223000000_remove_saga_redundant_columns.sql
@@ -1,0 +1,5 @@
+-- Remove blinded_secrets and input_ys columns from saga_state table
+-- These values can be looked up from proof and blind_signature tables using operation_id
+
+ALTER TABLE saga_state DROP COLUMN IF EXISTS blinded_secrets;
+ALTER TABLE saga_state DROP COLUMN IF EXISTS input_ys;

--- a/crates/cdk-sql-common/src/mint/migrations/sqlite/20251223000000_remove_saga_redundant_columns.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/sqlite/20251223000000_remove_saga_redundant_columns.sql
@@ -1,0 +1,29 @@
+-- Remove blinded_secrets and input_ys columns from saga_state table
+-- These values can be looked up from proof and blind_signature tables using operation_id
+
+-- SQLite doesn't support DROP COLUMN directly, so we need to recreate the table
+
+-- Step 1: Create new table without the redundant columns
+CREATE TABLE IF NOT EXISTS saga_state_new (
+    operation_id TEXT PRIMARY KEY,
+    operation_kind TEXT NOT NULL,
+    state TEXT NOT NULL,
+    quote_id TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+
+-- Step 2: Copy data from old table to new table
+INSERT INTO saga_state_new (operation_id, operation_kind, state, quote_id, created_at, updated_at)
+SELECT operation_id, operation_kind, state, quote_id, created_at, updated_at
+FROM saga_state;
+
+-- Step 3: Drop old table
+DROP TABLE saga_state;
+
+-- Step 4: Rename new table to original name
+ALTER TABLE saga_state_new RENAME TO saga_state;
+
+-- Step 5: Recreate indexes
+CREATE INDEX IF NOT EXISTS idx_saga_state_operation_kind ON saga_state(operation_kind);
+CREATE INDEX IF NOT EXISTS idx_saga_state_quote_id ON saga_state(quote_id);

--- a/crates/cdk/src/mint/melt/melt_saga/mod.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/mod.rs
@@ -378,8 +378,6 @@ impl MeltSaga<Initial> {
         let saga = Saga::new_melt(
             self.operation_id,
             MeltSagaState::SetupComplete,
-            input_ys.clone(),
-            blinded_secrets.clone(),
             quote.id.to_string(),
         );
 

--- a/crates/cdk/src/mint/melt/melt_saga/tests.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/tests.rs
@@ -95,16 +95,21 @@ async fn test_saga_state_persistence_after_setup() {
         _ => panic!("Expected Melt saga state"),
     }
 
-    // STEP 6: Verify input_ys are stored
+    // STEP 6: Verify input_ys can be looked up by operation_id
     let input_ys = proofs.ys().unwrap();
+    let stored_input_ys = mint
+        .localstore
+        .get_proof_ys_by_operation_id(&persisted_saga.operation_id)
+        .await
+        .unwrap();
     assert_eq!(
-        persisted_saga.input_ys.len(),
+        stored_input_ys.len(),
         input_ys.len(),
         "Should store all input Ys"
     );
     for y in &input_ys {
         assert!(
-            persisted_saga.input_ys.contains(y),
+            stored_input_ys.contains(y),
             "Input Y should be stored: {:?}",
             y
         );
@@ -124,10 +129,15 @@ async fn test_saga_state_persistence_after_setup() {
         "Timestamps should match for new saga"
     );
 
-    // STEP 8: Verify blinded_secrets is empty (not used for melt)
+    // STEP 8: Verify blinded_secrets lookup returns empty (not used for melt without change)
+    let stored_blinded_secrets = mint
+        .localstore
+        .get_blinded_secrets_by_operation_id(&persisted_saga.operation_id)
+        .await
+        .unwrap();
     assert!(
-        persisted_saga.blinded_secrets.is_empty(),
-        "Melt saga should not store blinded_secrets"
+        stored_blinded_secrets.is_empty(),
+        "Melt saga without change should have no blinded_secrets"
     );
 
     // SUCCESS: Saga persisted correctly!
@@ -1213,17 +1223,22 @@ async fn test_saga_content_validation() {
         _ => panic!("Expected Melt saga state, got {:?}", persisted_saga.state),
     }
 
-    // STEP 7: Verify input_ys are stored correctly
+    // STEP 7: Verify input_ys can be looked up by operation_id
+    let stored_input_ys = mint
+        .localstore
+        .get_proof_ys_by_operation_id(&persisted_saga.operation_id)
+        .await
+        .unwrap();
     assert_eq!(
-        persisted_saga.input_ys.len(),
+        stored_input_ys.len(),
         input_ys.len(),
         "Should store all input Ys"
     );
 
-    // Verify each Y is present and in correct order
+    // Verify each Y is present
     for (i, expected_y) in input_ys.iter().enumerate() {
         assert!(
-            persisted_saga.input_ys.contains(expected_y),
+            stored_input_ys.contains(expected_y),
             "Input Y at index {} should be stored: {:?}",
             i,
             expected_y
@@ -1261,10 +1276,15 @@ async fn test_saga_content_validation() {
         "Timestamps should match for newly created saga"
     );
 
-    // STEP 9: Verify blinded_secrets is empty (not used for melt)
+    // STEP 9: Verify blinded_secrets lookup returns empty (not used for melt without change)
+    let stored_blinded_secrets = mint
+        .localstore
+        .get_blinded_secrets_by_operation_id(&persisted_saga.operation_id)
+        .await
+        .unwrap();
     assert!(
-        persisted_saga.blinded_secrets.is_empty(),
-        "Melt saga should not use blinded_secrets field"
+        stored_blinded_secrets.is_empty(),
+        "Melt saga without change should have no blinded_secrets"
     );
 
     // SUCCESS: All saga content validated!

--- a/crates/cdk/src/mint/start_up_check.rs
+++ b/crates/cdk/src/mint/start_up_check.rs
@@ -126,11 +126,21 @@ impl Mint {
                 saga.updated_at
             );
 
+            // Look up input_ys and blinded_secrets from the proof and blind_signature tables
+            let input_ys = self
+                .localstore
+                .get_proof_ys_by_operation_id(&saga.operation_id)
+                .await?;
+            let blinded_secrets = self
+                .localstore
+                .get_blinded_secrets_by_operation_id(&saga.operation_id)
+                .await?;
+
             // Use the same compensation logic as in-process failures
             // Saga deletion is included in the compensation transaction
             let compensation = RemoveSwapSetup {
-                blinded_secrets: saga.blinded_secrets.clone(),
-                input_ys: saga.input_ys.clone(),
+                blinded_secrets,
+                input_ys,
                 operation_id: saga.operation_id,
             };
 
@@ -200,6 +210,16 @@ impl Mint {
                 saga.updated_at
             );
 
+            // Look up input_ys and blinded_secrets from the proof and blind_signature tables
+            let input_ys = self
+                .localstore
+                .get_proof_ys_by_operation_id(&saga.operation_id)
+                .await?;
+            let blinded_secrets = self
+                .localstore
+                .get_blinded_secrets_by_operation_id(&saga.operation_id)
+                .await?;
+
             // Get quote_id from saga (new field added for efficient lookup)
             let quote_id = match saga.quote_id {
                 Some(ref qid) => qid.clone(),
@@ -228,9 +248,9 @@ impl Mint {
                         let proof_ys = tx.get_proof_ys_by_quote_id(&quote.id).await?;
                         tx.rollback().await?;
 
-                        if !saga.input_ys.is_empty()
+                        if !input_ys.is_empty()
                             && !proof_ys.is_empty()
-                            && saga.input_ys.iter().any(|y| proof_ys.contains(y))
+                            && input_ys.iter().any(|y| proof_ys.contains(y))
                         {
                             quote_id_found = Some(quote.id.clone());
                             break;
@@ -515,20 +535,18 @@ impl Mint {
 
             // Compensate if needed
             if should_compensate {
-                // Use saga data directly for compensation (like swap does)
                 tracing::info!(
                     "Compensating melt saga {} (removing {} proofs, {} change outputs)",
                     saga.operation_id,
-                    saga.input_ys.len(),
-                    saga.blinded_secrets.len()
+                    input_ys.len(),
+                    blinded_secrets.len()
                 );
 
-                // Compensate using saga data only - don't rely on quote state
                 let mut tx = self.localstore.begin_transaction().await?;
 
                 // Remove blinded messages (change outputs)
-                if !saga.blinded_secrets.is_empty() {
-                    if let Err(e) = tx.delete_blinded_messages(&saga.blinded_secrets).await {
+                if !blinded_secrets.is_empty() {
+                    if let Err(e) = tx.delete_blinded_messages(&blinded_secrets).await {
                         tracing::error!(
                             "Failed to delete blinded messages for saga {}: {}",
                             saga.operation_id,
@@ -539,9 +557,9 @@ impl Mint {
                     }
                 }
 
-                // Remove proofs (inputs) - use None for quote_id like swap does
-                if !saga.input_ys.is_empty() {
-                    match tx.remove_proofs(&saga.input_ys, None).await {
+                // Remove proofs (inputs)
+                if !input_ys.is_empty() {
+                    match tx.remove_proofs(&input_ys, None).await {
                         Ok(()) => {}
                         Err(DatabaseError::AttemptRemoveSpentProof) => {
                             // Proofs are already spent or missing - this is okay for compensation.

--- a/crates/cdk/src/mint/swap/swap_saga/mod.rs
+++ b/crates/cdk/src/mint/swap/swap_saga/mod.rs
@@ -253,12 +253,7 @@ impl<'a> SwapSaga<'a, Initial> {
             .collect();
 
         // Persist saga state for crash recovery (atomic with TX1)
-        let saga = Saga::new_swap(
-            self.operation_id,
-            SwapSagaState::SetupComplete,
-            blinded_secrets.clone(),
-            ys.clone(),
-        );
+        let saga = Saga::new_swap(self.operation_id, SwapSagaState::SetupComplete);
 
         if let Err(err) = tx.add_saga(&saga).await {
             tx.rollback().await?;

--- a/crates/cdk/src/test_helpers/mint.rs
+++ b/crates/cdk/src/test_helpers/mint.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 //! Test helpers for creating test mints and related utilities
 
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -19,8 +20,6 @@ use tokio::time::sleep;
 use crate::mint::{Mint, MintBuilder, MintMeltLimits};
 use crate::types::{FeeReserve, QuoteTTL};
 use crate::Error;
-
-use std::cell::RefCell;
 
 thread_local! {
     /// Thread-local storage for test failure flags.


### PR DESCRIPTION
The saga table was storing serialized lists of input_ys and blinded_secrets, but this data is redundant since the proof and blind_signature tables already store these values with operation_id as a foreign key.

### Description
closes: https://github.com/cashubtc/cdk/issues/1427
<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
