### PR TITLE
fix: refresh auth wallet keyset 

### DIFF
--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -353,7 +353,9 @@ impl Wallet {
                     );
                     *auth_wallet = Some(new_auth_wallet.clone());
 
-                    self.client.set_auth_wallet(Some(new_auth_wallet.clone())).await;
+                    self.client
+                        .set_auth_wallet(Some(new_auth_wallet.clone()))
+                        .await;
 
                     if let Err(e) = new_auth_wallet.refresh_keysets().await {
                         tracing::error!("Could not fetch auth keysets: {}", e);


### PR DESCRIPTION
### Description

I have noticed that auth keysets do not get persisted with the ffi wallet when using a auth mint.


-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
