### PR TITLE
chore: bump payment processor gRPC protocol version to 2.0.0

### DIFF
--- a/crates/cdk-common/src/lib.rs
+++ b/crates/cdk-common/src/lib.rs
@@ -12,7 +12,7 @@ pub mod task;
 pub const MINT_RPC_PROTOCOL_VERSION: &str = "1.0.0";
 
 /// Protocol version for gRPC Payment Processor communication
-pub const PAYMENT_PROCESSOR_PROTOCOL_VERSION: &str = "1.0.0";
+pub const PAYMENT_PROCESSOR_PROTOCOL_VERSION: &str = "2.0.0";
 
 #[cfg(feature = "grpc")]
 pub mod grpc;


### PR DESCRIPTION
### Description

Bump `PAYMENT_PROCESSOR_PROTOCOL_VERSION` from `"1.0.0"` to `"2.0.0"` in `cdk-common`.                                                                
                                                                                                                                                      
Since the version header was introduced (#1617), the payment processor proto has had breaking changes:                                                
- Fields changed from `uint64` to `AmountMessage` (#1616, #1673)
- Redundant `unit` fields removed (#1704)                                                                                                             
- Field numbers renumbered                                                                                                                            
                                                                                                                                                      
Closes #1720 

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

Single line change in `crates/cdk-common/src/lib.rs`. The version is used by both the client and server interceptors to ensure protocol compatibility.

#### CHANGED

- Bumped payment processor gRPC protocol version to 2.0.0

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
