### PR TITLE
Simplify subscription quote fetching by removing try_join_all

### DIFF
--- a/crates/cdk/src/mint/subscription.rs
+++ b/crates/cdk/src/mint/subscription.rs
@@ -76,12 +76,12 @@ impl MintPubSubSpec {
                     if let Some(mint_quote) =
                         self.get_mint_quote(uuid).await.map_err(|e| e.to_string())?
                     {
-                        let mint_quote = match mint_quote.payment_method.as_str() {
-                            "bolt11" => {
+                        let mint_quote = match idx {
+                            NotificationId::MintQuoteBolt11(_) => {
                                 let response: MintQuoteBolt11Response<QuoteId> = mint_quote.into();
                                 response.into()
                             }
-                            "bolt12" => match mint_quote.try_into() {
+                            NotificationId::MintQuoteBolt12(_) => match mint_quote.try_into() {
                                 Ok(response) => {
                                     let response: MintQuoteBolt12Response<QuoteId> = response;
                                     response.into()


### PR DESCRIPTION
### Description

Replace batch query execution with inline sequential processing for melt and mint quote lookups. This reduces code complexity by handling each quote type immediately within the match statement instead of collecting futures and joining them at the end.

This is a continuation of #1514

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
