### PR TITLE
Move fee calculation to cdk-common and add fee methods to Wallet trait

### DIFF
--- a/crates/cdk-common/src/fees.rs
+++ b/crates/cdk-common/src/fees.rs
@@ -1,0 +1,15 @@
+//! Fee types shared across crates
+
+use std::collections::HashMap;
+
+use crate::nuts::Id;
+use crate::Amount;
+
+/// Fee breakdown containing total fee and fee per keyset
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProofsFeeBreakdown {
+    /// Total fee across all keysets
+    pub total: Amount,
+    /// Fee collected per keyset
+    pub per_keyset: HashMap<Id, Amount>,
+}

--- a/crates/cdk-common/src/lib.rs
+++ b/crates/cdk-common/src/lib.rs
@@ -24,6 +24,7 @@ pub mod grpc;
 pub mod common;
 pub mod database;
 pub mod error;
+pub mod fees;
 pub mod melt;
 #[cfg(feature = "mint")]
 pub mod mint;

--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use bitcoin::bip32::DerivationPath;
 use bitcoin::hashes::{sha256, Hash, HashEngine};
 use cashu::amount::{FeeAndAmounts, KeysetFeeAndAmounts, SplitTarget};
+use cashu::nut00::ProofsMethods;
 use cashu::nuts::nut07::ProofState;
 use cashu::nuts::nut18::PaymentRequest;
 use cashu::nuts::{AuthProof, Keys};
@@ -22,6 +23,7 @@ use crate::nuts::{
 };
 use crate::{Amount, Error};
 
+pub use crate::fees;
 pub mod saga;
 
 pub use saga::{
@@ -798,6 +800,28 @@ pub trait Wallet: Send + Sync {
         keyset_id: Id,
     ) -> Result<Self::Amount, Self::Error>;
 
+    /// Fee required to redeem proof set by count per keyset
+    async fn get_proofs_fee_by_count(
+        &self,
+        proofs_per_keyset: HashMap<Id, u64>,
+    ) -> Result<fees::ProofsFeeBreakdown, Self::Error>;
+
+    /// Fee required to redeem a proof set
+    async fn get_proofs_fee(
+        &self,
+        proofs: &Proofs,
+    ) -> Result<fees::ProofsFeeBreakdown, Self::Error> {
+        let proofs_per_keyset = proofs.count_by_keyset();
+        self.get_proofs_fee_by_count(proofs_per_keyset).await
+    }
+
+    /// Get proofs filtered by state and/or spending conditions
+    async fn get_proofs_with(
+        &self,
+        state: Option<Vec<State>>,
+        spending_conditions: Option<Vec<SpendingConditions>>,
+    ) -> Result<Proofs, Self::Error>;
+
     /// Receive an encoded token
     async fn receive(
         &self,
@@ -992,7 +1016,9 @@ pub trait Wallet: Send + Sync {
     /// Returns all proofs whose state matches any of the given states.
     /// The `Spent` state is typically excluded since spent proofs are removed
     /// from the database.
-    async fn get_proofs_by_states(&self, states: Vec<State>) -> Result<Proofs, Self::Error>;
+    async fn get_proofs_by_states(&self, states: Vec<State>) -> Result<Proofs, Self::Error> {
+        self.get_proofs_with(Some(states), None).await
+    }
 
     // P2PK proofs
     /// generates and stores public key in database

--- a/crates/cdk-ffi/src/types/amount.rs
+++ b/crates/cdk-ffi/src/types/amount.rs
@@ -1,5 +1,7 @@
 //! Amount and currency related types
 
+use std::collections::HashMap;
+
 use cdk::nuts::CurrencyUnit as CdkCurrencyUnit;
 use cdk::Amount as CdkAmount;
 use serde::{Deserialize, Serialize};
@@ -104,6 +106,28 @@ impl From<cdk_common::amount::FeeAndAmounts> for FeeAndAmounts {
         Self {
             fee: fa.fee(),
             amounts: fa.amounts().to_vec(),
+        }
+    }
+}
+
+/// FFI-compatible ProofsFeeBreakdown
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct ProofsFeeBreakdown {
+    /// Total fee across all keysets
+    pub total: Amount,
+    /// Fee per keyset (keyset ID string -> fee amount)
+    pub per_keyset: HashMap<String, Amount>,
+}
+
+impl From<cdk_common::fees::ProofsFeeBreakdown> for ProofsFeeBreakdown {
+    fn from(b: cdk_common::fees::ProofsFeeBreakdown) -> Self {
+        Self {
+            total: b.total.into(),
+            per_keyset: b
+                .per_keyset
+                .into_iter()
+                .map(|(id, a)| (id.to_string(), a.into()))
+                .collect(),
         }
     }
 }

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -1,5 +1,6 @@
 //! FFI Wallet bindings
 
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -119,6 +120,54 @@ impl Wallet {
     pub async fn total_reserved_balance(&self) -> Result<Amount, FfiError> {
         let balance = self.inner.total_reserved_balance().await?;
         Ok(balance.into())
+    }
+
+    /// Get fee breakdown for a set of proofs
+    pub async fn get_proofs_fee(&self, proofs: Proofs) -> Result<ProofsFeeBreakdown, FfiError> {
+        let cdk_proofs: Result<Vec<cdk::nuts::Proof>, _> =
+            proofs.into_iter().map(|p| p.try_into()).collect();
+        let cdk_proofs = cdk_proofs?;
+        let breakdown = self.inner.get_proofs_fee(&cdk_proofs).await?;
+        Ok(breakdown.into())
+    }
+
+    /// Get fee breakdown by proof count per keyset
+    pub async fn get_proofs_fee_by_count(
+        &self,
+        proofs_per_keyset: HashMap<String, u64>,
+    ) -> Result<ProofsFeeBreakdown, FfiError> {
+        let map = proofs_per_keyset
+            .into_iter()
+            .map(|(id_str, count)| {
+                let id: cdk::nuts::Id = id_str
+                    .parse()
+                    .map_err(|e| FfiError::internal(format!("Invalid keyset ID: {e}")))?;
+                Ok((id, count))
+            })
+            .collect::<Result<HashMap<_, _>, FfiError>>()?;
+        let breakdown = self.inner.get_proofs_fee_by_count(map).await?;
+        Ok(breakdown.into())
+    }
+
+    /// Get proofs filtered by state and spending conditions
+    pub async fn get_proofs_with(
+        &self,
+        states: Option<Vec<ProofState>>,
+        spending_conditions: Option<Vec<SpendingConditions>>,
+    ) -> Result<Proofs, FfiError> {
+        let cdk_states = states.map(|s| s.into_iter().map(Into::into).collect());
+        let cdk_conditions: Option<Vec<cdk::nuts::SpendingConditions>> = spending_conditions
+            .map(|c| {
+                c.into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, _>>()
+            })
+            .transpose()?;
+        let proofs = self
+            .inner
+            .get_proofs_with(cdk_states, cdk_conditions)
+            .await?;
+        Ok(proofs.into_iter().map(Into::into).collect())
     }
 
     /// Get mint info from mint

--- a/crates/cdk-ffi/src/wallet_trait.rs
+++ b/crates/cdk-ffi/src/wallet_trait.rs
@@ -486,12 +486,23 @@ impl WalletTraitDef for Wallet {
         Ok(quote.into())
     }
 
-    async fn get_proofs_by_states(
+    async fn get_proofs_fee_by_count(
         &self,
-        states: Vec<cdk_common::nuts::State>,
+        proofs_per_keyset: HashMap<cdk_common::nuts::Id, u64>,
+    ) -> Result<cdk_common::fees::ProofsFeeBreakdown, Self::Error> {
+        WalletTraitDef::get_proofs_fee_by_count(self.inner().as_ref(), proofs_per_keyset)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn get_proofs_with(
+        &self,
+        state: Option<Vec<cdk_common::nuts::State>>,
+        spending_conditions: Option<Vec<cdk_common::nuts::SpendingConditions>>,
     ) -> Result<cdk_common::Proofs, Self::Error> {
-        let proofs = WalletTraitDef::get_proofs_by_states(self.inner().as_ref(), states).await?;
-        Ok(proofs)
+        WalletTraitDef::get_proofs_with(self.inner().as_ref(), state, spending_conditions)
+            .await
+            .map_err(Into::into)
     }
 
     /// generates and stores public key in database

--- a/crates/cdk/src/fees.rs
+++ b/crates/cdk/src/fees.rs
@@ -4,19 +4,11 @@
 
 use std::collections::{BTreeMap, HashMap};
 
+pub use cdk_common::fees::ProofsFeeBreakdown;
 use tracing::instrument;
 
 use crate::nuts::Id;
-use crate::{Amount, Error};
-
-/// Fee breakdown containing total fee and fee per keyset
-#[derive(Debug, Clone, PartialEq)]
-pub struct ProofsFeeBreakdown {
-    /// Total fee across all keysets
-    pub total: Amount,
-    /// Fee collected per keyset
-    pub per_keyset: HashMap<Id, Amount>,
-}
+use crate::Error;
 
 /// Fee required for proof set
 #[instrument(skip_all)]

--- a/crates/cdk/src/wallet/wallet_trait.rs
+++ b/crates/cdk/src/wallet/wallet_trait.rs
@@ -395,13 +395,21 @@ impl WalletTrait for super::Wallet {
             .await
     }
 
-    #[instrument(skip(self))]
-    async fn get_proofs_by_states(
+    async fn get_proofs_fee_by_count(
         &self,
-        states: Vec<cdk_common::nuts::State>,
-    ) -> Result<Proofs, Self::Error> {
-        self.get_proofs_by_states(states).await
+        proofs_per_keyset: HashMap<Id, u64>,
+    ) -> Result<cdk_common::fees::ProofsFeeBreakdown, Self::Error> {
+        self.get_proofs_fee_by_count(proofs_per_keyset).await
     }
+
+    async fn get_proofs_with(
+        &self,
+        state: Option<Vec<cdk_common::nuts::State>>,
+        spending_conditions: Option<Vec<SpendingConditions>>,
+    ) -> Result<Proofs, Self::Error> {
+        self.get_proofs_with(state, spending_conditions).await
+    }
+
     /// generates and stores public key in database
     async fn generate_public_key(&self) -> Result<PublicKey, Self::Error> {
         return self.generate_public_key().await;


### PR DESCRIPTION

### Description

Move `calculate_fee` and `ProofsFeeBreakdown` from `cdk/src/fees.rs` to `cdk-common/src/wallet/fees.rs` so downstream consumers of cdk-common can compute fees without depending on the full cdk crate.

Add `get_proofs_fee`, `get_proofs_fee_by_count`, and `get_proofs_with` to the Wallet trait, and make `get_proofs_by_states` a default method that delegates to `get_proofs_with`. Expose corresponding FFI bindings.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
