### PR TITLE
chore: update Rust to 1.94.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772420823,
-        "narHash": "sha256-q3oVwz1Rx41D1D+F6vg41kpOkk3Zi3KwnkHEZp7DCGs=",
+        "lastModified": 1773025773,
+        "narHash": "sha256-Wik8+xApNfldpUFjPmJkPdg0RrvUPSWGIZis+A/0N1w=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "458eea8d905c609e9d889423e6b8a1c7bc2f792c",
+        "rev": "3c06fdbbd36ff60386a1e590ee0cd52dcd1892bf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -98,7 +98,7 @@
 
         # Toolchains
         # latest stable
-        stable_toolchain = pkgs.rust-bin.stable."1.93.1".default.override {
+        stable_toolchain = pkgs.rust-bin.stable."1.94.0".default.override {
           targets = [ "wasm32-unknown-unknown" ]; # wasm
           extensions = [
             "rustfmt"
@@ -134,7 +134,7 @@
         # Stable toolchain with musl target for static builds (Linux only)
         static_toolchain =
           if muslTarget != null then
-            pkgs.rust-bin.stable."1.93.1".default.override
+            pkgs.rust-bin.stable."1.94.0".default.override
               {
                 targets = [ muslTarget ];
               }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel="1.93.1"
+channel="1.94.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 


### PR DESCRIPTION
### Description

Update Rust toolchain from 1.93.1 to 1.94.0.                                                                                                          
                                                                                                                                                      
- `rust-toolchain.toml` - Updated channel to `1.94.0`                                                                                                 
- `flake.nix` - Updated stable_toolchain and static_toolchain to `1.94.0`
- `flake.lock` - Updated rust-overlay input                                                                                                           
                                                                                                                                                      
Closes #1717

-----

### Notes to the reviewers

Straightforward version bump, no code changes.                                                                                                        

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

- Updated Rust toolchain from 1.93.1 to 1.94.0                                                                                                        

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
