### PR TITLE
Correct SQLite connection pool size check

### DIFF
--- a/crates/cdk-sqlite/src/common.rs
+++ b/crates/cdk-sqlite/src/common.rs
@@ -22,7 +22,7 @@ impl pool::DatabaseConfig for Config {
     }
 
     fn max_size(&self) -> usize {
-        if self.password.is_none() {
+        if self.path.is_none() {
             1
         } else {
             20


### PR DESCRIPTION
### Description

The max_size method was checking `password.is_none()` to determine the pool size, but should check `path.is_none()` instead. An in-memory database (no path) needs a single connection to avoid data loss, while file-backed databases can use a larger pool.

Fixes #1604


<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
