### PR TITLE
fix: remove to_string from payment request ffi

### DIFF
--- a/crates/cdk-ffi/src/types/payment_request.rs
+++ b/crates/cdk-ffi/src/types/payment_request.rs
@@ -309,11 +309,6 @@ impl PaymentRequestPayload {
         Ok(Arc::new(PaymentRequestPayload { inner }))
     }
 
-    /// Encode PaymentRequestPayload to JSON string
-    pub fn to_string(&self) -> Result<String, FfiError> {
-        Ok(serde_json::to_string(&self.inner)?)
-    }
-
     /// Get the ID
     pub fn id(&self) -> Option<String> {
         self.inner.id.clone()
@@ -337,6 +332,16 @@ impl PaymentRequestPayload {
     /// Get the proofs
     pub fn proofs(&self) -> Vec<Proof> {
         self.inner.proofs.iter().map(|p| p.clone().into()).collect()
+    }
+}
+
+impl std::fmt::Display for PaymentRequestPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(&self.inner).map_err(|_| std::fmt::Error)?
+        )
     }
 }
 
@@ -385,7 +390,7 @@ mod tests {
 
         let payload = PaymentRequestPayload { inner };
 
-        let json = payload.to_string().unwrap();
+        let json = payload.to_string();
         let decoded = PaymentRequestPayload::from_string(json).unwrap();
 
         assert_eq!(decoded.id(), payload.id());


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

closes: https://github.com/cashubtc/cdk/issues/1553

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
