### PR TITLE
Add keyset methods to Wallet trait and FFI

### DIFF
--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -7,10 +7,10 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use bitcoin::bip32::DerivationPath;
 use bitcoin::hashes::{sha256, Hash, HashEngine};
-use cashu::amount::SplitTarget;
+use cashu::amount::{FeeAndAmounts, KeysetFeeAndAmounts, SplitTarget};
 use cashu::nuts::nut07::ProofState;
 use cashu::nuts::nut18::PaymentRequest;
-use cashu::nuts::AuthProof;
+use cashu::nuts::{AuthProof, Keys};
 use cashu::util::hex;
 use cashu::{nut00, PaymentMethod, Proof, Proofs, PublicKey};
 use serde::{Deserialize, Serialize};
@@ -634,6 +634,15 @@ impl FromStr for OperationKind {
     }
 }
 
+/// Filter for keyset queries
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeysetFilter {
+    /// Only return active keysets
+    Active,
+    /// Return all keysets (active and inactive)
+    All,
+}
+
 /// Unified wallet trait providing a common interface for wallet operations.
 ///
 /// This trait abstracts over different wallet implementations (CDK wallet, FFI
@@ -706,6 +715,39 @@ pub trait Wallet: Send + Sync {
 
     /// Get the active keyset with lowest fees
     async fn get_active_keyset(&self) -> Result<Self::KeySetInfo, Self::Error>;
+
+    /// Load keys for a specific keyset from cache or mint
+    async fn load_keyset_keys(&self, keyset_id: Id) -> Result<Keys, Self::Error>;
+
+    /// Get keysets for this wallet's unit, filtered by active/all
+    async fn get_mint_keysets(
+        &self,
+        filter: KeysetFilter,
+    ) -> Result<Vec<Self::KeySetInfo>, Self::Error>;
+
+    /// Load active keysets (alias for get_mint_keysets with Active filter)
+    async fn load_mint_keysets(&self) -> Result<Vec<Self::KeySetInfo>, Self::Error> {
+        self.get_mint_keysets(KeysetFilter::Active).await
+    }
+
+    /// Fetch the active keyset with lowest fees
+    async fn fetch_active_keyset(&self) -> Result<Self::KeySetInfo, Self::Error>;
+
+    /// Get fees and available amounts for all keysets
+    async fn get_keyset_fees_and_amounts(&self) -> Result<KeysetFeeAndAmounts, Self::Error>;
+
+    /// Get fee for count of proofs in a keyset
+    async fn get_keyset_count_fee(
+        &self,
+        keyset_id: &Id,
+        count: u64,
+    ) -> Result<Self::Amount, Self::Error>;
+
+    /// Get fees and amounts for a specific keyset ID
+    async fn get_keyset_fees_and_amounts_by_id(
+        &self,
+        keyset_id: Id,
+    ) -> Result<FeeAndAmounts, Self::Error>;
 
     /// Create a mint quote for the given payment method
     async fn mint_quote(

--- a/crates/cdk-ffi/src/types/amount.rs
+++ b/crates/cdk-ffi/src/types/amount.rs
@@ -90,6 +90,24 @@ impl From<Amount> for CdkAmount {
     }
 }
 
+/// FFI-compatible FeeAndAmounts
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct FeeAndAmounts {
+    /// Input fee per thousand (ppk)
+    pub fee: u64,
+    /// Available amounts for this keyset
+    pub amounts: Vec<u64>,
+}
+
+impl From<cdk_common::amount::FeeAndAmounts> for FeeAndAmounts {
+    fn from(fa: cdk_common::amount::FeeAndAmounts) -> Self {
+        Self {
+            fee: fa.fee(),
+            amounts: fa.amounts().to_vec(),
+        }
+    }
+}
+
 /// FFI-compatible Currency Unit
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
 pub enum CurrencyUnit {

--- a/crates/cdk-ffi/src/types/keys.rs
+++ b/crates/cdk-ffi/src/types/keys.rs
@@ -60,6 +60,24 @@ pub fn encode_key_set_info(info: KeySetInfo) -> Result<String, FfiError> {
     Ok(serde_json::to_string(&info)?)
 }
 
+/// FFI-compatible KeysetFilter
+#[derive(Debug, Clone, Copy, uniffi::Enum)]
+pub enum KeysetFilter {
+    /// Only return active keysets
+    Active,
+    /// Return all keysets (active and inactive)
+    All,
+}
+
+impl From<KeysetFilter> for cdk_common::wallet::KeysetFilter {
+    fn from(filter: KeysetFilter) -> Self {
+        match filter {
+            KeysetFilter::Active => cdk_common::wallet::KeysetFilter::Active,
+            KeysetFilter::All => cdk_common::wallet::KeysetFilter::All,
+        }
+    }
+}
+
 /// FFI-compatible PublicKey
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
 #[serde(transparent)]

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -560,6 +560,66 @@ impl Wallet {
         Ok(self.inner.get_keyset_fees_by_id(id).await?)
     }
 
+    /// Load keys for a specific keyset
+    pub async fn load_keyset_keys(&self, keyset_id: String) -> Result<Keys, FfiError> {
+        let id = cdk::nuts::Id::from_str(&keyset_id).map_err(FfiError::internal)?;
+        let keys = self.inner.load_keyset_keys(id).await?;
+        Ok(keys.into())
+    }
+
+    /// Get keysets for this wallet's unit with filter
+    pub async fn get_mint_keysets(
+        &self,
+        filter: KeysetFilter,
+    ) -> Result<Vec<KeySetInfo>, FfiError> {
+        let keysets = self.inner.get_mint_keysets(filter.into()).await?;
+        Ok(keysets.into_iter().map(Into::into).collect())
+    }
+
+    /// Load active keysets
+    pub async fn load_mint_keysets(&self) -> Result<Vec<KeySetInfo>, FfiError> {
+        let keysets = self.inner.load_mint_keysets().await?;
+        Ok(keysets.into_iter().map(Into::into).collect())
+    }
+
+    /// Fetch active keyset with lowest fees
+    pub async fn fetch_active_keyset(&self) -> Result<KeySetInfo, FfiError> {
+        let keyset = self.inner.fetch_active_keyset().await?;
+        Ok(keyset.into())
+    }
+
+    /// Get fees and amounts for all keysets
+    pub async fn get_keyset_fees_and_amounts(
+        &self,
+    ) -> Result<std::collections::HashMap<String, FeeAndAmounts>, FfiError> {
+        let fees = self.inner.get_keyset_fees_and_amounts().await?;
+        Ok(fees
+            .into_iter()
+            .map(|(id, fa)| (id.to_string(), fa.into()))
+            .collect())
+    }
+
+    /// Get fees and amounts for a specific keyset
+    pub async fn get_keyset_fees_and_amounts_by_id(
+        &self,
+        keyset_id: String,
+    ) -> Result<FeeAndAmounts, FfiError> {
+        let id = cdk::nuts::Id::from_str(&keyset_id).map_err(FfiError::internal)?;
+        let fa = self.inner.get_keyset_fees_and_amounts_by_id(id).await?;
+        Ok(fa.into())
+    }
+
+    /// Get fee for count of proofs in a keyset
+    pub async fn get_keyset_count_fee(
+        &self,
+        keyset_id: String,
+        count: u64,
+    ) -> Result<Amount, FfiError> {
+        let id = cdk::nuts::Id::from_str(&keyset_id).map_err(FfiError::internal)?;
+        let fee = self.inner.get_keyset_count_fee(&id, count).await?;
+        Ok(fee.into())
+    }
+
     /// Check all pending proofs and return the total amount still pending
     ///
     /// This function checks orphaned pending proofs (not managed by active sagas)

--- a/crates/cdk-ffi/src/wallet_trait.rs
+++ b/crates/cdk-ffi/src/wallet_trait.rs
@@ -77,6 +77,54 @@ impl WalletTraitDef for Wallet {
         Ok(keyset.into())
     }
 
+    async fn load_keyset_keys(
+        &self,
+        keyset_id: cdk_common::nuts::Id,
+    ) -> Result<cdk_common::nuts::Keys, Self::Error> {
+        let keys = WalletTraitDef::load_keyset_keys(self.inner().as_ref(), keyset_id).await?;
+        Ok(keys)
+    }
+
+    async fn get_mint_keysets(
+        &self,
+        filter: cdk_common::wallet::KeysetFilter,
+    ) -> Result<Vec<Self::KeySetInfo>, Self::Error> {
+        let keysets = WalletTraitDef::get_mint_keysets(self.inner().as_ref(), filter).await?;
+        Ok(keysets.into_iter().map(Into::into).collect())
+    }
+
+    async fn fetch_active_keyset(&self) -> Result<Self::KeySetInfo, Self::Error> {
+        let keyset = WalletTraitDef::fetch_active_keyset(self.inner().as_ref()).await?;
+        Ok(keyset.into())
+    }
+
+    async fn get_keyset_fees_and_amounts(
+        &self,
+    ) -> Result<cdk_common::amount::KeysetFeeAndAmounts, Self::Error> {
+        let fees = WalletTraitDef::get_keyset_fees_and_amounts(self.inner().as_ref()).await?;
+        Ok(fees)
+    }
+
+    async fn get_keyset_count_fee(
+        &self,
+        keyset_id: &cdk_common::nuts::Id,
+        count: u64,
+    ) -> Result<Self::Amount, Self::Error> {
+        let fee =
+            WalletTraitDef::get_keyset_count_fee(self.inner().as_ref(), keyset_id, count).await?;
+        Ok(fee.into())
+    }
+
+    async fn get_keyset_fees_and_amounts_by_id(
+        &self,
+        keyset_id: cdk_common::nuts::Id,
+    ) -> Result<cdk_common::amount::FeeAndAmounts, Self::Error> {
+        let fee =
+            WalletTraitDef::get_keyset_fees_and_amounts_by_id(self.inner().as_ref(), keyset_id)
+                .await?;
+        Ok(fee)
+    }
+
     async fn mint_quote(
         &self,
         method: Self::PaymentMethod,

--- a/crates/cdk/src/wallet/keysets.rs
+++ b/crates/cdk/src/wallet/keysets.rs
@@ -2,19 +2,11 @@ use std::collections::HashMap;
 
 use cdk_common::amount::{FeeAndAmounts, KeysetFeeAndAmounts};
 use cdk_common::nut02::KeySetInfosMethods;
+pub use cdk_common::wallet::KeysetFilter;
 use tracing::instrument;
 
 use crate::nuts::{Id, KeySetInfo, Keys};
 use crate::{Error, Wallet};
-
-/// Filter for keyset queries
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum KeysetFilter {
-    /// Only return active keysets
-    Active,
-    /// Return all keysets (active and inactive)
-    All,
-}
 
 impl Wallet {
     /// Load keys for mint keyset

--- a/crates/cdk/src/wallet/wallet_trait.rs
+++ b/crates/cdk/src/wallet/wallet_trait.rs
@@ -4,18 +4,18 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use async_trait::async_trait;
-use cdk_common::amount::SplitTarget;
+use cdk_common::amount::{FeeAndAmounts, KeysetFeeAndAmounts, SplitTarget};
 use cdk_common::mint_url::MintUrl;
 use cdk_common::nuts::nut07::ProofState;
 use cdk_common::nuts::nut18::PaymentRequest;
 use cdk_common::nuts::{
-    AuthProof, CurrencyUnit, Id, KeySetInfo, MeltOptions, MintInfo, PaymentMethod, Proofs,
+    AuthProof, CurrencyUnit, Id, KeySetInfo, Keys, MeltOptions, MintInfo, PaymentMethod, Proofs,
     SpendingConditions,
 };
 use cdk_common::subscription::WalletParams;
 use cdk_common::wallet::{
-    MeltQuote, MintQuote, ReceiveOptions, Restored, SendOptions, Transaction, TransactionDirection,
-    TransactionId, Wallet as WalletTrait,
+    KeysetFilter, MeltQuote, MintQuote, ReceiveOptions, Restored, SendOptions, Transaction,
+    TransactionDirection, TransactionId, Wallet as WalletTrait,
 };
 use cdk_common::{Amount, PublicKey, SecretKey};
 use tracing::instrument;
@@ -84,6 +84,43 @@ impl WalletTrait for super::Wallet {
     #[instrument(skip(self))]
     async fn get_active_keyset(&self) -> Result<KeySetInfo, Self::Error> {
         self.get_active_keyset().await
+    }
+
+    #[instrument(skip(self))]
+    async fn load_keyset_keys(&self, keyset_id: Id) -> Result<Keys, Self::Error> {
+        self.load_keyset_keys(keyset_id).await
+    }
+
+    #[instrument(skip(self))]
+    async fn get_mint_keysets(&self, filter: KeysetFilter) -> Result<Vec<KeySetInfo>, Self::Error> {
+        self.get_mint_keysets(filter).await
+    }
+
+    #[instrument(skip(self))]
+    async fn fetch_active_keyset(&self) -> Result<KeySetInfo, Self::Error> {
+        self.fetch_active_keyset().await
+    }
+
+    #[instrument(skip(self))]
+    async fn get_keyset_fees_and_amounts(&self) -> Result<KeysetFeeAndAmounts, Self::Error> {
+        self.get_keyset_fees_and_amounts().await
+    }
+
+    #[instrument(skip(self))]
+    async fn get_keyset_count_fee(
+        &self,
+        keyset_id: &Id,
+        count: u64,
+    ) -> Result<Amount, Self::Error> {
+        self.get_keyset_count_fee(keyset_id, count).await
+    }
+
+    #[instrument(skip(self))]
+    async fn get_keyset_fees_and_amounts_by_id(
+        &self,
+        keyset_id: Id,
+    ) -> Result<FeeAndAmounts, Self::Error> {
+        self.get_keyset_fees_and_amounts_by_id(keyset_id).await
     }
 
     #[instrument(skip(self, method))]


### PR DESCRIPTION


### Description

Move keyset query and fee methods from inherent impl on cdk::Wallet into the cdk-common Wallet trait so they are available through the trait interface and FFI bindings.

Methods added to the trait:
- load_keyset_keys, get_mint_keysets, load_mint_keysets (default impl), fetch_active_keyset, get_keyset_fees_and_amounts, get_keyset_fees_and_amounts_by_id, get_keyset_count_fee

KeysetFilter enum relocated from cdk to cdk-common to support the trait signature. New FFI types (KeysetFilter, FeeAndAmounts) and public wrapper methods added to cdk-ffi.

This partially fixes #1767

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
