### PR TITLE
feat: add grpc version header to ensure client and server match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,7 @@ dependencies = [
  "serde_with",
  "thiserror 2.0.18",
  "tokio",
+ "tonic 0.14.2",
  "tracing",
  "url",
  "utoipa",

--- a/crates/cdk-common/Cargo.toml
+++ b/crates/cdk-common/Cargo.toml
@@ -20,6 +20,7 @@ mint = ["cashu/mint", "dep:uuid"]
 nostr = ["wallet", "cashu/nostr"]
 prometheus = ["cdk-prometheus/default"]
 http = ["dep:cdk-http-client"]
+grpc = ["dep:tonic"]
 
 [dependencies]
 cdk-http-client = { workspace = true, optional = true }
@@ -44,6 +45,7 @@ serde_with.workspace = true
 web-time.workspace = true
 parking_lot = "0.12.5"
 paste = "1.0.15"
+tonic = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", default-features = false, features = ["rt", "rt-multi-thread", "macros", "test-util", "sync"] }

--- a/crates/cdk-common/src/grpc.rs
+++ b/crates/cdk-common/src/grpc.rs
@@ -1,0 +1,45 @@
+//! gRPC version checking utilities
+
+use tonic::{Request, Status};
+
+/// Header name for protocol version
+pub const VERSION_HEADER: &str = "x-cdk-protocol-version";
+
+/// Creates a client-side interceptor that injects a specific protocol version into outgoing requests
+///
+/// # Panics
+/// Panics if the version string is not a valid gRPC metadata ASCII value
+pub fn create_version_inject_interceptor(
+    version: &'static str,
+) -> impl Fn(Request<()>) -> Result<Request<()>, Status> + Clone {
+    move |mut request: Request<()>| {
+        request.metadata_mut().insert(
+            VERSION_HEADER,
+            version.parse().expect("Invalid protocol version"),
+        );
+        Ok(request)
+    }
+}
+
+/// Creates a server-side interceptor that validates a specific protocol version on incoming requests
+pub fn create_version_check_interceptor(
+    expected_version: &'static str,
+) -> impl Fn(Request<()>) -> Result<Request<()>, Status> + Clone {
+    move |request: Request<()>| match request.metadata().get(VERSION_HEADER) {
+        Some(version) => {
+            let version = version
+                .to_str()
+                .map_err(|_| Status::invalid_argument("Invalid protocol version header"))?;
+            if version != expected_version {
+                return Err(Status::failed_precondition(format!(
+                    "Protocol version mismatch: server={}, client={}",
+                    expected_version, version
+                )));
+            }
+            Ok(request)
+        }
+        None => Err(Status::failed_precondition(
+            "Missing x-cdk-protocol-version header",
+        )),
+    }
+}

--- a/crates/cdk-common/src/lib.rs
+++ b/crates/cdk-common/src/lib.rs
@@ -8,6 +8,18 @@
 
 pub mod task;
 
+/// Protocol version for gRPC Mint RPC communication
+pub const MINT_RPC_PROTOCOL_VERSION: &str = "1.0.0";
+
+/// Protocol version for gRPC Signatory communication
+pub const SIGNATORY_PROTOCOL_VERSION: &str = "1.0.0";
+
+/// Protocol version for gRPC Payment Processor communication
+pub const PAYMENT_PROCESSOR_PROTOCOL_VERSION: &str = "1.0.0";
+
+#[cfg(feature = "grpc")]
+pub mod grpc;
+
 pub mod common;
 pub mod database;
 pub mod error;

--- a/crates/cdk-mint-rpc/Cargo.toml
+++ b/crates/cdk-mint-rpc/Cargo.toml
@@ -23,7 +23,7 @@ anyhow.workspace = true
 cdk = { workspace = true, features = [
     "mint",
 ] }
-cdk-common.workspace = true
+cdk-common = { workspace = true, features = ["grpc"] }
 clap.workspace = true
 tonic = { workspace = true, features = ["transport", "tls-ring", "codegen", "router"] }
 tracing.workspace = true

--- a/crates/cdk-mint-rpc/src/lib.rs
+++ b/crates/cdk-mint-rpc/src/lib.rs
@@ -5,3 +5,6 @@ pub mod proto;
 pub mod mint_rpc_cli;
 
 pub use proto::*;
+
+/// Type alias for the CdkMintClient that works with any tower service
+pub type CdkMintClient<S> = cdk_mint_client::CdkMintClient<S>;

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
@@ -1,3 +1,18 @@
+//! Subcommands for the mint RPC CLI
+
+use cdk_common::grpc::VERSION_HEADER;
+use tonic::metadata::MetadataValue;
+use tonic::Request;
+
+/// Helper function to add version header to a request
+pub fn with_version_header<T>(mut request: Request<T>) -> Request<T> {
+    request.metadata_mut().insert(
+        VERSION_HEADER,
+        MetadataValue::from_static(cdk_common::MINT_RPC_PROTOCOL_VERSION),
+    );
+    request
+}
+
 /// Module for rotating to the next keyset
 mod rotate_next_keyset;
 /// Module for updating mint contact information

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_nut04.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_nut04.rs
@@ -52,14 +52,16 @@ pub async fn update_nut04(
         .map(|description| MintMethodOptions { description });
 
     let _response = client
-        .update_nut04(Request::new(UpdateNut04Request {
-            method: sub_command_args.method.clone(),
-            unit: sub_command_args.unit.clone(),
-            disabled: sub_command_args.disabled,
-            min_amount: sub_command_args.min_amount,
-            max_amount: sub_command_args.max_amount,
-            options,
-        }))
+        .update_nut04(crate::mint_rpc_cli::subcommands::with_version_header(
+            Request::new(UpdateNut04Request {
+                method: sub_command_args.method.clone(),
+                unit: sub_command_args.unit.clone(),
+                disabled: sub_command_args.disabled,
+                min_amount: sub_command_args.min_amount,
+                max_amount: sub_command_args.max_amount,
+                options,
+            }),
+        ))
         .await?;
 
     Ok(())

--- a/crates/cdk-mint-rpc/src/proto/cdk-mint-rpc.proto
+++ b/crates/cdk-mint-rpc/src/proto/cdk-mint-rpc.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package cdk_mint_rpc;
+package cdk_mint_management_v1;
 
 service CdkMint {
     rpc GetInfo(GetInfoRequest) returns (GetInfoResponse) {}

--- a/crates/cdk-mint-rpc/src/proto/mod.rs
+++ b/crates/cdk-mint-rpc/src/proto/mod.rs
@@ -1,7 +1,9 @@
 //! CDK mint proto types
 
-tonic::include_proto!("cdk_mint_rpc");
+tonic::include_proto!("cdk_mint_management_v1");
 
 mod server;
 
+/// Protocol version for gRPC Mint RPC communication
+pub use cdk_common::MINT_RPC_PROTOCOL_VERSION as PROTOCOL_VERSION;
 pub use server::MintRPCServer;

--- a/crates/cdk-payment-processor/Cargo.toml
+++ b/crates/cdk-payment-processor/Cargo.toml
@@ -26,7 +26,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bitcoin.workspace = true
 cashu.workspace = true
-cdk-common = { workspace = true, features = ["mint"] }
+cdk-common = { workspace = true, features = ["mint", "grpc"] }
 cdk-cln = { workspace = true, optional = true }
 cdk-lnd = { workspace = true, optional = true }
 cdk-fake-wallet = { workspace = true, optional = true }

--- a/crates/cdk-signatory/Cargo.toml
+++ b/crates/cdk-signatory/Cargo.toml
@@ -20,6 +20,7 @@ async-trait.workspace = true
 bitcoin.workspace = true
 cdk-common = { workspace = true, default-features = false, features = [
     "mint",
+    "grpc",
 ] }
 tonic = { workspace = true, optional = true, features = ["transport", "tls-ring", "codegen", "router"] }
 tonic-prost = { workspace = true, optional = true }

--- a/crates/cdk-signatory/src/proto/server.rs
+++ b/crates/cdk-signatory/src/proto/server.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
 
+use cdk_common::grpc::create_version_check_interceptor;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_stream::Stream;
 use tonic::metadata::MetadataMap;
@@ -267,8 +268,9 @@ where
     };
 
     server
-        .add_service(signatory_server::SignatoryServer::new(
+        .add_service(signatory_server::SignatoryServer::with_interceptor(
             CdkSignatoryServer::new(signatory_loader),
+            create_version_check_interceptor(cdk_common::SIGNATORY_PROTOCOL_VERSION),
         ))
         .serve(addr)
         .await?;
@@ -288,8 +290,9 @@ where
     IE: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     Server::builder()
-        .add_service(signatory_server::SignatoryServer::new(
+        .add_service(signatory_server::SignatoryServer::with_interceptor(
             CdkSignatoryServer::new(signatory_loader),
+            create_version_check_interceptor(cdk_common::SIGNATORY_PROTOCOL_VERSION),
         ))
         .serve_with_incoming(incoming)
         .await?;


### PR DESCRIPTION
This change adds a gprc injector that adds a version header to each grpc request. This is then checked by the server to make sure the client and server are compatible versions. When the grpc proto file is changed we **MUST** update the version used in the header.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

closes: https://github.com/cashubtc/cdk/issues/1547

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
