### PR TITLE
feat: show node pubkey in ldk-node UI dashboard

### DIFF
--- a/crates/cdk-ldk-node/src/web/handlers/dashboard.rs
+++ b/crates/cdk-ldk-node/src/web/handlers/dashboard.rs
@@ -90,7 +90,7 @@ fn calculate_usage_metrics(payments: &[ldk_node::payment::PaymentDetails]) -> Us
 pub async fn dashboard(State(state): State<AppState>) -> Result<Html<String>, StatusCode> {
     let node = &state.node.inner;
 
-    let _node_id = node.node_id().to_string();
+    let node_id = node.node_id().to_string();
     let alias = node
         .node_alias()
         .map(|a| a.to_string())
@@ -171,6 +171,9 @@ pub async fn dashboard(State(state): State<AppState>) -> Result<Html<String>, St
                     }
                     div class="node-details" {
                         h2 class="node-name" { (alias.clone()) }
+                        p class="node-address" {
+                            "Node ID: " (node_id)
+                        }
                         p class="node-address" {
                             "Listening Address: "
                             (listening_addresses.first().unwrap_or(&"127.0.0.1:8090".to_string()))


### PR DESCRIPTION
### Description

Display the node's public key (Node ID) in the LDK-node UI dashboard. The pubkey was already being fetched (`_node_id`) but not rendered in the template. This change removes the unused prefix and adds it to the node info section above the listening address. Closes #1139 

-----

### Notes to the reviewers

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

#### ADDED

- Show node pubkey in ldk-node UI dashboard (#1139)

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just final-check` before committing
