### PR TITLE
fix(sql): persist extra_json on mint_quotes

### DIFF
--- a/crates/cdk-sql-common/src/mint/migrations/postgres/20260316000000_add_extra_json_to_mint_quote.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/postgres/20260316000000_add_extra_json_to_mint_quote.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mint_quote ADD COLUMN extra_json TEXT;

--- a/crates/cdk-sql-common/src/mint/migrations/sqlite/20260316000000_add_extra_json_to_mint_quote.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/sqlite/20260316000000_add_extra_json_to_mint_quote.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mint_quote ADD COLUMN extra_json TEXT;

--- a/crates/cdk-sql-common/src/mint/quotes.rs
+++ b/crates/cdk-sql-common/src/mint/quotes.rs
@@ -128,7 +128,8 @@ where
             amount_paid,
             amount_issued,
             payment_method,
-            request_lookup_id_kind
+            request_lookup_id_kind,
+            extra_json
         FROM
             mint_quote
         WHERE id = :id
@@ -167,7 +168,8 @@ where
             amount_paid,
             amount_issued,
             payment_method,
-            request_lookup_id_kind
+            request_lookup_id_kind,
+            extra_json
         FROM
             mint_quote
         WHERE request = :request
@@ -215,7 +217,8 @@ where
             amount_paid,
             amount_issued,
             payment_method,
-            request_lookup_id_kind
+            request_lookup_id_kind,
+            extra_json
         FROM
             mint_quote
         WHERE request_lookup_id = :request_lookup_id
@@ -319,7 +322,8 @@ where
             amount_paid,
             amount_issued,
             payment_method,
-            request_lookup_id_kind
+            request_lookup_id_kind,
+            extra_json
         FROM
             mint_quote
         WHERE id IN ({in_clause})
@@ -481,7 +485,8 @@ fn sql_row_to_mint_quote(
     unpack_into!(
         let (
             id, amount, unit, request, expiry, request_lookup_id,
-            pubkey, created_time, amount_paid, amount_issued, payment_method, request_lookup_id_kind
+            pubkey, created_time, amount_paid, amount_issued, payment_method, request_lookup_id_kind,
+            extra_json
         ) = row
     );
 
@@ -503,6 +508,8 @@ fn sql_row_to_mint_quote(
     let amount_issued: u64 = column_as_number!(amount_issued);
     let payment_method = column_as_string!(payment_method, PaymentMethod::from_str);
     let unit = column_as_string!(unit, CurrencyUnit::from_str);
+    let extra_json = column_as_nullable_string!(&extra_json)
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok());
 
     Ok(MintQuote::new(
         Some(QuoteId::from_str(&id)?),
@@ -519,7 +526,7 @@ fn sql_row_to_mint_quote(
         column_as_number!(created_time),
         payments,
         issueances,
-        None,
+        extra_json,
     ))
 }
 
@@ -887,10 +894,10 @@ where
         query(
             r#"
                 INSERT INTO mint_quote (
-                id, amount, unit, request, expiry, request_lookup_id, pubkey, created_time, payment_method, request_lookup_id_kind
+                id, amount, unit, request, expiry, request_lookup_id, pubkey, created_time, payment_method, request_lookup_id_kind, extra_json
                 )
                 VALUES (
-                :id, :amount, :unit, :request, :expiry, :request_lookup_id, :pubkey, :created_time, :payment_method, :request_lookup_id_kind
+                :id, :amount, :unit, :request, :expiry, :request_lookup_id, :pubkey, :created_time, :payment_method, :request_lookup_id_kind, :extra_json
                 )
             "#,
         )?
@@ -907,6 +914,10 @@ where
         .bind("created_time", quote.created_time as i64)
         .bind("payment_method", quote.payment_method.to_string())
         .bind("request_lookup_id_kind", quote.request_lookup_id.kind())
+        .bind(
+            "extra_json",
+            quote.extra_json.as_ref().map(|v| v.to_string()),
+        )
         .execute(&self.inner)
         .await?;
 
@@ -1161,7 +1172,8 @@ where
                 amount_paid,
                 amount_issued,
                 payment_method,
-                request_lookup_id_kind
+                request_lookup_id_kind,
+                extra_json
             FROM
                 mint_quote
             "#,


### PR DESCRIPTION
--- 

Description 

MintQuote.extra_json is populated in the memory layer but was never persisted to the database, causing it to silently return None after a mint restart. The 
upstream data model clearly intends for this field to survive restarts — it is present on cdk_common::MintQuote, CreateIncomingPaymentResponse, and
cdk_axum::MintQuoteCustomResponse — but the SQL layer was missing the column entirely.

This PR adds an ALTER TABLE migration (SQLite + Postgres) and wires extra_json through all affected SELECT queries and the INSERT in
cdk-sql-common/src/mint/quotes.rs.

---

Notes to the reviewers

The fix is purely additive: one nullable TEXT column added via ALTER TABLE, with no schema changes to existing columns. The column is optional (None is
serialized as NULL) so existing rows are unaffected.

All five SELECT paths for mint_quote rows now include extra_json:
- get_mint_quote_inner (by id)
- get_mint_quote_by_request_inner
- get_mint_quote_by_request_lookup_id_inner
- get_mint_quotes_inner (batch by ids)
- get_mint_quotes (all quotes)

---

Suggested CHANGELOG Updates

FIXED

- extra_json on MintQuote is now persisted to the database and restored correctly after a mint restart

---

Checklist

- I followed the code style guidelines
- I ran just final-check before committing

---
