### PR TITLE
fix: remove deprecated promises field from RestoreResponse

### DIFF
--- a/crates/cashu/src/nuts/nut09.rs
+++ b/crates/cashu/src/nuts/nut09.rs
@@ -22,9 +22,6 @@ pub struct RestoreResponse {
     pub outputs: Vec<BlindedMessage>,
     /// Signatures
     pub signatures: Vec<BlindSignature>,
-    /// Promises
-    // Temp compatibility with cashu-ts
-    pub promises: Option<Vec<BlindSignature>>,
 }
 
 mod test {

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1015,8 +1015,7 @@ impl Mint {
 
             Ok(RestoreResponse {
                 outputs,
-                signatures: signatures.clone(),
-                promises: Some(signatures),
+                signatures,
             })
         }
         .await;

--- a/crates/cdk/src/wallet/issue/saga/resume.rs
+++ b/crates/cdk/src/wallet/issue/saga/resume.rs
@@ -519,7 +519,6 @@ mod tests {
         mock_client._set_restore_response(Ok(RestoreResponse {
             signatures: vec![],
             outputs: vec![],
-            promises: None,
         }));
 
         let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;

--- a/crates/cdk/src/wallet/receive/saga/resume.rs
+++ b/crates/cdk/src/wallet/receive/saga/resume.rs
@@ -368,7 +368,6 @@ mod tests {
         mock_client._set_restore_response(Ok(RestoreResponse {
             signatures: vec![],
             outputs: vec![],
-            promises: None,
         }));
 
         let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;


### PR DESCRIPTION
### Description

 Remove the deprecated promises field from RestoreResponse (NUT-09).           
                  
This field was a temporary compatibility shim for old cashu-ts clients (< v2.3.0, March 2025). It has been over a year since that was fixed upstream, and after discussion in #1644, it was confirmed safe to remove.

-----

### Notes to the reviewers

Straightforward removal the promises field was always a duplicate of signatures. The .clone() in mint/mod.rs was also removed since it was only needed because signatures was reused for promises.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

#### ADDED

#### REMOVED

- Removed deprecated promises field from RestoreResponse in NUT-09

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
