### PR TITLE
chore: Removes `clone` from Wallet struct

### DIFF
--- a/crates/cdk-cli/src/sub_commands/mint.rs
+++ b/crates/cdk-cli/src/sub_commands/mint.rs
@@ -234,7 +234,7 @@ pub async fn mint(
 /// created (e.g. for unsupported payment methods); in that case the main flow
 /// continues silently as before.
 async fn spawn_progress_task(
-    wallet: Wallet,
+    wallet: Arc<Wallet>,
     quote_id: String,
     payment_method: PaymentMethod,
     stop: Arc<Notify>,

--- a/crates/cdk-cli/src/sub_commands/npubcash.rs
+++ b/crates/cdk-cli/src/sub_commands/npubcash.rs
@@ -45,12 +45,10 @@ async fn get_wallet_for_mint_without_probe(
         .get_wallet(&mint_url, &CurrencyUnit::Sat)
         .await
     {
-        Ok(wallet) => Ok(Arc::new(wallet)),
-        Err(_) => Ok(Arc::new(
-            wallet_repository
-                .create_wallet(mint_url, CurrencyUnit::Sat, None)
-                .await?,
-        )),
+        Ok(wallet) => Ok(wallet),
+        Err(_) => Ok(wallet_repository
+            .create_wallet(mint_url, CurrencyUnit::Sat, None)
+            .await?),
     }
 }
 

--- a/crates/cdk-cli/src/sub_commands/npubcash.rs
+++ b/crates/cdk-cli/src/sub_commands/npubcash.rs
@@ -29,12 +29,10 @@ async fn get_wallet_for_mint(
         .get_wallet(&mint_url, &CurrencyUnit::Sat)
         .await
     {
-        Ok(wallet) => Ok(Arc::new(wallet)),
-        Err(_) => Ok(Arc::new(
-            wallet_repository
-                .create_wallet(mint_url, CurrencyUnit::Sat, None)
-                .await?,
-        )),
+        Ok(wallet) => Ok(wallet),
+        Err(_) => Ok(wallet_repository
+            .create_wallet(mint_url, CurrencyUnit::Sat, None)
+            .await?),
     }
 }
 
@@ -226,7 +224,9 @@ async fn subscribe(
 
     // Run polling and wait for Ctrl+C
     let mut stream =
-        wallet.npubcash_proof_stream(SplitTarget::default(), None, Duration::from_secs(5));
+        wallet
+            .clone()
+            .npubcash_proof_stream(SplitTarget::default(), None, Duration::from_secs(5));
 
     tokio::select! {
         _ = async {

--- a/crates/cdk-cli/src/sub_commands/update_mint_url.rs
+++ b/crates/cdk-cli/src/sub_commands/update_mint_url.rs
@@ -1,8 +1,11 @@
+use std::sync::Arc;
+
 use anyhow::Result;
 use cdk::mint_url::MintUrl;
 use cdk::nuts::CurrencyUnit;
 use cdk::wallet::WalletRepository;
 use clap::Args;
+use tokio::sync::Mutex;
 
 #[derive(Args)]
 pub struct UpdateMintUrlSubCommand {
@@ -22,12 +25,17 @@ pub async fn update_mint_url(
         new_mint_url,
     } = sub_command_args;
 
-    let mut wallet = wallet_repository
-        .get_wallet(&sub_command_args.old_mint_url, unit)
-        .await?
-        .clone();
+    let wallet = Arc::new(Mutex::new(
+        Arc::try_unwrap(
+            wallet_repository
+                .get_wallet(&sub_command_args.old_mint_url, unit)
+                .await?,
+        )
+        .expect("Unable to unwrap wallet"),
+    ));
 
-    wallet.update_mint_url(new_mint_url.clone()).await?;
+    let mut wallet_lock = wallet.lock().await;
+    wallet_lock.update_mint_url(new_mint_url.clone()).await?;
 
     println!("Mint Url changed from {old_mint_url} to {new_mint_url}");
 

--- a/crates/cdk-cli/src/sub_commands/update_mint_url.rs
+++ b/crates/cdk-cli/src/sub_commands/update_mint_url.rs
@@ -1,11 +1,8 @@
-use std::sync::Arc;
-
 use anyhow::Result;
 use cdk::mint_url::MintUrl;
 use cdk::nuts::CurrencyUnit;
 use cdk::wallet::WalletRepository;
 use clap::Args;
-use tokio::sync::Mutex;
 
 #[derive(Args)]
 pub struct UpdateMintUrlSubCommand {
@@ -25,17 +22,9 @@ pub async fn update_mint_url(
         new_mint_url,
     } = sub_command_args;
 
-    let wallet = Arc::new(Mutex::new(
-        Arc::try_unwrap(
-            wallet_repository
-                .get_wallet(&sub_command_args.old_mint_url, unit)
-                .await?,
-        )
-        .expect("Unable to unwrap wallet"),
-    ));
-
-    let mut wallet_lock = wallet.lock().await;
-    wallet_lock.update_mint_url(new_mint_url.clone()).await?;
+    wallet_repository
+        .update_mint_url(old_mint_url, new_mint_url, unit)
+        .await?;
 
     println!("Mint Url changed from {old_mint_url} to {new_mint_url}");
 

--- a/crates/cdk-cli/src/utils.rs
+++ b/crates/cdk-cli/src/utils.rs
@@ -1,6 +1,9 @@
 use std::io::{self, Write};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use anyhow::{bail, Result};
 use cdk::mint_url::MintUrl;
@@ -44,7 +47,7 @@ pub async fn get_or_create_wallet(
     wallet_repository: &WalletRepository,
     mint_url: &MintUrl,
     unit: &CurrencyUnit,
-) -> Result<cdk::wallet::Wallet> {
+) -> Result<Arc<cdk::wallet::Wallet>> {
     match wallet_repository.get_wallet(mint_url, unit).await {
         Ok(wallet) => Ok(wallet),
         Err(_) => wallet_repository

--- a/crates/cdk-ffi/src/wallet_repository.rs
+++ b/crates/cdk-ffi/src/wallet_repository.rs
@@ -244,7 +244,7 @@ impl WalletRepository {
         let wallets = self.inner.get_wallets().await;
         wallets
             .into_iter()
-            .map(|w| Arc::new(crate::wallet::Wallet::from_inner(Arc::new(w))))
+            .map(|w| Arc::new(crate::wallet::Wallet::from_inner(w)))
             .collect()
     }
 
@@ -259,9 +259,7 @@ impl WalletRepository {
         let cdk_mint_url: cdk::mint_url::MintUrl = mint_url.try_into()?;
         let unit_cdk: cdk::nuts::CurrencyUnit = unit.into();
         let wallet = self.inner.get_wallet(&cdk_mint_url, &unit_cdk).await?;
-        Ok(Arc::new(crate::wallet::Wallet::from_inner(Arc::new(
-            wallet,
-        ))))
+        Ok(Arc::new(crate::wallet::Wallet::from_inner(wallet)))
     }
 
     /// Get token data, including the expected redemption fee, without redeeming it.

--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -573,7 +573,7 @@ pub async fn create_mint_with_limits(limits: Option<(usize, usize)>) -> Result<M
     Ok(mint)
 }
 
-pub async fn create_test_wallet_for_mint(mint: Mint) -> Result<Wallet> {
+pub async fn create_test_wallet_for_mint(mint: Mint) -> Result<Arc<Wallet>> {
     let seed = Mnemonic::generate(12)?.to_seed_normalized("");
     create_test_wallet_for_mint_with_seed(mint, seed).await
 }
@@ -581,7 +581,10 @@ pub async fn create_test_wallet_for_mint(mint: Mint) -> Result<Wallet> {
 /// Create a test wallet connected directly to a mint with a specific seed
 ///
 /// Useful for restore tests where two wallets must share the same seed.
-pub async fn create_test_wallet_for_mint_with_seed(mint: Mint, seed: [u8; 64]) -> Result<Wallet> {
+pub async fn create_test_wallet_for_mint_with_seed(
+    mint: Mint,
+    seed: [u8; 64],
+) -> Result<Arc<Wallet>> {
     let connector = DirectMintConnection::new(mint.clone());
 
     let mint_info = mint.mint_info().await?;
@@ -625,13 +628,15 @@ pub async fn create_test_wallet_for_mint_with_seed(mint: Mint, seed: [u8; 64]) -
             }
         };
 
-    let wallet = WalletBuilder::new()
-        .mint_url(mint_url.parse().unwrap())
-        .unit(unit)
-        .localstore(localstore)
-        .seed(seed)
-        .client(connector)
-        .build()?;
+    let wallet = Arc::new(
+        WalletBuilder::new()
+            .mint_url(mint_url.parse().unwrap())
+            .unit(unit)
+            .localstore(localstore)
+            .seed(seed)
+            .client(connector)
+            .build()?,
+    );
 
     Ok(wallet)
 }
@@ -647,7 +652,7 @@ fn create_temp_dir(prefix: &str) -> Result<PathBuf> {
 }
 
 pub async fn fund_wallet(
-    wallet: Wallet,
+    wallet: &Arc<Wallet>,
     amount: u64,
     split_target: Option<SplitTarget>,
 ) -> Result<Amount> {

--- a/crates/cdk-integration-tests/tests/fake_auth.rs
+++ b/crates/cdk-integration-tests/tests/fake_auth.rs
@@ -372,21 +372,21 @@ async fn test_mint_with_auth() {
 async fn test_swap_with_auth() {
     let db = Arc::new(memory::empty().await.unwrap());
 
-    let wallet = WalletBuilder::new()
-        .mint_url(MintUrl::from_str(MINT_URL).expect("Valid mint url"))
-        .unit(CurrencyUnit::Sat)
-        .localstore(db.clone())
-        .seed(Mnemonic::generate(12).unwrap().to_seed_normalized(""))
-        .build()
-        .expect("Wallet");
+    let wallet = Arc::new(
+        WalletBuilder::new()
+            .mint_url(MintUrl::from_str(MINT_URL).expect("Valid mint url"))
+            .unit(CurrencyUnit::Sat)
+            .localstore(db.clone())
+            .seed(Mnemonic::generate(12).unwrap().to_seed_normalized(""))
+            .build()
+            .expect("Wallet"),
+    );
     let mint_info = wallet.fetch_mint_info().await.unwrap().unwrap();
     let (access_token, _) = get_tokens(&mint_info, false)
         .await
         .expect("could not get access token");
 
     wallet.set_cat(access_token).await.unwrap();
-
-    let wallet = Arc::new(wallet);
 
     wallet.mint_blind_auth(10.into()).await.unwrap();
 
@@ -428,13 +428,15 @@ async fn test_swap_with_auth() {
 async fn test_melt_with_auth() {
     let db = Arc::new(memory::empty().await.unwrap());
 
-    let wallet = WalletBuilder::new()
-        .mint_url(MintUrl::from_str(MINT_URL).expect("Valid mint url"))
-        .unit(CurrencyUnit::Sat)
-        .localstore(db.clone())
-        .seed(Mnemonic::generate(12).unwrap().to_seed_normalized(""))
-        .build()
-        .expect("Wallet");
+    let wallet = Arc::new(
+        WalletBuilder::new()
+            .mint_url(MintUrl::from_str(MINT_URL).expect("Valid mint url"))
+            .unit(CurrencyUnit::Sat)
+            .localstore(db.clone())
+            .seed(Mnemonic::generate(12).unwrap().to_seed_normalized(""))
+            .build()
+            .expect("Wallet"),
+    );
 
     let mint_info = wallet
         .fetch_mint_info()
@@ -447,8 +449,6 @@ async fn test_melt_with_auth() {
         .expect("could not get access token");
 
     wallet.set_cat(access_token).await.unwrap();
-
-    let wallet = Arc::new(wallet);
 
     wallet.mint_blind_auth(10.into()).await.unwrap();
 
@@ -574,13 +574,15 @@ async fn test_reuse_auth_proof() {
 async fn test_melt_with_invalid_auth() {
     let db = Arc::new(memory::empty().await.unwrap());
 
-    let wallet = WalletBuilder::new()
-        .mint_url(MintUrl::from_str(MINT_URL).expect("Valid mint url"))
-        .unit(CurrencyUnit::Sat)
-        .localstore(db.clone())
-        .seed(Mnemonic::generate(12).unwrap().to_seed_normalized(""))
-        .build()
-        .expect("Wallet");
+    let wallet = Arc::new(
+        WalletBuilder::new()
+            .mint_url(MintUrl::from_str(MINT_URL).expect("Valid mint url"))
+            .unit(CurrencyUnit::Sat)
+            .localstore(db.clone())
+            .seed(Mnemonic::generate(12).unwrap().to_seed_normalized(""))
+            .build()
+            .expect("Wallet"),
+    );
     let mint_info = wallet.fetch_mint_info().await.unwrap().unwrap();
 
     let (access_token, _) = get_tokens(&mint_info, false)
@@ -591,7 +593,7 @@ async fn test_melt_with_invalid_auth() {
 
     wallet.mint_blind_auth(10.into()).await.unwrap();
 
-    fund_wallet(Arc::new(wallet.clone()), 1.into()).await;
+    fund_wallet(wallet.clone(), 1.into()).await;
 
     let proofs = wallet
         .get_unspent_proofs()

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -43,6 +43,7 @@ use cdk_common::{MeltQuoteCreateResponse, MeltQuoteRequest, MeltQuoteResponse};
 use cdk_fake_wallet::create_fake_invoice;
 use cdk_integration_tests::init_pure_tests::*;
 use futures::Stream;
+use tokio::sync::Mutex;
 use tokio::time::sleep;
 
 fn to_keyset_infos(keysets: &[KeySet]) -> Vec<KeySetInfo> {
@@ -74,7 +75,7 @@ async fn test_swap_to_send() {
         .expect("Failed to create test wallet");
 
     // Alice gets 64 sats
-    fund_wallet(wallet_alice.clone(), 64, None)
+    fund_wallet(&wallet_alice, 64, None)
         .await
         .expect("Failed to fund wallet");
     let balance_alice = wallet_alice
@@ -195,12 +196,13 @@ async fn test_mint_nut06() {
     let mint_bob = create_and_start_test_mint()
         .await
         .expect("Failed to create test mint");
-    let mut wallet_alice = create_test_wallet_for_mint(mint_bob.clone())
+
+    let wallet_alice = create_test_wallet_for_mint(mint_bob.clone())
         .await
         .expect("Failed to create test wallet");
 
     // Alice gets 64 sats
-    fund_wallet(wallet_alice.clone(), 64, None)
+    fund_wallet(&wallet_alice, 64, None)
         .await
         .expect("Failed to fund wallet");
     let balance_alice = wallet_alice
@@ -247,13 +249,20 @@ async fn test_mint_nut06() {
 
     // Wallet updates mint URL
     let new_mint_url = MintUrl::from_str("https://new-mint-url").expect("Failed to parse mint URL");
-    wallet_alice
+
+    let wallet_alice = Arc::new(Mutex::new(
+        Arc::try_unwrap(wallet_alice).expect("Unable to unwrap the wallet"),
+    ));
+
+    let mut wallet_alice_lock = wallet_alice.lock().await;
+
+    wallet_alice_lock
         .update_mint_url(new_mint_url.clone())
         .await
         .expect("Failed to update mint URL");
 
     // Check balance after mint URL was updated
-    let balance_alice_after = wallet_alice
+    let balance_alice_after = wallet_alice_lock
         .total_balance()
         .await
         .expect("Failed to get balance after URL update");
@@ -272,7 +281,7 @@ async fn test_mint_double_spend() {
         .expect("Failed to create test wallet");
 
     // Alice gets 64 sats
-    fund_wallet(wallet_alice.clone(), 64, None)
+    fund_wallet(&wallet_alice, 64, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -330,7 +339,7 @@ async fn test_attempt_to_swap_by_overflowing() {
         .expect("Failed to create test wallet");
 
     // Alice gets 64 sats
-    fund_wallet(wallet_alice.clone(), 64, None)
+    fund_wallet(&wallet_alice, 64, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -398,7 +407,7 @@ async fn test_swap_unbalanced() {
         .expect("Failed to create test wallet");
 
     // Alice gets 100 sats
-    fund_wallet(wallet_alice.clone(), 100, None)
+    fund_wallet(&wallet_alice, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -461,7 +470,7 @@ pub async fn test_p2pk_swap() {
         .expect("Failed to create test wallet");
 
     // Alice gets 100 sats
-    fund_wallet(wallet_alice.clone(), 100, None)
+    fund_wallet(&wallet_alice, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -602,7 +611,7 @@ async fn test_swap_overpay_underpay_fee() {
         .expect("Failed to create test wallet");
 
     // Alice gets 100 sats
-    fund_wallet(wallet_alice.clone(), 1000, None)
+    fund_wallet(&wallet_alice, 1000, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -682,13 +691,9 @@ async fn test_mint_enforce_fee() {
         .expect("Failed to create test wallet");
 
     // Alice gets 100 sats
-    fund_wallet(
-        wallet_alice.clone(),
-        1010,
-        Some(SplitTarget::Value(Amount::ONE)),
-    )
-    .await
-    .expect("Failed to fund wallet");
+    fund_wallet(&wallet_alice, 1010, Some(SplitTarget::Value(Amount::ONE)))
+        .await
+        .expect("Failed to fund wallet");
 
     let mut proofs = wallet_alice
         .get_unspent_proofs()
@@ -788,12 +793,7 @@ async fn test_mint_max_outputs_exceeded_mint() {
 
     // Alice tries to mint 10 sats with split target 1 (requesting 10 outputs)
     // This should fail because max_outputs is 5
-    let result = fund_wallet(
-        wallet_alice.clone(),
-        10,
-        Some(SplitTarget::Value(Amount::ONE)),
-    )
-    .await;
+    let result = fund_wallet(&wallet_alice, 10, Some(SplitTarget::Value(Amount::ONE))).await;
 
     match result {
         Ok(_) => panic!("Mint allowed exceeding max outputs"),
@@ -824,13 +824,9 @@ async fn test_mint_max_inputs_exceeded_melt() {
         .expect("Failed to create test wallet");
 
     // Alice gets 10 sats with small outputs to have enough proofs
-    fund_wallet(
-        wallet_alice.clone(),
-        10,
-        Some(SplitTarget::Value(Amount::ONE)),
-    )
-    .await
-    .expect("Failed to fund wallet");
+    fund_wallet(&wallet_alice, 10, Some(SplitTarget::Value(Amount::ONE)))
+        .await
+        .expect("Failed to fund wallet");
 
     let proofs = wallet_alice
         .get_unspent_proofs()
@@ -874,7 +870,7 @@ async fn test_mint_max_outputs_exceeded_melt() {
         .expect("Failed to create test wallet");
 
     // Alice gets 100 sats
-    fund_wallet(wallet_alice.clone(), 100, None)
+    fund_wallet(&wallet_alice, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -936,13 +932,9 @@ async fn test_mint_max_inputs_exceeded() {
         .expect("Failed to create test wallet");
 
     // Alice gets 100 sats with small outputs to have enough proofs
-    fund_wallet(
-        wallet_alice.clone(),
-        100,
-        Some(SplitTarget::Value(Amount::ONE)),
-    )
-    .await
-    .expect("Failed to fund wallet");
+    fund_wallet(&wallet_alice, 100, Some(SplitTarget::Value(Amount::ONE)))
+        .await
+        .expect("Failed to fund wallet");
 
     let proofs = wallet_alice
         .get_unspent_proofs()
@@ -992,7 +984,7 @@ async fn test_mint_max_outputs_exceeded() {
         .expect("Failed to create test wallet");
 
     // Alice gets 50 sats
-    fund_wallet(wallet_alice.clone(), 50, None)
+    fund_wallet(&wallet_alice, 50, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -1059,13 +1051,9 @@ async fn test_mint_change_with_fee_melt() {
         .expect("Failed to create test wallet");
 
     // Alice gets 100 sats
-    fund_wallet(
-        wallet_alice.clone(),
-        100,
-        Some(SplitTarget::Value(Amount::ONE)),
-    )
-    .await
-    .expect("Failed to fund wallet");
+    fund_wallet(&wallet_alice, 100, Some(SplitTarget::Value(Amount::ONE)))
+        .await
+        .expect("Failed to fund wallet");
 
     let keyset_id = mint_bob.pubkeys().keysets.first().unwrap().id;
 
@@ -1145,7 +1133,7 @@ async fn test_concurrent_double_spend_swap() {
         .expect("Failed to create test wallet");
 
     // Alice gets 100 sats
-    fund_wallet(wallet_alice.clone(), 100, None)
+    fund_wallet(&wallet_alice, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -1252,7 +1240,7 @@ async fn test_concurrent_double_spend_melt() {
         .expect("Failed to create test wallet");
 
     // Alice gets 100 sats
-    fund_wallet(wallet_alice.clone(), 100, None)
+    fund_wallet(&wallet_alice, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -1369,7 +1357,7 @@ async fn test_p2pk_send_force_swap_with_fees() {
         .expect("Failed to create test wallet");
 
     // Fund wallet with 64 sats (normal proofs, no P2PK conditions)
-    fund_wallet(wallet.clone(), 64, None)
+    fund_wallet(&wallet, 64, None)
         .await
         .expect("Failed to fund wallet");
     assert_eq!(
@@ -1458,7 +1446,7 @@ async fn test_p2pk_send_force_swap_with_fees_include_fee() {
         .expect("Failed to create receiver wallet");
 
     // Fund sender with 64 sats
-    fund_wallet(wallet_sender.clone(), 64, None)
+    fund_wallet(&wallet_sender, 64, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -2117,7 +2105,7 @@ async fn test_p2bk_send_and_receive() {
         .expect("Failed to create receiver wallet");
 
     // Fund sender with 64 sats
-    fund_wallet(wallet_sender.clone(), 64, None)
+    fund_wallet(&wallet_sender, 64, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -2192,7 +2180,7 @@ async fn test_p2bk_multi_key_receive() {
         .expect("Failed to create receiver wallet");
 
     // Fund sender with 64 sats
-    fund_wallet(wallet_sender.clone(), 64, None)
+    fund_wallet(&wallet_sender, 64, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -2273,7 +2261,7 @@ async fn test_restore_after_keyset_rotation() {
 
     // Mint 100 sats under the initial keyset
     let amount_before_rotation = 100;
-    fund_wallet(wallet.clone(), amount_before_rotation, None)
+    fund_wallet(&wallet, amount_before_rotation, None)
         .await
         .expect("Failed to fund wallet before rotation");
 
@@ -2290,7 +2278,7 @@ async fn test_restore_after_keyset_rotation() {
 
     // Mint 50 sats under the new active keyset
     let amount_after_rotation = 50;
-    fund_wallet(wallet.clone(), amount_after_rotation, None)
+    fund_wallet(&wallet, amount_after_rotation, None)
         .await
         .expect("Failed to fund wallet after rotation");
 
@@ -2585,7 +2573,7 @@ async fn test_p2pk_send_options_signing_keys() {
         .expect("Failed to create bob wallet");
 
     // Fund alice with 64 sats (plain proofs)
-    fund_wallet(wallet_alice.clone(), 64, None)
+    fund_wallet(&wallet_alice.clone(), 64, None)
         .await
         .expect("Failed to fund alice");
 
@@ -2702,7 +2690,7 @@ async fn test_p2pk_signing_keys_exact_denomination_short_circuit() {
         .expect("Failed to create bob wallet");
 
     // Fund alice with 8 sats (plain proofs)
-    fund_wallet(wallet_alice.clone(), 8, None)
+    fund_wallet(&wallet_alice.clone(), 8, None)
         .await
         .expect("Failed to fund alice");
 
@@ -2814,7 +2802,7 @@ async fn test_p2pk_locked_proof_sign_and_send_passthrough() {
         .expect("Failed to create bob wallet");
 
     // Fund alice with 8 sats (plain proofs)
-    fund_wallet(wallet_alice.clone(), 8, None)
+    fund_wallet(&wallet_alice.clone(), 8, None)
         .await
         .expect("Failed to fund alice");
 
@@ -2916,7 +2904,7 @@ async fn test_p2pk_locked_proof_sign_and_send_rejects_sig_all() {
         .await
         .expect("Failed to create alice wallet");
 
-    fund_wallet(wallet_alice.clone(), 8, None)
+    fund_wallet(&wallet_alice.clone(), 8, None)
         .await
         .expect("Failed to fund alice");
 
@@ -3026,7 +3014,7 @@ async fn test_p2pk_send_keyring_auto_detection() {
     let spending_conditions = SpendingConditions::new_p2pk(alice_pubkey, None);
 
     // Fund alice with plain proofs, then swap them for P2PK-locked proofs.
-    fund_wallet(wallet_alice.clone(), 64, None)
+    fund_wallet(&wallet_alice.clone(), 64, None)
         .await
         .expect("Failed to fund alice");
 
@@ -3125,7 +3113,7 @@ async fn test_p2pk_unsignable_proof_falls_back_to_bearer() {
         .expect("Failed to create bob wallet");
 
     // Fund alice with 64 sats of plain bearer proofs.
-    fund_wallet(wallet_alice.clone(), 64, None)
+    fund_wallet(&wallet_alice.clone(), 64, None)
         .await
         .expect("Failed to fund alice");
 
@@ -3220,7 +3208,7 @@ async fn test_malformed_p2pk_proof_falls_back_to_bearer() {
         .await
         .expect("Failed to create bob wallet");
 
-    fund_wallet(wallet_alice.clone(), 64, None)
+    fund_wallet(&wallet_alice.clone(), 64, None)
         .await
         .expect("Failed to fund alice");
 
@@ -3313,7 +3301,7 @@ async fn test_p2pk_unsignable_proof_only_gives_insufficient_funds() {
         .expect("Failed to create alice wallet");
 
     // Fund alice with 64 sats, then swap all of them for proofs locked to an unknown key.
-    fund_wallet(wallet_alice.clone(), 64, None)
+    fund_wallet(&wallet_alice.clone(), 64, None)
         .await
         .expect("Failed to fund alice");
 
@@ -3410,7 +3398,7 @@ async fn test_p2pk_partially_signable_proof_only_gives_insufficient_funds() {
     .unwrap();
     let spending_conditions = SpendingConditions::new_p2pk(alice_pubkey, Some(conditions));
 
-    fund_wallet(wallet_alice.clone(), 8, None)
+    fund_wallet(&wallet_alice.clone(), 8, None)
         .await
         .expect("Failed to fund alice");
 
@@ -3485,7 +3473,7 @@ async fn test_p2pk_locked_proof_sign_and_send_rejects_partial_signatures() {
         .await
         .expect("Failed to create alice wallet");
 
-    fund_wallet(wallet_alice.clone(), 8, None)
+    fund_wallet(&wallet_alice.clone(), 8, None)
         .await
         .expect("Failed to fund alice");
 
@@ -3595,7 +3583,7 @@ async fn test_p2pk_signing_keys_mixed_locked_and_unlocked_proofs() {
         .expect("Failed to create bob wallet");
 
     // Fund alice with 64 sats of plain (unlocked) proofs.
-    fund_wallet(wallet_alice.clone(), 64, None)
+    fund_wallet(&wallet_alice.clone(), 64, None)
         .await
         .expect("Failed to fund alice");
 

--- a/crates/cdk-integration-tests/tests/test_swap_flow.rs
+++ b/crates/cdk-integration-tests/tests/test_swap_flow.rs
@@ -52,7 +52,7 @@ async fn test_swap_happy_path() {
         .expect("Failed to create test wallet");
 
     // Fund wallet with 100 sats
-    fund_wallet(wallet.clone(), 100, None)
+    fund_wallet(&wallet, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -184,7 +184,7 @@ async fn test_swap_duplicate_blinded_messages() {
         .expect("Failed to create test wallet");
 
     // Fund wallet with 200 sats (enough for two swaps)
-    fund_wallet(wallet.clone(), 200, None)
+    fund_wallet(&wallet, 200, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -243,7 +243,7 @@ async fn test_swap_double_spend_detection() {
         .expect("Failed to create test wallet");
 
     // Fund wallet with 100 sats
-    fund_wallet(wallet.clone(), 100, None)
+    fund_wallet(&wallet, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -305,7 +305,7 @@ async fn test_swap_unbalanced_transaction_detection() {
         .expect("Failed to create test wallet");
 
     // Fund wallet with 100 sats
-    fund_wallet(wallet.clone(), 100, None)
+    fund_wallet(&wallet, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -372,7 +372,7 @@ async fn test_swap_empty_inputs_or_outputs() {
         .expect("Failed to create test wallet");
 
     // Fund wallet with 100 sats
-    fund_wallet(wallet.clone(), 100, None)
+    fund_wallet(&wallet, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -433,7 +433,7 @@ async fn test_swap_p2pk_signature_validation() {
         .expect("Failed to create test wallet");
 
     // Fund wallet with 100 sats
-    fund_wallet(wallet.clone(), 100, None)
+    fund_wallet(&wallet, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -536,7 +536,7 @@ async fn test_swap_rollback_on_duplicate_blinded_message() {
         .expect("Failed to create test wallet");
 
     // Fund with enough for multiple swaps
-    fund_wallet(wallet.clone(), 200, None)
+    fund_wallet(&wallet, 200, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -613,7 +613,7 @@ async fn test_swap_concurrent_double_spend_prevention() {
         .expect("Failed to create test wallet");
 
     // Fund wallet
-    fund_wallet(wallet.clone(), 100, None)
+    fund_wallet(&wallet, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -736,7 +736,7 @@ async fn test_swap_with_fees() {
     // Wait a bit for keyset to be available
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-    fund_wallet(wallet.clone(), 1000, Some(SplitTarget::Value(Amount::ONE)))
+    fund_wallet(&wallet, 1000, Some(SplitTarget::Value(Amount::ONE)))
         .await
         .expect("Failed to fund wallet");
 
@@ -838,7 +838,7 @@ async fn test_melt_with_fees_swap_before_melt() {
     // Fund with default split target to get optimal denominations
     // Use larger amount to ensure enough margin for swap fees
     let initial_amount = 4096u64;
-    fund_wallet(wallet.clone(), initial_amount, None)
+    fund_wallet(&wallet, initial_amount, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -973,7 +973,7 @@ async fn test_melt_exact_match_no_swap() {
     // For a 1000 sat melt, fee_reserve = max(1, 1000 * 2%) = 20 sats
     // inputs_needed = 1000 + 20 = 1020 sats
     let initial_amount = 1020u64;
-    fund_wallet(wallet.clone(), initial_amount, None)
+    fund_wallet(&wallet, initial_amount, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -1087,7 +1087,7 @@ async fn test_melt_small_amount_tight_margin() {
     // Fund with enough to cover melt + fees, but amounts that will trigger swap
     // 32 sats gives us enough margin even with 1 sat/proof fees
     let initial_amount = 32;
-    fund_wallet(wallet.clone(), initial_amount, None)
+    fund_wallet(&wallet, initial_amount, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -1195,7 +1195,7 @@ async fn test_melt_swap_tight_margin_regression() {
     // Fund with 100 sats using default split to get optimal denominations
     // This should give us proofs like [64, 32, 4] or similar power-of-2 split
     let initial_amount = 100;
-    fund_wallet(wallet.clone(), initial_amount, None)
+    fund_wallet(&wallet, initial_amount, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -1277,7 +1277,7 @@ async fn test_swap_amount_overflow_protection() {
         .expect("Failed to create test wallet");
 
     // Fund wallet
-    fund_wallet(wallet.clone(), 100, None)
+    fund_wallet(&wallet, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -1347,7 +1347,7 @@ async fn test_swap_state_transition_notifications() {
         .expect("Failed to create test wallet");
 
     // Fund wallet
-    fund_wallet(wallet.clone(), 100, None)
+    fund_wallet(&wallet, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -1432,7 +1432,7 @@ async fn test_swap_proof_state_consistency() {
         .expect("Failed to create test wallet");
 
     // Fund wallet
-    fund_wallet(wallet.clone(), 100, None)
+    fund_wallet(&wallet, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -1502,7 +1502,7 @@ async fn test_wallet_multi_keyset_counter_updates() {
         .expect("Failed to create test wallet");
 
     // Fund wallet with initial 100 sats using first keyset
-    fund_wallet(wallet.clone(), 100, None)
+    fund_wallet(&wallet, 100, None)
         .await
         .expect("Failed to fund wallet");
 
@@ -1529,7 +1529,7 @@ async fn test_wallet_multi_keyset_counter_updates() {
         .expect("Failed to refresh wallet keysets");
 
     // Fund wallet again with 100 sats using second keyset
-    fund_wallet(wallet.clone(), 100, None)
+    fund_wallet(&wallet, 100, None)
         .await
         .expect("Failed to fund wallet with second keyset");
 

--- a/crates/cdk-integration-tests/tests/wallet_saga.rs
+++ b/crates/cdk-integration-tests/tests/wallet_saga.rs
@@ -8,6 +8,8 @@
 //! Basic happy-path flows are covered by other integration tests (fake_wallet.rs,
 //! integration_tests_pure.rs, etc.)
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use cashu::{MeltQuoteState, PaymentMethod};
 use cdk::nuts::nut00::ProofsMethods;
@@ -29,7 +31,7 @@ async fn test_send_cancel_releases_proofs() -> Result<()> {
 
     // Fund wallet
     let initial_amount = Amount::from(1000);
-    fund_wallet(wallet.clone(), initial_amount.into(), None).await?;
+    fund_wallet(&wallet, initial_amount.into(), None).await?;
 
     let send_amount = Amount::from(400);
 
@@ -64,7 +66,7 @@ async fn test_reserved_proofs_excluded_from_selection() -> Result<()> {
     let wallet = create_test_wallet_for_mint(mint.clone()).await?;
 
     // Fund wallet with exact amount for two sends
-    fund_wallet(wallet.clone(), 600, None).await?;
+    fund_wallet(&wallet, 600, None).await?;
 
     // First prepare reserves some proofs
     let prepared1 = wallet
@@ -103,15 +105,15 @@ async fn test_reserved_proofs_excluded_from_selection() -> Result<()> {
 async fn test_concurrent_sends_isolated() -> Result<()> {
     setup_tracing();
     let mint = create_and_start_test_mint().await?;
-    let wallet = create_test_wallet_for_mint(mint.clone()).await?;
+    let wallet = Arc::new(create_test_wallet_for_mint(mint.clone()).await?);
 
     // Fund wallet
     let initial_amount = Amount::from(2000);
-    fund_wallet(wallet.clone(), initial_amount.into(), None).await?;
+    fund_wallet(&wallet, initial_amount.into(), None).await?;
 
     // Prepare two sends concurrently
-    let wallet1 = wallet.clone();
-    let wallet2 = wallet.clone();
+    let wallet1 = Arc::clone(&wallet);
+    let wallet2 = Arc::clone(&wallet);
 
     let (prepared1, prepared2) = tokio::join!(
         wallet1.prepare_send(Amount::from(300), SendOptions::default()),
@@ -148,10 +150,10 @@ async fn test_concurrent_sends_isolated() -> Result<()> {
 async fn test_concurrent_melts_isolated() -> Result<()> {
     setup_tracing();
     let mint = create_and_start_test_mint().await?;
-    let wallet = create_test_wallet_for_mint(mint.clone()).await?;
+    let wallet = Arc::new(create_test_wallet_for_mint(mint.clone()).await?);
 
     // Fund wallet with enough for multiple melts
-    fund_wallet(wallet.clone(), 2000, None).await?;
+    fund_wallet(&wallet, 2000, None).await?;
 
     // Create two invoices
     let invoice1 = create_fake_invoice(200_000, "melt 1".to_string());
@@ -166,8 +168,8 @@ async fn test_concurrent_melts_isolated() -> Result<()> {
         .await?;
 
     // Execute both melts concurrently
-    let wallet1 = wallet.clone();
-    let wallet2 = wallet.clone();
+    let wallet1 = Arc::clone(&wallet);
+    let wallet2 = Arc::clone(&wallet);
     let quote_id1 = quote1.id.clone();
     let quote_id2 = quote2.id.clone();
 
@@ -245,7 +247,7 @@ async fn test_melt_saga_includes_input_fees() -> Result<()> {
     // Fund wallet with enough to cover melt amount + fee_reserve + input fees
     // Use larger amounts to ensure there are enough proofs of the right denominations
     let initial_amount = 500u64;
-    fund_wallet(wallet.clone(), initial_amount, None).await?;
+    fund_wallet(&wallet, initial_amount, None).await?;
 
     let initial_balance = wallet.total_balance().await?;
     assert_eq!(initial_balance, Amount::from(initial_amount));
@@ -339,7 +341,7 @@ async fn test_melt_with_swap_non_optimal_proofs() -> Result<()> {
     // may have more proofs than the "optimal" estimate
     let initial_amount = 200u64;
     fund_wallet(
-        wallet.clone(),
+        &wallet,
         initial_amount,
         Some(SplitTarget::Value(Amount::ONE)),
     )
@@ -436,7 +438,7 @@ async fn test_melt_swap_gap_recovery() -> Result<()> {
     // 500 sats total in 50-sat proofs.
     let initial_amount = 500u64;
     fund_wallet(
-        wallet.clone(),
+        &wallet,
         initial_amount,
         Some(SplitTarget::Value(Amount::from(50))),
     )
@@ -568,7 +570,7 @@ async fn test_send_with_swap_succeeds() -> Result<()> {
     // denominations during confirm.
     let initial_amount = 1000u64;
     fund_wallet(
-        wallet.clone(),
+        &wallet,
         initial_amount,
         Some(SplitTarget::Value(Amount::from(64))),
     )
@@ -637,7 +639,7 @@ async fn test_send_with_swap_then_receive() -> Result<()> {
     // forces a swap during confirm.
     let initial_amount = 1000u64;
     fund_wallet(
-        wallet1.clone(),
+        &wallet1,
         initial_amount,
         Some(SplitTarget::Value(Amount::from(64))),
     )

--- a/crates/cdk/examples/nostr_backup.rs
+++ b/crates/cdk/examples/nostr_backup.rs
@@ -73,7 +73,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Verify mints were added
-    let wallets: Vec<cdk::Wallet> = wallet.get_wallets().await;
+    let wallets: Vec<Arc<cdk::Wallet>> = wallet.get_wallets().await;
     println!("\n  Wallet now contains {} mint(s):", wallets.len());
     for w in &wallets {
         println!("    - {}", w.mint_url);
@@ -135,7 +135,7 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     // Verify the new wallet is empty
-    let new_wallets: Vec<cdk::Wallet> = new_wallet.get_wallets().await;
+    let new_wallets: Vec<Arc<cdk::Wallet>> = new_wallet.get_wallets().await;
     println!("  New wallet starts with {} mint(s)", new_wallets.len());
 
     // Derive keys on the new wallet - should be the same!
@@ -175,7 +175,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Verify the mints were restored
-    let restored_wallets: Vec<cdk::Wallet> = new_wallet.get_wallets().await;
+    let restored_wallets: Vec<Arc<cdk::Wallet>> = new_wallet.get_wallets().await;
     println!(
         "\n  New wallet now contains {} mint(s):",
         restored_wallets.len()

--- a/crates/cdk/examples/npubcash.rs
+++ b/crates/cdk/examples/npubcash.rs
@@ -99,8 +99,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Waiting for the invoice to be paid and processed...\n");
 
     // Subscribe to quote updates and wait for the single payment
-    let mut stream =
-        wallet.npubcash_proof_stream(SplitTarget::default(), None, Duration::from_secs(5));
+    let mut stream = Arc::clone(&wallet).npubcash_proof_stream(
+        SplitTarget::default(),
+        None,
+        Duration::from_secs(5),
+    );
 
     if let Some(result) = stream.next().await {
         match result {

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -121,7 +121,7 @@ use crate::nuts::nut00::ProofsMethods;
 ///
 /// For pending mint quotes, call [`Wallet::mint_unissued_quotes`] which checks
 /// quote states with the mint and mints available tokens. This makes network calls.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Wallet {
     /// Mint Url
     pub mint_url: MintUrl,

--- a/crates/cdk/src/wallet/npubcash.rs
+++ b/crates/cdk/src/wallet/npubcash.rs
@@ -271,13 +271,13 @@ impl Wallet {
     /// * `spending_conditions` - Optional spending conditions for the minted proofs
     /// * `poll_interval` - How often to check for new quotes
     pub fn npubcash_proof_stream(
-        &self,
+        self: Arc<Self>,
         split_target: cdk_common::amount::SplitTarget,
         spending_conditions: Option<crate::nuts::SpendingConditions>,
         poll_interval: std::time::Duration,
     ) -> crate::wallet::streams::npubcash::WalletNpubCashProofStream {
         crate::wallet::streams::npubcash::WalletNpubCashProofStream::new(
-            self.clone(),
+            self,
             poll_interval,
             split_target,
             spending_conditions,

--- a/crates/cdk/src/wallet/payment_request.rs
+++ b/crates/cdk/src/wallet/payment_request.rs
@@ -315,14 +315,12 @@ impl WalletRepository {
                 if *balance >= amount && *balance > best_balance {
                     if let Ok(wallet) = self.get_wallet(&wallet_key.mint_url, &unit).await {
                         best_balance = *balance;
-                        best_wallet = Some(Arc::new(wallet));
+                        best_wallet = Some(wallet);
                     }
                 }
             }
 
-            best_wallet
-                .map(|w| (*w).clone())
-                .ok_or(Error::InsufficientFunds)?
+            best_wallet.ok_or(Error::InsufficientFunds)?
         };
 
         // Use the selected wallet to pay the request

--- a/crates/cdk/src/wallet/streams/npubcash.rs
+++ b/crates/cdk/src/wallet/streams/npubcash.rs
@@ -3,6 +3,7 @@
 //! This stream continuously polls NpubCash for new paid quotes and yields them as proofs.
 
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -114,7 +115,7 @@ pub struct WalletNpubCashProofStream {
 impl WalletNpubCashProofStream {
     /// Create a new NpubCash proof stream for a single wallet
     pub fn new(
-        wallet: Wallet,
+        wallet: Arc<Wallet>,
         poll_interval: Duration,
         split_target: SplitTarget,
         spending_conditions: Option<SpendingConditions>,

--- a/crates/cdk/src/wallet/wallet_repository.rs
+++ b/crates/cdk/src/wallet/wallet_repository.rs
@@ -545,6 +545,38 @@ impl WalletRepository {
         client.get_mint_info().await
     }
 
+    /// Update mint url from wallet
+    ///
+    /// This will removes the old wallet and creates a new one with new mint url
+    pub async fn update_mint_url(
+        &self,
+        mint_url: &MintUrl,
+        new_mint_url: &MintUrl,
+        unit: &CurrencyUnit,
+    ) -> Result<(), Error> {
+        let key = WalletKey::new(mint_url.clone(), unit.clone());
+
+        let mut wallets = self.wallets.write().await;
+        let mut wallet = match Arc::try_unwrap(
+            wallets
+                .remove(&key)
+                .ok_or(Error::UnknownWallet(key.clone()))?,
+        ) {
+            Ok(wallet) => wallet,
+            Err(wallet) => {
+                wallets.insert(key.clone(), wallet);
+                return Err(Error::UnknownWallet(key.clone()));
+            }
+        };
+
+        wallet.update_mint_url(new_mint_url.clone()).await?;
+
+        let key = WalletKey::new(new_mint_url.clone(), unit.clone());
+        wallets.insert(key, Arc::new(wallet));
+
+        Ok(())
+    }
+
     /// Internal: Create wallet with optional custom configuration
     ///
     /// Priority order for configuration:

--- a/crates/cdk/src/wallet/wallet_repository.rs
+++ b/crates/cdk/src/wallet/wallet_repository.rs
@@ -284,7 +284,7 @@ pub struct WalletRepository {
     localstore: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
     seed: [u8; 64],
     /// Wallets indexed by (mint URL, currency unit)
-    wallets: Arc<RwLock<BTreeMap<WalletKey, Wallet>>>,
+    wallets: Arc<RwLock<BTreeMap<WalletKey, Arc<Wallet>>>>,
     /// Proxy configuration for HTTP clients (optional)
     proxy_config: Option<url::Url>,
     /// Whether proxied HTTPS clients should accept invalid TLS certificates
@@ -314,7 +314,7 @@ impl WalletRepository {
         &self,
         mint_url: &MintUrl,
         unit: &CurrencyUnit,
-    ) -> Result<Wallet, Error> {
+    ) -> Result<Arc<Wallet>, Error> {
         let key = WalletKey::new(mint_url.clone(), unit.clone());
         self.wallets
             .read()
@@ -326,7 +326,7 @@ impl WalletRepository {
 
     /// Get all wallets for a specific mint URL (any currency unit)
     #[instrument(skip(self))]
-    pub async fn get_wallets_for_mint(&self, mint_url: &MintUrl) -> Vec<Wallet> {
+    pub async fn get_wallets_for_mint(&self, mint_url: &MintUrl) -> Vec<Arc<Wallet>> {
         self.wallets
             .read()
             .await
@@ -362,7 +362,7 @@ impl WalletRepository {
     /// Fetches the mint info to discover all supported currency units and creates
     /// a wallet for each unit. Returns all created wallets.
     #[instrument(skip(self))]
-    pub async fn add_wallet(&self, mint_url: MintUrl) -> Result<Vec<Wallet>, Error> {
+    pub async fn add_wallet(&self, mint_url: MintUrl) -> Result<Vec<Arc<Wallet>>, Error> {
         self.add_wallet_with_config(mint_url, None).await
     }
 
@@ -375,7 +375,7 @@ impl WalletRepository {
         &self,
         mint_url: MintUrl,
         config: Option<WalletConfig>,
-    ) -> Result<Vec<Wallet>, Error> {
+    ) -> Result<Vec<Arc<Wallet>>, Error> {
         // Fetch mint info to get supported units
         let mint_info = self.fetch_mint_info(&mint_url).await?;
         let supported_units = mint_info.supported_units();
@@ -414,7 +414,7 @@ impl WalletRepository {
         mint_url: MintUrl,
         unit: CurrencyUnit,
         config: WalletConfig,
-    ) -> Result<Wallet, Error> {
+    ) -> Result<Arc<Wallet>, Error> {
         // Re-create wallet with new config
         self.create_wallet(mint_url, unit, Some(config)).await
     }
@@ -427,10 +427,11 @@ impl WalletRepository {
         mint_url: MintUrl,
         unit: CurrencyUnit,
         config: Option<WalletConfig>,
-    ) -> Result<Wallet, Error> {
-        let wallet = self
-            .create_wallet_internal(mint_url.clone(), unit.clone(), config.as_ref())
-            .await?;
+    ) -> Result<Arc<Wallet>, Error> {
+        let wallet = Arc::new(
+            self.create_wallet_internal(mint_url.clone(), unit.clone(), config.as_ref())
+                .await?,
+        );
 
         // Insert into wallets map using WalletKey
         let key = WalletKey::new(mint_url, unit);
@@ -464,7 +465,7 @@ impl WalletRepository {
 
     /// Get all wallets
     #[instrument(skip(self))]
-    pub async fn get_wallets(&self) -> Vec<Wallet> {
+    pub async fn get_wallets(&self) -> Vec<Arc<Wallet>> {
         self.wallets.read().await.values().cloned().collect()
     }
 
@@ -720,9 +721,10 @@ impl WalletRepository {
                     continue;
                 }
 
-                let wallet = self
-                    .create_wallet_internal(mint_url.clone(), unit, None)
-                    .await?;
+                let wallet = Arc::new(
+                    self.create_wallet_internal(mint_url.clone(), unit, None)
+                        .await?,
+                );
 
                 let mut wallets = self.wallets.write().await;
                 wallets.insert(key, wallet);


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
It's a part from https://github.com/cashubtc/cdk/issues/1310

Removes `clone` from `Wallet` struct

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
