### PR TITLE
fix(cdk-axum): allow all headers in CORS preflight 

### DIFF
--- a/crates/cdk-axum/src/lib.rs
+++ b/crates/cdk-axum/src/lib.rs
@@ -167,7 +167,7 @@ async fn cors_middleware(
     req: axum::http::Request<axum::body::Body>,
     next: axum::middleware::Next,
 ) -> Response {
-    let allowed_headers = "Content-Type, Clear-auth, Blind-auth, Prefer, Cache-Control, Pragma";
+    let allowed_headers = "*";
 
     // Handle preflight requests
     if req.method() == axum::http::Method::OPTIONS {


### PR DESCRIPTION
Changes CORS `Access-Control-Allow-Headers` from an explicit allowlist  to `*`.

This aligns with [Nutshell's CORS configuration](https://github.com/cashubtc/nutshell/blob/a0ef44dba03785b2de4353fff9bd3e1457642bc7/cashu/mint/middleware.py#L36)

Mints are public APIs with no cookie-based auth, so restricting request headers provides no security benefit. The explicit allowlist caused wallet clients to fail preflight when sending standard HTTP headers (e.g. caching directives), particularly if mints are sat behind proxies/CDNs.