### PR TITLE
Replace std::time::SystemTime with web_time::SystemTime for WASM compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,6 +1351,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "uuid",
+ "web-time",
 ]
 
 [[package]]
@@ -1462,6 +1463,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "urlencoding",
+ "web-time",
 ]
 
 [[package]]
@@ -1589,6 +1591,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "web-time",
 ]
 
 [[package]]

--- a/crates/cdk-common/src/database/mint/test/mod.rs
+++ b/crates/cdk-common/src/database/mint/test/mod.rs
@@ -5,11 +5,11 @@
 #![allow(clippy::unwrap_used, clippy::missing_panics_doc)]
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 // For derivation path parsing
 use bitcoin::bip32::DerivationPath;
 use cashu::CurrencyUnit;
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use super::*;
 use crate::common::IssuerVersion;

--- a/crates/cdk-common/src/database/wallet/test/mod.rs
+++ b/crates/cdk-common/src/database/wallet/test/mod.rs
@@ -8,11 +8,11 @@
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use cashu::nut00::KnownMethod;
 use cashu::secret::Secret;
 use cashu::{Amount, CurrencyUnit, MeltQuoteState, MintQuoteState, SecretKey};
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use super::*;
 use crate::mint_url::MintUrl;

--- a/crates/cdk-common/src/wallet/saga/mod.rs
+++ b/crates/cdk-common/src/wallet/saga/mod.rs
@@ -204,8 +204,8 @@ impl WalletSaga {
         unit: CurrencyUnit,
         data: OperationData,
     ) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
+        let now = web_time::SystemTime::now()
+            .duration_since(web_time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
 
@@ -238,8 +238,8 @@ impl WalletSaga {
     pub fn update_state(&mut self, state: WalletSagaState) {
         self.state = state;
         self.kind = state.kind();
-        self.updated_at = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
+        self.updated_at = web_time::SystemTime::now()
+            .duration_since(web_time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
         self.version += 1;

--- a/crates/cdk-fake-wallet/Cargo.toml
+++ b/crates/cdk-fake-wallet/Cargo.toml
@@ -25,6 +25,7 @@ lightning-invoice.workspace = true
 lightning.workspace = true
 tokio-stream.workspace = true
 uuid.workspace = true
+web-time.workspace = true
 
 [lints]
 workspace = true

--- a/crates/cdk-fake-wallet/src/lib.rs
+++ b/crates/cdk-fake-wallet/src/lib.rs
@@ -285,8 +285,8 @@ impl SecondaryRepaymentQueue {
                     use bitcoin::hashes::{sha256, Hash};
                     let mut random_bytes = [0u8; 16];
                     rng.fill(&mut random_bytes);
-                    let timestamp = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
+                    let timestamp = web_time::SystemTime::now()
+                        .duration_since(web_time::UNIX_EPOCH)
                         .expect("System time before UNIX_EPOCH")
                         .as_nanos() as u64;
 

--- a/crates/cdk-ldk-node/Cargo.toml
+++ b/crates/cdk-ldk-node/Cargo.toml
@@ -30,6 +30,7 @@ rust-embed = "8.5.0"
 serde_urlencoded = "0.7"
 urlencoding = "2.1"
 bip39.workspace = true
+web-time.workspace = true
 
 [lints]
 workspace = true

--- a/crates/cdk-ldk-node/src/web/handlers/dashboard.rs
+++ b/crates/cdk-ldk-node/src/web/handlers/dashboard.rs
@@ -21,7 +21,7 @@ pub struct UsageMetrics {
 
 /// Calculate usage metrics from payment history
 fn calculate_usage_metrics(payments: &[ldk_node::payment::PaymentDetails]) -> UsageMetrics {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use web_time::{SystemTime, UNIX_EPOCH};
 
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/crates/cdk-ldk-node/src/web/handlers/invoices.rs
+++ b/crates/cdk-ldk-node/src/web/handlers/invoices.rs
@@ -198,8 +198,8 @@ pub async fn post_create_bolt11(
                 "Web interface: Successfully created BOLT11 invoice with payment_hash={}",
                 invoice.payment_hash()
             );
-            let current_time = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
+            let current_time = web_time::SystemTime::now()
+                .duration_since(web_time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
 
@@ -280,8 +280,8 @@ pub async fn post_create_bolt12(
                 "Web interface: Successfully created BOLT12 offer with offer_id={}",
                 offer.id()
             );
-            let current_time = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
+            let current_time = web_time::SystemTime::now()
+                .duration_since(web_time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
 

--- a/crates/cdk-ldk-node/src/web/templates/formatters.rs
+++ b/crates/cdk-ldk-node/src/web/templates/formatters.rs
@@ -47,7 +47,7 @@ pub fn format_msats_as_btc(msats: u64) -> String {
 
 /// Format a Unix timestamp as a human-readable date and time
 pub fn format_timestamp(timestamp: u64) -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use web_time::{SystemTime, UNIX_EPOCH};
 
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -120,7 +120,7 @@ mod tests {
 
     #[test]
     fn test_format_timestamp() {
-        use std::time::{SystemTime, UNIX_EPOCH};
+        use web_time::{SystemTime, UNIX_EPOCH};
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/cdk-npubcash/Cargo.toml
+++ b/crates/cdk-npubcash/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 url = { workspace = true }
+web-time.workspace = true
 
 # Additional dependencies not in workspace
 base64 = "0.22"

--- a/crates/cdk-npubcash/examples/basic_usage.rs
+++ b/crates/cdk-npubcash/examples/basic_usage.rs
@@ -47,8 +47,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let one_hour_ago = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)?
+    let one_hour_ago = web_time::SystemTime::now()
+        .duration_since(web_time::UNIX_EPOCH)?
         .as_secs()
         - 3600;
 

--- a/crates/cdk-npubcash/examples/create_and_wait_payment.rs
+++ b/crates/cdk-npubcash/examples/create_and_wait_payment.rs
@@ -104,8 +104,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::debug!("Starting quote polling with 5 second interval");
 
     // Get initial timestamp for polling
-    let mut last_timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)?
+    let mut last_timestamp = web_time::SystemTime::now()
+        .duration_since(web_time::UNIX_EPOCH)?
         .as_secs();
 
     // Poll for quotes and handle Ctrl+C

--- a/crates/cdk-npubcash/src/auth.rs
+++ b/crates/cdk-npubcash/src/auth.rs
@@ -3,11 +3,12 @@
 //! Implements NIP-98 and JWT authentication
 
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use base64::Engine;
 use nostr_sdk::{EventBuilder, Keys, Kind, Tag};
 use tokio::sync::RwLock;
+use web_time::SystemTime;
 
 use crate::types::Nip98Response;
 use crate::{Error, Result};

--- a/crates/cdk/examples/multimint-npubcash.rs
+++ b/crates/cdk/examples/multimint-npubcash.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let seed: [u8; 64] = {
         let mut s = [0u8; 64];
-        use std::time::{SystemTime, UNIX_EPOCH};
+        use web_time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()

--- a/crates/cdk/src/mint/melt/melt_saga/tests.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/tests.rs
@@ -1311,8 +1311,8 @@ async fn test_saga_content_validation() {
     }
 
     // STEP 8: Verify timestamps are set and reasonable
-    let current_timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
+    let current_timestamp = web_time::SystemTime::now()
+        .duration_since(web_time::UNIX_EPOCH)
         .unwrap()
         .as_secs();
 


### PR DESCRIPTION
### Description

`std::time::SystemTime::now()` panics on WASM targets. The web-time crate is a drop-in replacement that re-exports std::time on native and uses JS timing APIs on WASM.

This PR is a mainstream fix for issues found in #1660 and a following up PR that creates a WASM build off the FFI crate.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
