### PR TITLE
fix: replace Option<Vec<T>> with Vec<T> in NUT-18 payment requests

### DIFF
--- a/crates/cashu/examples/payment_request_encoding_benchmark.rs
+++ b/crates/cashu/examples/payment_request_encoding_benchmark.rs
@@ -93,7 +93,7 @@ fn minimal_comparison() -> Result<(), Box<dyn std::error::Error>> {
         amount: None,
         unit: None,
         single_use: None,
-        mints: Some(vec![MintUrl::from_str("https://mint.example.com")?]),
+        mints: vec![MintUrl::from_str("https://mint.example.com")?],
         description: None,
         transports: vec![],
         nut10: None,
@@ -109,7 +109,7 @@ fn amount_unit_comparison() -> Result<(), Box<dyn std::error::Error>> {
         amount: Some(Amount::from(2100)),
         unit: Some(CurrencyUnit::Sat),
         single_use: None,
-        mints: Some(vec![MintUrl::from_str("https://mint.example.com")?]),
+        mints: vec![MintUrl::from_str("https://mint.example.com")?],
         description: None,
         transports: vec![],
         nut10: None,
@@ -125,12 +125,12 @@ fn multiple_mints_comparison() -> Result<(), Box<dyn std::error::Error>> {
         amount: Some(Amount::from(10000)),
         unit: Some(CurrencyUnit::Sat),
         single_use: Some(true),
-        mints: Some(vec![
+        mints: vec![
             MintUrl::from_str("https://mint1.example.com")?,
             MintUrl::from_str("https://mint2.example.com")?,
             MintUrl::from_str("https://mint3.example.com")?,
             MintUrl::from_str("https://backup-mint.cashu.space")?,
-        ]),
+        ],
         description: Some("Payment with multiple mint options".to_string()),
         transports: vec![],
         nut10: None,
@@ -144,10 +144,10 @@ fn transport_comparison() -> Result<(), Box<dyn std::error::Error>> {
     let transport = Transport {
         _type: TransportType::HttpPost,
         target: "https://api.example.com/cashu/payment/callback".to_string(),
-        tags: Some(vec![
+        tags: vec![
             vec!["method".to_string(), "POST".to_string()],
             vec!["auth".to_string(), "bearer".to_string()],
-        ]),
+        ],
     };
 
     let payment_request = PaymentRequest {
@@ -155,7 +155,7 @@ fn transport_comparison() -> Result<(), Box<dyn std::error::Error>> {
         amount: Some(Amount::from(5000)),
         unit: Some(CurrencyUnit::Sat),
         single_use: Some(true),
-        mints: Some(vec![MintUrl::from_str("https://mint.example.com")?]),
+        mints: vec![MintUrl::from_str("https://mint.example.com")?],
         description: Some("Payment with callback transport".to_string()),
         transports: vec![transport],
         nut10: None,
@@ -181,7 +181,7 @@ fn complete_with_nut10_comparison() -> Result<(), Box<dyn std::error::Error>> {
     let transport = Transport {
         _type: TransportType::HttpPost,
         target: "https://callback.example.com/payment".to_string(),
-        tags: Some(vec![vec!["priority".to_string(), "high".to_string()]]),
+        tags: vec![vec!["priority".to_string(), "high".to_string()]],
     };
 
     let payment_request = PaymentRequest {
@@ -189,10 +189,10 @@ fn complete_with_nut10_comparison() -> Result<(), Box<dyn std::error::Error>> {
         amount: Some(Amount::from(5000)),
         unit: Some(CurrencyUnit::Sat),
         single_use: Some(true),
-        mints: Some(vec![
+        mints: vec![
             MintUrl::from_str("https://mint1.example.com")?,
             MintUrl::from_str("https://mint2.example.com")?,
-        ]),
+        ],
         description: Some("Complete payment with P2PK locking and refund key".to_string()),
         transports: vec![transport],
         nut10: Some(nut10),
@@ -218,19 +218,19 @@ fn very_complex_comparison() -> Result<(), Box<dyn std::error::Error>> {
     let transport1 = Transport {
         _type: TransportType::HttpPost,
         target: "https://primary-callback.example.com/payment/webhook".to_string(),
-        tags: Some(vec![
+        tags: vec![
             vec!["priority".to_string(), "high".to_string()],
             vec!["timeout".to_string(), "30".to_string()],
-        ]),
+        ],
     };
 
     let transport2 = Transport {
         _type: TransportType::HttpPost,
         target: "https://backup-callback.example.com/payment/webhook".to_string(),
-        tags: Some(vec![
+        tags: vec![
             vec!["priority".to_string(), "medium".to_string()],
             vec!["timeout".to_string(), "60".to_string()],
-        ]),
+        ],
     };
 
     let payment_request = PaymentRequest {
@@ -238,13 +238,13 @@ fn very_complex_comparison() -> Result<(), Box<dyn std::error::Error>> {
         amount: Some(Amount::from(21000)),
         unit: Some(CurrencyUnit::Sat),
         single_use: Some(true),
-        mints: Some(vec![
+        mints: vec![
             MintUrl::from_str("https://primary-mint.cashu.space")?,
             MintUrl::from_str("https://secondary-mint.example.com")?,
             MintUrl::from_str("https://backup-mint-1.example.org")?,
             MintUrl::from_str("https://backup-mint-2.example.net")?,
             MintUrl::from_str("https://emergency-mint.example.io")?,
-        ]),
+        ],
         description: Some("Complex payment with multiple mints and transports".to_string()),
         transports: vec![transport1, transport2],
         nut10: Some(nut10),
@@ -273,10 +273,7 @@ fn compare_formats(
     println!("  {} Payment Request:", label);
     println!("  Payment ID: {:?}", payment_request.payment_id);
     println!("  Amount: {:?}", payment_request.amount);
-    println!(
-        "  Mints: {}",
-        payment_request.mints.as_ref().map_or(0, |m| m.len())
-    );
+    println!("  Mints: {}", payment_request.mints.len());
     println!("  Transports: {}", payment_request.transports.len());
     println!("  NUT-10: {}", payment_request.nut10.is_some());
 

--- a/crates/cashu/src/nuts/nut18/transport.rs
+++ b/crates/cashu/src/nuts/nut18/transport.rs
@@ -51,7 +51,8 @@ pub struct Transport {
     pub target: String,
     /// Tags
     #[serde(rename = "g")]
-    pub tags: Option<Vec<Vec<String>>>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub tags: Vec<Vec<String>>,
 }
 
 impl Transport {
@@ -78,7 +79,7 @@ impl FromStr for Transport {
 pub struct TransportBuilder {
     _type: Option<TransportType>,
     target: Option<String>,
-    tags: Option<Vec<Vec<String>>>,
+    tags: Vec<Vec<String>>,
 }
 
 impl TransportBuilder {
@@ -96,13 +97,13 @@ impl TransportBuilder {
 
     /// Add a tag
     pub fn add_tag(mut self, tag: Vec<String>) -> Self {
-        self.tags.get_or_insert_with(Vec::new).push(tag);
+        self.tags.push(tag);
         self
     }
 
     /// Set tags
     pub fn tags(mut self, tags: Vec<Vec<String>>) -> Self {
-        self.tags = Some(tags);
+        self.tags = tags;
         self
     }
 

--- a/crates/cdk-cli/src/sub_commands/pay_request.rs
+++ b/crates/cdk-cli/src/sub_commands/pay_request.rs
@@ -51,10 +51,8 @@ pub async fn pay_request(
     for wallet in wallet_mints.iter() {
         let balance = wallet.total_balance().await?;
 
-        if let Some(request_mints) = request_mints {
-            if !request_mints.contains(&wallet.mint_url) {
-                continue;
-            }
+        if !request_mints.is_empty() && !request_mints.contains(&wallet.mint_url) {
+            continue;
         }
 
         if let Some(unit) = unit {

--- a/crates/cdk-ffi/src/types/payment_request.rs
+++ b/crates/cdk-ffi/src/types/payment_request.rs
@@ -43,8 +43,8 @@ pub struct Transport {
     pub transport_type: TransportType,
     /// Target (e.g., nprofile for Nostr, URL for HTTP)
     pub target: String,
-    /// Optional tags
-    pub tags: Option<Vec<Vec<String>>>,
+    /// Tags
+    pub tags: Vec<Vec<String>>,
 }
 
 impl From<cdk::nuts::Transport> for Transport {
@@ -119,11 +119,8 @@ impl PaymentRequest {
     }
 
     /// Get the list of acceptable mint URLs
-    pub fn mints(&self) -> Option<Vec<String>> {
-        self.inner
-            .mints
-            .as_ref()
-            .map(|mints| mints.iter().map(|m| m.to_string()).collect())
+    pub fn mints(&self) -> Vec<String> {
+        self.inner.mints.iter().map(|m| m.to_string()).collect()
     }
 
     /// Get the description
@@ -395,7 +392,7 @@ mod tests {
         assert_eq!(req.amount().unwrap().value, 10);
         assert!(matches!(req.unit().unwrap(), CurrencyUnit::Sat));
 
-        let mints = req.mints().unwrap();
+        let mints = req.mints();
         assert_eq!(mints.len(), 1);
         assert_eq!(mints[0], "https://nofees.testnut.cashu.space");
 
@@ -422,7 +419,7 @@ mod tests {
         let ffi_transport = Transport {
             transport_type: TransportType::Nostr,
             target: "nprofile1...".to_string(),
-            tags: Some(vec![vec!["n".to_string(), "17".to_string()]]),
+            tags: vec![vec!["n".to_string(), "17".to_string()]],
         };
 
         let cdk_transport: cdk::nuts::Transport = ffi_transport.clone().into();


### PR DESCRIPTION
### Description
  
Replace `Option<Vec<T>>` with `Vec<T>` for `PaymentRequest.mints` and `Transport.tags` in NUT-18 where `None` and an empty `Vec` are semantically equivalent. Added `#[serde(skip_serializing_if = "Vec::is_empty", default)]` attributes to maintain backward-compatible serialization.

Closes #1645

-----

### Notes to the reviewers

- `Nut10SecretRequest.tags` was intentionally NOT changed because it has `From` impls with `nut10::SecretData` which also uses `Option<Vec<Vec<String>>>` changing one without the other would break conversions and goes beyond the scope of this issue.
- There is a pre-existing test compilation error in `encoding.rs` (~line 2163) where `nut10.tags.len()` is called on `Option` this exists on `main` and is unrelated to this PR.
- The wallet logic in `pay_payment_request` was updated so that an empty `mints` vec means "any mint is accepted"(previously `None` had that meaning).

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

- NUT-18: `PaymentRequest.mints` changed from `Option<Vec<MintUrl>>` to `Vec<MintUrl>`
- NUT-18: `Transport.tags` changed from `Option<Vec<Vec<String>>>` to `Vec<Vec<String>>`
- FFI: `PaymentRequest.mints()` now returns `Vec<String>` instead of `Option<Vec<String>>`
- FFI: `Transport.tags` changed from `Option<Vec<Vec<String>>>` to `Vec<Vec<String>>`

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
