### PR TITLE
feat: replace async header with prefer in body

### DIFF
--- a/crates/cashu/src/nuts/nut05.rs
+++ b/crates/cashu/src/nuts/nut05.rs
@@ -92,6 +92,10 @@ pub struct MeltRequest<Q> {
     /// Blinded Message that can be used to return change [NUT-08]
     /// Amount field of BlindedMessages `SHOULD` be set to zero
     outputs: Option<Vec<BlindedMessage>>,
+    /// Whether the client prefers asynchronous processing
+    #[serde(default)]
+    #[cfg_attr(feature = "swagger", schema(value_type = bool))]
+    prefer_async: bool,
 }
 
 #[cfg(feature = "mint")]
@@ -103,6 +107,7 @@ impl TryFrom<MeltRequest<String>> for MeltRequest<QuoteId> {
             quote: QuoteId::from_str(&value.quote).map_err(|_e| Error::InvalidQuote)?,
             inputs: value.inputs,
             outputs: value.outputs,
+            prefer_async: value.prefer_async,
         })
     }
 }
@@ -140,7 +145,19 @@ where
             quote,
             inputs: inputs.without_dleqs(),
             outputs,
+            prefer_async: false,
         }
+    }
+
+    /// Set the prefer_async flag for asynchronous processing
+    pub fn prefer_async(mut self, prefer_async: bool) -> Self {
+        self.prefer_async = prefer_async;
+        self
+    }
+
+    /// Get the prefer_async flag
+    pub fn is_prefer_async(&self) -> bool {
+        self.prefer_async
     }
 
     /// Get quote

--- a/crates/cdk-axum/src/custom_handlers.rs
+++ b/crates/cdk-axum/src/custom_handlers.rs
@@ -338,7 +338,10 @@ pub async fn post_melt_custom(
         .await
         .map_err(into_response)?;
 
-    let res = if prefer.respond_async {
+    // Check for async preference in either the Prefer header or the request body
+    let respond_async = prefer.respond_async || payload.is_prefer_async();
+
+    let res = if respond_async {
         // Asynchronous processing - return immediately after setup
         state
             .mint

--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -139,11 +139,10 @@ impl MintConnector for DirectMintConnection {
             .map(Into::into)
     }
 
-    async fn post_melt_with_options(
+    async fn post_melt(
         &self,
         _method: &PaymentMethod,
         request: MeltRequest<String>,
-        _options: cdk::wallet::MeltOptions,
     ) -> Result<MeltQuoteBolt11Response<String>, Error> {
         let request_uuid = request.try_into().unwrap();
         self.mint.melt(&request_uuid).await.map(Into::into)

--- a/crates/cdk/examples/mint-token-bolt12-with-custom-http.rs
+++ b/crates/cdk/examples/mint-token-bolt12-with-custom-http.rs
@@ -56,22 +56,12 @@ impl HttpTransport for CustomHttp {
         panic!("Not supported");
     }
 
-    async fn http_get_with_headers<R>(
-        &self,
-        url: Url,
-        _auth: Option<AuthToken>,
-        custom_headers: &[(&str, &str)],
-    ) -> Result<R, Error>
+    async fn http_get<R>(&self, url: Url, _auth: Option<AuthToken>) -> Result<R, Error>
     where
         R: DeserializeOwned,
     {
-        let mut request = self.agent.get(url.as_str());
-
-        for (key, value) in custom_headers {
-            request = request.header(*key, *value);
-        }
-
-        request
+        self.agent
+            .get(url.as_str())
             .call()
             .map_err(|e| Error::HttpError(None, e.to_string()))?
             .body_mut()
@@ -79,25 +69,18 @@ impl HttpTransport for CustomHttp {
             .map_err(|e| Error::HttpError(None, e.to_string()))
     }
 
-    /// HTTP Post request
-    async fn http_post_with_headers<P, R>(
+    async fn http_post<P, R>(
         &self,
         url: Url,
         _auth_token: Option<AuthToken>,
-        custom_headers: &[(&str, &str)],
         payload: &P,
     ) -> Result<R, Error>
     where
         P: Serialize + ?Sized + Send + Sync,
         R: DeserializeOwned,
     {
-        let mut request = self.agent.post(url.as_str());
-
-        for (key, value) in custom_headers {
-            request = request.header(*key, *value);
-        }
-
-        request
+        self.agent
+            .post(url.as_str())
             .send_json(payload)
             .map_err(|e| Error::HttpError(None, e.to_string()))?
             .body_mut()

--- a/crates/cdk/src/wallet/melt/saga/mod.rs
+++ b/crates/cdk/src/wallet/melt/saga/mod.rs
@@ -50,7 +50,6 @@ use super::MeltConfirmOptions;
 use crate::nuts::nut00::ProofsMethods;
 use crate::nuts::{MeltRequest, PreMintSecrets, Proofs, State};
 use crate::util::unix_time;
-use crate::wallet::mint_connector::MeltOptions;
 use crate::wallet::saga::{add_compensation, new_compensations, Compensations};
 use crate::{ensure_cdk, Amount, Error, Wallet};
 
@@ -872,16 +871,13 @@ impl<'a> MeltSaga<'a, MeltRequested> {
             quote_info.id.clone(),
             self.state_data.final_proofs.clone(),
             Some(self.state_data.premint_secrets.blinded_messages()),
-        );
+        )
+        .prefer_async(true);
 
         let melt_result = self
             .wallet
             .client
-            .post_melt_with_options(
-                &quote_info.payment_method,
-                request,
-                MeltOptions { async_melt: true },
-            )
+            .post_melt(&quote_info.payment_method, request)
             .await;
 
         let melt_response = match melt_result {

--- a/crates/cdk/src/wallet/mint_connector/mod.rs
+++ b/crates/cdk/src/wallet/mint_connector/mod.rs
@@ -22,13 +22,6 @@ use crate::wallet::AuthWallet;
 pub mod http_client;
 pub mod transport;
 
-/// Melt Options
-#[derive(Debug, Clone, Default)]
-pub struct MeltOptions {
-    /// Prefer respond-async
-    pub async_melt: bool,
-}
-
 /// Auth HTTP Client with async transport
 pub type AuthHttpClient = http_client::AuthHttpClient<transport::Async>;
 /// Default Http Client with async transport (non-Tor)
@@ -98,17 +91,6 @@ pub trait MintConnector: Debug {
         &self,
         method: &PaymentMethod,
         request: MeltRequest<String>,
-    ) -> Result<MeltQuoteBolt11Response<String>, Error> {
-        self.post_melt_with_options(method, request, MeltOptions::default())
-            .await
-    }
-
-    /// Melt [NUT-05] with options (e.g. async)
-    async fn post_melt_with_options(
-        &self,
-        method: &PaymentMethod,
-        request: MeltRequest<String>,
-        options: MeltOptions,
     ) -> Result<MeltQuoteBolt11Response<String>, Error>;
 
     /// Split Token [NUT-06]

--- a/crates/cdk/src/wallet/mint_connector/transport.rs
+++ b/crates/cdk/src/wallet/mint_connector/transport.rs
@@ -38,19 +38,6 @@ pub trait Transport: Default + Send + Sync + Debug + Clone {
         auth: Option<cdk_common::AuthToken>,
     ) -> Result<R, super::Error>
     where
-        R: serde::de::DeserializeOwned,
-    {
-        self.http_get_with_headers(url, auth, &[]).await
-    }
-
-    /// HTTP Get request with custom headers
-    async fn http_get_with_headers<R>(
-        &self,
-        url: url::Url,
-        auth: Option<cdk_common::AuthToken>,
-        custom_headers: &[(&str, &str)],
-    ) -> Result<R, super::Error>
-    where
         R: serde::de::DeserializeOwned;
 
     /// HTTP Post request
@@ -58,22 +45,6 @@ pub trait Transport: Default + Send + Sync + Debug + Clone {
         &self,
         url: url::Url,
         auth_token: Option<cdk_common::AuthToken>,
-        payload: &P,
-    ) -> Result<R, super::Error>
-    where
-        P: serde::Serialize + ?Sized + Send + Sync,
-        R: serde::de::DeserializeOwned,
-    {
-        self.http_post_with_headers(url, auth_token, &[], payload)
-            .await
-    }
-
-    /// HTTP Post request with custom headers
-    async fn http_post_with_headers<P, R>(
-        &self,
-        url: url::Url,
-        auth_token: Option<cdk_common::AuthToken>,
-        custom_headers: &[(&str, &str)],
         payload: &P,
     ) -> Result<R, super::Error>
     where
@@ -164,12 +135,7 @@ impl Transport for Async {
             .collect::<Vec<_>>())
     }
 
-    async fn http_get_with_headers<R>(
-        &self,
-        url: Url,
-        auth: Option<AuthToken>,
-        custom_headers: &[(&str, &str)],
-    ) -> Result<R, Error>
+    async fn http_get<R>(&self, url: Url, auth: Option<AuthToken>) -> Result<R, Error>
     where
         R: DeserializeOwned,
     {
@@ -178,10 +144,6 @@ impl Transport for Async {
 
         if let Some(auth) = auth {
             request = request.header(auth.header_key(), auth.to_string());
-        }
-
-        for (key, value) in custom_headers {
-            request = request.header(*key, *value);
         }
 
         let response = request
@@ -201,11 +163,10 @@ impl Transport for Async {
         })
     }
 
-    async fn http_post_with_headers<P, R>(
+    async fn http_post<P, R>(
         &self,
         url: Url,
         auth_token: Option<AuthToken>,
-        custom_headers: &[(&str, &str)],
         payload: &P,
     ) -> Result<R, Error>
     where
@@ -217,10 +178,6 @@ impl Transport for Async {
 
         if let Some(auth) = auth_token {
             request = request.header(auth.header_key(), auth.to_string());
-        }
-
-        for (key, value) in custom_headers {
-            request = request.header(*key, *value);
         }
 
         let response = request

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -71,8 +71,7 @@ pub use cdk_common::wallet as types;
 pub use melt::{MeltConfirmOptions, MeltOutcome, PendingMelt, PreparedMelt};
 pub use mint_connector::transport::Transport as HttpTransport;
 pub use mint_connector::{
-    AuthHttpClient, HttpClient, LnurlPayInvoiceResponse, LnurlPayResponse, MeltOptions,
-    MintConnector,
+    AuthHttpClient, HttpClient, LnurlPayInvoiceResponse, LnurlPayResponse, MintConnector,
 };
 pub use multi_mint_wallet::{MultiMintReceiveOptions, MultiMintSendOptions, MultiMintWallet};
 #[cfg(feature = "nostr")]

--- a/crates/cdk/src/wallet/test_utils.rs
+++ b/crates/cdk/src/wallet/test_utils.rs
@@ -349,11 +349,10 @@ impl MintConnector for MockMintConnector {
         unimplemented!()
     }
 
-    async fn post_melt_with_options(
+    async fn post_melt(
         &self,
         _method: &PaymentMethod,
         _request: MeltRequest<String>,
-        _options: crate::wallet::MeltOptions,
     ) -> Result<MeltQuoteBolt11Response<String>, Error> {
         unimplemented!()
     }


### PR DESCRIPTION
User the async header caused issues with cors.
To fix this we are changing it so the prefer is in the body. To support both for now the mint will accept either the header or the body.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
