### PR TITLE
feat(wallet): default-on token-bucket rate limiting

### DIFF
--- a/crates/cdk/src/wallet/builder.rs
+++ b/crates/cdk/src/wallet/builder.rs
@@ -11,6 +11,11 @@ use crate::error::Error;
 use crate::mint_url::MintUrl;
 use crate::nuts::CurrencyUnit;
 use crate::wallet::auth::{AuthMintConnector, AuthWallet};
+use crate::wallet::mint_connector::transport;
+use crate::wallet::mint_connector::transport::rate_limit::TokenBucket;
+use crate::wallet::mint_connector::{
+    AuthHttpClient, RateLimitConfig, RateLimitedAuthHttpClient, RateLimitedHttpClient,
+};
 use crate::wallet::mint_metadata_cache::MintMetadataCache;
 use crate::wallet::{HttpClient, MintConnector, SubscriptionManager, Wallet};
 
@@ -25,6 +30,8 @@ pub struct WalletBuilder {
     seed: Option<[u8; 64]>,
     use_http_subscription: bool,
     client: Option<Arc<dyn MintConnector + Send + Sync>>,
+    rate_limiter: Option<TokenBucket>,
+    auth_cat: Option<String>,
     metadata_cache_ttl: Option<Duration>,
     metadata_cache: Option<Arc<MintMetadataCache>>,
     metadata_caches: HashMap<MintUrl, Arc<MintMetadataCache>>,
@@ -51,6 +58,8 @@ impl Default for WalletBuilder {
             auth_connector: None,
             seed: None,
             client: None,
+            rate_limiter: Some(TokenBucket::new(RateLimitConfig::default())),
+            auth_cat: None,
             metadata_cache_ttl: Some(Duration::from_secs(3600)),
             use_http_subscription: false,
             metadata_cache: None,
@@ -158,6 +167,18 @@ impl WalletBuilder {
         self
     }
 
+    /// Configure rate limiting with a custom config.
+    pub fn with_rate_limiting_config(mut self, config: RateLimitConfig) -> Self {
+        self.rate_limiter = Some(TokenBucket::new(config));
+        self
+    }
+
+    /// Disable rate limiting.
+    pub fn without_rate_limiting(mut self) -> Self {
+        self.rate_limiter = None;
+        self
+    }
+
     /// Set a shared MintMetadataCache
     ///
     /// This allows multiple wallets to share the same metadata cache instance for
@@ -180,39 +201,21 @@ impl WalletBuilder {
         self
     }
 
-    /// Set auth CAT (Clear Auth Token)
+    /// Set auth CAT (Clear Auth Token). Construction is deferred to `build()`
+    /// so the auth client can share the wallet's rate-limit bucket.
     ///
     /// # Errors
     ///
     /// Returns an error if `mint_url` or `localstore` have not been set on the builder.
     pub fn set_auth_cat(mut self, cat: String) -> Result<Self, Error> {
-        let mint_url = self
-            .mint_url
-            .clone()
+        self.mint_url
+            .as_ref()
             .ok_or_else(|| Error::Custom("Mint URL required".to_string()))?;
-        let localstore = self
-            .localstore
-            .clone()
+        self.localstore
+            .as_ref()
             .ok_or_else(|| Error::Custom("Localstore required".to_string()))?;
-
-        let metadata_cache = self.metadata_cache.clone().unwrap_or_else(|| {
-            // Check if we already have a cache for this mint in the HashMap
-            if let Some(cache) = self.metadata_caches.get(&mint_url) {
-                cache.clone()
-            } else {
-                // Create a new one
-                Arc::new(MintMetadataCache::new(mint_url.clone()))
-            }
-        });
-
-        self.auth_wallet = Some(AuthWallet::new(
-            mint_url,
-            Some(AuthToken::ClearAuth(cat)),
-            localstore,
-            metadata_cache,
-            HashMap::new(),
-            None,
-        ));
+        self.auth_cat = Some(cat);
+        self.auth_wallet = None;
         Ok(self)
     }
 
@@ -234,24 +237,69 @@ impl WalletBuilder {
             .seed
             .ok_or(Error::Custom("Seed required".to_string()))?;
 
-        let client = match self.client.take() {
-            Some(client) => client,
-            None => Arc::new(HttpClient::new(mint_url.clone(), self.auth_wallet.clone()))
-                as Arc<dyn MintConnector + Send + Sync>,
-        };
-        let auth_wallet = self.auth_wallet.take();
-
         let metadata_cache = self.metadata_cache.take().unwrap_or_else(|| {
             // Check if we already have a cache for this mint in the HashMap
             if let Some(cache) = self.metadata_caches.get(&mint_url) {
                 cache.clone()
             } else {
-                // Create a new one
                 Arc::new(MintMetadataCache::new(mint_url.clone()))
             }
         });
 
         metadata_cache.set_ttl(self.metadata_cache_ttl);
+
+        let rate_limiter = self.rate_limiter.take();
+
+        // Auth client shares the bucket so NUT-22 traffic counts against it.
+        let auth_wallet = match self.auth_wallet.take() {
+            Some(aw) => Some(aw),
+            None => self.auth_cat.take().map(|cat| {
+                let auth_token = Some(AuthToken::ClearAuth(cat));
+                let auth_client: Arc<dyn AuthMintConnector + Send + Sync> = match &rate_limiter {
+                    Some(bucket) => {
+                        let inner = RateLimitedAuthHttpClient::with_transport(
+                            mint_url.clone(),
+                            transport::rate_limit::RateLimitedTransport::with_bucket(
+                                transport::Async::default(),
+                                bucket.clone(),
+                            ),
+                            auth_token,
+                        );
+                        Arc::new(inner)
+                    }
+                    None => {
+                        let inner = AuthHttpClient::new(mint_url.clone(), auth_token);
+                        Arc::new(inner)
+                    }
+                };
+                AuthWallet::with_auth_client(
+                    mint_url.clone(),
+                    localstore.clone(),
+                    metadata_cache.clone(),
+                    HashMap::new(),
+                    None,
+                    auth_client,
+                )
+            }),
+        };
+
+        let client: Arc<dyn MintConnector + Send + Sync> = match self.client.take() {
+            Some(client) => client,
+            None => match rate_limiter {
+                Some(bucket) => {
+                    let transport = transport::rate_limit::RateLimitedTransport::with_bucket(
+                        transport::Async::default(),
+                        bucket,
+                    );
+                    Arc::new(RateLimitedHttpClient::with_transport(
+                        mint_url.clone(),
+                        transport,
+                        auth_wallet.clone(),
+                    ))
+                }
+                None => Arc::new(HttpClient::new(mint_url.clone(), auth_wallet.clone())),
+            },
+        };
 
         Ok(Wallet {
             mint_url,

--- a/crates/cdk/src/wallet/builder.rs
+++ b/crates/cdk/src/wallet/builder.rs
@@ -11,10 +11,9 @@ use crate::error::Error;
 use crate::mint_url::MintUrl;
 use crate::nuts::CurrencyUnit;
 use crate::wallet::auth::{AuthMintConnector, AuthWallet};
-use crate::wallet::mint_connector::transport;
 use crate::wallet::mint_connector::transport::rate_limit::TokenBucket;
 use crate::wallet::mint_connector::{
-    AuthHttpClient, RateLimitConfig, RateLimitedAuthHttpClient, RateLimitedHttpClient,
+    transport, AuthHttpClient, RateLimitConfig, RateLimitedAuthHttpClient, RateLimitedHttpClient,
 };
 use crate::wallet::mint_metadata_cache::MintMetadataCache;
 use crate::wallet::{HttpClient, MintConnector, SubscriptionManager, Wallet};

--- a/crates/cdk/src/wallet/builder.rs
+++ b/crates/cdk/src/wallet/builder.rs
@@ -327,4 +327,19 @@ mod tests {
         let builder = WalletBuilder::default();
         assert_eq!(builder.metadata_cache_ttl, Some(Duration::from_secs(3600)));
     }
+
+    #[test]
+    fn test_rate_limiting_default_on() {
+        let builder = WalletBuilder::default();
+        assert!(
+            builder.rate_limiter.is_some(),
+            "rate limiting should be enabled by default"
+        );
+    }
+
+    #[test]
+    fn test_without_rate_limiting_disables() {
+        let builder = WalletBuilder::default().without_rate_limiting();
+        assert!(builder.rate_limiter.is_none());
+    }
 }

--- a/crates/cdk/src/wallet/mint_connector/mod.rs
+++ b/crates/cdk/src/wallet/mint_connector/mod.rs
@@ -42,7 +42,7 @@ pub type RateLimitedHttpClient =
 pub type RateLimitedAuthHttpClient =
     http_client::AuthHttpClient<transport::rate_limit::RateLimitedTransport<transport::Async>>;
 
-pub use transport::rate_limit::RateLimitConfig;
+pub use transport::rate_limit::{RateLimitConfig, TokenBucket};
 
 /// Interface that connects a wallet to a mint. Typically represents an [HttpClient].
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]

--- a/crates/cdk/src/wallet/mint_connector/mod.rs
+++ b/crates/cdk/src/wallet/mint_connector/mod.rs
@@ -34,6 +34,16 @@ pub type TorAuthHttpClient = http_client::AuthHttpClient<transport::TorAsync>;
 #[cfg(all(feature = "tor", not(target_arch = "wasm32")))]
 pub type TorHttpClient = http_client::HttpClient<transport::TorAsync>;
 
+/// Http Client with rate-limited async transport
+pub type RateLimitedHttpClient =
+    http_client::HttpClient<transport::rate_limit::RateLimitedTransport<transport::Async>>;
+
+/// Auth Http Client with rate-limited async transport
+pub type RateLimitedAuthHttpClient =
+    http_client::AuthHttpClient<transport::rate_limit::RateLimitedTransport<transport::Async>>;
+
+pub use transport::rate_limit::RateLimitConfig;
+
 /// Interface that connects a wallet to a mint. Typically represents an [HttpClient].
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]

--- a/crates/cdk/src/wallet/mint_connector/transport.rs
+++ b/crates/cdk/src/wallet/mint_connector/transport.rs
@@ -1,5 +1,6 @@
 //! Transport re-exports for wallet mint connector.
 
+pub mod rate_limit;
 #[cfg(all(feature = "tor", not(target_arch = "wasm32")))]
 pub use cdk_http_client::TorAsync;
 pub use cdk_http_client::{Async, Transport};

--- a/crates/cdk/src/wallet/mint_connector/transport/rate_limit.rs
+++ b/crates/cdk/src/wallet/mint_connector/transport/rate_limit.rs
@@ -142,7 +142,10 @@ where
         url: &str,
         headers: &[(&str, &str)],
     ) -> Result<
-        (cdk_http_client::ws::WsSender, cdk_http_client::ws::WsReceiver),
+        (
+            cdk_http_client::ws::WsSender,
+            cdk_http_client::ws::WsReceiver,
+        ),
         cdk_http_client::ws::WsError,
     > {
         self.inner.ws_connect(url, headers).await
@@ -204,7 +207,9 @@ where
         P: serde::Serialize + Send + Sync,
     {
         self.bucket.acquire().await;
-        self.inner.http_post_form_raw(url, auth_token, payload).await
+        self.inner
+            .http_post_form_raw(url, auth_token, payload)
+            .await
     }
 }
 
@@ -331,6 +336,127 @@ mod tests {
         assert!(
             elapsed.as_millis() < 100,
             "Draining full bucket took too long: {:?}",
+            elapsed
+        );
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod integration_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::time::{Duration, Instant};
+    use url::Url;
+
+    use super::super::{Async, Transport};
+    use super::{RateLimitConfig, RateLimitedTransport, TokenBucket};
+
+    /// Spawn a loopback HTTP server that accepts up to `num_requests`
+    /// connections, replies 200 with `{}`, and increments the counter.
+    async fn spawn_counting_server(num_requests: usize) -> (Url, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = counter.clone();
+
+        tokio::spawn(async move {
+            for _ in 0..num_requests {
+                if let Ok((mut socket, _)) = listener.accept().await {
+                    let mut buf = [0u8; 2048];
+                    let _ = socket.read(&mut buf).await;
+                    let body = "{}";
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body,
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.shutdown().await;
+                    counter_clone.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        });
+
+        let url = Url::parse(&format!("http://{}/", addr)).expect("valid url");
+        (url, counter)
+    }
+
+    /// The bucket gates real HTTP traffic through the Transport trait, not
+    /// just in isolation. Capacity 2 with 2/sec refill means the third call
+    /// must wait ~500ms and the fourth ~1s.
+    #[tokio::test]
+    async fn rate_limited_transport_paces_real_http() {
+        let (url, _counter) = spawn_counting_server(4).await;
+
+        let bucket = TokenBucket::new(RateLimitConfig {
+            capacity: 2,
+            refill_per_minute: 120,
+        });
+        let transport = RateLimitedTransport::with_bucket(Async::default(), bucket);
+
+        let start = Instant::now();
+        let mut elapsed = Vec::with_capacity(4);
+        for _ in 0..4 {
+            let _: serde_json::Value = transport
+                .http_get(url.clone(), None)
+                .await
+                .expect("request succeeds");
+            elapsed.push(start.elapsed());
+        }
+
+        assert!(
+            elapsed[0] < Duration::from_millis(200),
+            "burst call 1 should be fast: {:?}",
+            elapsed[0]
+        );
+        assert!(
+            elapsed[1] < Duration::from_millis(200),
+            "burst call 2 should be fast: {:?}",
+            elapsed[1]
+        );
+        assert!(
+            elapsed[2] >= Duration::from_millis(400),
+            "call 3 should wait for refill: {:?}",
+            elapsed[2]
+        );
+        assert!(
+            elapsed[3] >= Duration::from_millis(900),
+            "call 4 should wait for second refill: {:?}",
+            elapsed[3]
+        );
+    }
+
+    /// Two transports cloning the same bucket share the rate-limit budget.
+    /// This is the mechanism the wallet uses to pace blind-auth and main
+    /// traffic together.
+    #[tokio::test]
+    async fn shared_bucket_paces_two_transports() {
+        let (url, _counter) = spawn_counting_server(3).await;
+
+        let bucket = TokenBucket::new(RateLimitConfig {
+            capacity: 2,
+            refill_per_minute: 120,
+        });
+        let transport_a = RateLimitedTransport::with_bucket(Async::default(), bucket.clone());
+        let transport_b = RateLimitedTransport::with_bucket(Async::default(), bucket);
+
+        // Drain the shared bucket via transport_a.
+        let _: serde_json::Value = transport_a.http_get(url.clone(), None).await.expect("a1");
+        let _: serde_json::Value = transport_a.http_get(url.clone(), None).await.expect("a2");
+
+        // transport_b sees an empty bucket and must wait for refill.
+        let start = Instant::now();
+        let _: serde_json::Value = transport_b.http_get(url.clone(), None).await.expect("b1");
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(400),
+            "transport_b should wait because the shared bucket is empty: {:?}",
             elapsed
         );
     }

--- a/crates/cdk/src/wallet/mint_connector/transport/rate_limit.rs
+++ b/crates/cdk/src/wallet/mint_connector/transport/rate_limit.rs
@@ -1,5 +1,6 @@
 //! Token bucket rate limiter for transport-level request throttling
 
+use std::num::NonZero;
 use std::sync::Arc;
 
 use cdk_common::AuthToken;
@@ -11,17 +12,17 @@ use tokio::time::{Duration, Instant};
 #[derive(Debug, Clone)]
 pub struct RateLimitConfig {
     /// Maximum number of tokens (burst capacity)
-    pub capacity: u32,
+    pub capacity: NonZero<u32>,
     /// Number of tokens added per minute
-    pub refill_per_minute: u32,
+    pub refill_per_minute: NonZero<u32>,
 }
 
 impl Default for RateLimitConfig {
     fn default() -> Self {
         // Stays under nutshell's default 60/min global cap.
         Self {
-            capacity: 20,
-            refill_per_minute: 20,
+            capacity: NonZero::new(20).expect("valid non zero default"),
+            refill_per_minute: NonZero::new(20).expect("valid non zero default"),
         }
     }
 }
@@ -45,19 +46,10 @@ struct BucketState {
 
 impl TokenBucket {
     /// Create a new token bucket from config.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `capacity` or `refill_per_minute` is zero.
     pub fn new(config: RateLimitConfig) -> Self {
-        assert!(config.capacity > 0, "RateLimitConfig::capacity must be > 0",);
-        assert!(
-            config.refill_per_minute > 0,
-            "RateLimitConfig::refill_per_minute must be > 0",
-        );
         Self {
             state: Arc::new(Mutex::new(BucketState {
-                tokens: f64::from(config.capacity),
+                tokens: f64::from(config.capacity.get()),
                 last_refill: Instant::now(),
             })),
             config,
@@ -77,7 +69,8 @@ impl TokenBucket {
                 }
 
                 let tokens_needed = 1.0 - state.tokens;
-                let refill_per_ms = f64::from(self.config.refill_per_minute) / (60.0 * 1000.0);
+                let refill_per_ms =
+                    f64::from(self.config.refill_per_minute.get()) / (60.0 * 1000.0);
                 Duration::from_millis((tokens_needed / refill_per_ms).ceil() as u64)
             };
 
@@ -88,11 +81,11 @@ impl TokenBucket {
     fn refill(&self, state: &mut BucketState) {
         let now = Instant::now();
         let elapsed_ms = now.duration_since(state.last_refill).as_millis() as f64;
-        let refill_per_ms = f64::from(self.config.refill_per_minute) / (60.0 * 1000.0);
+        let refill_per_ms = f64::from(self.config.refill_per_minute.get()) / (60.0 * 1000.0);
         let new_tokens = elapsed_ms * refill_per_ms;
 
         if new_tokens > 0.0 {
-            state.tokens = (state.tokens + new_tokens).min(f64::from(self.config.capacity));
+            state.tokens = (state.tokens + new_tokens).min(f64::from(self.config.capacity.get()));
             state.last_refill = now;
         }
     }
@@ -220,33 +213,15 @@ mod tests {
     #[tokio::test]
     async fn test_default_config() {
         let config = RateLimitConfig::default();
-        assert_eq!(config.capacity, 20);
-        assert_eq!(config.refill_per_minute, 20);
-    }
-
-    #[test]
-    #[should_panic(expected = "capacity must be > 0")]
-    fn test_zero_capacity_panics() {
-        let _ = TokenBucket::new(RateLimitConfig {
-            capacity: 0,
-            refill_per_minute: 20,
-        });
-    }
-
-    #[test]
-    #[should_panic(expected = "refill_per_minute must be > 0")]
-    fn test_zero_refill_panics() {
-        let _ = TokenBucket::new(RateLimitConfig {
-            capacity: 20,
-            refill_per_minute: 0,
-        });
+        assert_eq!(config.capacity.get(), 20);
+        assert_eq!(config.refill_per_minute.get(), 20);
     }
 
     #[tokio::test]
     async fn test_acquire_within_capacity() {
         let bucket = TokenBucket::new(RateLimitConfig {
-            capacity: 5,
-            refill_per_minute: 60,
+            capacity: NonZero::new(5).unwrap(),
+            refill_per_minute: NonZero::new(60).unwrap(),
         });
 
         // Should acquire up to capacity without waiting
@@ -258,8 +233,8 @@ mod tests {
     #[tokio::test]
     async fn test_acquire_blocks_when_empty() {
         let bucket = TokenBucket::new(RateLimitConfig {
-            capacity: 1,
-            refill_per_minute: 6000, // 100/sec so the wait is short
+            capacity: NonZero::new(1).unwrap(),
+            refill_per_minute: NonZero::new(6000).unwrap(), // 100/sec so the wait is short
         });
 
         // Drain the bucket
@@ -280,8 +255,8 @@ mod tests {
     #[tokio::test]
     async fn test_refill_does_not_exceed_capacity() {
         let bucket = TokenBucket::new(RateLimitConfig {
-            capacity: 3,
-            refill_per_minute: 60_000, // fast refill for test
+            capacity: NonZero::new(3).unwrap(),
+            refill_per_minute: NonZero::new(60_000).unwrap(), // fast refill for test
         });
 
         // Drain one token
@@ -299,8 +274,8 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_acquire() {
         let bucket = TokenBucket::new(RateLimitConfig {
-            capacity: 10,
-            refill_per_minute: 600, // 10/sec
+            capacity: NonZero::new(10).unwrap(),
+            refill_per_minute: NonZero::new(600).unwrap(), // 10/sec
         });
 
         // Spawn 10 tasks all acquiring at once
@@ -321,8 +296,8 @@ mod tests {
     #[tokio::test]
     async fn test_bucket_new_starts_full() {
         let bucket = TokenBucket::new(RateLimitConfig {
-            capacity: 25,
-            refill_per_minute: 25,
+            capacity: NonZero::new(25).unwrap(),
+            refill_per_minute: NonZero::new(25).unwrap(),
         });
 
         // Should be able to drain all 25 without waiting
@@ -343,6 +318,7 @@ mod tests {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod integration_tests {
+    use std::num::NonZero;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
@@ -394,8 +370,8 @@ mod integration_tests {
         let (url, _counter) = spawn_counting_server(4).await;
 
         let bucket = TokenBucket::new(RateLimitConfig {
-            capacity: 2,
-            refill_per_minute: 120,
+            capacity: NonZero::new(2).unwrap(),
+            refill_per_minute: NonZero::new(120).unwrap(),
         });
         let transport = RateLimitedTransport::with_bucket(Async::default(), bucket);
 
@@ -439,8 +415,8 @@ mod integration_tests {
         let (url, _counter) = spawn_counting_server(3).await;
 
         let bucket = TokenBucket::new(RateLimitConfig {
-            capacity: 2,
-            refill_per_minute: 120,
+            capacity: NonZero::new(2).unwrap(),
+            refill_per_minute: NonZero::new(120).unwrap(),
         });
         let transport_a = RateLimitedTransport::with_bucket(Async::default(), bucket.clone());
         let transport_b = RateLimitedTransport::with_bucket(Async::default(), bucket);

--- a/crates/cdk/src/wallet/mint_connector/transport/rate_limit.rs
+++ b/crates/cdk/src/wallet/mint_connector/transport/rate_limit.rs
@@ -35,7 +35,8 @@ impl Default for RateLimitConfig {
 #[derive(Debug, Clone)]
 pub struct TokenBucket {
     state: Arc<Mutex<BucketState>>,
-    config: RateLimitConfig,
+    capacity: f64,
+    tokens_per_ms: f64,
 }
 
 #[derive(Debug)]
@@ -47,46 +48,50 @@ struct BucketState {
 impl TokenBucket {
     /// Create a new token bucket from config.
     pub fn new(config: RateLimitConfig) -> Self {
+        let capacity = f64::from(config.capacity.get());
         Self {
             state: Arc::new(Mutex::new(BucketState {
-                tokens: f64::from(config.capacity.get()),
+                tokens: capacity,
                 last_refill: Instant::now(),
             })),
-            config,
+            capacity,
+            tokens_per_ms: f64::from(config.refill_per_minute.get()) / (60.0 * 1000.0),
         }
     }
 
     /// Wait until a token is available, then consume it
     pub async fn acquire(&self) {
         loop {
-            let wait_duration = {
+            let wait = {
                 let mut state = self.state.lock().await;
-                self.refill(&mut state);
-
-                if state.tokens >= 1.0 {
-                    state.tokens -= 1.0;
-                    return;
+                match self.refill(&mut state) {
+                    Some(wait) => wait,
+                    None => {
+                        state.tokens -= 1.0;
+                        return;
+                    }
                 }
-
-                let tokens_needed = 1.0 - state.tokens;
-                let refill_per_ms =
-                    f64::from(self.config.refill_per_minute.get()) / (60.0 * 1000.0);
-                Duration::from_millis((tokens_needed / refill_per_ms).ceil() as u64)
             };
 
-            tokio::time::sleep(wait_duration).await;
+            tokio::time::sleep(wait).await;
         }
     }
 
-    fn refill(&self, state: &mut BucketState) {
+    /// Accrue tokens for the time elapsed since the last refill and report how
+    /// long until the next token is available. Returns `None` when a token can
+    /// be consumed right away.
+    fn refill(&self, state: &mut BucketState) -> Option<Duration> {
         let now = Instant::now();
-        let elapsed_ms = now.duration_since(state.last_refill).as_millis() as f64;
-        let refill_per_ms = f64::from(self.config.refill_per_minute.get()) / (60.0 * 1000.0);
-        let new_tokens = elapsed_ms * refill_per_ms;
+        let elapsed_ms = now.duration_since(state.last_refill).as_secs_f64() * 1000.0;
+        state.tokens = (state.tokens + elapsed_ms * self.tokens_per_ms).min(self.capacity);
+        state.last_refill = now;
 
-        if new_tokens > 0.0 {
-            state.tokens = (state.tokens + new_tokens).min(f64::from(self.config.capacity.get()));
-            state.last_refill = now;
+        if state.tokens >= 1.0 {
+            None
+        } else {
+            Some(Duration::from_millis(
+                ((1.0 - state.tokens) / self.tokens_per_ms).ceil() as u64,
+            ))
         }
     }
 }

--- a/crates/cdk/src/wallet/mint_connector/transport/rate_limit.rs
+++ b/crates/cdk/src/wallet/mint_connector/transport/rate_limit.rs
@@ -1,4 +1,4 @@
-//! Token bucket rate limiter for transport-level request throttling
+//! GCRA rate limiter for transport-level request throttling
 
 use std::num::NonZero;
 use std::sync::Arc;
@@ -6,7 +6,16 @@ use std::sync::Arc;
 use cdk_common::AuthToken;
 use cdk_http_client::{HttpError, RawResponse};
 use tokio::sync::Mutex;
-use tokio::time::{Duration, Instant};
+use web_time::{Duration, Instant};
+
+/// Sleep for `dur`, using the platform timer. On wasm32 `tokio::time` has no
+/// timer driver, so route through `gloo-timers` (browser `setTimeout`).
+async fn sleep(dur: Duration) {
+    #[cfg(not(target_arch = "wasm32"))]
+    tokio::time::sleep(dur).await;
+    #[cfg(target_arch = "wasm32")]
+    gloo_timers::future::TimeoutFuture::new(dur.as_millis().min(u32::MAX as u128) as u32).await;
+}
 
 /// Configuration for the rate limiter
 #[derive(Debug, Clone)]
@@ -27,72 +36,82 @@ impl Default for RateLimitConfig {
     }
 }
 
-/// Token bucket rate limiter
+/// Rate limiter using GCRA (generic cell rate algorithm)
 ///
-/// Allows up to `capacity` requests in a burst, then refills at
-/// `refill_per_minute` tokens per minute. When no tokens are available,
-/// `acquire` sleeps until one is ready.
+/// Allows up to `capacity` requests in a burst, then paces at one request per
+/// `emission_interval` (derived from `refill_per_minute`). Each `acquire`
+/// reserves its slot under the lock and sleeps once, so concurrent callers are
+/// served in lock-acquisition order without a retry loop.
 #[derive(Debug, Clone)]
 pub struct TokenBucket {
     state: Arc<Mutex<BucketState>>,
-    capacity: f64,
-    tokens_per_ms: f64,
+    /// Time to earn one token (one request's worth of budget).
+    emission_interval: Duration,
+    /// Burst window: how far ahead of `now` the theoretical arrival time may
+    /// run before requests start waiting. `(capacity - 1) * emission_interval`.
+    tolerance: Duration,
 }
 
 #[derive(Debug)]
 struct BucketState {
-    tokens: f64,
-    last_refill: Instant,
+    /// Theoretical arrival time: the instant at which the most recently
+    /// reserved request is scheduled. Requests before `arrival_time - tolerance` wait.
+    arrival_time: Instant,
 }
 
 impl TokenBucket {
     /// Create a new token bucket from config.
     pub fn new(config: RateLimitConfig) -> Self {
-        let capacity = f64::from(config.capacity.get());
+        let emission_interval =
+            Duration::from_secs_f64(60.0 / f64::from(config.refill_per_minute.get()));
         Self {
             state: Arc::new(Mutex::new(BucketState {
-                tokens: capacity,
-                last_refill: Instant::now(),
+                arrival_time: Instant::now(),
             })),
-            capacity,
-            tokens_per_ms: f64::from(config.refill_per_minute.get()) / (60.0 * 1000.0),
+            emission_interval,
+            tolerance: emission_interval * (config.capacity.get() - 1),
         }
     }
 
-    /// Wait until a token is available, then consume it
-    pub async fn acquire(&self) {
-        loop {
-            let wait = {
-                let mut state = self.state.lock().await;
-                match self.refill(&mut state) {
-                    Some(wait) => wait,
-                    None => {
-                        state.tokens -= 1.0;
-                        return;
-                    }
-                }
-            };
-
-            tokio::time::sleep(wait).await;
-        }
-    }
-
-    /// Accrue tokens for the time elapsed since the last refill and report how
-    /// long until the next token is available. Returns `None` when a token can
-    /// be consumed right away.
-    fn refill(&self, state: &mut BucketState) -> Option<Duration> {
+    /// Reserve the next slot and return how long to wait before using it.
+    ///
+    /// Advances the theoretical arrival time, so calling this commits the
+    /// caller to the slot whether or not it later sleeps.
+    fn reserve(&self, state: &mut BucketState) -> Duration {
         let now = Instant::now();
-        let elapsed_ms = now.duration_since(state.last_refill).as_secs_f64() * 1000.0;
-        state.tokens = (state.tokens + elapsed_ms * self.tokens_per_ms).min(self.capacity);
-        state.last_refill = now;
+        let arrival_time = state.arrival_time.max(now);
+        let wait = arrival_time
+            .checked_sub(self.tolerance)
+            .map(|allowed| allowed.saturating_duration_since(now))
+            .unwrap_or(Duration::ZERO);
+        state.arrival_time = arrival_time + self.emission_interval;
+        wait
+    }
 
-        if state.tokens >= 1.0 {
-            None
-        } else {
-            Some(Duration::from_millis(
-                ((1.0 - state.tokens) / self.tokens_per_ms).ceil() as u64,
-            ))
+    /// Wait until a token is available, then consume it.
+    pub async fn acquire(&self) {
+        let wait = {
+            let mut state = self.state.lock().await;
+            self.reserve(&mut state)
+        };
+
+        sleep(wait).await;
+    }
+
+    /// Consume a token without waiting. Returns `true` if one was available (a
+    /// slot within the burst window), `false` otherwise. On `false` no slot is
+    /// reserved.
+    pub async fn try_acquire(&self) -> bool {
+        let mut state = self.state.lock().await;
+        let now = Instant::now();
+        let arrival_time = state.arrival_time.max(now);
+        let ready = arrival_time
+            .checked_sub(self.tolerance)
+            .is_none_or(|allowed| allowed <= now);
+        if ready {
+            state.arrival_time = arrival_time + self.emission_interval;
         }
+        ready
     }
 }
 
@@ -296,6 +315,26 @@ mod tests {
         for handle in handles {
             handle.await.unwrap();
         }
+    }
+
+    #[tokio::test]
+    async fn test_try_acquire_within_and_beyond_burst() {
+        let bucket = TokenBucket::new(RateLimitConfig {
+            capacity: NonZero::new(3).unwrap(),
+            refill_per_minute: NonZero::new(60).unwrap(), // 1/sec, slow refill
+        });
+
+        // Burst capacity of 3 is available immediately.
+        for _ in 0..3 {
+            assert!(bucket.try_acquire().await);
+        }
+
+        // Burst spent, refill too slow to have produced another token.
+        assert!(!bucket.try_acquire().await);
+
+        // A failed try_acquire must not have reserved a slot, so acquire still
+        // sees the same budget (it will simply pace instead of erroring).
+        assert!(!bucket.try_acquire().await);
     }
 
     #[tokio::test]

--- a/crates/cdk/src/wallet/mint_connector/transport/rate_limit.rs
+++ b/crates/cdk/src/wallet/mint_connector/transport/rate_limit.rs
@@ -207,3 +207,131 @@ where
         self.inner.http_post_form_raw(url, auth_token, payload).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_default_config() {
+        let config = RateLimitConfig::default();
+        assert_eq!(config.capacity, 20);
+        assert_eq!(config.refill_per_minute, 20);
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity must be > 0")]
+    fn test_zero_capacity_panics() {
+        let _ = TokenBucket::new(RateLimitConfig {
+            capacity: 0,
+            refill_per_minute: 20,
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "refill_per_minute must be > 0")]
+    fn test_zero_refill_panics() {
+        let _ = TokenBucket::new(RateLimitConfig {
+            capacity: 20,
+            refill_per_minute: 0,
+        });
+    }
+
+    #[tokio::test]
+    async fn test_acquire_within_capacity() {
+        let bucket = TokenBucket::new(RateLimitConfig {
+            capacity: 5,
+            refill_per_minute: 60,
+        });
+
+        // Should acquire up to capacity without waiting
+        for _ in 0..5 {
+            bucket.acquire().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_acquire_blocks_when_empty() {
+        let bucket = TokenBucket::new(RateLimitConfig {
+            capacity: 1,
+            refill_per_minute: 6000, // 100/sec so the wait is short
+        });
+
+        // Drain the bucket
+        bucket.acquire().await;
+
+        // Next acquire should block briefly then succeed
+        let start = Instant::now();
+        bucket.acquire().await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed.as_millis() >= 5,
+            "Expected some wait time, got {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test]
+    async fn test_refill_does_not_exceed_capacity() {
+        let bucket = TokenBucket::new(RateLimitConfig {
+            capacity: 3,
+            refill_per_minute: 60_000, // fast refill for test
+        });
+
+        // Drain one token
+        bucket.acquire().await;
+
+        // Wait long enough to overshoot capacity if uncapped
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Should still only get capacity tokens (capped at 3)
+        for _ in 0..3 {
+            bucket.acquire().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_acquire() {
+        let bucket = TokenBucket::new(RateLimitConfig {
+            capacity: 10,
+            refill_per_minute: 600, // 10/sec
+        });
+
+        // Spawn 10 tasks all acquiring at once
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let b = bucket.clone();
+            handles.push(tokio::spawn(async move {
+                b.acquire().await;
+            }));
+        }
+
+        // All should complete (we have 10 capacity)
+        for handle in handles {
+            handle.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_bucket_new_starts_full() {
+        let bucket = TokenBucket::new(RateLimitConfig {
+            capacity: 25,
+            refill_per_minute: 25,
+        });
+
+        // Should be able to drain all 25 without waiting
+        let start = Instant::now();
+        for _ in 0..25 {
+            bucket.acquire().await;
+        }
+        let elapsed = start.elapsed();
+
+        // All 25 should be near-instant (well under 100ms)
+        assert!(
+            elapsed.as_millis() < 100,
+            "Draining full bucket took too long: {:?}",
+            elapsed
+        );
+    }
+}

--- a/crates/cdk/src/wallet/mint_connector/transport/rate_limit.rs
+++ b/crates/cdk/src/wallet/mint_connector/transport/rate_limit.rs
@@ -1,0 +1,209 @@
+//! Token bucket rate limiter for transport-level request throttling
+
+use std::sync::Arc;
+
+use cdk_common::AuthToken;
+use cdk_http_client::{HttpError, RawResponse};
+use tokio::sync::Mutex;
+use tokio::time::{Duration, Instant};
+
+/// Configuration for the rate limiter
+#[derive(Debug, Clone)]
+pub struct RateLimitConfig {
+    /// Maximum number of tokens (burst capacity)
+    pub capacity: u32,
+    /// Number of tokens added per minute
+    pub refill_per_minute: u32,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        // Stays under nutshell's default 60/min global cap.
+        Self {
+            capacity: 20,
+            refill_per_minute: 20,
+        }
+    }
+}
+
+/// Token bucket rate limiter
+///
+/// Allows up to `capacity` requests in a burst, then refills at
+/// `refill_per_minute` tokens per minute. When no tokens are available,
+/// `acquire` sleeps until one is ready.
+#[derive(Debug, Clone)]
+pub struct TokenBucket {
+    state: Arc<Mutex<BucketState>>,
+    config: RateLimitConfig,
+}
+
+#[derive(Debug)]
+struct BucketState {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    /// Create a new token bucket from config.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` or `refill_per_minute` is zero.
+    pub fn new(config: RateLimitConfig) -> Self {
+        assert!(config.capacity > 0, "RateLimitConfig::capacity must be > 0",);
+        assert!(
+            config.refill_per_minute > 0,
+            "RateLimitConfig::refill_per_minute must be > 0",
+        );
+        Self {
+            state: Arc::new(Mutex::new(BucketState {
+                tokens: f64::from(config.capacity),
+                last_refill: Instant::now(),
+            })),
+            config,
+        }
+    }
+
+    /// Wait until a token is available, then consume it
+    pub async fn acquire(&self) {
+        loop {
+            let wait_duration = {
+                let mut state = self.state.lock().await;
+                self.refill(&mut state);
+
+                if state.tokens >= 1.0 {
+                    state.tokens -= 1.0;
+                    return;
+                }
+
+                let tokens_needed = 1.0 - state.tokens;
+                let refill_per_ms = f64::from(self.config.refill_per_minute) / (60.0 * 1000.0);
+                Duration::from_millis((tokens_needed / refill_per_ms).ceil() as u64)
+            };
+
+            tokio::time::sleep(wait_duration).await;
+        }
+    }
+
+    fn refill(&self, state: &mut BucketState) {
+        let now = Instant::now();
+        let elapsed_ms = now.duration_since(state.last_refill).as_millis() as f64;
+        let refill_per_ms = f64::from(self.config.refill_per_minute) / (60.0 * 1000.0);
+        let new_tokens = elapsed_ms * refill_per_ms;
+
+        if new_tokens > 0.0 {
+            state.tokens = (state.tokens + new_tokens).min(f64::from(self.config.capacity));
+            state.last_refill = now;
+        }
+    }
+}
+
+/// A transport wrapper that rate-limits outbound requests using a token bucket
+#[derive(Debug, Clone)]
+pub struct RateLimitedTransport<T>
+where
+    T: super::Transport,
+{
+    inner: T,
+    bucket: TokenBucket,
+}
+
+impl<T> RateLimitedTransport<T>
+where
+    T: super::Transport,
+{
+    /// Wrap a transport using a token bucket. Cloning the bucket shares its
+    /// state, so the same bucket can pace multiple transports.
+    pub fn with_bucket(inner: T, bucket: TokenBucket) -> Self {
+        Self { inner, bucket }
+    }
+}
+
+impl<T> Default for RateLimitedTransport<T>
+where
+    T: super::Transport,
+{
+    fn default() -> Self {
+        Self {
+            inner: T::default(),
+            bucket: TokenBucket::new(RateLimitConfig::default()),
+        }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<T> super::Transport for RateLimitedTransport<T>
+where
+    T: super::Transport + Send + Sync,
+{
+    async fn ws_connect(
+        &self,
+        url: &str,
+        headers: &[(&str, &str)],
+    ) -> Result<
+        (cdk_http_client::ws::WsSender, cdk_http_client::ws::WsReceiver),
+        cdk_http_client::ws::WsError,
+    > {
+        self.inner.ws_connect(url, headers).await
+    }
+
+    fn with_proxy(
+        &mut self,
+        proxy: url::Url,
+        host_matcher: Option<&str>,
+        accept_invalid_certs: bool,
+    ) -> Result<(), HttpError> {
+        self.inner
+            .with_proxy(proxy, host_matcher, accept_invalid_certs)
+    }
+
+    #[cfg(all(feature = "bip353", not(target_arch = "wasm32")))]
+    async fn resolve_dns_txt(&self, domain: &str) -> Result<Vec<String>, HttpError> {
+        self.inner.resolve_dns_txt(domain).await
+    }
+
+    async fn http_get<R>(&self, url: url::Url, auth: Option<AuthToken>) -> Result<R, HttpError>
+    where
+        R: serde::de::DeserializeOwned,
+    {
+        self.bucket.acquire().await;
+        self.inner.http_get(url, auth).await
+    }
+
+    async fn http_get_raw(
+        &self,
+        url: url::Url,
+        auth: Option<AuthToken>,
+    ) -> Result<RawResponse, HttpError> {
+        self.bucket.acquire().await;
+        self.inner.http_get_raw(url, auth).await
+    }
+
+    async fn http_post<P, R>(
+        &self,
+        url: url::Url,
+        auth_token: Option<AuthToken>,
+        payload: &P,
+    ) -> Result<R, HttpError>
+    where
+        P: serde::Serialize + Send + Sync,
+        R: serde::de::DeserializeOwned,
+    {
+        self.bucket.acquire().await;
+        self.inner.http_post(url, auth_token, payload).await
+    }
+
+    async fn http_post_form_raw<P>(
+        &self,
+        url: url::Url,
+        auth_token: Option<AuthToken>,
+        payload: &P,
+    ) -> Result<RawResponse, HttpError>
+    where
+        P: serde::Serialize + Send + Sync,
+    {
+        self.bucket.acquire().await;
+        self.inner.http_post_form_raw(url, auth_token, payload).await
+    }
+}

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -87,6 +87,7 @@ pub use melt::{MeltConfirmOptions, MeltOutcome, PendingMelt, PreparedMelt};
 pub use mint_connector::transport::Transport as HttpTransport;
 pub use mint_connector::{
     AuthHttpClient, HttpClient, LnurlPayInvoiceResponse, LnurlPayResponse, MintConnector,
+    RateLimitConfig, TokenBucket,
 };
 pub use mint_metadata_cache::MintMetadata;
 #[cfg(feature = "nostr")]


### PR DESCRIPTION
Closes #1642

This PR adds preemptive rate limiting to the wallet at the transport level, using a token bucket (same approach as Coco's `RequestRateLimiter`). Default-on with 20 capacity / 20 per minute; NUT-22 blind-auth shares the same bucket so mint-side rate limits count everything against one budget.

Usage through `WalletBuilder`:

```rust
WalletBuilder::new()
    .with_rate_limiting_config(config) // custom (defaults: 20 capacity, 20/min)
    .without_rate_limiting()           // opt out (default-on)
```

### Not covered here

- `WalletRepository` creates wallets through its own code paths that don't go through `WalletBuilder` yet, can be a follow-up
- No reactive 429 backoff, the limiter is proactive only