### PR TITLE
fix: Inherit keyset amounts during rotation if not provided

### DIFF
--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -745,11 +745,7 @@ impl CdkMint for MintRPCServer {
         let unit = CurrencyUnit::from_str(&request.unit)
             .map_err(|_| Status::invalid_argument("Invalid unit".to_string()))?;
 
-        let amounts = if request.amounts.is_empty() {
-            return Err(Status::invalid_argument("amounts cannot be empty"));
-        } else {
-            request.amounts
-        };
+        let amounts = request.amounts;
 
         let keyset_info = self
             .mint

--- a/crates/cdk-signatory/src/signatory.rs
+++ b/crates/cdk-signatory/src/signatory.rs
@@ -42,7 +42,7 @@ impl From<CurrencyUnit> for KeysetIdentifier {
 pub struct RotateKeyArguments {
     /// Unit
     pub unit: CurrencyUnit,
-    /// Max order
+    /// List of amounts to support
     pub amounts: Vec<u64>,
     /// Input fee
     pub input_fee_ppk: u64,


### PR DESCRIPTION
## Summary
This PR fixes an issue where rotating a keyset without explicitly specifying amounts resulted in a keyset with no amounts (or an error), or if a single amount was provided (e.g. to misunderstand the flag), it would create a restricted keyset.

## Changes
- **RPC Server (`crates/cdk-mint-rpc/src/proto/server.rs`)**: Removed the check that prevented empty `amounts` in the `RotateNextKeysetRequest`.
- **Signatory (`crates/cdk-signatory/src/db_signatory.rs`)**: Modified `rotate_keyset` to inherit the `amounts` from the currently active keyset if `args.amounts` is empty.
- **Documentation (`crates/cdk-signatory/src/signatory.rs`)**: Corrected the misleading "Max order" comment to "List of amounts".

## Motivation
A mint operator recently rotated their keyset to update fees but inadvertently created a keyset with only a single denomination because they believed the `--amounts` flag required a single value (or max order). By defaulting to the previous keyset's amounts, we prevent this footgun and allow for safer fee updates.