### PR TITLE
Fix ProofsTransaction::get_proof_ys_by_quote_id to use &mut self

### DIFF
--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -232,13 +232,13 @@ pub trait ProofsTransaction {
 
     /// Get ys by quote id
     async fn get_proof_ys_by_quote_id(
-        &self,
+        &mut self,
         quote_id: &QuoteId,
     ) -> Result<Vec<PublicKey>, Self::Err>;
 
     /// Get proof ys by operation id
     async fn get_proof_ys_by_operation_id(
-        &self,
+        &mut self,
         operation_id: &uuid::Uuid,
     ) -> Result<Vec<PublicKey>, Self::Err>;
 }

--- a/crates/cdk-sql-common/src/mint/mod.rs
+++ b/crates/cdk-sql-common/src/mint/mod.rs
@@ -300,7 +300,7 @@ where
     }
 
     async fn get_proof_ys_by_quote_id(
-        &self,
+        &mut self,
         quote_id: &QuoteId,
     ) -> Result<Vec<PublicKey>, Self::Err> {
         Ok(query(
@@ -327,7 +327,7 @@ where
     }
 
     async fn get_proof_ys_by_operation_id(
-        &self,
+        &mut self,
         operation_id: &uuid::Uuid,
     ) -> Result<Vec<PublicKey>, Self::Err> {
         Ok(query(

--- a/crates/cdk/src/mint/start_up_check.rs
+++ b/crates/cdk/src/mint/start_up_check.rs
@@ -244,7 +244,7 @@ impl Mint {
 
                     let mut quote_id_found = None;
                     for quote in melt_quotes {
-                        let tx = self.localstore.begin_transaction().await?;
+                        let mut tx = self.localstore.begin_transaction().await?;
                         let proof_ys = tx.get_proof_ys_by_quote_id(&quote.id).await?;
                         tx.rollback().await?;
 


### PR DESCRIPTION

### Description

Changes the method signature from `&self` to `&mut self` for consistency with all other methods in the `ProofsTransaction` trait.

Transaction traits should uniformly use `&mut self` because they operate within a transactional context that may need to track state or hold exclusive access to resources. The read-only `ProofsDatabase` trait correctly retains `&self` for its version of this method.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
