### PR TITLE
Refactor: Make max fee enforcement explicit in payment flow

### DIFF
--- a/crates/cdk-common/src/payment.rs
+++ b/crates/cdk-common/src/payment.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 
-use crate::mint::MeltPaymentRequest;
+use crate::mint::{MeltPaymentRequest, MeltQuote};
 use crate::nuts::{CurrencyUnit, MeltQuoteState};
 use crate::Amount;
 
@@ -284,15 +284,16 @@ pub enum OutgoingPaymentOptions {
     Custom(Box<CustomOutgoingPaymentOptions>),
 }
 
-impl TryFrom<crate::mint::MeltQuote> for OutgoingPaymentOptions {
-    type Error = Error;
-
-    fn try_from(melt_quote: crate::mint::MeltQuote) -> Result<Self, Self::Error> {
+impl OutgoingPaymentOptions {
+    /// Creates payment options from a melt quote
+    pub fn from_melt_quote_with_fee(
+        melt_quote: MeltQuote,
+    ) -> Result<OutgoingPaymentOptions, Error> {
         let fee_reserve = melt_quote.fee_reserve();
         match &melt_quote.request {
             MeltPaymentRequest::Bolt11 { bolt11 } => Ok(OutgoingPaymentOptions::Bolt11(Box::new(
                 Bolt11OutgoingPaymentOptions {
-                    max_fee_amount: Some(fee_reserve.to_owned()),
+                    max_fee_amount: Some(fee_reserve),
                     timeout_secs: None,
                     bolt11: bolt11.clone(),
                     melt_options: melt_quote.options,
@@ -300,14 +301,14 @@ impl TryFrom<crate::mint::MeltQuote> for OutgoingPaymentOptions {
             ))),
             MeltPaymentRequest::Bolt12 { offer } => {
                 let melt_options = match melt_quote.options {
-                    None => None,
                     Some(MeltOptions::Mpp { mpp: _ }) => return Err(Error::UnsupportedUnit),
                     Some(options) => Some(options),
+                    _ => None,
                 };
 
                 Ok(OutgoingPaymentOptions::Bolt12(Box::new(
                     Bolt12OutgoingPaymentOptions {
-                        max_fee_amount: Some(fee_reserve.clone()),
+                        max_fee_amount: Some(fee_reserve),
                         timeout_secs: None,
                         offer: *offer.clone(),
                         melt_options,
@@ -318,7 +319,7 @@ impl TryFrom<crate::mint::MeltQuote> for OutgoingPaymentOptions {
                 Box::new(CustomOutgoingPaymentOptions {
                     method: method.to_string(),
                     request: request.to_string(),
-                    max_fee_amount: Some(melt_quote.fee_reserve()),
+                    max_fee_amount: Some(fee_reserve),
                     timeout_secs: None,
                     melt_options: melt_quote.options,
                     extra_json: None,

--- a/crates/cdk/src/mint/melt/melt_saga/mod.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/mod.rs
@@ -6,6 +6,7 @@ use cdk_common::database::DynMintDatabase;
 use cdk_common::mint::{MeltSagaState, Operation, Saga, SagaStateEnum};
 use cdk_common::nut00::KnownMethod;
 use cdk_common::nuts::MeltQuoteState;
+use cdk_common::payment::OutgoingPaymentOptions;
 use cdk_common::{
     Amount, CurrencyUnit, Error, ProofsMethods, PublicKey, QuoteId, SpendingConditionVerification,
     State,
@@ -700,13 +701,10 @@ impl MeltSaga<SetupComplete> {
         >,
     ) -> Result<MakePaymentResponse, Error> {
         // Make payment with idempotent verification
-        match ln
-            .make_payment(
-                &self.state_data.quote.unit,
-                self.state_data.quote.clone().try_into()?,
-            )
-            .await
-        {
+        let quote = &self.state_data.quote;
+        let payment_options = OutgoingPaymentOptions::from_melt_quote_with_fee(quote.clone())?;
+
+        match ln.make_payment(&quote.unit, payment_options).await {
             Ok(pay) if pay.status == MeltQuoteState::Paid => Ok(pay),
             Ok(pay) => self.verify_ambiguous_payment(ln, pay).await,
             Err(err) => self.handle_payment_error(ln, err).await,


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

It's a PR for https://github.com/cashubtc/cdk/issues/1499 

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->
Replaced `TryFrom<MeltQuote>` to a function `OutgoingPaymentOptions` directly

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED
- Remove the `TryFrom<MeltQuote>` implementation
- Add `OutgoingPaymentOptions::from_melt_quote_with_fee(melt_quote)` function
- Replace the old `.try_into()` to new function call

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
