### PR TITLE
Add currecy unit to Amount in grpc for payment trait

### DIFF
--- a/crates/cashu/src/amount.rs
+++ b/crates/cashu/src/amount.rs
@@ -560,6 +560,22 @@ impl Amount<CurrencyUnit> {
     pub fn display_with_unit(&self) -> String {
         format!("{} {}", self.value, self.unit)
     }
+
+    /// Convert to millisatoshis and return the raw u64 value
+    ///
+    /// Returns an error if the unit cannot be converted to Msat
+    /// (i.e., the unit is not Sat or Msat).
+    pub fn to_msat(&self) -> Result<u64, Error> {
+        self.convert_to(&CurrencyUnit::Msat).map(|a| a.value())
+    }
+
+    /// Convert to satoshis and return the raw u64 value
+    ///
+    /// Returns an error if the unit cannot be converted to Sat
+    /// (i.e., the unit is not Sat or Msat).
+    pub fn to_sat(&self) -> Result<u64, Error> {
+        self.convert_to(&CurrencyUnit::Sat).map(|a| a.value())
+    }
 }
 
 impl<U> fmt::Display for Amount<U> {

--- a/crates/cdk-common/src/payment.rs
+++ b/crates/cdk-common/src/payment.rs
@@ -167,14 +167,24 @@ impl std::fmt::Debug for PaymentIdentifier {
 }
 
 /// Options for creating a BOLT11 incoming payment request
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Bolt11IncomingPaymentOptions {
     /// Optional description for the payment request
     pub description: Option<String>,
     /// Amount for the payment request in sats
-    pub amount: Amount,
+    pub amount: Amount<CurrencyUnit>,
     /// Optional expiry time as Unix timestamp in seconds
     pub unix_expiry: Option<u64>,
+}
+
+impl Default for Bolt11IncomingPaymentOptions {
+    fn default() -> Self {
+        Self {
+            description: None,
+            amount: Amount::new(0, CurrencyUnit::Sat),
+            unix_expiry: None,
+        }
+    }
 }
 
 /// Options for creating a BOLT12 incoming payment request
@@ -183,7 +193,7 @@ pub struct Bolt12IncomingPaymentOptions {
     /// Optional description for the payment request
     pub description: Option<String>,
     /// Optional amount for the payment request in sats
-    pub amount: Option<Amount>,
+    pub amount: Option<Amount<CurrencyUnit>>,
     /// Optional expiry time as Unix timestamp in seconds
     pub unix_expiry: Option<u64>,
 }
@@ -196,7 +206,7 @@ pub struct CustomIncomingPaymentOptions {
     /// Optional description for the payment request
     pub description: Option<String>,
     /// Amount for the payment request
-    pub amount: Amount,
+    pub amount: Amount<CurrencyUnit>,
     /// Optional expiry time as Unix timestamp in seconds
     pub unix_expiry: Option<u64>,
     /// Extra payment-method-specific fields as JSON string
@@ -223,7 +233,7 @@ pub struct Bolt11OutgoingPaymentOptions {
     /// Bolt11
     pub bolt11: Bolt11Invoice,
     /// Maximum fee amount allowed for the payment
-    pub max_fee_amount: Option<Amount>,
+    pub max_fee_amount: Option<Amount<CurrencyUnit>>,
     /// Optional timeout in seconds
     pub timeout_secs: Option<u64>,
     /// Melt options
@@ -236,7 +246,7 @@ pub struct Bolt12OutgoingPaymentOptions {
     /// Offer
     pub offer: Offer,
     /// Maximum fee amount allowed for the payment
-    pub max_fee_amount: Option<Amount>,
+    pub max_fee_amount: Option<Amount<CurrencyUnit>>,
     /// Optional timeout in seconds
     pub timeout_secs: Option<u64>,
     /// Melt options
@@ -251,7 +261,7 @@ pub struct CustomOutgoingPaymentOptions {
     /// Payment request string (method-specific format)
     pub request: String,
     /// Maximum fee amount allowed for the payment
-    pub max_fee_amount: Option<Amount>,
+    pub max_fee_amount: Option<Amount<CurrencyUnit>>,
     /// Optional timeout in seconds
     pub timeout_secs: Option<u64>,
     /// Melt options
@@ -282,7 +292,7 @@ impl TryFrom<crate::mint::MeltQuote> for OutgoingPaymentOptions {
         match &melt_quote.request {
             MeltPaymentRequest::Bolt11 { bolt11 } => Ok(OutgoingPaymentOptions::Bolt11(Box::new(
                 Bolt11OutgoingPaymentOptions {
-                    max_fee_amount: Some(fee_reserve.to_owned().into()),
+                    max_fee_amount: Some(fee_reserve.to_owned()),
                     timeout_secs: None,
                     bolt11: bolt11.clone(),
                     melt_options: melt_quote.options,
@@ -297,7 +307,7 @@ impl TryFrom<crate::mint::MeltQuote> for OutgoingPaymentOptions {
 
                 Ok(OutgoingPaymentOptions::Bolt12(Box::new(
                     Bolt12OutgoingPaymentOptions {
-                        max_fee_amount: Some(fee_reserve.clone().into()),
+                        max_fee_amount: Some(fee_reserve.clone()),
                         timeout_secs: None,
                         offer: *offer.clone(),
                         melt_options,
@@ -308,7 +318,7 @@ impl TryFrom<crate::mint::MeltQuote> for OutgoingPaymentOptions {
                 Box::new(CustomOutgoingPaymentOptions {
                     method: method.to_string(),
                     request: request.to_string(),
-                    max_fee_amount: Some(melt_quote.fee_reserve().into()),
+                    max_fee_amount: Some(melt_quote.fee_reserve()),
                     timeout_secs: None,
                     melt_options: melt_quote.options,
                     extra_json: None,

--- a/crates/cdk-lnbits/src/lib.rs
+++ b/crates/cdk-lnbits/src/lib.rs
@@ -351,9 +351,7 @@ impl MintPayment for LNbits {
                 let expiry = unix_expiry.map(|t| t - time_now);
 
                 let invoice_request = CreateInvoiceRequest {
-                    amount: Amount::new(amount.into(), unit.clone())
-                        .convert_to(&CurrencyUnit::Sat)?
-                        .value(),
+                    amount: amount.to_sat()?,
                     memo: Some(description),
                     unit: unit.to_string(),
                     expiry,

--- a/crates/cdk-lnd/src/lib.rs
+++ b/crates/cdk-lnd/src/lib.rs
@@ -432,7 +432,8 @@ impl MintPayment for Lnd {
                         {
                             let partial_amount_msat = mpp.amount;
                             let invoice = bolt11;
-                            let max_fee: Option<Amount> = bolt11_options.max_fee_amount;
+                            let max_fee: Option<Amount<CurrencyUnit>> =
+                                bolt11_options.max_fee_amount.clone();
 
                             // Extract information from invoice
                             let pub_key = invoice.get_payee_pub_key();
@@ -447,10 +448,9 @@ impl MintPayment for Lnd {
                                     pub_key: hex::encode(pub_key.serialize()),
                                     amt_msat: u64::from(partial_amount_msat) as i64,
                                     fee_limit: max_fee
+                                        .clone()
                                         .map(|f| {
-                                            let fee_msat = Amount::new(f.into(), unit.clone())
-                                                .convert_to(&CurrencyUnit::Msat)?
-                                                .value();
+                                            let fee_msat = f.to_msat()?;
                                             let limit = Limit::FixedMsat(fee_msat as i64);
                                             Ok::<_, Error>(FeeLimit { limit: Some(limit) })
                                         })
@@ -511,11 +511,10 @@ impl MintPayment for Lnd {
                                     _ => (MeltQuoteState::Unknown, None),
                                 };
 
-                                // Get the actual amount paid in sats
-                                let mut total_amt: u64 = 0;
-                                if let Some(route) = payment_response.route {
-                                    total_amt = (route.total_amt_msat / 1000) as u64;
-                                }
+                                // Get the actual amount paid in msats
+                                let total_amt_msat: u64 = payment_response
+                                    .route
+                                    .map_or(0, |route| route.total_amt_msat as u64);
 
                                 return Ok(MakePaymentResponse {
                                     payment_lookup_id: PaymentIdentifier::PaymentHash(
@@ -523,7 +522,8 @@ impl MintPayment for Lnd {
                                     ),
                                     payment_proof: payment_preimage,
                                     status,
-                                    total_spent: Amount::new(total_amt, CurrencyUnit::Sat),
+                                    total_spent: Amount::new(total_amt_msat, CurrencyUnit::Msat)
+                                        .convert_to(unit)?,
                                 });
                             }
 
@@ -536,7 +536,7 @@ impl MintPayment for Lnd {
                     _ => {
                         let mut lnd_client = self.lnd_client.clone();
 
-                        let max_fee: Option<Amount> = bolt11_options.max_fee_amount;
+                        let max_fee: Option<Amount<CurrencyUnit>> = bolt11_options.max_fee_amount;
 
                         let amount_msat = u64::from(
                             bolt11_options
@@ -546,9 +546,7 @@ impl MintPayment for Lnd {
                         );
 
                         let fee_limit_msat = match max_fee {
-                            Some(fee) => Amount::new(fee.into(), unit.clone())
-                                .convert_to(&CurrencyUnit::Msat)?
-                                .value() as i64,
+                            Some(fee) => fee.convert_to(&CurrencyUnit::Msat)?.value() as i64,
                             None => 0,
                         };
 
@@ -631,9 +629,9 @@ impl MintPayment for Lnd {
                 let amount = bolt11_options.amount;
                 let unix_expiry = bolt11_options.unix_expiry;
 
-                let amount_msat: Amount = Amount::new(amount.into(), unit.clone())
-                    .convert_to(&CurrencyUnit::Msat)?
-                    .into();
+                debug_assert_eq!(amount.unit(), unit, "amount unit must match unit parameter");
+
+                let amount_msat: Amount = amount.convert_to(&CurrencyUnit::Msat)?.into();
 
                 let invoice_request = lnrpc::Invoice {
                     value_msat: u64::from(amount_msat) as i64,

--- a/crates/cdk-payment-processor/src/error.rs
+++ b/crates/cdk-payment-processor/src/error.rs
@@ -18,6 +18,9 @@ pub enum Error {
     /// Invalid currency unit
     #[error("Invalid currency unit: {0}")]
     InvalidCurrencyUnit(String),
+    /// Missing amount field
+    #[error("Missing amount field")]
+    MissingAmount,
     /// Parse invoice error
     #[error(transparent)]
     Invoice(#[from] lightning_invoice::ParseOrSemanticError),
@@ -49,6 +52,7 @@ impl From<Error> for Status {
             Error::InvalidCurrencyUnit(unit) => {
                 Status::invalid_argument(format!("Invalid currency unit: {unit}"))
             }
+            Error::MissingAmount => Status::invalid_argument("Missing amount field"),
             Error::Invoice(err) => Status::invalid_argument(format!("Invoice error: {err}")),
             Error::Hex(err) => Status::invalid_argument(format!("Hex decode error: {err}")),
             Error::Bolt12Parse => Status::invalid_argument("BOLT12 parse error"),
@@ -70,6 +74,7 @@ impl From<Error> for cdk_common::payment::Error {
             Error::InvalidCurrencyUnit(unit) => {
                 Self::Custom(format!("Invalid currency unit: {unit}"))
             }
+            Error::MissingAmount => Self::Custom("Missing amount field".to_string()),
             Error::Invoice(err) => Self::Custom(format!("Invoice error: {err}")),
             Error::Hex(err) => Self::Custom(format!("Hex decode error: {err}")),
             Error::Bolt12Parse => Self::Custom("BOLT12 parse error".to_string()),

--- a/crates/cdk-payment-processor/src/proto/payment_processor.proto
+++ b/crates/cdk-payment-processor/src/proto/payment_processor.proto
@@ -14,6 +14,11 @@ service CdkPaymentProcessor {
 
 message EmptyRequest {}
 
+message AmountMessage {
+  uint64 value = 1;
+  string unit = 2;
+}
+
 message SettingsResponse {
   string unit = 1;
   Bolt11Settings bolt11 = 2;
@@ -34,12 +39,12 @@ message Bolt11Settings {
 
 message Bolt11IncomingPaymentOptions {
   optional string description = 1;
-  uint64 amount = 2;
+  AmountMessage amount = 2;
   optional uint64 unix_expiry = 3;
 }
 message CustomIncomingPaymentOptions {
   optional string description = 1;
-  optional uint64 amount = 2;
+  optional AmountMessage amount = 2;
   optional uint64 unix_expiry = 3;
   // Extra payment-method-specific fields as JSON string
   // These fields are flattened into the JSON representation on the client side
@@ -47,7 +52,7 @@ message CustomIncomingPaymentOptions {
 }
 message Bolt12IncomingPaymentOptions {
   optional string description = 1;
-  optional uint64 amount = 2;
+  optional AmountMessage amount = 2;
   optional uint64 unix_expiry = 3;
 }
 
@@ -144,31 +149,30 @@ enum QuoteState {
 
 message PaymentQuoteResponse {
   PaymentIdentifier request_identifier = 1;
-  uint64 amount = 2;
-  uint64 fee = 3;
+  AmountMessage amount = 2;
+  AmountMessage fee = 3;
   QuoteState state = 4;
-  string unit = 5;
   // Extra payment-method-specific fields as JSON string
   // For custom payment methods, these fields are flattened into the response
-  optional string extra_json = 6;
+  optional string extra_json = 5;
 }
 
 message Bolt11OutgoingPaymentOptions {
   string bolt11 = 1;
-  optional uint64 max_fee_amount = 2;
+  optional AmountMessage max_fee_amount = 2;
   optional uint64 timeout_secs = 3;
   optional MeltOptions melt_options = 4;
 }
 
 message Bolt12OutgoingPaymentOptions {
   string offer = 1;
-  optional uint64 max_fee_amount = 2;
+  optional AmountMessage max_fee_amount = 2;
   optional uint64 timeout_secs = 3;
   optional MeltOptions melt_options = 5;
 }
 message CustomOutgoingPaymentOptions {
   string offer = 1;
-  optional uint64 max_fee_amount = 2;
+  optional AmountMessage max_fee_amount = 2;
   optional uint64 timeout_secs = 3;
   optional MeltOptions melt_options = 5;
   // Extra payment-method-specific fields as JSON string
@@ -193,8 +197,8 @@ message OutgoingPaymentVariant {
 
 message MakePaymentRequest {
   OutgoingPaymentVariant payment_options = 1;
-  optional uint64 partial_amount = 2;
-  optional uint64 max_fee_amount = 3;
+  optional AmountMessage partial_amount = 2;
+  optional AmountMessage max_fee_amount = 3;
   string unit = 4;
 }
 
@@ -202,11 +206,10 @@ message MakePaymentResponse {
   PaymentIdentifier payment_identifier = 1;
   optional string payment_proof = 2;
   QuoteState status = 3;
-  uint64 total_spent = 4;
-  string unit = 5;
+  AmountMessage total_spent = 4;
   // Extra payment-method-specific fields as JSON string
   // For custom payment methods, these fields are flattened into the response
-  optional string extra_json = 6;
+  optional string extra_json = 5;
 }
 
 message CheckIncomingPaymentRequest {
@@ -223,7 +226,6 @@ message CheckOutgoingPaymentRequest {
 
 message WaitIncomingPaymentResponse {
   PaymentIdentifier payment_identifier = 1;
-  uint64 payment_amount = 2;
-  string unit = 3;
-  string payment_id = 4;
+  AmountMessage payment_amount = 2;
+  string payment_id = 3;
 }

--- a/crates/cdk-payment-processor/src/proto/server.rs
+++ b/crates/cdk-payment-processor/src/proto/server.rs
@@ -20,7 +20,7 @@ use tracing::instrument;
 
 use super::cdk_payment_processor_server::{CdkPaymentProcessor, CdkPaymentProcessorServer};
 use crate::error::Error;
-use crate::proto::*;
+use crate::proto::{TryFromProtoAmount, *};
 
 type ResponseStream =
     Pin<Box<dyn Stream<Item = Result<WaitIncomingPaymentResponse, Status>> + Send>>;
@@ -222,29 +222,50 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
             .options
             .ok_or_else(|| Status::invalid_argument("Missing options"))?
         {
-            incoming_payment_options::Options::Custom(opts) => IncomingPaymentOptions::Custom(
-                Box::new(cdk_common::payment::CustomIncomingPaymentOptions {
-                    method: "".to_string(),
-                    description: opts.description,
-                    amount: opts.amount.unwrap_or(0).into(),
-                    unix_expiry: opts.unix_expiry,
-                    extra_json: opts.extra_json,
-                }),
-            ),
+            incoming_payment_options::Options::Custom(opts) => {
+                let amount = opts
+                    .amount
+                    .ok_or_else(|| Status::invalid_argument("Missing amount"))?
+                    .try_into()
+                    .map_err(|_| Status::invalid_argument("Invalid amount"))?;
+                IncomingPaymentOptions::Custom(Box::new(
+                    cdk_common::payment::CustomIncomingPaymentOptions {
+                        method: "".to_string(),
+                        description: opts.description,
+                        amount,
+                        unix_expiry: opts.unix_expiry,
+                        extra_json: opts.extra_json,
+                    },
+                ))
+            }
             incoming_payment_options::Options::Bolt11(opts) => {
+                let amount = opts
+                    .amount
+                    .ok_or_else(|| Status::invalid_argument("Missing amount"))?
+                    .try_into()
+                    .map_err(|_| Status::invalid_argument("Invalid amount"))?;
                 IncomingPaymentOptions::Bolt11(cdk_common::payment::Bolt11IncomingPaymentOptions {
                     description: opts.description,
-                    amount: opts.amount.into(),
+                    amount,
                     unix_expiry: opts.unix_expiry,
                 })
             }
-            incoming_payment_options::Options::Bolt12(opts) => IncomingPaymentOptions::Bolt12(
-                Box::new(cdk_common::payment::Bolt12IncomingPaymentOptions {
-                    description: opts.description,
-                    amount: opts.amount.map(Into::into),
-                    unix_expiry: opts.unix_expiry,
-                }),
-            ),
+            incoming_payment_options::Options::Bolt12(opts) => {
+                let amount: Option<cdk_common::Amount<CurrencyUnit>> = match opts.amount {
+                    Some(a) => Some(
+                        a.try_into()
+                            .map_err(|_| Status::invalid_argument("Invalid amount"))?,
+                    ),
+                    None => None,
+                };
+                IncomingPaymentOptions::Bolt12(Box::new(
+                    cdk_common::payment::Bolt12IncomingPaymentOptions {
+                        description: opts.description,
+                        amount,
+                        unix_expiry: opts.unix_expiry,
+                    },
+                ))
+            }
         };
 
         let invoice_response = self
@@ -344,10 +365,15 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
                 let bolt11: cdk_common::Bolt11Invoice =
                     opts.bolt11.parse().map_err(Error::Invoice)?;
 
+                let max_fee_amount = opts
+                    .max_fee_amount
+                    .try_from_proto()
+                    .map_err(|_| Status::invalid_argument("Invalid max_fee_amount"))?;
+
                 cdk_common::payment::OutgoingPaymentOptions::Bolt11(Box::new(
                     cdk_common::payment::Bolt11OutgoingPaymentOptions {
                         bolt11,
-                        max_fee_amount: opts.max_fee_amount.map(Into::into),
+                        max_fee_amount,
                         timeout_secs: opts.timeout_secs,
                         melt_options: opts.melt_options.map(Into::into),
                     },
@@ -356,21 +382,31 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
             outgoing_payment_variant::Options::Bolt12(opts) => {
                 let offer = Offer::from_str(&opts.offer).map_err(|_| Error::Bolt12Parse)?;
 
+                let max_fee_amount = opts
+                    .max_fee_amount
+                    .try_from_proto()
+                    .map_err(|_| Status::invalid_argument("Invalid max_fee_amount"))?;
+
                 cdk_common::payment::OutgoingPaymentOptions::Bolt12(Box::new(
                     cdk_common::payment::Bolt12OutgoingPaymentOptions {
                         offer,
-                        max_fee_amount: opts.max_fee_amount.map(Into::into),
+                        max_fee_amount,
                         timeout_secs: opts.timeout_secs,
                         melt_options: opts.melt_options.map(Into::into),
                     },
                 ))
             }
             outgoing_payment_variant::Options::Custom(opts) => {
+                let max_fee_amount = opts
+                    .max_fee_amount
+                    .try_from_proto()
+                    .map_err(|_| Status::invalid_argument("Invalid max_fee_amount"))?;
+
                 cdk_common::payment::OutgoingPaymentOptions::Custom(Box::new(
                     cdk_common::payment::CustomOutgoingPaymentOptions {
                         method: String::new(), // Method will be determined from context
                         request: opts.offer,   // Reusing offer field for custom request string
-                        max_fee_amount: opts.max_fee_amount.map(Into::into),
+                        max_fee_amount,
                         timeout_secs: opts.timeout_secs,
                         melt_options: opts.melt_options.map(Into::into),
                         extra_json: opts.extra_json,

--- a/crates/cdk/src/mint/issue/mod.rs
+++ b/crates/cdk/src/mint/issue/mod.rs
@@ -396,7 +396,7 @@ impl Mint {
 
                     let bolt11_options = Bolt11IncomingPaymentOptions {
                         description,
-                        amount: bolt11_request.amount,
+                        amount: bolt11_request.amount.with_unit(unit.clone()),
                         unix_expiry: Some(quote_expiry),
                     };
 
@@ -417,7 +417,7 @@ impl Mint {
 
                     let bolt12_options = Bolt12IncomingPaymentOptions {
                         description,
-                        amount,
+                        amount: amount.map(|a| a.with_unit(unit.clone())),
                         unix_expiry: None,
                     };
 
@@ -458,7 +458,7 @@ impl Mint {
                     let custom_options = CustomIncomingPaymentOptions {
                         method: method.to_string(),
                         description: request.description,
-                        amount: request.amount,
+                        amount: request.amount.with_unit(unit.clone()),
                         unix_expiry: Some(quote_expiry),
                         extra_json,
                     };


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

This add the use of the Amount<CurrencyUnit> to the grpc.
Using this types enforces that unit conversions are correct
and the unit of a given amount is known.

- [x] depends on https://github.com/cashubtc/cdk/pull/1614
### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
