### PR TITLE
feat: For mint and melt quotes use enum for mint connector

### DIFF
--- a/crates/cdk-axum/src/custom_handlers.rs
+++ b/crates/cdk-axum/src/custom_handlers.rs
@@ -132,7 +132,7 @@ pub async fn post_mint_custom_quote(
                 })?;
 
             let quote_request = cdk::mint::MintQuoteRequest::Custom {
-                method,
+                method: method.clone(),
                 request: custom_request,
             };
 
@@ -196,7 +196,7 @@ pub async fn get_check_mint_custom_quote(
                     method: quote_method,
                     response,
                 } => {
-                    if quote_method != method {
+                    if quote_method != method.clone() {
                         return Err(into_response(cdk::Error::InvalidPaymentMethod));
                     }
                     Ok(Json(response).into_response())

--- a/crates/cdk-common/src/lib.rs
+++ b/crates/cdk-common/src/lib.rs
@@ -20,10 +20,10 @@ pub mod grpc;
 pub mod common;
 pub mod database;
 pub mod error;
-#[cfg(feature = "mint")]
 pub mod melt;
 #[cfg(feature = "mint")]
 pub mod mint;
+pub mod mint_quote;
 #[cfg(feature = "mint")]
 pub mod payment;
 pub mod pub_sub;
@@ -53,5 +53,7 @@ pub use cdk_http_client::{
 // Re-export common types
 pub use common::FinalizedMelt;
 pub use error::Error;
+pub use melt::{MeltQuoteRequest, MeltQuoteResponse};
+pub use mint_quote::{MintQuoteRequest, MintQuoteResponse};
 /// Re-export parking_lot for reuse
 pub use parking_lot;

--- a/crates/cdk-common/src/melt.rs
+++ b/crates/cdk-common/src/melt.rs
@@ -1,11 +1,19 @@
-//! Melt types
-use cashu::{MeltQuoteBolt11Request, MeltQuoteBolt12Request, MeltQuoteCustomRequest};
+//! Unified Melt Quote types for melt use-cases.
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+use crate::nuts::nut00::KnownMethod;
+use crate::nuts::nut05::{MeltQuoteCustomRequest, MeltQuoteCustomResponse};
+use crate::nuts::nut23::{MeltQuoteBolt11Request, MeltQuoteBolt11Response};
+use crate::nuts::nut25::{MeltQuoteBolt12Request, MeltQuoteBolt12Response};
+use crate::{Amount, CurrencyUnit, MeltQuoteState, PaymentMethod};
 
 /// Melt quote request enum for different types of quotes
 ///
 /// This enum represents the different types of melt quote requests
 /// that can be made, either BOLT11, BOLT12, or Custom.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MeltQuoteRequest {
     /// Lightning Network BOLT11 invoice request
     Bolt11(MeltQuoteBolt11Request),
@@ -30,5 +38,120 @@ impl From<MeltQuoteBolt12Request> for MeltQuoteRequest {
 impl From<MeltQuoteCustomRequest> for MeltQuoteRequest {
     fn from(request: MeltQuoteCustomRequest) -> Self {
         MeltQuoteRequest::Custom(request)
+    }
+}
+
+impl MeltQuoteRequest {
+    /// Returns the payment method for this request.
+    pub fn method(&self) -> PaymentMethod {
+        match self {
+            Self::Bolt11(_) => PaymentMethod::Known(KnownMethod::Bolt11),
+            Self::Bolt12(_) => PaymentMethod::Known(KnownMethod::Bolt12),
+            Self::Custom(request) => PaymentMethod::from(request.method.as_str()),
+        }
+    }
+}
+
+/// Unified melt quote response for all payment methods
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "Q: Serialize + DeserializeOwned")]
+pub enum MeltQuoteResponse<Q> {
+    /// Bolt11 (Lightning invoice)
+    Bolt11(MeltQuoteBolt11Response<Q>),
+    /// Bolt12 (Offers)
+    Bolt12(MeltQuoteBolt12Response<Q>),
+    /// Custom payment method
+    Custom((PaymentMethod, MeltQuoteCustomResponse<Q>)),
+}
+
+impl<Q> MeltQuoteResponse<Q> {
+    /// Returns the payment method for this response.
+    pub fn method(&self) -> PaymentMethod {
+        match self {
+            Self::Bolt11(_) => PaymentMethod::Known(KnownMethod::Bolt11),
+            Self::Bolt12(_) => PaymentMethod::Known(KnownMethod::Bolt12),
+            Self::Custom((method, _)) => method.clone(),
+        }
+    }
+
+    /// Returns the quote ID.
+    pub fn quote(&self) -> &Q {
+        match self {
+            Self::Bolt11(r) => &r.quote,
+            Self::Bolt12(r) => &r.quote,
+            Self::Custom((_, r)) => &r.quote,
+        }
+    }
+
+    /// Returns the quoted amount.
+    pub fn amount(&self) -> Amount {
+        match self {
+            Self::Bolt11(r) => r.amount,
+            Self::Bolt12(r) => r.amount,
+            Self::Custom((_, r)) => r.amount,
+        }
+    }
+
+    /// Returns the fee reserve.
+    pub fn fee_reserve(&self) -> Amount {
+        match self {
+            Self::Bolt11(r) => r.fee_reserve,
+            Self::Bolt12(r) => r.fee_reserve,
+            Self::Custom((_, r)) => r.fee_reserve,
+        }
+    }
+
+    /// Returns the quote state.
+    pub fn state(&self) -> MeltQuoteState {
+        match self {
+            Self::Bolt11(r) => r.state,
+            Self::Bolt12(r) => r.state,
+            Self::Custom((_, r)) => r.state,
+        }
+    }
+
+    /// Returns the quote expiry timestamp.
+    pub fn expiry(&self) -> u64 {
+        match self {
+            Self::Bolt11(r) => r.expiry,
+            Self::Bolt12(r) => r.expiry,
+            Self::Custom((_, r)) => r.expiry,
+        }
+    }
+
+    /// Returns the payment preimage.
+    pub fn payment_preimage(&self) -> Option<&str> {
+        match self {
+            Self::Bolt11(r) => r.payment_preimage.as_deref(),
+            Self::Bolt12(r) => r.payment_preimage.as_deref(),
+            Self::Custom((_, r)) => r.payment_preimage.as_deref(),
+        }
+    }
+
+    /// Returns the change signatures when present.
+    pub fn change(&self) -> Option<&Vec<crate::BlindSignature>> {
+        match self {
+            Self::Bolt11(r) => r.change.as_ref(),
+            Self::Bolt12(r) => r.change.as_ref(),
+            Self::Custom((_, r)) => r.change.as_ref(),
+        }
+    }
+
+    /// Returns the payment request string when present.
+    pub fn request(&self) -> Option<&str> {
+        match self {
+            Self::Bolt11(r) => r.request.as_deref(),
+            Self::Bolt12(r) => r.request.as_deref(),
+            Self::Custom((_, r)) => r.request.as_deref(),
+        }
+    }
+
+    /// Returns the unit when present.
+    pub fn unit(&self) -> Option<CurrencyUnit> {
+        match self {
+            Self::Bolt11(r) => r.unit.clone(),
+            Self::Bolt12(r) => r.unit.clone(),
+            Self::Custom((_, r)) => r.unit.clone(),
+        }
     }
 }

--- a/crates/cdk-common/src/mint.rs
+++ b/crates/cdk-common/src/mint.rs
@@ -17,6 +17,7 @@ use tracing::instrument;
 use uuid::Uuid;
 
 use crate::common::IssuerVersion;
+use crate::mint_quote::MintQuoteResponse;
 use crate::nuts::{MeltQuoteState, MintQuoteState};
 use crate::payment::PaymentIdentifier;
 use crate::{Amount, CurrencyUnit, Error, Id, KeySetInfo, PublicKey};
@@ -1002,6 +1003,63 @@ impl TryFrom<MintQuote> for crate::nuts::MintQuoteCustomResponse<String> {
         let quote: crate::nuts::MintQuoteCustomResponse<QuoteId> = quote.try_into()?;
 
         Ok(quote.into())
+    }
+}
+
+impl TryFrom<MintQuoteResponse<QuoteId>> for MintQuoteBolt11Response<QuoteId> {
+    type Error = Error;
+
+    fn try_from(response: MintQuoteResponse<QuoteId>) -> Result<Self, Self::Error> {
+        match response {
+            MintQuoteResponse::Bolt11(bolt11_response) => Ok(bolt11_response),
+            _ => Err(Error::InvalidPaymentMethod),
+        }
+    }
+}
+
+impl TryFrom<MintQuoteResponse<QuoteId>> for MintQuoteBolt12Response<QuoteId> {
+    type Error = Error;
+
+    fn try_from(response: MintQuoteResponse<QuoteId>) -> Result<Self, Self::Error> {
+        match response {
+            MintQuoteResponse::Bolt12(bolt12_response) => Ok(bolt12_response),
+            _ => Err(Error::InvalidPaymentMethod),
+        }
+    }
+}
+
+impl TryFrom<MintQuote> for MintQuoteResponse<QuoteId> {
+    type Error = Error;
+
+    fn try_from(quote: MintQuote) -> Result<Self, Self::Error> {
+        if quote.payment_method.is_bolt11() {
+            let bolt11_response: MintQuoteBolt11Response<QuoteId> = quote.into();
+            Ok(MintQuoteResponse::Bolt11(bolt11_response))
+        } else if quote.payment_method.is_bolt12() {
+            let bolt12_response = MintQuoteBolt12Response::try_from(quote)?;
+            Ok(MintQuoteResponse::Bolt12(bolt12_response))
+        } else {
+            let method = quote.payment_method.clone();
+            let custom_response = crate::nuts::MintQuoteCustomResponse::try_from(quote)?;
+            Ok(MintQuoteResponse::Custom((method, custom_response)))
+        }
+    }
+}
+
+impl From<MintQuoteResponse<QuoteId>> for MintQuoteBolt11Response<String> {
+    fn from(response: MintQuoteResponse<QuoteId>) -> Self {
+        match response {
+            MintQuoteResponse::Bolt11(bolt11_response) => MintQuoteBolt11Response {
+                quote: bolt11_response.quote.to_string(),
+                state: bolt11_response.state,
+                request: bolt11_response.request,
+                expiry: bolt11_response.expiry,
+                pubkey: bolt11_response.pubkey,
+                amount: bolt11_response.amount,
+                unit: bolt11_response.unit,
+            },
+            _ => panic!("Expected Bolt11 response"),
+        }
     }
 }
 

--- a/crates/cdk-common/src/mint_quote.rs
+++ b/crates/cdk-common/src/mint_quote.rs
@@ -1,0 +1,143 @@
+//! Unified Mint Quote types for mint use-cases.
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+use crate::nuts::nut00::KnownMethod;
+use crate::nuts::nut04::{MintQuoteCustomRequest, MintQuoteCustomResponse};
+use crate::nuts::nut23::{MintQuoteBolt11Request, MintQuoteBolt11Response};
+use crate::nuts::nut25::{MintQuoteBolt12Request, MintQuoteBolt12Response};
+use crate::{Amount, CurrencyUnit, PaymentMethod, PublicKey};
+
+/// Unified mint quote request for all payment methods
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MintQuoteRequest {
+    /// Bolt11 (Lightning invoice)
+    Bolt11(MintQuoteBolt11Request),
+    /// Bolt12 (Offers)
+    Bolt12(MintQuoteBolt12Request),
+    /// Custom payment method
+    Custom((PaymentMethod, MintQuoteCustomRequest)),
+}
+
+impl From<MintQuoteBolt11Request> for MintQuoteRequest {
+    fn from(request: MintQuoteBolt11Request) -> Self {
+        MintQuoteRequest::Bolt11(request)
+    }
+}
+
+impl From<MintQuoteBolt12Request> for MintQuoteRequest {
+    fn from(request: MintQuoteBolt12Request) -> Self {
+        MintQuoteRequest::Bolt12(request)
+    }
+}
+
+impl MintQuoteRequest {
+    /// Returns the payment method for this request.
+    pub fn method(&self) -> PaymentMethod {
+        match self {
+            Self::Bolt11(_) => PaymentMethod::Known(KnownMethod::Bolt11),
+            Self::Bolt12(_) => PaymentMethod::Known(KnownMethod::Bolt12),
+            Self::Custom((method, _)) => method.clone(),
+        }
+    }
+
+    /// Returns the amount for this request when present.
+    pub fn amount(&self) -> Option<Amount> {
+        match self {
+            Self::Bolt11(request) => Some(request.amount),
+            Self::Bolt12(request) => request.amount,
+            Self::Custom((_, request)) => Some(request.amount),
+        }
+    }
+
+    /// Returns the unit for this request.
+    pub fn unit(&self) -> CurrencyUnit {
+        match self {
+            Self::Bolt11(request) => request.unit.clone(),
+            Self::Bolt12(request) => request.unit.clone(),
+            Self::Custom((_, request)) => request.unit.clone(),
+        }
+    }
+
+    /// Returns the payment method for this request.
+    pub fn payment_method(&self) -> PaymentMethod {
+        self.method()
+    }
+
+    /// Returns the pubkey for this request when present.
+    pub fn pubkey(&self) -> Option<PublicKey> {
+        match self {
+            Self::Bolt11(request) => request.pubkey,
+            Self::Bolt12(request) => Some(request.pubkey),
+            Self::Custom((_, request)) => request.pubkey,
+        }
+    }
+}
+
+/// Unified mint quote response for all payment methods
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound = "Q: Serialize + DeserializeOwned")]
+pub enum MintQuoteResponse<Q> {
+    /// Bolt11 (Lightning invoice)
+    Bolt11(MintQuoteBolt11Response<Q>),
+    /// Bolt12 (Offers)
+    Bolt12(MintQuoteBolt12Response<Q>),
+    /// Custom payment method
+    Custom((PaymentMethod, MintQuoteCustomResponse<Q>)),
+}
+
+impl<Q> MintQuoteResponse<Q> {
+    /// Returns the payment method for this response.
+    pub fn method(&self) -> PaymentMethod {
+        match self {
+            Self::Bolt11(_) => PaymentMethod::Known(KnownMethod::Bolt11),
+            Self::Bolt12(_) => PaymentMethod::Known(KnownMethod::Bolt12),
+            Self::Custom((method, _)) => method.clone(),
+        }
+    }
+
+    /// Returns the quote ID.
+    pub fn quote(&self) -> &Q {
+        match self {
+            Self::Bolt11(r) => &r.quote,
+            Self::Bolt12(r) => &r.quote,
+            Self::Custom((_, r)) => &r.quote,
+        }
+    }
+
+    /// Returns the payment request string.
+    pub fn request(&self) -> &str {
+        match self {
+            Self::Bolt11(r) => &r.request,
+            Self::Bolt12(r) => &r.request,
+            Self::Custom((_, r)) => &r.request,
+        }
+    }
+
+    /// Returns the quote state.
+    pub fn state(&self) -> crate::nuts::nut23::QuoteState {
+        match self {
+            Self::Bolt11(r) => r.state,
+            Self::Bolt12(r) => {
+                if r.amount_issued > Amount::ZERO {
+                    crate::nuts::nut23::QuoteState::Issued
+                } else if r.amount_paid >= r.amount.unwrap_or(Amount::ZERO) {
+                    crate::nuts::nut23::QuoteState::Paid
+                } else {
+                    crate::nuts::nut23::QuoteState::Unpaid
+                }
+            }
+            Self::Custom((_, r)) => r.state,
+        }
+    }
+
+    /// Returns the quote expiry timestamp.
+    pub fn expiry(&self) -> Option<u64> {
+        match self {
+            Self::Bolt11(r) => r.expiry,
+            Self::Bolt12(r) => r.expiry,
+            Self::Custom((_, r)) => r.expiry,
+        }
+    }
+}

--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -10,25 +10,21 @@ use async_trait::async_trait;
 use bip39::Mnemonic;
 use cashu::nut00::KnownMethod;
 use cashu::quote_id::QuoteId;
-use cashu::{
-    MeltQuoteBolt12Request, MeltQuoteCustomRequest, MeltQuoteCustomResponse,
-    MintQuoteBolt12Request, MintQuoteBolt12Response, MintQuoteCustomRequest,
-    MintQuoteCustomResponse,
-};
 use cdk::amount::SplitTarget;
 use cdk::cdk_database::{self, WalletDatabase};
 use cdk::mint::{MintBuilder, MintMeltLimits};
 use cdk::nuts::nut00::ProofsMethods;
 use cdk::nuts::{
     BatchCheckMintQuoteRequest, BatchMintRequest, CheckStateRequest, CheckStateResponse,
-    CurrencyUnit, Id, KeySet, KeysetResponse, MeltQuoteBolt11Request, MeltQuoteBolt11Response,
-    MeltRequest, MintInfo, MintQuoteBolt11Request, MintQuoteBolt11Response, MintRequest,
-    MintResponse, PaymentMethod, RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
+    CurrencyUnit, Id, KeySet, KeysetResponse, MeltQuoteBolt11Response, MeltRequest, MintInfo,
+    MintQuoteBolt11Response, MintRequest, MintResponse, PaymentMethod, RestoreRequest,
+    RestoreResponse, SwapRequest, SwapResponse,
 };
 use cdk::types::{FeeReserve, QuoteTTL};
 use cdk::util::unix_time;
 use cdk::wallet::{AuthWallet, MintConnector, Wallet, WalletBuilder};
 use cdk::{Amount, Error, Mint, StreamExt};
+use cdk_common::{MeltQuoteRequest, MeltQuoteResponse, MintQuoteRequest, MintQuoteResponse};
 use cdk_fake_wallet::FakeWallet;
 use tokio::sync::RwLock;
 use tracing_subscriber::EnvFilter;
@@ -92,27 +88,31 @@ impl MintConnector for DirectMintConnection {
 
     async fn post_mint_quote(
         &self,
-        request: MintQuoteBolt11Request,
-    ) -> Result<MintQuoteBolt11Response<String>, Error> {
-        self.mint
-            .get_mint_quote(request.into())
-            .await
-            .map(Into::into)
+        request: MintQuoteRequest,
+    ) -> Result<MintQuoteResponse<String>, Error> {
+        match request {
+            MintQuoteRequest::Bolt11(req) => {
+                let response = self.mint.get_mint_quote(req.into()).await?.into();
+                Ok(MintQuoteResponse::Bolt11(response))
+            }
+            _ => unimplemented!(),
+        }
     }
 
     async fn get_mint_quote_status(
         &self,
+        _method: PaymentMethod,
         quote_id: &str,
-    ) -> Result<MintQuoteBolt11Response<String>, Error> {
-        self.mint
+    ) -> Result<MintQuoteResponse<String>, Error> {
+        let response = self
+            .mint
             .check_mint_quotes(&[QuoteId::from_str(quote_id)?])
-            .await
-            .and_then(|v| {
-                v.first()
-                    .cloned()
-                    .map(Into::into)
-                    .ok_or(Error::UnknownQuote)
-            })
+            .await?
+            .first()
+            .ok_or(Error::UnknownQuote)?
+            .clone()
+            .into();
+        Ok(MintQuoteResponse::Bolt11(response))
     }
 
     async fn post_mint(
@@ -167,22 +167,37 @@ impl MintConnector for DirectMintConnection {
 
     async fn post_melt_quote(
         &self,
-        request: MeltQuoteBolt11Request,
-    ) -> Result<MeltQuoteBolt11Response<String>, Error> {
-        self.mint
-            .get_melt_quote(request.into())
-            .await
-            .map(Into::into)
+        request: MeltQuoteRequest,
+    ) -> Result<MeltQuoteResponse<String>, Error> {
+        match request {
+            MeltQuoteRequest::Bolt11(req) => {
+                let response = self.mint.get_melt_quote(req.into()).await.map(Into::into)?;
+                Ok(MeltQuoteResponse::Bolt11(response))
+            }
+            MeltQuoteRequest::Bolt12(req) => {
+                let response = self.mint.get_melt_quote(req.into()).await.map(Into::into)?;
+                Ok(MeltQuoteResponse::Bolt12(response))
+            }
+            MeltQuoteRequest::Custom(_) => Err(Error::UnsupportedPaymentMethod),
+        }
     }
 
     async fn get_melt_quote_status(
         &self,
+        method: PaymentMethod,
         quote_id: &str,
-    ) -> Result<MeltQuoteBolt11Response<String>, Error> {
-        self.mint
+    ) -> Result<MeltQuoteResponse<String>, Error> {
+        let response: MeltQuoteBolt11Response<String> = self
+            .mint
             .check_melt_quote(&QuoteId::from_str(quote_id)?)
             .await
-            .map(Into::into)
+            .map(Into::into)?;
+
+        match method {
+            PaymentMethod::Known(KnownMethod::Bolt11) => Ok(MeltQuoteResponse::Bolt11(response)),
+            PaymentMethod::Known(KnownMethod::Bolt12) => Ok(MeltQuoteResponse::Bolt12(response)),
+            PaymentMethod::Custom(_) => Err(Error::UnsupportedPaymentMethod),
+        }
     }
 
     async fn post_melt(
@@ -223,88 +238,6 @@ impl MintConnector for DirectMintConnection {
         let mut auth_wallet = self.auth_wallet.write().await;
 
         *auth_wallet = wallet;
-    }
-
-    async fn post_mint_bolt12_quote(
-        &self,
-        request: MintQuoteBolt12Request,
-    ) -> Result<MintQuoteBolt12Response<String>, Error> {
-        let res: MintQuoteBolt12Response<QuoteId> =
-            self.mint.get_mint_quote(request.into()).await?.try_into()?;
-        Ok(res.into())
-    }
-
-    async fn get_mint_quote_bolt12_status(
-        &self,
-        quote_id: &str,
-    ) -> Result<MintQuoteBolt12Response<String>, Error> {
-        let quote: MintQuoteBolt12Response<QuoteId> = self
-            .mint
-            .check_mint_quote(&QuoteId::from_str(quote_id)?)
-            .await?
-            .try_into()?;
-
-        Ok(quote.into())
-    }
-
-    /// Melt Quote [NUT-23]
-    async fn post_melt_bolt12_quote(
-        &self,
-        request: MeltQuoteBolt12Request,
-    ) -> Result<MeltQuoteBolt11Response<String>, Error> {
-        self.mint
-            .get_melt_quote(request.into())
-            .await
-            .map(Into::into)
-    }
-    /// Melt Quote Status [NUT-23]
-    async fn get_melt_bolt12_quote_status(
-        &self,
-        quote_id: &str,
-    ) -> Result<MeltQuoteBolt11Response<String>, Error> {
-        self.mint
-            .check_melt_quote(&QuoteId::from_str(quote_id)?)
-            .await
-            .map(Into::into)
-    }
-
-    /// Mint Quote for Custom Payment Method
-    async fn post_mint_custom_quote(
-        &self,
-        _method: &PaymentMethod,
-        _request: MintQuoteCustomRequest,
-    ) -> Result<MintQuoteCustomResponse<String>, Error> {
-        // Custom payment methods not implemented in test mock
-        Err(Error::UnsupportedPaymentMethod)
-    }
-
-    /// Mint Quote Status for Custom Payment Method
-    async fn get_mint_quote_custom_status(
-        &self,
-        _method: &str,
-        _quote_id: &str,
-    ) -> Result<MintQuoteCustomResponse<String>, Error> {
-        // Custom payment methods not implemented in test mock
-        Err(Error::UnsupportedPaymentMethod)
-    }
-
-    /// Melt Quote for Custom Payment Method
-    async fn post_melt_custom_quote(
-        &self,
-        _request: MeltQuoteCustomRequest,
-    ) -> Result<MeltQuoteCustomResponse<String>, Error> {
-        // Custom payment methods not implemented in test mock
-        Err(Error::UnsupportedPaymentMethod)
-    }
-
-    /// Melt Quote Status for Custom Payment Method
-    async fn get_melt_quote_custom_status(
-        &self,
-        _method: &str,
-        _quote_id: &str,
-    ) -> Result<MeltQuoteCustomResponse<String>, Error> {
-        // Custom payment methods not implemented in test mock
-        Err(Error::UnsupportedPaymentMethod)
     }
 }
 

--- a/crates/cdk-integration-tests/tests/fake_auth.rs
+++ b/crates/cdk-integration-tests/tests/fake_auth.rs
@@ -65,7 +65,10 @@ async fn test_quote_status_without_auth() {
     // Test mint quote status
     {
         let quote_res = client
-            .get_mint_quote_status("123e4567-e89b-12d3-a456-426614174000")
+            .get_mint_quote_status(
+                PaymentMethod::BOLT11,
+                "123e4567-e89b-12d3-a456-426614174000",
+            )
             .await;
 
         assert!(
@@ -78,7 +81,10 @@ async fn test_quote_status_without_auth() {
     // Test melt quote status
     {
         let quote_res = client
-            .get_melt_quote_status("123e4567-e89b-12d3-a456-426614174000")
+            .get_melt_quote_status(
+                PaymentMethod::BOLT11,
+                "123e4567-e89b-12d3-a456-426614174000",
+            )
             .await;
 
         assert!(
@@ -100,7 +106,7 @@ async fn test_mint_without_auth() {
             pubkey: None,
         };
 
-        let quote_res = client.post_mint_quote(request).await;
+        let quote_res = client.post_mint_quote(request.into()).await;
 
         assert!(
             matches!(quote_res, Err(Error::BlindAuthRequired)),
@@ -129,7 +135,10 @@ async fn test_mint_without_auth() {
 
     {
         let mint_res = client
-            .get_mint_quote_status("123e4567-e89b-12d3-a456-426614174000")
+            .get_mint_quote_status(
+                PaymentMethod::BOLT11,
+                "123e4567-e89b-12d3-a456-426614174000",
+            )
             .await;
 
         assert!(
@@ -182,7 +191,7 @@ async fn test_melt_without_auth() {
             options: None,
         };
 
-        let quote_res = client.post_melt_quote(request).await;
+        let quote_res = client.post_melt_quote(request.into()).await;
 
         assert!(
             matches!(quote_res, Err(Error::BlindAuthRequired)),
@@ -199,7 +208,7 @@ async fn test_melt_without_auth() {
             options: None,
         };
 
-        let quote_res = client.post_melt_quote(request).await;
+        let quote_res = client.post_melt_quote(request.into()).await;
 
         assert!(
             matches!(quote_res, Err(Error::BlindAuthRequired)),
@@ -230,7 +239,10 @@ async fn test_melt_without_auth() {
     // Check melt quote state
     {
         let melt_res = client
-            .get_melt_quote_status("123e4567-e89b-12d3-a456-426614174000")
+            .get_melt_quote_status(
+                PaymentMethod::BOLT11,
+                "123e4567-e89b-12d3-a456-426614174000",
+            )
             .await;
 
         assert!(
@@ -593,7 +605,7 @@ async fn test_melt_with_invalid_auth() {
             pubkey: None,
         };
 
-        let quote_res = client.post_mint_quote(request).await;
+        let quote_res = client.post_mint_quote(request.into()).await;
 
         assert!(
             matches!(quote_res, Err(Error::BlindAuthRequired)),

--- a/crates/cdk-integration-tests/tests/fake_wallet.rs
+++ b/crates/cdk-integration-tests/tests/fake_wallet.rs
@@ -538,11 +538,17 @@ async fn test_fake_melt_change_in_quote() {
 
     assert!(melt_response.change.is_some());
 
-    let check = client.get_melt_quote_status(&melt_quote.id).await.unwrap();
+    let check = client
+        .get_melt_quote_status(PaymentMethod::BOLT11, &melt_quote.id)
+        .await
+        .unwrap();
     let mut melt_change = melt_response.change.unwrap();
     melt_change.sort_by_key(|a| a.amount);
 
-    let mut check = check.change.unwrap();
+    let mut check = match check {
+        cdk_common::MeltQuoteResponse::Bolt11(r) => r.change.unwrap(),
+        _ => panic!("Expected Bolt11 melt quote response"),
+    };
     check.sort_by_key(|a| a.amount);
 
     assert_eq!(melt_change, check);

--- a/crates/cdk-integration-tests/tests/happy_path_mint_wallet.rs
+++ b/crates/cdk-integration-tests/tests/happy_path_mint_wallet.rs
@@ -920,11 +920,17 @@ async fn test_fake_melt_change_in_quote() {
 
     assert!(melt_response.change.is_some());
 
-    let check = client.get_melt_quote_status(&melt_quote.id).await.unwrap();
+    let check = client
+        .get_melt_quote_status(PaymentMethod::BOLT11, &melt_quote.id)
+        .await
+        .unwrap();
     let mut melt_change = melt_response.change.unwrap();
     melt_change.sort_by_key(|a| a.amount);
 
-    let mut check = check.change.unwrap();
+    let mut check = match check {
+        cdk_common::MeltQuoteResponse::Bolt11(r) => r.change.unwrap(),
+        _ => panic!("Expected Bolt11 melt quote response"),
+    };
     check.sort_by_key(|a| a.amount);
 
     assert_eq!(melt_change, check);

--- a/crates/cdk/src/mint/issue/mod.rs
+++ b/crates/cdk/src/mint/issue/mod.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use cdk_common::database::mint::Acquired;
 use cdk_common::mint::{MintQuote, Operation};
-use cdk_common::nut00::KnownMethod;
 use cdk_common::payment::{
     Bolt11IncomingPaymentOptions, Bolt12IncomingPaymentOptions, CustomIncomingPaymentOptions,
     IncomingPaymentOptions, WaitPaymentResponse,
@@ -24,6 +23,8 @@ use crate::Mint;
 
 mod auth;
 
+use cdk_common::nut00::KnownMethod;
+
 /// Input enum to handle both single and batch mint formats (internal to CDK, not spec)
 #[derive(Debug, Clone)]
 pub enum MintInput {
@@ -38,18 +39,17 @@ pub enum MintInput {
 struct QuoteEntry {
     quote_id: QuoteId,
     signature: Option<String>,
-    /// For batch: optional expected amount from quote_amounts
     expected_amount: Option<u64>,
 }
 
 impl MintInput {
-    /// Validate the structural invariants of the input.
+    /// Validates the structure of the mint input
     ///
-    /// Checks that:
-    /// - The request contains at least one quote
-    /// - Quote IDs are unique (batch only)
-    /// - `quote_amounts` length matches `quotes` length (if present)
-    /// - `signatures` length matches `quotes` length (if present)
+    /// For single requests, this is a no-op. For batch requests, checks that:
+    /// - The quotes list is non-empty
+    /// - There are no duplicate quote IDs
+    /// - The `quote_amounts` array (if present) has the same length as `quotes`
+    /// - The `signatures` array (if present) has the same length as `quotes`
     pub fn validate(&self) -> Result<(), Error> {
         match self {
             MintInput::Single(_) => Ok(()),
@@ -58,7 +58,6 @@ impl MintInput {
                     return Err(Error::UnknownQuote);
                 }
 
-                // Validate unique quote IDs
                 let unique_ids: std::collections::HashSet<_> = batch.quotes.iter().collect();
                 if unique_ids.len() != batch.quotes.len() {
                     return Err(Error::DuplicateInputs);
@@ -81,10 +80,6 @@ impl MintInput {
         }
     }
 
-    /// Extract per-quote metadata entries.
-    ///
-    /// For single requests this returns a single entry.
-    /// For batch requests this zips quotes with their optional signatures and amounts.
     fn quote_entries(&self) -> Vec<QuoteEntry> {
         match self {
             MintInput::Single(req) => {
@@ -114,7 +109,7 @@ impl MintInput {
         }
     }
 
-    /// Get the quote IDs.
+    /// Returns the list of quote IDs referenced by this mint input
     pub fn quote_ids(&self) -> Vec<QuoteId> {
         match self {
             MintInput::Single(req) => vec![req.quote.clone()],
@@ -122,9 +117,7 @@ impl MintInput {
         }
     }
 
-    /// Get the blinded message outputs.
-    ///
-    /// Returns a reference to the shared outputs without cloning.
+    /// Returns a reference to the blinded messages (outputs) to be signed
     pub fn outputs(&self) -> &[BlindedMessage] {
         match self {
             MintInput::Single(req) => &req.outputs,
@@ -132,17 +125,17 @@ impl MintInput {
         }
     }
 
-    /// Whether this is a batch (NUT-29) request.
+    /// Returns `true` if this is a batch mint request (NUT-29)
     pub fn is_batch(&self) -> bool {
         matches!(self, MintInput::Batch(_))
     }
 }
 
-/// Request for creating a mint quote
+/// Unified request type for creating mint quotes across different payment methods
 ///
-/// This enum represents the different types of payment requests that can be used
-/// to create a mint quote.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Wraps the protocol-specific request types (BOLT11, BOLT12, custom) into a
+/// single enum so the mint can handle quote creation through a common interface.
+#[derive(Debug)]
 pub enum MintQuoteRequest {
     /// Lightning Network BOLT11 invoice request
     Bolt11(MintQuoteBolt11Request),
@@ -171,10 +164,6 @@ impl From<MintQuoteBolt12Request> for MintQuoteRequest {
 
 impl MintQuoteRequest {
     /// Get the amount from the mint quote request
-    ///
-    /// For Bolt11 requests, this returns `Some(amount)` as the amount is required.
-    /// For Bolt12 requests, this returns the optional amount.
-    /// For Custom requests, this returns `Some(amount)` as the amount is required.
     pub fn amount(&self) -> Option<Amount> {
         match self {
             MintQuoteRequest::Bolt11(request) => Some(request.amount),
@@ -202,10 +191,6 @@ impl MintQuoteRequest {
     }
 
     /// Get the pubkey from the mint quote request
-    ///
-    /// For Bolt11 requests, this returns the optional pubkey.
-    /// For Bolt12 requests, this returns `Some(pubkey)` as the pubkey is required.
-    /// For Custom requests, this returns the optional pubkey.
     pub fn pubkey(&self) -> Option<PublicKey> {
         match self {
             MintQuoteRequest::Bolt11(request) => request.pubkey,
@@ -216,9 +201,6 @@ impl MintQuoteRequest {
 }
 
 /// Response for a mint quote request
-///
-/// This enum represents the different types of payment responses that can be returned
-/// when creating a mint quote.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MintQuoteResponse {
     /// Lightning Network BOLT11 invoice response
@@ -474,7 +456,7 @@ impl Mint {
                     };
 
                     let custom_options = CustomIncomingPaymentOptions {
-                        method,
+                        method: method.to_string(),
                         description: request.description,
                         amount: request.amount,
                         unix_expiry: Some(quote_expiry),

--- a/crates/cdk/src/wallet/issue/mod.rs
+++ b/crates/cdk/src/wallet/issue/mod.rs
@@ -6,15 +6,13 @@ pub(crate) mod saga;
 
 use cdk_common::nut00::KnownMethod;
 use cdk_common::nut04::MintMethodOptions;
-use cdk_common::nut25::MintQuoteBolt12Request;
-use cdk_common::PaymentMethod;
+use cdk_common::{MintQuoteRequest, MintQuoteResponse, PaymentMethod};
 pub(crate) use saga::MintSaga;
 use tracing::instrument;
 
 use crate::amount::SplitTarget;
 use crate::nuts::{
-    BatchCheckMintQuoteRequest, MintQuoteBolt11Request, MintQuoteCustomRequest, Proofs, SecretKey,
-    SpendingConditions,
+    BatchCheckMintQuoteRequest, MintQuoteCustomRequest, Proofs, SecretKey, SpendingConditions,
 };
 use crate::util::unix_time;
 use crate::wallet::recovery::RecoveryAction;
@@ -58,44 +56,43 @@ impl Wallet {
 
         let secret_key = SecretKey::generate();
 
-        let (quote_id, request_str, expiry) = match &method {
+        let request = match &method {
             PaymentMethod::Known(KnownMethod::Bolt11) => {
                 let amount = amount.ok_or(Error::AmountUndefined)?;
-                let request = MintQuoteBolt11Request {
+                MintQuoteRequest::Bolt11(cdk_common::nut23::MintQuoteBolt11Request {
                     amount,
                     unit: unit.clone(),
                     description,
                     pubkey: Some(secret_key.public_key()),
-                };
-
-                let response = self.client.post_mint_quote(request).await?;
-                (response.quote, response.request, response.expiry)
+                })
             }
             PaymentMethod::Known(KnownMethod::Bolt12) => {
-                let request = MintQuoteBolt12Request {
+                MintQuoteRequest::Bolt12(cdk_common::nut25::MintQuoteBolt12Request {
                     amount,
                     unit: unit.clone(),
                     description,
                     pubkey: secret_key.public_key(),
-                };
-
-                let response = self.client.post_mint_bolt12_quote(request).await?;
-                (response.quote, response.request, response.expiry)
+                })
             }
             PaymentMethod::Custom(_) => {
                 let amount = amount.ok_or(Error::AmountUndefined)?;
-                let request = MintQuoteCustomRequest {
-                    amount,
-                    unit: unit.clone(),
-                    description,
-                    pubkey: Some(secret_key.public_key()),
-                    extra: serde_json::from_str(&extra.unwrap_or_default())?,
-                };
-
-                let response = self.client.post_mint_custom_quote(&method, request).await?;
-                (response.quote, response.request, response.expiry)
+                MintQuoteRequest::Custom((
+                    method.clone(),
+                    MintQuoteCustomRequest {
+                        amount,
+                        unit: unit.clone(),
+                        description,
+                        pubkey: Some(secret_key.public_key()),
+                        extra: serde_json::from_str(&extra.unwrap_or_default())?,
+                    },
+                ))
             }
         };
+
+        let response: MintQuoteResponse<String> = self.client.post_mint_quote(request).await?;
+        let quote_id = response.quote().to_string();
+        let request_str = response.request().to_string();
+        let expiry = response.expiry();
 
         let quote = MintQuote::new(
             quote_id,
@@ -115,51 +112,37 @@ impl Wallet {
 
     /// Checks the state of a mint quote with the mint
     async fn check_state(&self, mint_quote: &mut MintQuote) -> Result<(), Error> {
-        match mint_quote.payment_method {
-            PaymentMethod::Known(KnownMethod::Bolt11) => {
-                let mint_quote_response = self.client.get_mint_quote_status(&mint_quote.id).await?;
-                mint_quote.state = mint_quote_response.state;
+        let mint_quote_response: MintQuoteResponse<String> = self
+            .client
+            .get_mint_quote_status(mint_quote.payment_method.clone(), &mint_quote.id)
+            .await?;
+        mint_quote.state = mint_quote_response.state();
 
-                match mint_quote_response.state {
-                    MintQuoteState::Paid => {
-                        mint_quote.amount_paid = mint_quote.amount.unwrap_or_default();
-                    }
-                    MintQuoteState::Issued => {
-                        mint_quote.amount_paid = mint_quote.amount.unwrap_or_default();
-                        mint_quote.amount_issued = mint_quote.amount.unwrap_or_default();
-                    }
-                    MintQuoteState::Unpaid => (),
+        match &mint_quote_response {
+            MintQuoteResponse::Bolt11(response) => match response.state {
+                MintQuoteState::Paid => {
+                    mint_quote.amount_paid = mint_quote.amount.unwrap_or_default();
                 }
-            }
-            PaymentMethod::Known(KnownMethod::Bolt12) => {
-                let mint_quote_response = self
-                    .client
-                    .get_mint_quote_bolt12_status(&mint_quote.id)
-                    .await?;
-
-                mint_quote.amount_issued = mint_quote_response.amount_issued;
-                mint_quote.amount_paid = mint_quote_response.amount_paid;
-            }
-            PaymentMethod::Custom(ref method) => {
-                let mint_quote_response = self
-                    .client
-                    .get_mint_quote_custom_status(method, &mint_quote.id)
-                    .await?;
-
-                mint_quote.state = mint_quote_response.state;
-
-                // Update amounts based on state
-                match mint_quote_response.state {
-                    MintQuoteState::Paid => {
-                        mint_quote.amount_paid = mint_quote_response.amount.unwrap_or_default();
-                    }
-                    MintQuoteState::Issued => {
-                        mint_quote.amount_paid = mint_quote_response.amount.unwrap_or_default();
-                        mint_quote.amount_issued = mint_quote_response.amount.unwrap_or_default();
-                    }
-                    MintQuoteState::Unpaid => (),
+                MintQuoteState::Issued => {
+                    mint_quote.amount_paid = mint_quote.amount.unwrap_or_default();
+                    mint_quote.amount_issued = mint_quote.amount.unwrap_or_default();
                 }
+                MintQuoteState::Unpaid => (),
+            },
+            MintQuoteResponse::Bolt12(response) => {
+                mint_quote.amount_issued = response.amount_issued;
+                mint_quote.amount_paid = response.amount_paid;
             }
+            MintQuoteResponse::Custom((_, response)) => match response.state {
+                MintQuoteState::Paid => {
+                    mint_quote.amount_paid = response.amount.unwrap_or_default();
+                }
+                MintQuoteState::Issued => {
+                    mint_quote.amount_paid = response.amount.unwrap_or_default();
+                    mint_quote.amount_issued = response.amount.unwrap_or_default();
+                }
+                MintQuoteState::Unpaid => (),
+            },
         }
 
         Ok(())
@@ -416,84 +399,57 @@ impl Wallet {
             (None, None) => return Err(Error::PaymentMethodRequired),
         };
 
-        // Fetch the quote status from the mint based on payment method
-        let quote = match &method {
-            PaymentMethod::Known(KnownMethod::Bolt11) => {
-                let response = self.client.get_mint_quote_status(quote_id).await?;
+        // Fetch the quote status from the mint using unified method
+        let response: MintQuoteResponse<String> = self
+            .client
+            .get_mint_quote_status(method.clone(), quote_id)
+            .await?;
 
-                match existing_quote {
-                    Some(mut existing) => {
-                        // Update the existing quote with new state
-                        existing.state = response.state;
-                        existing
+        let quote = match existing_quote {
+            Some(mut existing) => {
+                // Update the existing quote with new state
+                existing.state = response.state();
+                match &response {
+                    MintQuoteResponse::Bolt12(r) => {
+                        existing.amount_paid = r.amount_paid;
+                        existing.amount_issued = r.amount_issued;
                     }
-                    None => {
-                        // Create a new quote from the response
-                        MintQuote::new(
-                            quote_id.to_string(),
-                            self.mint_url.clone(),
-                            method,
-                            response.amount,
-                            response.unit.unwrap_or(self.unit.clone()),
-                            response.request,
-                            response.expiry.unwrap_or(0),
-                            None,
-                        )
+                    MintQuoteResponse::Bolt11(r) => {
+                        if let Some(amount) = r.amount {
+                            existing.amount_paid = amount;
+                        }
+                    }
+                    MintQuoteResponse::Custom((_, r)) => {
+                        if let Some(amount) = r.amount {
+                            existing.amount_paid = amount;
+                            existing.amount_issued = amount;
+                        }
                     }
                 }
+                existing
             }
-            PaymentMethod::Known(KnownMethod::Bolt12) => {
-                let response = self.client.get_mint_quote_bolt12_status(quote_id).await?;
-
-                match existing_quote {
-                    Some(mut existing) => {
-                        // Update the existing quote with new state from bolt12 response
-                        existing.amount_paid = response.amount_paid;
-                        existing.amount_issued = response.amount_issued;
-                        existing
-                    }
-                    None => {
-                        // Create a new quote from the response
-                        MintQuote::new(
-                            quote_id.to_string(),
-                            self.mint_url.clone(),
-                            method,
-                            response.amount,
-                            response.unit,
-                            response.request,
-                            response.expiry.unwrap_or(0),
-                            None,
-                        )
-                    }
-                }
-            }
-            PaymentMethod::Custom(custom_method) => {
-                let response = self
-                    .client
-                    .get_mint_quote_custom_status(custom_method, quote_id)
-                    .await?;
-
-                match existing_quote {
-                    Some(mut existing) => {
-                        // Update the existing quote with new state
-                        existing.amount_paid = response.amount.unwrap_or_default();
-                        existing.amount_issued = response.amount.unwrap_or_default();
-                        existing
-                    }
-                    None => {
-                        // Create a new quote from the response
-                        MintQuote::new(
-                            quote_id.to_string(),
-                            self.mint_url.clone(),
-                            method,
-                            response.amount,
-                            response.unit.unwrap_or(self.unit.clone()),
-                            response.request,
-                            response.expiry.unwrap_or(0),
-                            None,
-                        )
-                    }
-                }
+            None => {
+                // Create a new quote from the response
+                let amount = match &response {
+                    MintQuoteResponse::Bolt11(r) => r.amount,
+                    MintQuoteResponse::Bolt12(r) => r.amount,
+                    MintQuoteResponse::Custom((_, r)) => r.amount,
+                };
+                let unit = match &response {
+                    MintQuoteResponse::Bolt11(r) => r.unit.clone(),
+                    MintQuoteResponse::Bolt12(r) => Some(r.unit.clone()),
+                    MintQuoteResponse::Custom((_, r)) => r.unit.clone(),
+                };
+                MintQuote::new(
+                    quote_id.to_string(),
+                    self.mint_url.clone(),
+                    method,
+                    amount,
+                    unit.unwrap_or(self.unit.clone()),
+                    response.request().to_string(),
+                    response.expiry().unwrap_or(0),
+                    None,
+                )
             }
         };
 

--- a/crates/cdk/src/wallet/melt/bolt11.rs
+++ b/crates/cdk/src/wallet/melt/bolt11.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use cdk_common::nut00::KnownMethod;
 use cdk_common::wallet::MeltQuote;
-use cdk_common::PaymentMethod;
+use cdk_common::{MeltQuoteRequest, MeltQuoteResponse, PaymentMethod};
 use lightning_invoice::Bolt11Invoice;
 use tracing::instrument;
 
@@ -25,7 +25,15 @@ impl Wallet {
             options,
         };
 
-        let quote_res = self.client.post_melt_quote(quote_request).await?;
+        let quote_res = self
+            .client
+            .post_melt_quote(MeltQuoteRequest::Bolt11(quote_request))
+            .await?;
+
+        let quote_res = match quote_res {
+            MeltQuoteResponse::Bolt11(response) => response,
+            _ => return Err(Error::InvalidPaymentMethod),
+        };
 
         if self.unit == CurrencyUnit::Msat || self.unit == CurrencyUnit::Sat {
             let amount_msat = options

--- a/crates/cdk/src/wallet/melt/bolt12.rs
+++ b/crates/cdk/src/wallet/melt/bolt12.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use cdk_common::amount::amount_for_offer;
 use cdk_common::nut00::KnownMethod;
 use cdk_common::wallet::MeltQuote;
-use cdk_common::PaymentMethod;
+use cdk_common::{MeltQuoteRequest, MeltQuoteResponse, PaymentMethod};
 use lightning::offers::offer::Offer;
 use tracing::instrument;
 
@@ -28,7 +28,15 @@ impl Wallet {
             options,
         };
 
-        let quote_res = self.client.post_melt_bolt12_quote(quote_request).await?;
+        let quote_res = self
+            .client
+            .post_melt_quote(MeltQuoteRequest::Bolt12(quote_request))
+            .await?;
+
+        let quote_res = match quote_res {
+            MeltQuoteResponse::Bolt12(response) => response,
+            _ => return Err(Error::InvalidPaymentMethod),
+        };
 
         if self.unit == CurrencyUnit::Sat || self.unit == CurrencyUnit::Msat {
             let offer = Offer::from_str(&request).map_err(|_| Error::Bolt12parse)?;

--- a/crates/cdk/src/wallet/melt/custom.rs
+++ b/crates/cdk/src/wallet/melt/custom.rs
@@ -1,5 +1,5 @@
 use cdk_common::wallet::MeltQuote;
-use cdk_common::PaymentMethod;
+use cdk_common::{MeltQuoteRequest, MeltQuoteResponse, PaymentMethod};
 use tracing::instrument;
 
 use crate::nuts::{MeltOptions, MeltQuoteCustomRequest};
@@ -29,7 +29,15 @@ impl Wallet {
             unit: self.unit.clone(),
             extra: extra.unwrap_or(serde_json::Value::Null),
         };
-        let quote_res = self.client.post_melt_custom_quote(quote_request).await?;
+        let quote_res = self
+            .client
+            .post_melt_quote(MeltQuoteRequest::Custom(quote_request))
+            .await?;
+
+        let quote_res = match quote_res {
+            MeltQuoteResponse::Custom((_, response)) => response,
+            _ => return Err(Error::InvalidPaymentMethod),
+        };
 
         // Construct MeltQuote from custom response
         // Use response's request if present, otherwise fallback to input request

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -1030,7 +1030,14 @@ impl Wallet {
 
         match &quote.payment_method {
             PaymentMethod::Known(KnownMethod::Bolt11) => {
-                let response = self.client.get_melt_quote_status(quote_id).await?;
+                let response = self
+                    .client
+                    .get_melt_quote_status(quote.payment_method.clone(), quote_id)
+                    .await?;
+                let response = match response {
+                    cdk_common::MeltQuoteResponse::Bolt11(response) => response,
+                    _ => return Err(Error::InvalidPaymentMethod),
+                };
                 self.update_melt_quote_state(
                     &mut quote,
                     response.state,
@@ -1041,7 +1048,14 @@ impl Wallet {
                 .await?;
             }
             PaymentMethod::Known(KnownMethod::Bolt12) => {
-                let response = self.client.get_melt_bolt12_quote_status(quote_id).await?;
+                let response = self
+                    .client
+                    .get_melt_quote_status(quote.payment_method.clone(), quote_id)
+                    .await?;
+                let response = match response {
+                    cdk_common::MeltQuoteResponse::Bolt12(response) => response,
+                    _ => return Err(Error::InvalidPaymentMethod),
+                };
                 self.update_melt_quote_state(
                     &mut quote,
                     response.state,
@@ -1051,11 +1065,15 @@ impl Wallet {
                 )
                 .await?;
             }
-            PaymentMethod::Custom(method) => {
+            PaymentMethod::Custom(_) => {
                 let response = self
                     .client
-                    .get_melt_quote_custom_status(method, quote_id)
+                    .get_melt_quote_status(quote.payment_method.clone(), quote_id)
                     .await?;
+                let response = match response {
+                    cdk_common::MeltQuoteResponse::Custom((_, response)) => response,
+                    _ => return Err(Error::InvalidPaymentMethod),
+                };
                 let change_amount = response
                     .change
                     .as_ref()
@@ -1091,22 +1109,15 @@ impl Wallet {
             .ok_or(Error::UnknownQuote)?;
 
         // Route to correct endpoint based on payment method
-        let response = match &quote.payment_method {
-            PaymentMethod::Known(KnownMethod::Bolt11) => {
-                let r = self.client.get_melt_quote_status(quote_id).await?;
-                MeltQuoteStatusResponse::Standard(r)
-            }
-            PaymentMethod::Known(KnownMethod::Bolt12) => {
-                let r = self.client.get_melt_bolt12_quote_status(quote_id).await?;
-                MeltQuoteStatusResponse::Bolt12(r)
-            }
-            PaymentMethod::Custom(method) => {
-                let r = self
-                    .client
-                    .get_melt_quote_custom_status(method, quote_id)
-                    .await?;
-                MeltQuoteStatusResponse::Custom(r)
-            }
+        let response = self
+            .client
+            .get_melt_quote_status(quote.payment_method.clone(), quote_id)
+            .await?;
+
+        let response = match response {
+            cdk_common::MeltQuoteResponse::Bolt11(r) => MeltQuoteStatusResponse::Standard(r),
+            cdk_common::MeltQuoteResponse::Bolt12(r) => MeltQuoteStatusResponse::Bolt12(r),
+            cdk_common::MeltQuoteResponse::Custom((_, r)) => MeltQuoteStatusResponse::Custom(r),
         };
 
         Ok(response)

--- a/crates/cdk/src/wallet/mint_connector/http_client.rs
+++ b/crates/cdk/src/wallet/mint_connector/http_client.rs
@@ -4,8 +4,9 @@ use std::sync::{Arc, RwLock as StdRwLock};
 
 use async_trait::async_trait;
 use cdk_common::{
-    nut19, MeltQuoteBolt12Request, MeltQuoteBolt12Response, MeltQuoteCustomResponse, Method,
-    MintQuoteBolt12Request, MintQuoteBolt12Response, ProtectedEndpoint, RoutePath,
+    nut19, MeltQuoteBolt11Response, MeltQuoteRequest, MeltQuoteResponse, Method,
+    MintQuoteBolt11Response, MintQuoteBolt12Response, MintQuoteCustomResponse, MintQuoteRequest,
+    MintQuoteResponse, ProtectedEndpoint, RoutePath,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -21,10 +22,8 @@ use crate::nuts::nut00::{KnownMethod, PaymentMethod};
 use crate::nuts::nut22::MintAuthRequest;
 use crate::nuts::{
     AuthToken, BatchCheckMintQuoteRequest, BatchMintRequest, CheckStateRequest, CheckStateResponse,
-    Id, KeySet, KeysResponse, KeysetResponse, MeltQuoteBolt11Request, MeltQuoteBolt11Response,
-    MeltQuoteCustomRequest, MeltRequest, MintInfo, MintQuoteBolt11Request, MintQuoteBolt11Response,
-    MintQuoteCustomRequest, MintQuoteCustomResponse, MintRequest, MintResponse, RestoreRequest,
-    RestoreResponse, SwapRequest, SwapResponse,
+    Id, KeySet, KeysResponse, KeysetResponse, MeltRequest, MintInfo, MintRequest, MintResponse,
+    RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
 };
 use crate::wallet::auth::{AuthMintConnector, AuthWallet};
 
@@ -249,44 +248,103 @@ where
         transport.http_get(url, None).await
     }
 
-    /// Mint Quote [NUT-04]
-    #[instrument(skip(self), fields(mint_url = %self.mint_url))]
+    /// Mint Quote [NUT-04, NUT-23, NUT-25]
+    #[instrument(skip(self, request), fields(mint_url = %self.mint_url))]
     async fn post_mint_quote(
         &self,
-        request: MintQuoteBolt11Request,
-    ) -> Result<MintQuoteBolt11Response<String>, Error> {
+        request: MintQuoteRequest,
+    ) -> Result<MintQuoteResponse<String>, Error> {
+        let method = request.method().to_string();
+        let path = format!("v1/mint/quote/{}", method);
+
         let url = self
             .mint_url
-            .join_paths(&["v1", "mint", "quote", "bolt11"])?;
+            .join_paths(&path.split('/').collect::<Vec<_>>())?;
 
         let auth_token = self
             .get_auth_token(
                 Method::Post,
-                RoutePath::MintQuote(PaymentMethod::Known(KnownMethod::Bolt11).to_string()),
+                RoutePath::MintQuote(request.method().to_string()),
             )
             .await?;
 
-        self.transport.http_post(url, auth_token, &request).await
+        match &request {
+            MintQuoteRequest::Bolt11(req) => {
+                let response: cdk_common::nut23::MintQuoteBolt11Response<String> =
+                    self.transport.http_post(url, auth_token, req).await?;
+                Ok(MintQuoteResponse::Bolt11(response))
+            }
+            MintQuoteRequest::Bolt12(req) => {
+                let response: cdk_common::nut25::MintQuoteBolt12Response<String> =
+                    self.transport.http_post(url, auth_token, req).await?;
+                Ok(MintQuoteResponse::Bolt12(response))
+            }
+            MintQuoteRequest::Custom(req) => {
+                let response: cdk_common::nut04::MintQuoteCustomResponse<String> =
+                    self.transport.http_post(url, auth_token, req).await?;
+                Ok(MintQuoteResponse::Custom((request.method(), response)))
+            }
+        }
     }
 
-    /// Mint Quote status
+    /// Mint Quote status with payment method
     #[instrument(skip(self), fields(mint_url = %self.mint_url))]
     async fn get_mint_quote_status(
         &self,
+        method: PaymentMethod,
         quote_id: &str,
-    ) -> Result<MintQuoteBolt11Response<String>, Error> {
-        let url = self
-            .mint_url
-            .join_paths(&["v1", "mint", "quote", "bolt11", quote_id])?;
+    ) -> Result<MintQuoteResponse<String>, Error> {
+        match &method {
+            PaymentMethod::Known(KnownMethod::Bolt11) => {
+                let url = self
+                    .mint_url
+                    .join_paths(&["v1", "mint", "quote", "bolt11", quote_id])?;
 
-        let auth_token = self
-            .get_auth_token(
-                Method::Get,
-                RoutePath::MintQuote(PaymentMethod::Known(KnownMethod::Bolt11).to_string()),
-            )
-            .await?;
+                let auth_token = self
+                    .get_auth_token(
+                        Method::Get,
+                        RoutePath::MintQuote(PaymentMethod::Known(KnownMethod::Bolt11).to_string()),
+                    )
+                    .await?;
 
-        self.transport.http_get(url, auth_token).await
+                let response: MintQuoteBolt11Response<String> =
+                    self.transport.http_get(url, auth_token).await?;
+
+                Ok(MintQuoteResponse::Bolt11(response))
+            }
+            PaymentMethod::Known(KnownMethod::Bolt12) => {
+                let url = self
+                    .mint_url
+                    .join_paths(&["v1", "mint", "quote", "bolt12", quote_id])?;
+
+                let auth_token = self
+                    .get_auth_token(
+                        Method::Get,
+                        RoutePath::MintQuote(PaymentMethod::Known(KnownMethod::Bolt12).to_string()),
+                    )
+                    .await?;
+
+                let response: MintQuoteBolt12Response<String> =
+                    self.transport.http_get(url, auth_token).await?;
+
+                Ok(MintQuoteResponse::Bolt12(response))
+            }
+            // PaymentMethod::Known(KnownMethod::Onchain) => Err(Error::UnsupportedPaymentMethod),
+            PaymentMethod::Custom(method_name) => {
+                let url =
+                    self.mint_url
+                        .join_paths(&["v1", "mint", "quote", method_name, quote_id])?;
+
+                let auth_token = self
+                    .get_auth_token(Method::Get, RoutePath::MintQuote(method_name.clone()))
+                    .await?;
+
+                let response: MintQuoteCustomResponse<String> =
+                    self.transport.http_get(url, auth_token).await?;
+
+                Ok(MintQuoteResponse::Custom((method, response)))
+            }
+        }
     }
 
     /// Mint Tokens [NUT-04]
@@ -353,39 +411,94 @@ where
     #[instrument(skip(self, request), fields(mint_url = %self.mint_url))]
     async fn post_melt_quote(
         &self,
-        request: MeltQuoteBolt11Request,
-    ) -> Result<MeltQuoteBolt11Response<String>, Error> {
+        request: MeltQuoteRequest,
+    ) -> Result<MeltQuoteResponse<String>, Error> {
+        let method = request.method().to_string();
+        let path = format!("v1/melt/quote/{}", method);
+
         let url = self
             .mint_url
-            .join_paths(&["v1", "melt", "quote", "bolt11"])?;
+            .join_paths(&path.split('/').collect::<Vec<_>>())?;
         let auth_token = self
-            .get_auth_token(
-                Method::Post,
-                RoutePath::MeltQuote(PaymentMethod::Known(KnownMethod::Bolt11).to_string()),
-            )
+            .get_auth_token(Method::Post, RoutePath::MeltQuote(method))
             .await?;
 
-        self.transport.http_post(url, auth_token, &request).await
+        match &request {
+            MeltQuoteRequest::Bolt11(req) => {
+                let response: cdk_common::nut23::MeltQuoteBolt11Response<String> =
+                    self.transport.http_post(url, auth_token, req).await?;
+                Ok(MeltQuoteResponse::Bolt11(response))
+            }
+            MeltQuoteRequest::Bolt12(req) => {
+                let response: cdk_common::nut25::MeltQuoteBolt12Response<String> =
+                    self.transport.http_post(url, auth_token, req).await?;
+                Ok(MeltQuoteResponse::Bolt12(response))
+            }
+            MeltQuoteRequest::Custom(req) => {
+                let response: cdk_common::nut05::MeltQuoteCustomResponse<String> =
+                    self.transport.http_post(url, auth_token, req).await?;
+                Ok(MeltQuoteResponse::Custom((request.method(), response)))
+            }
+        }
     }
 
     /// Melt Quote Status
     #[instrument(skip(self), fields(mint_url = %self.mint_url))]
     async fn get_melt_quote_status(
         &self,
+        method: PaymentMethod,
         quote_id: &str,
-    ) -> Result<MeltQuoteBolt11Response<String>, Error> {
-        let url = self
-            .mint_url
-            .join_paths(&["v1", "melt", "quote", "bolt11", quote_id])?;
+    ) -> Result<MeltQuoteResponse<String>, Error> {
+        match &method {
+            PaymentMethod::Known(KnownMethod::Bolt11) => {
+                let url = self
+                    .mint_url
+                    .join_paths(&["v1", "melt", "quote", "bolt11", quote_id])?;
 
-        let auth_token = self
-            .get_auth_token(
-                Method::Get,
-                RoutePath::MeltQuote(PaymentMethod::Known(KnownMethod::Bolt11).to_string()),
-            )
-            .await?;
+                let auth_token = self
+                    .get_auth_token(
+                        Method::Get,
+                        RoutePath::MeltQuote(PaymentMethod::Known(KnownMethod::Bolt11).to_string()),
+                    )
+                    .await?;
 
-        self.transport.http_get(url, auth_token).await
+                let response: cdk_common::nut23::MeltQuoteBolt11Response<String> =
+                    self.transport.http_get(url, auth_token).await?;
+
+                Ok(MeltQuoteResponse::Bolt11(response))
+            }
+            PaymentMethod::Known(KnownMethod::Bolt12) => {
+                let url = self
+                    .mint_url
+                    .join_paths(&["v1", "melt", "quote", "bolt12", quote_id])?;
+
+                let auth_token = self
+                    .get_auth_token(
+                        Method::Get,
+                        RoutePath::MeltQuote(PaymentMethod::Known(KnownMethod::Bolt12).to_string()),
+                    )
+                    .await?;
+
+                let response: cdk_common::nut25::MeltQuoteBolt12Response<String> =
+                    self.transport.http_get(url, auth_token).await?;
+
+                Ok(MeltQuoteResponse::Bolt12(response))
+            }
+            PaymentMethod::Custom(method_name) => {
+                let url =
+                    self.mint_url
+                        .join_paths(&["v1", "melt", "quote", method_name, quote_id])?;
+
+                let auth_token = self
+                    .get_auth_token(Method::Get, RoutePath::MeltQuote(method_name.clone()))
+                    .await?;
+
+                let response: cdk_common::nut05::MeltQuoteCustomResponse<String> =
+                    self.transport.http_get(url, auth_token).await?;
+
+                Ok(MeltQuoteResponse::Custom((method.clone(), response)))
+            }
+        }
     }
 
     /// Melt [NUT-05]
@@ -481,156 +594,6 @@ where
             .await?;
 
         self.transport.http_post(url, auth_token, &request).await
-    }
-
-    /// Mint Quote Bolt12 [NUT-23]
-    #[instrument(skip(self), fields(mint_url = %self.mint_url))]
-    async fn post_mint_bolt12_quote(
-        &self,
-        request: MintQuoteBolt12Request,
-    ) -> Result<MintQuoteBolt12Response<String>, Error> {
-        let url = self
-            .mint_url
-            .join_paths(&["v1", "mint", "quote", "bolt12"])?;
-
-        let auth_token = self
-            .get_auth_token(
-                Method::Post,
-                RoutePath::MintQuote(PaymentMethod::Known(KnownMethod::Bolt12).to_string()),
-            )
-            .await?;
-
-        self.transport.http_post(url, auth_token, &request).await
-    }
-
-    /// Mint Quote Bolt12 status
-    #[instrument(skip(self), fields(mint_url = %self.mint_url))]
-    async fn get_mint_quote_bolt12_status(
-        &self,
-        quote_id: &str,
-    ) -> Result<MintQuoteBolt12Response<String>, Error> {
-        let url = self
-            .mint_url
-            .join_paths(&["v1", "mint", "quote", "bolt12", quote_id])?;
-
-        let auth_token = self
-            .get_auth_token(
-                Method::Get,
-                RoutePath::MintQuote(PaymentMethod::Known(KnownMethod::Bolt12).to_string()),
-            )
-            .await?;
-
-        self.transport.http_get(url, auth_token).await
-    }
-
-    /// Melt Quote Bolt12 [NUT-23]
-    #[instrument(skip(self, request), fields(mint_url = %self.mint_url))]
-    async fn post_melt_bolt12_quote(
-        &self,
-        request: MeltQuoteBolt12Request,
-    ) -> Result<MeltQuoteBolt12Response<String>, Error> {
-        let url = self
-            .mint_url
-            .join_paths(&["v1", "melt", "quote", "bolt12"])?;
-        let auth_token = self
-            .get_auth_token(
-                Method::Post,
-                RoutePath::MeltQuote(PaymentMethod::Known(KnownMethod::Bolt12).to_string()),
-            )
-            .await?;
-
-        self.transport.http_post(url, auth_token, &request).await
-    }
-
-    /// Melt Quote Bolt12 Status [NUT-23]
-    #[instrument(skip(self), fields(mint_url = %self.mint_url))]
-    async fn get_melt_bolt12_quote_status(
-        &self,
-        quote_id: &str,
-    ) -> Result<MeltQuoteBolt12Response<String>, Error> {
-        let url = self
-            .mint_url
-            .join_paths(&["v1", "melt", "quote", "bolt12", quote_id])?;
-
-        let auth_token = self
-            .get_auth_token(
-                Method::Get,
-                RoutePath::MeltQuote(PaymentMethod::Known(KnownMethod::Bolt12).to_string()),
-            )
-            .await?;
-
-        self.transport.http_get(url, auth_token).await
-    }
-
-    /// Mint Quote for Custom Payment Method
-    #[instrument(skip(self), fields(mint_url = %self.mint_url))]
-    async fn post_mint_custom_quote(
-        &self,
-        method: &PaymentMethod,
-        request: MintQuoteCustomRequest,
-    ) -> Result<MintQuoteCustomResponse<String>, Error> {
-        let url = self
-            .mint_url
-            .join_paths(&["v1", "mint", "quote", &method.to_string()])?;
-
-        let auth_token = self
-            .get_auth_token(Method::Post, RoutePath::MintQuote(method.to_string()))
-            .await?;
-
-        self.transport.http_post(url, auth_token, &request).await
-    }
-
-    /// Mint Quote Status for Custom Payment Method
-    #[instrument(skip(self), fields(mint_url = %self.mint_url))]
-    async fn get_mint_quote_custom_status(
-        &self,
-        method: &str,
-        quote_id: &str,
-    ) -> Result<MintQuoteCustomResponse<String>, Error> {
-        let url = self
-            .mint_url
-            .join_paths(&["v1", "mint", "quote", method, quote_id])?;
-
-        let auth_token = self
-            .get_auth_token(Method::Get, RoutePath::MintQuote(method.to_string()))
-            .await?;
-
-        self.transport.http_get(url, auth_token).await
-    }
-
-    /// Melt Quote for Custom Payment Method
-    #[instrument(skip(self, request), fields(mint_url = %self.mint_url))]
-    async fn post_melt_custom_quote(
-        &self,
-        request: MeltQuoteCustomRequest,
-    ) -> Result<MeltQuoteCustomResponse<String>, Error> {
-        let url = self
-            .mint_url
-            .join_paths(&["v1", "melt", "quote", &request.method])?;
-
-        let auth_token = self
-            .get_auth_token(Method::Post, RoutePath::MeltQuote(request.method.clone()))
-            .await?;
-
-        self.transport.http_post(url, auth_token, &request).await
-    }
-
-    /// Melt Quote Status for Custom Payment Method
-    #[instrument(skip(self), fields(mint_url = %self.mint_url))]
-    async fn get_melt_quote_custom_status(
-        &self,
-        method: &str,
-        quote_id: &str,
-    ) -> Result<MeltQuoteCustomResponse<String>, Error> {
-        let url = self
-            .mint_url
-            .join_paths(&["v1", "melt", "quote", method, quote_id])?;
-
-        let auth_token = self
-            .get_auth_token(Method::Get, RoutePath::MeltQuote(method.to_string()))
-            .await?;
-
-        self.transport.http_get(url, auth_token).await
     }
 }
 

--- a/crates/cdk/src/wallet/mint_connector/mod.rs
+++ b/crates/cdk/src/wallet/mint_connector/mod.rs
@@ -3,20 +3,16 @@
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use cdk_common::{
-    MeltQuoteBolt12Request, MeltQuoteBolt12Response, MeltQuoteCustomResponse,
-    MintQuoteBolt12Request, MintQuoteBolt12Response,
-};
+use cdk_common::{MeltQuoteRequest, MeltQuoteResponse, MintQuoteRequest, MintQuoteResponse};
 
 use super::Error;
 // Re-export Lightning address types for trait implementers
 pub use crate::lightning_address::{LnurlPayInvoiceResponse, LnurlPayResponse};
 use crate::nuts::{
     BatchCheckMintQuoteRequest, BatchMintRequest, CheckStateRequest, CheckStateResponse, Id,
-    KeySet, KeysetResponse, MeltQuoteBolt11Request, MeltQuoteBolt11Response,
-    MeltQuoteCustomRequest, MeltRequest, MintInfo, MintQuoteBolt11Request, MintQuoteBolt11Response,
-    MintQuoteCustomRequest, MintQuoteCustomResponse, MintRequest, MintResponse, PaymentMethod,
-    RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
+    KeySet, KeysetResponse, MeltQuoteBolt11Response, MeltRequest, MintInfo,
+    MintQuoteBolt11Response, MintRequest, MintResponse, PaymentMethod, RestoreRequest,
+    RestoreResponse, SwapRequest, SwapResponse,
 };
 use crate::wallet::AuthWallet;
 
@@ -57,16 +53,11 @@ pub trait MintConnector: Debug {
     async fn get_mint_keyset(&self, keyset_id: Id) -> Result<KeySet, Error>;
     /// Get Keysets [NUT-02]
     async fn get_mint_keysets(&self) -> Result<KeysetResponse, Error>;
-    /// Mint Quote [NUT-04]
+    /// Mint Quote [NUT-04, NUT-23, NUT-25]
     async fn post_mint_quote(
         &self,
-        request: MintQuoteBolt11Request,
-    ) -> Result<MintQuoteBolt11Response<String>, Error>;
-    /// Mint Quote status
-    async fn get_mint_quote_status(
-        &self,
-        quote_id: &str,
-    ) -> Result<MintQuoteBolt11Response<String>, Error>;
+        request: MintQuoteRequest,
+    ) -> Result<MintQuoteResponse<String>, Error>;
     /// Mint Tokens [NUT-04]
     async fn post_mint(
         &self,
@@ -97,16 +88,24 @@ pub trait MintConnector: Debug {
     /// Melt Quote [NUT-05]
     async fn post_melt_quote(
         &self,
-        request: MeltQuoteBolt11Request,
-    ) -> Result<MeltQuoteBolt11Response<String>, Error>;
+        request: MeltQuoteRequest,
+    ) -> Result<MeltQuoteResponse<String>, Error>;
 
+    /// Mint Quote status with payment method
+    async fn get_mint_quote_status(
+        &self,
+        method: PaymentMethod,
+        quote_id: &str,
+    ) -> Result<MintQuoteResponse<String>, Error>;
+
+    /// Melt [NUT-05]
     /// Melt Quote Status
     async fn get_melt_quote_status(
         &self,
+        method: PaymentMethod,
         quote_id: &str,
-    ) -> Result<MeltQuoteBolt11Response<String>, Error>;
+    ) -> Result<MeltQuoteResponse<String>, Error>;
 
-    /// Melt [NUT-05]
     /// [Nut-08] Lightning fee return if outputs defined
     async fn post_melt(
         &self,
@@ -131,51 +130,4 @@ pub trait MintConnector: Debug {
 
     /// Set auth wallet on client
     async fn set_auth_wallet(&self, wallet: Option<AuthWallet>);
-    /// Mint Quote [NUT-04]
-    async fn post_mint_bolt12_quote(
-        &self,
-        request: MintQuoteBolt12Request,
-    ) -> Result<MintQuoteBolt12Response<String>, Error>;
-    /// Mint Quote status
-    async fn get_mint_quote_bolt12_status(
-        &self,
-        quote_id: &str,
-    ) -> Result<MintQuoteBolt12Response<String>, Error>;
-    /// Melt Quote [NUT-23]
-    async fn post_melt_bolt12_quote(
-        &self,
-        request: MeltQuoteBolt12Request,
-    ) -> Result<MeltQuoteBolt12Response<String>, Error>;
-    /// Melt Quote Status [NUT-23]
-    async fn get_melt_bolt12_quote_status(
-        &self,
-        quote_id: &str,
-    ) -> Result<MeltQuoteBolt12Response<String>, Error>;
-
-    /// Mint Quote for Custom Payment Method
-    async fn post_mint_custom_quote(
-        &self,
-        method: &PaymentMethod,
-        request: MintQuoteCustomRequest,
-    ) -> Result<MintQuoteCustomResponse<String>, Error>;
-
-    /// Mint Quote Status for Custom Payment Method
-    async fn get_mint_quote_custom_status(
-        &self,
-        method: &str,
-        quote_id: &str,
-    ) -> Result<MintQuoteCustomResponse<String>, Error>;
-
-    /// Melt Quote for Custom Payment Method
-    async fn post_melt_custom_quote(
-        &self,
-        request: MeltQuoteCustomRequest,
-    ) -> Result<MeltQuoteCustomResponse<String>, Error>;
-
-    /// Melt Quote Status for Custom Payment Method
-    async fn get_melt_quote_custom_status(
-        &self,
-        method: &str,
-        quote_id: &str,
-    ) -> Result<MeltQuoteCustomResponse<String>, Error>;
 }

--- a/crates/cdk/src/wallet/subscription.rs
+++ b/crates/cdk/src/wallet/subscription.rs
@@ -21,7 +21,7 @@ use cdk_common::pub_sub::remote_consumer::{
 use cdk_common::pub_sub::{Error as PubsubError, Spec, Subscriber};
 use cdk_common::subscription::WalletParams;
 use cdk_common::ws_client::{connect as ws_connect, WsError};
-use cdk_common::{CheckStateRequest, Method, RoutePath};
+use cdk_common::{CheckStateRequest, Method, PaymentMethod, RoutePath};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -255,8 +255,18 @@ impl Transport for SubscriptionClient {
         {
             match topic {
                 NotificationId::MintQuoteBolt11(id) => {
-                    let response = match self.http_client.get_mint_quote_status(&id).await {
-                        Ok(success) => success,
+                    let response = match self
+                        .http_client
+                        .get_mint_quote_status(PaymentMethod::BOLT11, &id)
+                        .await
+                    {
+                        Ok(success) => match success {
+                            cdk_common::MintQuoteResponse::Bolt11(r) => r,
+                            _ => {
+                                tracing::error!("Unexpected response type for MintBolt11 {}", id);
+                                continue;
+                            }
+                        },
                         Err(err) => {
                             tracing::error!("Error with MintBolt11 {} with {:?}", id, err);
                             continue;
@@ -264,12 +274,22 @@ impl Transport for SubscriptionClient {
                     };
 
                     reply_to.send(MintEvent::new(
-                        NotificationPayload::MintQuoteBolt11Response(response.clone()),
+                        NotificationPayload::MintQuoteBolt11Response(response),
                     ));
                 }
                 NotificationId::MeltQuoteBolt11(id) => {
-                    let response = match self.http_client.get_melt_quote_status(&id).await {
-                        Ok(success) => success,
+                    let response = match self
+                        .http_client
+                        .get_melt_quote_status(PaymentMethod::BOLT11, &id)
+                        .await
+                    {
+                        Ok(success) => match success {
+                            cdk_common::MeltQuoteResponse::Bolt11(r) => r,
+                            _ => {
+                                tracing::error!("Unexpected response type for MeltBolt11 {}", id);
+                                continue;
+                            }
+                        },
                         Err(err) => {
                             tracing::error!("Error with MeltBolt11 {} with {:?}", id, err);
                             continue;
@@ -281,8 +301,18 @@ impl Transport for SubscriptionClient {
                     ));
                 }
                 NotificationId::MintQuoteBolt12(id) => {
-                    let response = match self.http_client.get_mint_quote_bolt12_status(&id).await {
-                        Ok(success) => success,
+                    let response = match self
+                        .http_client
+                        .get_mint_quote_status(PaymentMethod::BOLT12, &id)
+                        .await
+                    {
+                        Ok(success) => match success {
+                            cdk_common::MintQuoteResponse::Bolt12(r) => r,
+                            _ => {
+                                tracing::error!("Unexpected response type for MintBolt12 {}", id);
+                                continue;
+                            }
+                        },
                         Err(err) => {
                             tracing::error!("Error with MintBolt12 {} with {:?}", id, err);
                             continue;
@@ -294,8 +324,18 @@ impl Transport for SubscriptionClient {
                     ));
                 }
                 NotificationId::MeltQuoteBolt12(id) => {
-                    let response = match self.http_client.get_melt_bolt12_quote_status(&id).await {
-                        Ok(success) => success,
+                    let response = match self
+                        .http_client
+                        .get_melt_quote_status(PaymentMethod::BOLT12, &id)
+                        .await
+                    {
+                        Ok(success) => match success {
+                            cdk_common::MeltQuoteResponse::Bolt12(r) => r,
+                            _ => {
+                                tracing::error!("Unexpected response type for MeltBolt12 {}", id);
+                                continue;
+                            }
+                        },
                         Err(err) => {
                             tracing::error!("Error with MeltBolt12 {} with {:?}", id, err);
                             continue;
@@ -307,12 +347,21 @@ impl Transport for SubscriptionClient {
                     ));
                 }
                 NotificationId::MintQuoteCustom(method, id) => {
-                    let response = match self
+                    let (_, response) = match self
                         .http_client
-                        .get_mint_quote_custom_status(&method, &id)
+                        .get_mint_quote_status(PaymentMethod::Custom(method.clone()), &id)
                         .await
                     {
-                        Ok(success) => success,
+                        Ok(success) => match success {
+                            cdk_common::MintQuoteResponse::Custom(r) => r,
+                            _ => {
+                                tracing::error!(
+                                    "Unexpected response type for Custom Mint Quote {}",
+                                    id
+                                );
+                                continue;
+                            }
+                        },
                         Err(err) => {
                             tracing::error!("Error with Custom Mint Quote {} with {:?}", id, err);
                             continue;
@@ -326,10 +375,19 @@ impl Transport for SubscriptionClient {
                 NotificationId::MeltQuoteCustom(method, id) => {
                     let response = match self
                         .http_client
-                        .get_melt_quote_custom_status(&method, &id)
+                        .get_melt_quote_status(PaymentMethod::Custom(method.clone()), &id)
                         .await
                     {
-                        Ok(success) => success,
+                        Ok(success) => match success {
+                            cdk_common::MeltQuoteResponse::Custom((_, r)) => r,
+                            _ => {
+                                tracing::error!(
+                                    "Unexpected response type for Custom Melt Quote {}",
+                                    id
+                                );
+                                continue;
+                            }
+                        },
                         Err(err) => {
                             tracing::error!("Error with Custom Melt Quote {} with {:?}", id, err);
                             continue;

--- a/crates/cdk/src/wallet/test_utils.rs
+++ b/crates/cdk/src/wallet/test_utils.rs
@@ -10,21 +10,19 @@ use cdk_common::database::WalletDatabase;
 use cdk_common::mint_url::MintUrl;
 use cdk_common::nut00::KnownMethod;
 use cdk_common::nuts::{
-    CheckStateResponse, CurrencyUnit, Id, KeysetResponse, MeltQuoteCustomRequest,
-    MeltQuoteCustomResponse, MintQuoteBolt11Request, MintQuoteBolt11Response,
-    MintQuoteCustomRequest, MintQuoteCustomResponse, MintRequest, MintResponse, Proof,
+    CheckStateResponse, CurrencyUnit, Id, KeysetResponse, MintRequest, MintResponse, Proof,
     RestoreResponse, SwapRequest, SwapResponse,
 };
 use cdk_common::secret::Secret;
 use cdk_common::wallet::{MeltQuote, MintQuote};
 use cdk_common::{
-    Amount, MeltQuoteBolt12Request, MeltQuoteState, MintQuoteBolt12Request,
-    MintQuoteBolt12Response, SecretKey, State,
+    Amount, MeltQuoteRequest, MeltQuoteResponse, MeltQuoteState, MintQuoteRequest,
+    MintQuoteResponse, SecretKey, State,
 };
 
 use crate::nuts::{
-    BatchCheckMintQuoteRequest, BatchMintRequest, CheckStateRequest, MeltQuoteBolt11Request,
-    MeltQuoteBolt11Response, MeltRequest, PaymentMethod, RestoreRequest,
+    BatchCheckMintQuoteRequest, BatchMintRequest, CheckStateRequest, MeltQuoteBolt11Response,
+    MeltRequest, MintQuoteBolt11Response, PaymentMethod, RestoreRequest,
 };
 use crate::wallet::{MintConnector, Wallet};
 use crate::Error;
@@ -219,15 +217,16 @@ impl MintConnector for MockMintConnector {
 
     async fn post_mint_quote(
         &self,
-        _request: MintQuoteBolt11Request,
-    ) -> Result<MintQuoteBolt11Response<String>, Error> {
+        _request: MintQuoteRequest,
+    ) -> Result<MintQuoteResponse<String>, Error> {
         unimplemented!()
     }
 
     async fn get_mint_quote_status(
         &self,
+        _method: PaymentMethod,
         _quote_id: &str,
-    ) -> Result<MintQuoteBolt11Response<String>, Error> {
+    ) -> Result<MintQuoteResponse<String>, Error> {
         unimplemented!()
     }
 
@@ -245,20 +244,25 @@ impl MintConnector for MockMintConnector {
 
     async fn post_melt_quote(
         &self,
-        _request: MeltQuoteBolt11Request,
-    ) -> Result<MeltQuoteBolt11Response<String>, Error> {
+        _request: MeltQuoteRequest,
+    ) -> Result<MeltQuoteResponse<String>, Error> {
         unimplemented!()
     }
 
     async fn get_melt_quote_status(
         &self,
+        _method: PaymentMethod,
         _quote_id: &str,
-    ) -> Result<MeltQuoteBolt11Response<String>, Error> {
-        self.melt_quote_status_response
+    ) -> Result<MeltQuoteResponse<String>, Error> {
+        let response = self
+            .melt_quote_status_response
             .lock()
             .unwrap()
             .take()
-            .expect("MockMintConnector: get_melt_quote_status called without configured response")
+            .expect(
+                "MockMintConnector: get_melt_quote_status called without configured response",
+            )?;
+        Ok(MeltQuoteResponse::Bolt11(response))
     }
 
     async fn post_swap(&self, _request: SwapRequest) -> Result<SwapResponse, Error> {
@@ -297,65 +301,6 @@ impl MintConnector for MockMintConnector {
     }
 
     async fn set_auth_wallet(&self, _wallet: Option<crate::wallet::AuthWallet>) {}
-
-    async fn get_mint_quote_custom_status(
-        &self,
-        _method: &str,
-        _quote_id: &str,
-    ) -> Result<MintQuoteCustomResponse<String>, Error> {
-        unimplemented!()
-    }
-
-    async fn get_melt_quote_custom_status(
-        &self,
-        _method: &str,
-        _quote_id: &str,
-    ) -> Result<MeltQuoteCustomResponse<String>, Error> {
-        unimplemented!()
-    }
-
-    async fn post_mint_bolt12_quote(
-        &self,
-        _request: MintQuoteBolt12Request,
-    ) -> Result<MintQuoteBolt12Response<String>, Error> {
-        unimplemented!()
-    }
-
-    async fn get_mint_quote_bolt12_status(
-        &self,
-        _quote_id: &str,
-    ) -> Result<MintQuoteBolt12Response<String>, Error> {
-        unimplemented!()
-    }
-
-    async fn post_melt_bolt12_quote(
-        &self,
-        _request: MeltQuoteBolt12Request,
-    ) -> Result<MeltQuoteBolt11Response<String>, Error> {
-        unimplemented!()
-    }
-
-    async fn get_melt_bolt12_quote_status(
-        &self,
-        _quote_id: &str,
-    ) -> Result<MeltQuoteBolt11Response<String>, Error> {
-        unimplemented!()
-    }
-
-    async fn post_mint_custom_quote(
-        &self,
-        _method: &PaymentMethod,
-        _request: MintQuoteCustomRequest,
-    ) -> Result<MintQuoteCustomResponse<String>, Error> {
-        unimplemented!()
-    }
-
-    async fn post_melt_custom_quote(
-        &self,
-        _request: MeltQuoteCustomRequest,
-    ) -> Result<MeltQuoteCustomResponse<String>, Error> {
-        unimplemented!()
-    }
 
     async fn post_melt(
         &self,


### PR DESCRIPTION
This means for each new payment type
we do not need to add a fn on the trait 
instead we add a vaient to the enum

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
