### PR TITLE
fix: pass currency unit through proto instead of hardcoding Msat in MakePayment

### DIFF
--- a/crates/cdk-payment-processor/src/proto/client.rs
+++ b/crates/cdk-payment-processor/src/proto/client.rs
@@ -248,7 +248,7 @@ impl MintPayment for PaymentProcessorClient {
 
     async fn make_payment(
         &self,
-        _unit: &cdk_common::CurrencyUnit,
+        unit: &cdk_common::CurrencyUnit,
         options: cdk_common::payment::OutgoingPaymentOptions,
     ) -> Result<CdkMakePaymentResponse, Self::Err> {
         let mut inner = self.inner.clone();
@@ -297,6 +297,7 @@ impl MintPayment for PaymentProcessorClient {
                 payment_options: Some(payment_options),
                 partial_amount: None,
                 max_fee_amount: None,
+                unit: unit.to_string(),
             })))
             .await
             .map_err(|err| {

--- a/crates/cdk-payment-processor/src/proto/payment_processor.proto
+++ b/crates/cdk-payment-processor/src/proto/payment_processor.proto
@@ -195,6 +195,7 @@ message MakePaymentRequest {
   OutgoingPaymentVariant payment_options = 1;
   optional uint64 partial_amount = 2;
   optional uint64 max_fee_amount = 3;
+  string unit = 4;
 }
 
 message MakePaymentResponse {


### PR DESCRIPTION
### Description

Pass currency unit through proto instead of hardcoding CurrencyUnit::Msat in  MakePayment.
                                                                                
The server-side make_payment handler was hardcoding CurrencyUnit::Msat for all three outgoing payment variants (Bolt11, Bolt12, Custom). This prevents mints  using non-msat units from working correctly for outgoing payments.

The fix adds a string unit field to MakePaymentRequest and wires it through client and server, matching the pattern already used by CreatePayment and GetPaymentQuote.

-----

### Notes to the reviewers

The incoming payment path (create_payment) already handled this correctly  the client sends the unit as a string and the server parses it with CurrencyUnit::from_str(). This PR replicates that same pattern for the outgoing path (make_payment).

Three files changed:
- Proto: Added string unit = 4 to MakePaymentRequest
- Server: Parse unit from request instead of hardcoding CurrencyUnit::Msat in the 3 match arms
- Client: Use the unit parameter (was _unit, ignored) and send it in the request

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

- Added unit field to MakePaymentRequest proto message ([#1651])

#### REMOVED

#### FIXED

- Fixed hardcoded CurrencyUnit::Msat in outgoing payments, now uses the unit provided by the client ([#1651])

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
