### PR TITLE
fix: batch proof witness queries in check_state to prevent pool exhau…

### DIFF
--- a/crates/cashu/src/nuts/nut13.rs
+++ b/crates/cashu/src/nuts/nut13.rs
@@ -204,7 +204,7 @@ impl PreMintSecrets {
     ) -> Result<Self, Error> {
         let mut pre_mint_secrets = PreMintSecrets::new(keyset_id);
 
-        for i in start_count..=end_count {
+        for i in start_count..end_count {
             let secret = Secret::from_seed(seed, keyset_id, i)?;
             let blinding_factor = SecretKey::from_seed(seed, keyset_id, i)?;
 
@@ -528,7 +528,7 @@ mod tests {
 
         assert_eq!(
             pre_mint_secrets.secrets.len(),
-            (end_count - start_count + 1) as usize
+            (end_count - start_count) as usize
         );
 
         // Verify each secret in the batch

--- a/crates/cdk-integration-tests/src/cli.rs
+++ b/crates/cdk-integration-tests/src/cli.rs
@@ -29,9 +29,10 @@ pub fn init_logging(enable_logging: bool, log_level: tracing::Level) {
         let rustls_filter = "rustls=warn";
         let reqwest_filter = "reqwest=warn";
         let tower_filter = "tower_http=warn";
+        let tokio_postgres_filter = "tokio_postgres=warn";
 
         let env_filter = EnvFilter::new(format!(
-            "{default_filter},{hyper_filter},{h2_filter},{rustls_filter},{reqwest_filter},{tower_filter}"
+            "{default_filter},{hyper_filter},{h2_filter},{rustls_filter},{reqwest_filter},{tower_filter},{tokio_postgres_filter}"
         ));
 
         // Ok if successful, Err if already initialized

--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -226,8 +226,11 @@ pub fn setup_tracing() {
 
     let h2_filter = "h2=warn";
     let hyper_filter = "hyper=warn";
+    let tokio_postgres = "tokio_postgres=warn";
 
-    let env_filter = EnvFilter::new(format!("{default_filter},{h2_filter},{hyper_filter}"));
+    let env_filter = EnvFilter::new(format!(
+        "{default_filter},{h2_filter},{hyper_filter},{tokio_postgres}"
+    ));
 
     // Ok if successful, Err if already initialized
     // Allows us to setup tracing at the start of several parallel tests

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -116,11 +116,13 @@ pub fn setup_tracing(
     let default_filter = "debug";
     let hyper_filter = "hyper=warn,rustls=warn,reqwest=warn";
     let h2_filter = "h2=warn";
-    let tower_http = "tower_http=warn";
+    let tower_filter = "tower_http=warn";
     let rustls = "rustls=warn";
+    let tungstenite = "tungstenite=warn";
+    let tokio_postgres = "tokio_postgres=warn";
 
     let env_filter = EnvFilter::new(format!(
-        "{default_filter},{hyper_filter},{h2_filter},{tower_http},{rustls}"
+        "{default_filter},{hyper_filter},{h2_filter},{tower_filter},{rustls},{tungstenite},{tokio_postgres}"
     ));
 
     use config::LoggingOutput;


### PR DESCRIPTION
…stion (#1514)

* feat: add tests with more proofs

* fix: batch proof witness queries in check_state to prevent pool exhaustion

The check_state function was making N individual database queries (one per proof) inside a try_join_all loop. With many proofs, this spawned concurrent queries that exhausted PostgreSQL's connection pool, causing timeouts.

This worked fine with SQLite (in-process, serialized) but failed with PostgreSQL (network connections, fixed pool size).

Changes:
- Replace N individual get_proofs_by_ys calls with single batched query
- Use HashMap for O(1) witness lookup while preserving input order
- Add empty slice guard to prevent invalid "WHERE y IN ()" SQL
- Remove futures::try_join_all dependency

(cherry picked from commit 2e004114479836a04887d6dddc8699755622d62c)

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
