### PR TITLE
fix: auth token should not require base64 padding (NUT-22)

### DIFF
--- a/crates/cashu/src/nuts/auth/nut22.rs
+++ b/crates/cashu/src/nuts/auth/nut22.rs
@@ -245,7 +245,8 @@ impl std::str::FromStr for BlindAuthToken {
         // Decode the base64 URL-safe string (accept with or without padding)
         let decode_config = GeneralPurposeConfig::new()
             .with_decode_padding_mode(bitcoin::base64::engine::DecodePaddingMode::Indifferent);
-        let json_string = GeneralPurpose::new(&alphabet::URL_SAFE, decode_config).decode(encoded)?;
+        let json_string =
+            GeneralPurpose::new(&alphabet::URL_SAFE, decode_config).decode(encoded)?;
 
         // Convert bytes to UTF-8 string
         let json_str = String::from_utf8(json_string)?;
@@ -305,14 +306,14 @@ mod tests {
         assert!(token_str.starts_with("authA"));
 
         // Parse with padding
-        let parsed = BlindAuthToken::from_str(&token_str)
-            .expect("Failed to parse token with padding");
+        let parsed =
+            BlindAuthToken::from_str(&token_str).expect("Failed to parse token with padding");
         assert_eq!(token, parsed);
 
         // Strip padding and parse again
         let token_no_pad = token_str.trim_end_matches('=');
-        let parsed_no_pad = BlindAuthToken::from_str(token_no_pad)
-            .expect("Failed to parse token without padding");
+        let parsed_no_pad =
+            BlindAuthToken::from_str(token_no_pad).expect("Failed to parse token without padding");
         assert_eq!(token, parsed_no_pad);
     }
 


### PR DESCRIPTION
### Description

`BlindAuthToken::from_str()` required base64 padding on auth tokens (`authA` prefix), while normal Cashu tokens (`cashuA`/`cashuB`) already accepted tokens with or without padding via `DecodePaddingMode::Indifferent`.                                                                                  

Closes #1740

-----

### Notes to the reviewers

Single-file change in `crates/cashu/src/nuts/auth/nut22.rs`:                                                                                          
- Updated `BlindAuthToken::from_str()` to use `DecodePaddingMode::Indifferent` instead of `general_purpose::URL_SAFE`
- Added `test_blind_auth_token_padding` test that verifies roundtrip with and without padding

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

- cashu: Auth token (NUT-22) no longer requires base64 padding

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
