### PR TITLE
fix: add missing version header to all mint RPC CLI subcommands

### DIFF
--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/rotate_next_keyset.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/rotate_next_keyset.rs
@@ -52,13 +52,15 @@ pub async fn rotate_next_keyset(
     };
 
     let response = client
-        .rotate_next_keyset(Request::new(RotateNextKeysetRequest {
-            unit: sub_command_args.unit.clone(),
-            amounts,
-            input_fee_ppk: sub_command_args.input_fee_ppk,
-            use_keyset_v2: sub_command_args.use_keyset_v2,
-            final_expiry: sub_command_args.final_expiry,
-        }))
+        .rotate_next_keyset(super::with_version_header(Request::new(
+            RotateNextKeysetRequest {
+                unit: sub_command_args.unit.clone(),
+                amounts,
+                input_fee_ppk: sub_command_args.input_fee_ppk,
+                use_keyset_v2: sub_command_args.use_keyset_v2,
+                final_expiry: sub_command_args.final_expiry,
+            },
+        )))
         .await?;
 
     let response = response.into_inner();

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_contact.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_contact.rs
@@ -30,10 +30,12 @@ pub async fn add_contact(
     sub_command_args: &AddContactCommand,
 ) -> Result<()> {
     let _response = client
-        .add_contact(Request::new(UpdateContactRequest {
-            method: sub_command_args.method.clone(),
-            info: sub_command_args.info.clone(),
-        }))
+        .add_contact(super::with_version_header(Request::new(
+            UpdateContactRequest {
+                method: sub_command_args.method.clone(),
+                info: sub_command_args.info.clone(),
+            },
+        )))
         .await?;
 
     Ok(())
@@ -63,10 +65,12 @@ pub async fn remove_contact(
     sub_command_args: &RemoveContactCommand,
 ) -> Result<()> {
     let _response = client
-        .remove_contact(Request::new(UpdateContactRequest {
-            method: sub_command_args.method.clone(),
-            info: sub_command_args.info.clone(),
-        }))
+        .remove_contact(super::with_version_header(Request::new(
+            UpdateContactRequest {
+                method: sub_command_args.method.clone(),
+                info: sub_command_args.info.clone(),
+            },
+        )))
         .await?;
 
     Ok(())

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_icon_url.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_icon_url.rs
@@ -28,9 +28,11 @@ pub async fn update_icon_url(
     sub_command_args: &UpdateIconUrlCommand,
 ) -> Result<()> {
     let _response = client
-        .update_icon_url(Request::new(UpdateIconUrlRequest {
-            icon_url: sub_command_args.name.clone(),
-        }))
+        .update_icon_url(super::with_version_header(Request::new(
+            UpdateIconUrlRequest {
+                icon_url: sub_command_args.name.clone(),
+            },
+        )))
         .await?;
 
     Ok(())

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_long_description.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_long_description.rs
@@ -28,9 +28,11 @@ pub async fn update_long_description(
     sub_command_args: &UpdateLongDescriptionCommand,
 ) -> Result<()> {
     let _response = client
-        .update_long_description(Request::new(UpdateDescriptionRequest {
-            description: sub_command_args.description.clone(),
-        }))
+        .update_long_description(super::with_version_header(Request::new(
+            UpdateDescriptionRequest {
+                description: sub_command_args.description.clone(),
+            },
+        )))
         .await?;
 
     Ok(())

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_motd.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_motd.rs
@@ -28,9 +28,11 @@ pub async fn update_motd(
     sub_command_args: &UpdateMotdCommand,
 ) -> Result<()> {
     let _response = client
-        .update_motd(Request::new(UpdateMotdRequest {
-            motd: sub_command_args.motd.clone(),
-        }))
+        .update_motd(super::with_version_header(Request::new(
+            UpdateMotdRequest {
+                motd: sub_command_args.motd.clone(),
+            },
+        )))
         .await?;
 
     Ok(())

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_name.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_name.rs
@@ -28,9 +28,11 @@ pub async fn update_name(
     sub_command_args: &UpdateNameCommand,
 ) -> Result<()> {
     let _response = client
-        .update_name(Request::new(UpdateNameRequest {
-            name: sub_command_args.name.clone(),
-        }))
+        .update_name(super::with_version_header(Request::new(
+            UpdateNameRequest {
+                name: sub_command_args.name.clone(),
+            },
+        )))
         .await?;
 
     Ok(())

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_nut04_quote.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_nut04_quote.rs
@@ -32,10 +32,12 @@ pub async fn update_nut04_quote_state(
     sub_command_args: &UpdateNut04QuoteCommand,
 ) -> Result<()> {
     let response = client
-        .update_nut04_quote(Request::new(UpdateNut04QuoteRequest {
-            quote_id: sub_command_args.quote_id.clone(),
-            state: sub_command_args.state.clone(),
-        }))
+        .update_nut04_quote(super::with_version_header(Request::new(
+            UpdateNut04QuoteRequest {
+                quote_id: sub_command_args.quote_id.clone(),
+                state: sub_command_args.state.clone(),
+            },
+        )))
         .await?;
 
     let response = response.into_inner();

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_nut05.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_nut05.rs
@@ -52,14 +52,16 @@ pub async fn update_nut05(
         .map(|amountless| MeltMethodOptions { amountless });
 
     let _response = client
-        .update_nut05(Request::new(UpdateNut05Request {
-            method: sub_command_args.method.clone(),
-            unit: sub_command_args.unit.clone(),
-            disabled: sub_command_args.disabled,
-            min_amount: sub_command_args.min_amount,
-            max_amount: sub_command_args.max_amount,
-            options,
-        }))
+        .update_nut05(super::with_version_header(Request::new(
+            UpdateNut05Request {
+                method: sub_command_args.method.clone(),
+                unit: sub_command_args.unit.clone(),
+                disabled: sub_command_args.disabled,
+                min_amount: sub_command_args.min_amount,
+                max_amount: sub_command_args.max_amount,
+                options,
+            },
+        )))
         .await?;
 
     Ok(())

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_short_description.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_short_description.rs
@@ -29,9 +29,11 @@ pub async fn update_short_description(
     sub_command_args: &UpdateShortDescriptionCommand,
 ) -> Result<()> {
     let _response = client
-        .update_short_description(Request::new(UpdateDescriptionRequest {
-            description: sub_command_args.description.clone(),
-        }))
+        .update_short_description(super::with_version_header(Request::new(
+            UpdateDescriptionRequest {
+                description: sub_command_args.description.clone(),
+            },
+        )))
         .await?;
 
     Ok(())

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_ttl.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_ttl.rs
@@ -32,10 +32,12 @@ pub async fn update_quote_ttl(
     sub_command_args: &UpdateQuoteTtlCommand,
 ) -> Result<()> {
     let _response = client
-        .update_quote_ttl(Request::new(UpdateQuoteTtlRequest {
-            mint_ttl: sub_command_args.mint_ttl,
-            melt_ttl: sub_command_args.melt_ttl,
-        }))
+        .update_quote_ttl(super::with_version_header(Request::new(
+            UpdateQuoteTtlRequest {
+                mint_ttl: sub_command_args.mint_ttl,
+                melt_ttl: sub_command_args.melt_ttl,
+            },
+        )))
         .await?;
 
     Ok(())
@@ -55,7 +57,9 @@ pub struct GetQuoteTtlCommand {}
 /// * `client` - The RPC client used to communicate with the mint
 pub async fn get_quote_ttl(client: &mut CdkMintClient<Channel>) -> Result<()> {
     let response = client
-        .get_quote_ttl(Request::new(GetQuoteTtlRequest {}))
+        .get_quote_ttl(super::with_version_header(Request::new(
+            GetQuoteTtlRequest {},
+        )))
         .await?
         .into_inner();
 

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_urls.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_urls.rs
@@ -29,9 +29,9 @@ pub async fn add_url(
     sub_command_args: &AddUrlCommand,
 ) -> Result<()> {
     let _response = client
-        .add_url(Request::new(UpdateUrlRequest {
+        .add_url(super::with_version_header(Request::new(UpdateUrlRequest {
             url: sub_command_args.url.clone(),
-        }))
+        })))
         .await?;
 
     Ok(())
@@ -59,9 +59,9 @@ pub async fn remove_url(
     sub_command_args: &RemoveUrlCommand,
 ) -> Result<()> {
     let _response = client
-        .remove_url(Request::new(UpdateUrlRequest {
+        .remove_url(super::with_version_header(Request::new(UpdateUrlRequest {
             url: sub_command_args.url.clone(),
-        }))
+        })))
         .await?;
 
     Ok(())


### PR DESCRIPTION
### Description

The server requires `x-cdk-protocol-version` header on all RPC requests, but 10 of 12 mint RPC CLI subcommands were not sending it. Every CLI command except `update_nut04` failed with "Missing x-cdk-protocol-version header". This wraps all `Request::new()` calls with `with_version_header()`.

-----

### Notes to the reviewers

I asked claude how tsk could forget such a thing to make sure this is actually a bug and I was reassured that he simply forgot.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### FIXED

- Fixed 10 of 12 mint RPC CLI subcommands failing due to missing `x-cdk-protocol-version` header

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
