### PR TITLE
chore: update Rust to 1.93.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770606655,
-        "narHash": "sha256-rpJf+kxvLWv32ivcgu8d+JeJooog3boJCT8J3joJvvM=",
+        "lastModified": 1772420823,
+        "narHash": "sha256-q3oVwz1Rx41D1D+F6vg41kpOkk3Zi3KwnkHEZp7DCGs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "11a396520bf911e4ed01e78e11633d3fc63b350e",
+        "rev": "458eea8d905c609e9d889423e6b8a1c7bc2f792c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,7 @@
 
         # Toolchains
         # latest stable
-        stable_toolchain = pkgs.rust-bin.stable."1.93.0".default.override {
+        stable_toolchain = pkgs.rust-bin.stable."1.93.1".default.override {
           targets = [ "wasm32-unknown-unknown" ]; # wasm
           extensions = [
             "rustfmt"
@@ -123,7 +123,7 @@
         );
 
         # Stable toolchain with musl target for static builds
-        static_toolchain = pkgs.rust-bin.stable."1.93.0".default.override {
+        static_toolchain = pkgs.rust-bin.stable."1.93.1".default.override {
           targets = [ muslTarget ];
         };
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel="1.93.0"
+channel="1.93.1"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 


### PR DESCRIPTION
### Description

Update Rust toolchain from 1.93.0 to 1.93.1 as requested in #1693.

  - `rust-toolchain.toml` — channel updated to `1.93.1`
  - `flake.nix` — `stable_toolchain` and `static_toolchain` updated to `1.93.1`

Note `nix flake update rust-overlay` was not run due to local Nix setup limitations. A maintainer with Nix configured can run it before merging if needed.

-----

### Notes to the reviewers

Straightforward version bump, no code changes.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

- Rust toolchain updated from 1.93.0 to 1.93.1

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
