### PR TITLE
fix: batch proof witness queries in check_state to prevent pool exhaustion

### DIFF
--- a/crates/cashu/src/nuts/nut13.rs
+++ b/crates/cashu/src/nuts/nut13.rs
@@ -528,7 +528,7 @@ mod tests {
 
         assert_eq!(
             pre_mint_secrets.secrets.len(),
-            (end_count - start_count + 1) as usize
+            (end_count - start_count) as usize
         );
 
         // Verify each secret in the batch

--- a/crates/cdk-integration-tests/src/cli.rs
+++ b/crates/cdk-integration-tests/src/cli.rs
@@ -29,9 +29,10 @@ pub fn init_logging(enable_logging: bool, log_level: tracing::Level) {
         let rustls_filter = "rustls=warn";
         let reqwest_filter = "reqwest=warn";
         let tower_filter = "tower_http=warn";
+        let tokio_postgres_filter = "tokio_postgres=warn";
 
         let env_filter = EnvFilter::new(format!(
-            "{default_filter},{hyper_filter},{h2_filter},{rustls_filter},{reqwest_filter},{tower_filter}"
+            "{default_filter},{hyper_filter},{h2_filter},{rustls_filter},{reqwest_filter},{tower_filter},{tokio_postgres_filter}"
         ));
 
         // Ok if successful, Err if already initialized

--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -249,8 +249,11 @@ pub fn setup_tracing() {
 
     let h2_filter = "h2=warn";
     let hyper_filter = "hyper=warn";
+    let tokio_postgres = "tokio_postgres=warn";
 
-    let env_filter = EnvFilter::new(format!("{default_filter},{h2_filter},{hyper_filter}"));
+    let env_filter = EnvFilter::new(format!(
+        "{default_filter},{h2_filter},{hyper_filter},{tokio_postgres}"
+    ));
 
     // Ok if successful, Err if already initialized
     // Allows us to setup tracing at the start of several parallel tests

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -121,9 +121,10 @@ pub fn setup_tracing(
     let tower_http = "tower_http=warn";
     let rustls = "rustls=warn";
     let tungstenite = "tungstenite=warn";
+    let tokio_postgres = "tokio_postgres=warn";
 
     let env_filter = EnvFilter::new(format!(
-        "{default_filter},{hyper_filter},{h2_filter},{tower_filter},{tower_http},{rustls},{tungstenite}"
+        "{default_filter},{hyper_filter},{h2_filter},{tower_filter},{tower_http},{rustls},{tungstenite},{tokio_postgres}"
     ));
 
     use config::LoggingOutput;

--- a/crates/cdk/src/mint/check_spendable.rs
+++ b/crates/cdk/src/mint/check_spendable.rs
@@ -1,4 +1,5 @@
-use futures::future::try_join_all;
+use std::collections::HashMap;
+
 use tracing::instrument;
 
 use super::{CheckStateRequest, CheckStateResponse, Mint, ProofState, State};
@@ -18,27 +19,38 @@ impl Mint {
             return Err(Error::UnknownPaymentState);
         }
 
-        let proof_states_futures =
-            check_state
-                .ys
-                .iter()
-                .zip(states.iter())
-                .map(|(y, state)| async move {
-                    let witness: Result<Option<cdk_common::Witness>, Error> = if state.is_some() {
-                        let proofs = self.localstore.get_proofs_by_ys(&[*y]).await?;
-                        Ok(proofs.first().cloned().flatten().and_then(|p| p.witness))
-                    } else {
-                        Ok(None)
-                    };
+        // Collect ys that need witness fetching (where state.is_some())
+        let ys_needing_witness: Vec<_> = check_state
+            .ys
+            .iter()
+            .zip(states.iter())
+            .filter_map(|(y, state)| state.as_ref().map(|_| *y))
+            .collect();
 
-                    witness.map(|w| ProofState {
-                        y: *y,
-                        state: state.unwrap_or(State::Unspent),
-                        witness: w,
-                    })
-                });
+        // Build a lookup map for witnesses (only query if there are ys to fetch)
+        let witness_map: HashMap<_, _> = if ys_needing_witness.is_empty() {
+            HashMap::new()
+        } else {
+            self.localstore
+                .get_proofs_by_ys(&ys_needing_witness)
+                .await?
+                .into_iter()
+                .flatten()
+                .filter_map(|p| p.y().ok().map(|y| (y, p.witness)))
+                .collect()
+        };
 
-        let proof_states = try_join_all(proof_states_futures).await?;
+        // Construct response without additional queries
+        let proof_states = check_state
+            .ys
+            .iter()
+            .zip(states.iter())
+            .map(|(y, state)| ProofState {
+                y: *y,
+                state: state.unwrap_or(State::Unspent),
+                witness: witness_map.get(y).cloned().flatten(),
+            })
+            .collect();
 
         Ok(CheckStateResponse {
             states: proof_states,


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----
The check_state function was making N individual database queries (one per
proof) inside a try_join_all loop. With many proofs, this spawned concurrent
queries that exhausted PostgreSQL's connection pool, causing timeouts.

This worked fine with SQLite (in-process, serialized) but failed with
PostgreSQL (network connections, fixed pool size).

Changes:
- Replace N individual get_proofs_by_ys calls with single batched query
- Use HashMap for O(1) witness lookup while preserving input order
- Add empty slice guard to prevent invalid "WHERE y IN ()" SQL
- Remove futures::try_join_all dependency


### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
