### PR TITLE
fix: replace blocking Condvar pool with async Semaphore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ ldk-node = "0.7.0"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 thiserror = { version = "2" }
-tokio = { version = "1", default-features = false, features = ["rt", "macros", "test-util", "sync"] }
+tokio = { version = "1", default-features = false, features = ["rt", "macros", "test-util", "sync", "time"] }
 tokio-util = { version = "0.7.11", default-features = false }
 tower = "0.5.2"
 tower-http = { version = "0.6.1", features = ["compression-full", "decompression-full", "cors", "trace", "fs"] }

--- a/bindings/dart/test/wallet_test.dart
+++ b/bindings/dart/test/wallet_test.dart
@@ -30,6 +30,28 @@ void main() {
     expect(balance.value, equals(0));
   });
 
+  test('in-memory sqlite handles concurrent access', () async {
+    final memoryWallet = Wallet(
+      mintUrl: 'https://testnut.cashudevkit.org',
+      unit: SatCurrencyUnit(),
+      mnemonic: generateMnemonic(),
+      store: SqliteWalletStore(':memory:'),
+      config: WalletConfig(targetProofCount: null),
+    );
+
+    try {
+      final balances = await Future.wait(
+        List.generate(64, (_) => memoryWallet.totalBalance()),
+      );
+
+      for (final balance in balances) {
+        expect(balance.value, equals(0));
+      }
+    } finally {
+      memoryWallet.dispose();
+    }
+  });
+
   test('mint flow', () async {
     final quote = await wallet.mintQuote(
       paymentMethod: Bolt11PaymentMethod(),

--- a/bindings/kotlin/cdk-jvm/src/test/kotlin/org/cashudevkit/WalletTest.kt
+++ b/bindings/kotlin/cdk-jvm/src/test/kotlin/org/cashudevkit/WalletTest.kt
@@ -1,5 +1,8 @@
 package org.cashudevkit
 
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
@@ -35,6 +38,31 @@ class WalletTest {
     fun `initial balance is zero`() = runBlocking {
         val balance = wallet.totalBalance()
         assertEquals(0UL, balance.value)
+    }
+
+    @Test
+    fun `in-memory sqlite handles concurrent access`() = runBlocking {
+        val memoryWallet = Wallet(
+            mintUrl = "https://testnut.cashudevkit.org",
+            unit = CurrencyUnit.Sat,
+            mnemonic = generateMnemonic(),
+            store = WalletStore.Sqlite(path = ":memory:"),
+            config = WalletConfig(targetProofCount = null),
+        )
+
+        try {
+            val balances = coroutineScope {
+                (0 until 64).map {
+                    async { memoryWallet.totalBalance() }
+                }.awaitAll()
+            }
+
+            balances.forEach { balance ->
+                assertEquals(0UL, balance.value)
+            }
+        } finally {
+            memoryWallet.close()
+        }
     }
 
     @Test

--- a/bindings/swift/Tests/CdkTests.swift
+++ b/bindings/swift/Tests/CdkTests.swift
@@ -25,6 +25,36 @@ struct CdkTests {
         #expect(balance.value == 0, "New wallet should have zero balance")
     }
 
+    @Test("In-memory SQLite handles concurrent access")
+    func inMemorySqliteHandlesConcurrentAccess() async throws {
+        let memoryWallet = try Wallet(
+            mintUrl: "https://testnut.cashudevkit.org",
+            unit: .sat,
+            mnemonic: try generateMnemonic(),
+            store: .sqlite(path: ":memory:"),
+            config: WalletConfig(targetProofCount: nil)
+        )
+
+        let balances = try await withThrowingTaskGroup(of: Amount.self) { group in
+            for _ in 0..<64 {
+                group.addTask {
+                    try await memoryWallet.totalBalance()
+                }
+            }
+
+            var balances: [Amount] = []
+            for try await balance in group {
+                balances.append(balance)
+            }
+            return balances
+        }
+
+        #expect(balances.count == 64, "All concurrent balance reads should complete")
+        for balance in balances {
+            #expect(balance.value == 0, "New in-memory wallet should have zero balance")
+        }
+    }
+
     @Test("Mint flow completes successfully")
     func mintFlow() async throws {
         let quote = try await wallet.mintQuote(

--- a/crates/cdk-ffi/src/lib.rs
+++ b/crates/cdk-ffi/src/lib.rs
@@ -14,6 +14,7 @@ pub mod logging;
 pub mod npubcash;
 #[cfg(feature = "postgres")]
 pub mod postgres;
+mod runtime;
 pub mod sqlite;
 #[cfg(feature = "supabase")]
 pub mod supabase;

--- a/crates/cdk-ffi/src/postgres.rs
+++ b/crates/cdk-ffi/src/postgres.rs
@@ -12,24 +12,8 @@ use crate::{
 #[derive(uniffi::Object)]
 pub struct WalletPostgresDatabase {
     inner: Arc<FfiWalletDatabaseWrapper<WalletPgDatabase, CdkDatabaseError>>,
-}
-
-// Keep a long-lived Tokio runtime for Postgres-created resources so that
-// background tasks (e.g., tokio-postgres connection drivers spawned during
-// construction) are not tied to a short-lived, ad-hoc runtime.
-#[cfg(feature = "postgres")]
-static PG_RUNTIME: once_cell::sync::OnceCell<tokio::runtime::Runtime> =
-    once_cell::sync::OnceCell::new();
-
-#[cfg(feature = "postgres")]
-fn pg_runtime() -> &'static tokio::runtime::Runtime {
-    PG_RUNTIME.get_or_init(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .thread_name("cdk-ffi-pg")
-            .build()
-            .expect("failed to build pg runtime")
-    })
+    // Keep the runtime alive so Postgres background connection tasks survive.
+    _runtime: crate::runtime::RuntimeGuard,
 }
 
 #[uniffi::export]
@@ -41,19 +25,13 @@ impl WalletPostgresDatabase {
     #[cfg(feature = "postgres")]
     #[uniffi::constructor]
     pub fn new(url: String) -> Result<Arc<Self>, FfiError> {
-        let inner = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| {
-                handle.block_on(
-                    async move { cdk_postgres::new_wallet_pg_database(url.as_str()).await },
-                )
-            }),
-            // Important: use a process-long runtime so background connection tasks stay alive.
-            Err(_) => pg_runtime()
-                .block_on(async move { cdk_postgres::new_wallet_pg_database(url.as_str()).await }),
-        }
-        .map_err(FfiError::internal)?;
+        let rt = crate::runtime::RuntimeGuard::new().map_err(FfiError::internal)?;
+        let inner = rt
+            .block_on(async move { cdk_postgres::new_wallet_pg_database(url.as_str()).await })
+            .map_err(FfiError::internal)?;
         Ok(Arc::new(WalletPostgresDatabase {
             inner: FfiWalletDatabaseWrapper::new(inner),
+            _runtime: rt,
         }))
     }
 }

--- a/crates/cdk-ffi/src/runtime.rs
+++ b/crates/cdk-ffi/src/runtime.rs
@@ -1,0 +1,58 @@
+//! Lightweight runtime guard for FFI constructors.
+//!
+//! When called from an FFI language (Python, Swift, …) there may be no Tokio
+//! runtime on the current thread.  `RuntimeGuard` detects this and, if needed,
+//! lazily creates a multi-threaded runtime that lives as long as the guard.
+
+use std::future::Future;
+
+use tokio::runtime::{Handle, Runtime};
+
+/// Holds either a borrowed handle to an existing Tokio runtime or an owned
+/// runtime created on demand.  Dropping the guard shuts down the owned runtime
+/// (if any), so it should be kept alive as long as work may be spawned on it.
+pub(crate) struct RuntimeGuard {
+    _runtime: Option<Runtime>,
+    handle: Handle,
+}
+
+impl RuntimeGuard {
+    /// Create a new guard.
+    ///
+    /// * If a Tokio runtime is already running on this thread the guard simply
+    ///   captures its [`Handle`] (zero cost).
+    /// * Otherwise a new multi-threaded runtime is created and owned by the
+    ///   guard.
+    pub fn new() -> Result<Self, String> {
+        match Handle::try_current() {
+            Ok(handle) => Ok(Self {
+                _runtime: None,
+                handle,
+            }),
+            Err(_) => {
+                let rt = Runtime::new().map_err(|e| format!("Failed to create runtime: {e}"))?;
+                let handle = rt.handle().clone();
+                Ok(Self {
+                    _runtime: Some(rt),
+                    handle,
+                })
+            }
+        }
+    }
+
+    /// Run a future to completion on the runtime.
+    ///
+    /// When the guard wraps an *existing* runtime this uses
+    /// [`tokio::task::block_in_place`] so we don't starve the caller's worker
+    /// threads.  When it owns its own runtime it calls [`Handle::block_on`]
+    /// directly.
+    pub fn block_on<F: Future>(&self, future: F) -> F::Output {
+        if self._runtime.is_some() {
+            // We own the runtime — safe to block_on directly.
+            self.handle.block_on(future)
+        } else {
+            // Running inside an external runtime — yield the worker thread.
+            tokio::task::block_in_place(|| self.handle.block_on(future))
+        }
+    }
+}

--- a/crates/cdk-ffi/src/sqlite.rs
+++ b/crates/cdk-ffi/src/sqlite.rs
@@ -13,6 +13,8 @@ use crate::{
 #[derive(uniffi::Object)]
 pub struct WalletSqliteDatabase {
     inner: Arc<FfiWalletDatabaseWrapper<CdkWalletSqliteDatabase, CdkDatabaseError>>,
+    // Keep the runtime alive so async pool operations work in FFI contexts.
+    _runtime: crate::runtime::RuntimeGuard,
 }
 
 #[uniffi::export]
@@ -20,41 +22,26 @@ impl WalletSqliteDatabase {
     /// Create a new WalletSqliteDatabase with the given work directory
     #[uniffi::constructor]
     pub fn new(file_path: String) -> Result<Arc<Self>, FfiError> {
-        let db = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| {
-                handle
-                    .block_on(async move { CdkWalletSqliteDatabase::new(file_path.as_str()).await })
-            }),
-            Err(_) => {
-                // No current runtime, create a new one
-                tokio::runtime::Runtime::new()
-                    .map_err(|e| FfiError::internal(format!("Failed to create runtime: {}", e)))?
-                    .block_on(async move { CdkWalletSqliteDatabase::new(file_path.as_str()).await })
-            }
-        }
-        .map_err(FfiError::internal)?;
+        let rt = crate::runtime::RuntimeGuard::new().map_err(FfiError::internal)?;
+        let db = rt
+            .block_on(async move { CdkWalletSqliteDatabase::new(file_path.as_str()).await })
+            .map_err(FfiError::internal)?;
         Ok(Arc::new(Self {
             inner: FfiWalletDatabaseWrapper::new(db),
+            _runtime: rt,
         }))
     }
 
     /// Create an in-memory database
     #[uniffi::constructor]
     pub fn new_in_memory() -> Result<Arc<Self>, FfiError> {
-        let db = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| {
-                handle.block_on(async move { cdk_sqlite::wallet::memory::empty().await })
-            }),
-            Err(_) => {
-                // No current runtime, create a new one
-                tokio::runtime::Runtime::new()
-                    .map_err(|e| FfiError::internal(format!("Failed to create runtime: {}", e)))?
-                    .block_on(async move { cdk_sqlite::wallet::memory::empty().await })
-            }
-        }
-        .map_err(FfiError::internal)?;
+        let rt = crate::runtime::RuntimeGuard::new().map_err(FfiError::internal)?;
+        let db = rt
+            .block_on(async move { cdk_sqlite::wallet::memory::empty().await })
+            .map_err(FfiError::internal)?;
         Ok(Arc::new(Self {
             inner: FfiWalletDatabaseWrapper::new(db),
+            _runtime: rt,
         }))
     }
 }

--- a/crates/cdk-ffi/src/wallet_repository.rs
+++ b/crates/cdk-ffi/src/wallet_repository.rs
@@ -37,29 +37,14 @@ impl WalletRepository {
         // Convert the FFI database trait to a CDK database implementation
         let localstore = crate::database::create_cdk_database_from_ffi(db);
 
-        let wallet = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| {
-                handle.block_on(async move {
-                    WalletRepositoryBuilder::new()
-                        .localstore(localstore)
-                        .seed(seed)
-                        .build()
-                        .await
-                })
-            }),
-            Err(_) => {
-                // No current runtime, create a new one
-                tokio::runtime::Runtime::new()
-                    .map_err(|e| FfiError::internal(format!("Failed to create runtime: {}", e)))?
-                    .block_on(async move {
-                        WalletRepositoryBuilder::new()
-                            .localstore(localstore)
-                            .seed(seed)
-                            .build()
-                            .await
-                    })
-            }
-        }?;
+        let rt = crate::runtime::RuntimeGuard::new().map_err(FfiError::internal)?;
+        let wallet = rt.block_on(async move {
+            WalletRepositoryBuilder::new()
+                .localstore(localstore)
+                .seed(seed)
+                .build()
+                .await
+        })?;
 
         Ok(Self {
             inner: Arc::new(wallet),
@@ -87,31 +72,15 @@ impl WalletRepository {
         let proxy_url = url::Url::parse(&proxy_url)
             .map_err(|e| FfiError::internal(format!("Invalid URL: {}", e)))?;
 
-        let wallet = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| {
-                handle.block_on(async move {
-                    WalletRepositoryBuilder::new()
-                        .localstore(localstore)
-                        .seed(seed)
-                        .proxy_url(proxy_url)
-                        .build()
-                        .await
-                })
-            }),
-            Err(_) => {
-                // No current runtime, create a new one
-                tokio::runtime::Runtime::new()
-                    .map_err(|e| FfiError::internal(format!("Failed to create runtime: {}", e)))?
-                    .block_on(async move {
-                        WalletRepositoryBuilder::new()
-                            .localstore(localstore)
-                            .seed(seed)
-                            .proxy_url(proxy_url)
-                            .build()
-                            .await
-                    })
-            }
-        }?;
+        let rt = crate::runtime::RuntimeGuard::new().map_err(FfiError::internal)?;
+        let wallet = rt.block_on(async move {
+            WalletRepositoryBuilder::new()
+                .localstore(localstore)
+                .seed(seed)
+                .proxy_url(proxy_url)
+                .build()
+                .await
+        })?;
 
         Ok(Self {
             inner: Arc::new(wallet),

--- a/crates/cdk-ffi/tests/test_kvstore.py
+++ b/crates/cdk-ffi/tests/test_kvstore.py
@@ -42,6 +42,12 @@ def create_test_db():
     return db, db_path
 
 
+def create_test_memory_db():
+    """Create an in-memory SQLite database for testing"""
+    backend = cdk_ffi.WalletDbBackend.SQLITE(path=":memory:")
+    return cdk_ffi.create_wallet_db(backend)
+
+
 def cleanup_db(db_path):
     """Clean up the temporary database file"""
     if os.path.exists(db_path):
@@ -374,6 +380,31 @@ async def test_kv_persistence_across_instances():
             os.unlink(db_path)
 
 
+async def test_kv_in_memory_concurrent_access():
+    """Test concurrent FFI access to the single-connection in-memory SQLite pool"""
+    print("\n=== Test: KV In-Memory Concurrent Access ===")
+
+    db = create_test_memory_db()
+
+    async def write_and_read(index):
+        key = f"key_{index}"
+        value = f"value_{index}".encode()
+        await db.kv_write("memory", "concurrent", key, value)
+        result = await db.kv_read("memory", "concurrent", key)
+        assert result is not None, f"Expected value for {key}"
+        assert bytes(result) == value, f"Expected {value}, got {bytes(result)}"
+
+    await asyncio.wait_for(
+        asyncio.gather(*(write_and_read(index) for index in range(64))),
+        timeout=10.0,
+    )
+
+    keys = await db.kv_list("memory", "concurrent")
+    assert len(keys) == 64, f"Expected 64 keys, got {len(keys)}"
+
+    print("  Test passed: concurrent in-memory KV access works")
+
+
 async def main():
     """Run all KV store tests"""
     print("Starting CDK FFI Key-Value Store Tests")
@@ -395,6 +426,8 @@ async def main():
         ("KV Special Key Names", test_kv_special_key_names),
         # Persistence
         ("KV Persistence Across Instances", test_kv_persistence_across_instances),
+        # In-memory SQLite pool
+        ("KV In-Memory Concurrent Access", test_kv_in_memory_concurrent_access),
     ]
 
     passed = 0

--- a/crates/cdk-sql-common/src/keyvalue.rs
+++ b/crates/cdk-sql-common/src/keyvalue.rs
@@ -162,7 +162,7 @@ where
     // Validate parameters according to KV store requirements
     validate_kvstore_params(primary_namespace, secondary_namespace, Some(key))?;
 
-    let conn = pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+    let conn = pool.get().await.map_err(|e| Error::Database(Box::new(e)))?;
     Ok(query(
         r#"
         SELECT value
@@ -195,7 +195,7 @@ where
     // Validate namespace parameters according to KV store requirements
     validate_kvstore_params(primary_namespace, secondary_namespace, None)?;
 
-    let conn = pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+    let conn = pool.get().await.map_err(|e| Error::Database(Box::new(e)))?;
     query(
         r#"
         SELECT key

--- a/crates/cdk-sql-common/src/mint/auth/mod.rs
+++ b/crates/cdk-sql-common/src/mint/auth/mod.rs
@@ -340,9 +340,6 @@ where
     }
 
     async fn get_proofs_states(&self, ys: &[PublicKey]) -> Result<Vec<Option<State>>, Self::Err> {
-        if ys.is_empty() {
-            return Ok(vec![]);
-        }
         let conn = self
             .pool
             .get()
@@ -368,10 +365,6 @@ where
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
-        if blinded_messages.is_empty() {
-            return Ok(vec![]);
-        }
-
         let conn = self
             .pool
             .get()

--- a/crates/cdk-sql-common/src/mint/auth/mod.rs
+++ b/crates/cdk-sql-common/src/mint/auth/mod.rs
@@ -42,7 +42,7 @@ where
         X: Into<RM::Config>,
     {
         let pool = Pool::new(db.into());
-        Self::migrate(pool.get().map_err(|e| Error::Database(Box::new(e)))?).await?;
+        Self::migrate(pool.get().await.map_err(|e| Error::Database(Box::new(e)))?).await?;
         Ok(Self { pool })
     }
 
@@ -251,14 +251,21 @@ where
     {
         Ok(Box::new(SQLTransaction {
             inner: ConnectionWithTransaction::new(
-                self.pool.get().map_err(|e| Error::Database(Box::new(e)))?,
+                self.pool
+                    .get()
+                    .await
+                    .map_err(|e| Error::Database(Box::new(e)))?,
             )
             .await?,
         }))
     }
 
     async fn get_active_keyset_id(&self) -> Result<Option<Id>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -277,7 +284,11 @@ where
     }
 
     async fn get_keyset_info(&self, id: &Id) -> Result<Option<MintKeySetInfo>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"SELECT
                 id,
@@ -301,7 +312,11 @@ where
     }
 
     async fn get_keyset_infos(&self) -> Result<Vec<MintKeySetInfo>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"SELECT
                 id,
@@ -325,7 +340,14 @@ where
     }
 
     async fn get_proofs_states(&self, ys: &[PublicKey]) -> Result<Vec<Option<State>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        if ys.is_empty() {
+            return Ok(vec![]);
+        }
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut current_states = query(r#"SELECT y, state FROM proof WHERE y IN (:ys)"#)?
             .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
             .fetch_all(&*conn)
@@ -346,7 +368,15 @@ where
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        if blinded_messages.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut blinded_signatures = query(
             r#"SELECT
                 keyset_id,
@@ -391,7 +421,11 @@ where
         &self,
         protected_endpoint: ProtectedEndpoint,
     ) -> Result<Option<AuthRequired>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(
             query(r#"SELECT auth FROM protected_endpoints WHERE endpoint = :endpoint"#)?
                 .bind("endpoint", serde_json::to_string(&protected_endpoint)?)
@@ -411,7 +445,11 @@ where
     async fn get_auth_for_endpoints(
         &self,
     ) -> Result<HashMap<ProtectedEndpoint, Option<AuthRequired>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(r#"SELECT endpoint, auth FROM protected_endpoints"#)?
             .fetch_all(&*conn)
             .await?

--- a/crates/cdk-sql-common/src/mint/completed_operations.rs
+++ b/crates/cdk-sql-common/src/mint/completed_operations.rs
@@ -124,7 +124,11 @@ where
         &self,
         operation_id: &uuid::Uuid,
     ) -> Result<Option<mint::Operation>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -152,7 +156,11 @@ where
         &self,
         operation_kind: mint::OperationKind,
     ) -> Result<Vec<mint::Operation>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -179,7 +187,11 @@ where
     }
 
     async fn get_completed_operations(&self) -> Result<Vec<mint::Operation>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/keys.rs
+++ b/crates/cdk-sql-common/src/mint/keys.rs
@@ -141,7 +141,10 @@ where
     ) -> Result<Box<dyn MintKeyDatabaseTransaction<'a, Error> + Send + Sync + 'a>, Error> {
         let tx = SQLTransaction {
             inner: ConnectionWithTransaction::new(
-                self.pool.get().map_err(|e| Error::Database(Box::new(e)))?,
+                self.pool
+                    .get()
+                    .await
+                    .map_err(|e| Error::Database(Box::new(e)))?,
             )
             .await?,
         };
@@ -150,7 +153,11 @@ where
     }
 
     async fn get_active_keyset_id(&self, unit: &CurrencyUnit) -> Result<Option<Id>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(
             query(r#" SELECT id FROM keyset WHERE active = :active AND unit = :unit"#)?
                 .bind("active", true)
@@ -167,7 +174,11 @@ where
     }
 
     async fn get_active_keysets(&self) -> Result<HashMap<CurrencyUnit, Id>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(
             query(r#"SELECT id, unit FROM keyset WHERE active = :active"#)?
                 .bind("active", true)
@@ -185,7 +196,11 @@ where
     }
 
     async fn get_keyset_info(&self, id: &Id) -> Result<Option<MintKeySetInfo>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"SELECT
                 id,
@@ -210,7 +225,11 @@ where
     }
 
     async fn get_keyset_infos(&self) -> Result<Vec<MintKeySetInfo>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"SELECT
                 id,

--- a/crates/cdk-sql-common/src/mint/keyvalue.rs
+++ b/crates/cdk-sql-common/src/mint/keyvalue.rs
@@ -105,7 +105,10 @@ where
     {
         Ok(Box::new(SQLTransaction {
             inner: ConnectionWithTransaction::new(
-                self.pool.get().map_err(|e| Error::Database(Box::new(e)))?,
+                self.pool
+                    .get()
+                    .await
+                    .map_err(|e| Error::Database(Box::new(e)))?,
             )
             .await?,
         }))

--- a/crates/cdk-sql-common/src/mint/mod.rs
+++ b/crates/cdk-sql-common/src/mint/mod.rs
@@ -66,7 +66,7 @@ where
     {
         let pool = Pool::new(db.into());
 
-        Self::migrate(pool.get().map_err(|e| Error::Database(Box::new(e)))?).await?;
+        Self::migrate(pool.get().await.map_err(|e| Error::Database(Box::new(e)))?).await?;
 
         Ok(Self { pool })
     }
@@ -125,7 +125,10 @@ where
     ) -> Result<Box<dyn database::MintTransaction<Error> + Send + Sync>, Error> {
         let tx = SQLTransaction {
             inner: ConnectionWithTransaction::new(
-                self.pool.get().map_err(|e| Error::Database(Box::new(e)))?,
+                self.pool
+                    .get()
+                    .await
+                    .map_err(|e| Error::Database(Box::new(e)))?,
             )
             .await?,
         };

--- a/crates/cdk-sql-common/src/mint/proofs.rs
+++ b/crates/cdk-sql-common/src/mint/proofs.rs
@@ -407,10 +407,6 @@ where
     type Err = Error;
 
     async fn get_proofs_by_ys(&self, ys: &[PublicKey]) -> Result<Vec<Option<Proof>>, Self::Err> {
-        if ys.is_empty() {
-            return Ok(vec![]);
-        }
-
         let conn = self
             .pool
             .get()

--- a/crates/cdk-sql-common/src/mint/proofs.rs
+++ b/crates/cdk-sql-common/src/mint/proofs.rs
@@ -407,7 +407,15 @@ where
     type Err = Error;
 
     async fn get_proofs_by_ys(&self, ys: &[PublicKey]) -> Result<Vec<Option<Proof>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        if ys.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut proofs = query(
             r#"
             SELECT
@@ -446,7 +454,11 @@ where
         &self,
         quote_id: &QuoteId,
     ) -> Result<Vec<PublicKey>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -471,7 +483,11 @@ where
     }
 
     async fn get_proofs_states(&self, ys: &[PublicKey]) -> Result<Vec<Option<State>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut current_states = get_current_states(&*conn, ys, false).await?;
 
         Ok(ys.iter().map(|y| current_states.remove(y)).collect())
@@ -481,7 +497,11 @@ where
         &self,
         keyset_id: &Id,
     ) -> Result<(Proofs, Vec<Option<State>>), Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let (proofs, states): (Vec<Proof>, Vec<State>) = query(
             r#"
@@ -512,7 +532,11 @@ where
 
     /// Get total proofs redeemed by keyset id
     async fn get_total_redeemed(&self) -> Result<HashMap<Id, Amount>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -533,7 +557,11 @@ where
         &self,
         operation_id: &uuid::Uuid,
     ) -> Result<Vec<PublicKey>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/quotes.rs
+++ b/crates/cdk-sql-common/src/mint/quotes.rs
@@ -1117,7 +1117,11 @@ where
 
         #[cfg(feature = "prometheus")]
         let start_time = std::time::Instant::now();
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let result = get_mint_quote_inner(&*conn, quote_id, false).await;
 
@@ -1141,7 +1145,11 @@ where
         &self,
         quote_ids: &[QuoteId],
     ) -> Result<Vec<Option<MintQuote>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         get_mint_quotes_inner(&*conn, quote_ids, false).await
     }
 
@@ -1149,7 +1157,11 @@ where
         &self,
         request: &str,
     ) -> Result<Option<MintQuote>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         get_mint_quote_by_request_inner(&*conn, request, false).await
     }
 
@@ -1157,12 +1169,20 @@ where
         &self,
         request_lookup_id: &PaymentIdentifier,
     ) -> Result<Option<MintQuote>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         get_mint_quote_by_request_lookup_id_inner(&*conn, request_lookup_id, false).await
     }
 
     async fn get_mint_quotes(&self) -> Result<Vec<MintQuote>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut mint_quotes = query(
             r#"
             SELECT
@@ -1208,7 +1228,11 @@ where
 
         #[cfg(feature = "prometheus")]
         let start_time = std::time::Instant::now();
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let result = get_melt_quote_inner(&*conn, quote_id, false).await;
 
@@ -1229,7 +1253,11 @@ where
     }
 
     async fn get_melt_quotes(&self) -> Result<Vec<mint::MeltQuote>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/saga.rs
+++ b/crates/cdk-sql-common/src/mint/saga.rs
@@ -222,7 +222,11 @@ where
         &self,
         quote_id: &cdk_common::QuoteId,
     ) -> Result<Option<mint::Saga>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/saga.rs
+++ b/crates/cdk-sql-common/src/mint/saga.rs
@@ -252,7 +252,11 @@ where
         &self,
         operation_kind: mint::OperationKind,
     ) -> Result<Vec<mint::Saga>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -261,10 +261,6 @@ where
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
-        if blinded_messages.is_empty() {
-            return Ok(vec![]);
-        }
-
         let conn = self
             .pool
             .get()

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -261,7 +261,15 @@ where
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        if blinded_messages.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut blinded_signatures = query(
             r#"SELECT
                 keyset_id,
@@ -306,7 +314,11 @@ where
         &self,
         keyset_id: &Id,
     ) -> Result<Vec<BlindSignature>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -334,7 +346,11 @@ where
         &self,
         quote_id: &QuoteId,
     ) -> Result<Vec<BlindSignature>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -359,7 +375,11 @@ where
 
     /// Get total proofs redeemed by keyset id
     async fn get_total_issued(&self) -> Result<HashMap<Id, Amount>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -380,7 +400,11 @@ where
         &self,
         operation_id: &uuid::Uuid,
     ) -> Result<Vec<PublicKey>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/pool.rs
+++ b/crates/cdk-sql-common/src/pool.rs
@@ -4,12 +4,13 @@
 
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
-use std::time::{Duration, Instant};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 #[cfg(feature = "prometheus")]
 use cdk_prometheus::metrics::METRICS;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::database::DatabaseConnector;
 
@@ -67,17 +68,29 @@ pub trait DatabasePool: Debug {
 }
 
 /// Generic connection pool of resources R
-#[derive(Debug)]
 pub struct Pool<RM>
 where
     RM: DatabasePool,
 {
     config: RM::Config,
     queue: Mutex<Vec<(Arc<AtomicBool>, RM::Connection)>>,
-    in_use: AtomicUsize,
     max_size: usize,
     default_timeout: Duration,
-    waiter: Condvar,
+    semaphore: Arc<Semaphore>,
+}
+
+impl<RM> Debug for Pool<RM>
+where
+    RM: DatabasePool,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Pool")
+            .field("config", &self.config)
+            .field("max_size", &self.max_size)
+            .field("default_timeout", &self.default_timeout)
+            .field("available_permits", &self.semaphore.available_permits())
+            .finish()
+    }
 }
 
 /// The pooled resource
@@ -87,8 +100,9 @@ where
 {
     resource: Option<(Arc<AtomicBool>, RM::Connection)>,
     pool: Arc<Pool<RM>>,
+    _permit: OwnedSemaphorePermit,
     #[cfg(feature = "prometheus")]
-    start_time: Instant,
+    start_time: std::time::Instant,
 }
 
 impl<RM> Debug for PooledResource<RM>
@@ -108,19 +122,19 @@ where
         if let Some(resource) = self.resource.take() {
             let mut active_resource = self.pool.queue.lock().expect("active_resource");
             active_resource.push(resource);
-            let _in_use = self.pool.in_use.fetch_sub(1, Ordering::AcqRel);
 
             #[cfg(feature = "prometheus")]
             {
-                METRICS.set_db_connections_active(_in_use as i64);
+                let in_use = self.pool.max_size - self.pool.semaphore.available_permits();
+                METRICS.set_db_connections_active(in_use as i64);
 
                 let duration = self.start_time.elapsed().as_secs_f64();
 
                 METRICS.record_db_operation(duration, "drop");
             }
 
-            // Notify a waiting thread
-            self.pool.waiter.notify_one();
+            // The semaphore permit is dropped automatically after this,
+            // which wakes any async task waiting in `get()`.
         }
     }
 }
@@ -151,103 +165,88 @@ where
 {
     /// Creates a new pool
     pub fn new(config: RM::Config) -> Arc<Self> {
+        let max_size = config.max_size();
         Arc::new(Self {
             default_timeout: config.default_timeout(),
-            max_size: config.max_size(),
+            max_size,
             config,
             queue: Default::default(),
-            in_use: Default::default(),
-            waiter: Default::default(),
+            semaphore: Arc::new(Semaphore::new(max_size)),
         })
     }
 
     /// Similar to get_timeout but uses the default timeout value.
     #[inline(always)]
-    pub fn get(self: &Arc<Self>) -> Result<PooledResource<RM>, Error<RM::Error>> {
-        self.get_timeout(self.default_timeout)
-    }
-
-    /// Increments the in_use connection counter and updates the metric
-    fn increment_connection_counter(&self) -> usize {
-        let in_use = self.in_use.fetch_add(1, Ordering::AcqRel);
-
-        #[cfg(feature = "prometheus")]
-        {
-            METRICS.set_db_connections_active(in_use as i64);
-        }
-
-        in_use
+    pub async fn get(self: &Arc<Self>) -> Result<PooledResource<RM>, Error<RM::Error>> {
+        self.get_timeout(self.default_timeout).await
     }
 
     /// Get a new resource or fail after timeout is reached.
     ///
     /// This function will return a free resource or create a new one if there is still room for it;
-    /// otherwise, it will wait for a resource to be released for reuse.
+    /// otherwise, it will asynchronously wait for a resource to be released for reuse.
     #[inline(always)]
-    pub fn get_timeout(
+    pub async fn get_timeout(
         self: &Arc<Self>,
         timeout: Duration,
     ) -> Result<PooledResource<RM>, Error<RM::Error>> {
-        let mut resources = self.queue.lock().map_err(|_| Error::Poison)?;
-        let time = Instant::now();
+        // Acquire a semaphore permit asynchronously. This yields the task instead of
+        // blocking the OS thread, preventing Tokio worker thread starvation.
+        let permit =
+            match tokio::time::timeout(timeout, self.semaphore.clone().acquire_owned()).await {
+                Ok(Ok(permit)) => permit,
+                Ok(Err(_closed)) => {
+                    // Semaphore was closed (pool is being dropped)
+                    return Err(Error::Poison);
+                }
+                Err(_elapsed) => {
+                    tracing::warn!(
+                        "Timeout waiting for the resource (pool size: {})",
+                        self.max_size,
+                    );
+                    return Err(Error::Timeout);
+                }
+            };
 
-        loop {
+        #[cfg(feature = "prometheus")]
+        {
+            let in_use = self.max_size - self.semaphore.available_permits();
+            METRICS.set_db_connections_active(in_use as i64);
+        }
+
+        // Briefly lock the idle queue to try to pop a non-stale connection.
+        // This mutex is held for nanoseconds (just a Vec::pop).
+        {
+            let mut resources = self.queue.lock().map_err(|_| Error::Poison)?;
             while let Some((stale, resource)) = resources.pop() {
                 if !stale.load(Ordering::SeqCst) {
-                    // Increment counter BEFORE releasing the mutex to prevent race condition
-                    // where another thread sees in_use < max_size and creates a duplicate connection.
-                    // For in-memory SQLite, each connection is a separate database, so this race
-                    // would cause some connections to miss migrations.
-                    self.increment_connection_counter();
-
                     return Ok(PooledResource {
                         resource: Some((stale, resource)),
                         pool: self.clone(),
+                        _permit: permit,
                         #[cfg(feature = "prometheus")]
-                        start_time: Instant::now(),
+                        start_time: std::time::Instant::now(),
                     });
                 }
+                // Stale connection — drop it and keep looking.
             }
+        }
 
-            if self.in_use.load(Ordering::Relaxed) < self.max_size {
-                // Increment counter BEFORE releasing the mutex to prevent race condition.
-                // This ensures other threads see the updated count and wait instead of
-                // creating additional connections beyond max_size.
-                self.increment_connection_counter();
-                let stale: Arc<AtomicBool> = Arc::new(false.into());
-                match RM::new_resource(&self.config, stale.clone(), timeout) {
-                    Ok(new_resource) => {
-                        return Ok(PooledResource {
-                            resource: Some((stale, new_resource)),
-                            pool: self.clone(),
-                            #[cfg(feature = "prometheus")]
-                            start_time: Instant::now(),
-                        });
-                    }
-                    Err(e) => {
-                        // If resource creation fails, decrement the counter we just incremented
-                        self.in_use.fetch_sub(1, Ordering::AcqRel);
-                        return Err(e);
-                    }
-                }
+        // No idle connection available — create a new one.
+        // The semaphore already guarantees we won't exceed max_size.
+        let stale: Arc<AtomicBool> = Arc::new(false.into());
+        match RM::new_resource(&self.config, stale.clone(), timeout) {
+            Ok(new_resource) => Ok(PooledResource {
+                resource: Some((stale, new_resource)),
+                pool: self.clone(),
+                _permit: permit,
+                #[cfg(feature = "prometheus")]
+                start_time: std::time::Instant::now(),
+            }),
+            Err(e) => {
+                // Permit is dropped here, releasing the slot back to the semaphore.
+                Err(e)
             }
-
-            resources = self
-                .waiter
-                .wait_timeout(resources, timeout)
-                .map_err(|_| Error::Poison)
-                .and_then(|(lock, timeout_result)| {
-                    if timeout_result.timed_out() {
-                        tracing::warn!(
-                            "Timeout waiting for the resource (pool size: {}). Waited {} ms",
-                            self.max_size,
-                            time.elapsed().as_millis()
-                        );
-                        Err(Error::Timeout)
-                    } else {
-                        Ok(lock)
-                    }
-                })?;
         }
     }
 }
@@ -257,21 +256,13 @@ where
     RM: DatabasePool,
 {
     fn drop(&mut self) {
+        // Close the semaphore so no new acquisitions can succeed.
+        self.semaphore.close();
+
+        // Drain all idle connections.
         if let Ok(mut resources) = self.queue.lock() {
-            loop {
-                while let Some(resource) = resources.pop() {
-                    RM::drop(resource.1);
-                }
-
-                if self.in_use.load(Ordering::Relaxed) == 0 {
-                    break;
-                }
-
-                resources = if let Ok(resources) = self.waiter.wait(resources) {
-                    resources
-                } else {
-                    break;
-                };
+            while let Some(resource) = resources.pop() {
+                RM::drop(resource.1);
             }
         }
     }

--- a/crates/cdk-sql-common/src/pool.rs
+++ b/crates/cdk-sql-common/src/pool.rs
@@ -190,23 +190,24 @@ where
         self: &Arc<Self>,
         timeout: Duration,
     ) -> Result<PooledResource<RM>, Error<RM::Error>> {
-        // Acquire a semaphore permit asynchronously. This yields the task instead of
-        // blocking the OS thread, preventing Tokio worker thread starvation.
-        let permit =
-            match tokio::time::timeout(timeout, self.semaphore.clone().acquire_owned()).await {
-                Ok(Ok(permit)) => permit,
-                Ok(Err(_closed)) => {
-                    // Semaphore was closed (pool is being dropped)
-                    return Err(Error::Poison);
-                }
-                Err(_elapsed) => {
-                    tracing::warn!(
-                        "Timeout waiting for the resource (pool size: {})",
-                        self.max_size,
-                    );
-                    return Err(Error::Timeout);
-                }
-            };
+        // Fast path: try to grab a permit without waiting.
+        let permit = match self.semaphore.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(tokio::sync::TryAcquireError::Closed) => return Err(Error::Poison),
+            Err(tokio::sync::TryAcquireError::NoPermits) => {
+                // All permits are in use — wait asynchronously.  This yields
+                // the task instead of blocking the OS thread, preventing Tokio
+                // worker thread starvation.
+                tracing::debug!(
+                    "Pool exhausted (size: {}), waiting for a connection",
+                    self.max_size,
+                );
+                tokio::time::timeout(timeout, self.semaphore.clone().acquire_owned())
+                    .await
+                    .map_err(|_| Error::Timeout)?
+                    .map_err(|_| Error::Poison)?
+            }
+        };
 
         #[cfg(feature = "prometheus")]
         {

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -550,10 +550,6 @@ where
         &self,
         ys: Vec<PublicKey>,
     ) -> Result<Vec<ProofInfo>, database::Error> {
-        if ys.is_empty() {
-            return Ok(Vec::new());
-        }
-
         let conn = self
             .pool
             .get()
@@ -853,10 +849,6 @@ where
         ys: Vec<PublicKey>,
         state: State,
     ) -> Result<(), database::Error> {
-        if ys.is_empty() {
-            return Ok(());
-        }
-
         let conn = self
             .pool
             .get()

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -55,7 +55,7 @@ where
         X: Into<RM::Config>,
     {
         let pool = Pool::new(db.into());
-        Self::migrate(pool.get().map_err(|e| Error::Database(Box::new(e)))?).await?;
+        Self::migrate(pool.get().await.map_err(|e| Error::Database(Box::new(e)))?).await?;
 
         Ok(Self { pool })
     }
@@ -150,7 +150,11 @@ where
 {
     #[instrument(skip(self))]
     async fn get_melt_quotes(&self) -> Result<Vec<wallet::MeltQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         Ok(query(
             r#"
@@ -180,7 +184,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_mint(&self, mint_url: MintUrl) -> Result<Option<MintInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -210,7 +218,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_mints(&self) -> Result<HashMap<MintUrl, Option<MintInfo>>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
                 SELECT
@@ -250,7 +262,11 @@ where
         &self,
         mint_url: MintUrl,
     ) -> Result<Option<Vec<KeySetInfo>>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let keysets = query(
             r#"
@@ -283,7 +299,11 @@ where
         &self,
         keyset_id: &Id,
     ) -> Result<Option<KeySetInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -306,7 +326,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_mint_quote(&self, quote_id: &str) -> Result<Option<MintQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -338,7 +362,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_mint_quotes(&self) -> Result<Vec<MintQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -368,7 +396,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_unissued_mint_quotes(&self) -> Result<Vec<MintQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -405,7 +437,11 @@ where
         &self,
         quote_id: &str,
     ) -> Result<Option<wallet::MeltQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -436,7 +472,11 @@ where
 
     #[instrument(skip(self), fields(keyset_id = %keyset_id))]
     async fn get_keys(&self, keyset_id: &Id) -> Result<Option<Keys>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -463,7 +503,11 @@ where
         state: Option<Vec<State>>,
         spending_conditions: Option<Vec<SpendingConditions>>,
     ) -> Result<Vec<ProofInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -506,7 +550,15 @@ where
         &self,
         ys: Vec<PublicKey>,
     ) -> Result<Vec<ProofInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        if ys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -544,7 +596,11 @@ where
         unit: Option<CurrencyUnit>,
         states: Option<Vec<State>>,
     ) -> Result<u64, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let mut query_str = "SELECT COALESCE(SUM(amount), 0) as total FROM proof".to_string();
         let mut where_clauses = Vec::new();
@@ -607,7 +663,11 @@ where
         &self,
         transaction_id: TransactionId,
     ) -> Result<Option<Transaction>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -645,7 +705,11 @@ where
         direction: Option<TransactionDirection>,
         unit: Option<CurrencyUnit>,
     ) -> Result<Vec<Transaction>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         Ok(query(
             r#"
@@ -688,7 +752,11 @@ where
         added: Vec<ProofInfo>,
         removed_ys: Vec<PublicKey>,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let tx = ConnectionWithTransaction::new(conn).await?;
 
         for proof in added {
@@ -785,7 +853,15 @@ where
         ys: Vec<PublicKey>,
         state: State,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        if ys.is_empty() {
+            return Ok(());
+        }
+
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query("UPDATE proof SET state = :state WHERE y IN (:ys)")?
             .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
@@ -798,7 +874,11 @@ where
 
     #[instrument(skip(self))]
     async fn add_transaction(&self, transaction: Transaction) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let mint_url = transaction.mint_url.to_string();
         let direction = transaction.direction.to_string();
@@ -866,7 +946,11 @@ where
         old_mint_url: MintUrl,
         new_mint_url: MintUrl,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let tx = ConnectionWithTransaction::new(conn).await?;
         let tables = ["mint_quote", "proof"];
 
@@ -895,7 +979,11 @@ where
         keyset_id: &Id,
         count: u32,
     ) -> Result<u32, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let new_counter = query(
             r#"
@@ -923,7 +1011,11 @@ where
         mint_url: MintUrl,
         mint_info: Option<MintInfo>,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let (
             name,
@@ -1024,7 +1116,11 @@ where
 
     #[instrument(skip(self))]
     async fn remove_mint(&self, mint_url: MintUrl) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM mint WHERE mint_url=:mint_url"#)?
             .bind("mint_url", mint_url.to_string())
@@ -1040,7 +1136,11 @@ where
         mint_url: MintUrl,
         keysets: Vec<KeySetInfo>,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let tx = ConnectionWithTransaction::new(conn).await?;
 
         for keyset in keysets {
@@ -1073,7 +1173,11 @@ where
 
     #[instrument(skip_all)]
     async fn add_mint_quote(&self, quote: MintQuote) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let expected_version = quote.version;
         let new_version = expected_version.wrapping_add(1);
@@ -1127,7 +1231,11 @@ where
 
     #[instrument(skip(self))]
     async fn remove_mint_quote(&self, quote_id: &str) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM mint_quote WHERE id=:id"#)?
             .bind("id", quote_id.to_string())
@@ -1139,7 +1247,11 @@ where
 
     #[instrument(skip_all)]
     async fn add_melt_quote(&self, quote: wallet::MeltQuote) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let expected_version = quote.version;
         let new_version = expected_version.wrapping_add(1);
@@ -1190,7 +1302,11 @@ where
 
     #[instrument(skip(self))]
     async fn remove_melt_quote(&self, quote_id: &str) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM melt_quote WHERE id=:id"#)?
             .bind("id", quote_id.to_owned())
@@ -1202,7 +1318,11 @@ where
 
     #[instrument(skip_all)]
     async fn add_keys(&self, keyset: KeySet) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         keyset.verify_id()?;
 
@@ -1228,7 +1348,11 @@ where
 
     #[instrument(skip(self))]
     async fn remove_keys(&self, id: &Id) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM key WHERE id = :id"#)?
             .bind("id", id.to_string())
@@ -1243,7 +1367,11 @@ where
         &self,
         transaction_id: TransactionId,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM transactions WHERE id=:id"#)?
             .bind("id", transaction_id.as_slice().to_vec())
@@ -1255,7 +1383,11 @@ where
 
     #[instrument(skip(self))]
     async fn add_saga(&self, saga: wallet::WalletSaga) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let state_json = serde_json::to_string(&saga.state).map_err(|e| {
             Error::Database(Box::new(std::io::Error::new(
@@ -1301,7 +1433,11 @@ where
         &self,
         id: &uuid::Uuid,
     ) -> Result<Option<wallet::WalletSaga>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows = query(
             r#"
@@ -1322,7 +1458,11 @@ where
 
     #[instrument(skip(self))]
     async fn update_saga(&self, saga: wallet::WalletSaga) -> Result<bool, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let state_json = serde_json::to_string(&saga.state).map_err(|e| {
             Error::Database(Box::new(std::io::Error::new(
@@ -1372,7 +1512,11 @@ where
 
     #[instrument(skip(self))]
     async fn delete_saga(&self, id: &uuid::Uuid) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM wallet_sagas WHERE id = :id"#)?
             .bind("id", id.to_string())
@@ -1384,7 +1528,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_incomplete_sagas(&self) -> Result<Vec<wallet::WalletSaga>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows = query(
             r#"
@@ -1405,7 +1553,11 @@ where
         ys: Vec<PublicKey>,
         operation_id: &uuid::Uuid,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         for y in ys {
             let rows_affected = query(
@@ -1430,7 +1582,11 @@ where
 
     #[instrument(skip(self))]
     async fn release_proofs(&self, operation_id: &uuid::Uuid) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(
             r#"
@@ -1451,7 +1607,11 @@ where
         &self,
         operation_id: &uuid::Uuid,
     ) -> Result<Vec<ProofInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows = query(
             r#"
@@ -1489,7 +1649,11 @@ where
         quote_id: &str,
         operation_id: &uuid::Uuid,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows_affected = query(
             r#"
@@ -1525,7 +1689,11 @@ where
 
     #[instrument(skip(self))]
     async fn release_melt_quote(&self, operation_id: &uuid::Uuid) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(
             r#"
@@ -1547,7 +1715,11 @@ where
         quote_id: &str,
         operation_id: &uuid::Uuid,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows_affected = query(
             r#"
@@ -1583,7 +1755,11 @@ where
 
     #[instrument(skip(self))]
     async fn release_mint_quote(&self, operation_id: &uuid::Uuid) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(
             r#"
@@ -1623,7 +1799,11 @@ where
         key: &str,
         value: &[u8],
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         crate::keyvalue::kv_write_standalone(
             &*conn,
             primary_namespace,
@@ -1641,7 +1821,11 @@ where
         secondary_namespace: &str,
         key: &str,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         crate::keyvalue::kv_remove_standalone(&*conn, primary_namespace, secondary_namespace, key)
             .await?;
         Ok(())
@@ -1656,7 +1840,11 @@ where
         derivation_path: DerivationPath,
         derivation_index: u32,
     ) -> Result<(), Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let query_str = r#"
         INSERT INTO p2pk_signing_key (pubkey, derivation_index, derivation_path, created_time)
         VALUES (:pubkey, :derivation_index, :derivation_path, :created_time)
@@ -1679,7 +1867,11 @@ where
         &self,
         pubkey: &PublicKey,
     ) -> Result<Option<wallet::P2PKSigningKey>, Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let query_str = r#"SELECT pubkey, derivation_index, derivation_path, created_time FROM p2pk_signing_key WHERE pubkey = :pubkey"#.to_string();
 
         query(&query_str)?
@@ -1692,7 +1884,11 @@ where
 
     #[instrument(skip(self))]
     async fn list_p2pk_keys(&self) -> Result<Vec<wallet::P2PKSigningKey>, Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let query_str = r#"
         SELECT pubkey, derivation_index, derivation_path, created_time FROM p2pk_signing_key ORDER BY derivation_index DESC
         "#.to_string();
@@ -1711,7 +1907,11 @@ where
 
     #[instrument(skip(self))]
     async fn latest_p2pk(&self) -> Result<Option<wallet::P2PKSigningKey>, Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let query_str = r#"
         SELECT pubkey, derivation_index, derivation_path, created_time FROM p2pk_signing_key ORDER BY derivation_index DESC LIMIT 1
         "#.to_string();

--- a/crates/cdk-sqlite/src/mint/mod.rs
+++ b/crates/cdk-sqlite/src/mint/mod.rs
@@ -35,7 +35,7 @@ mod test {
         let config: Config = "test.db".into();
 
         let pool = Pool::<SqliteConnectionManager>::new(config);
-        let db = pool.get();
+        let db = pool.get().await;
         assert!(db.is_ok());
         let _ = remove_file("test.db");
     }
@@ -56,7 +56,7 @@ mod test {
 
             let pool = Pool::<SqliteConnectionManager>::new(config);
 
-            let conn = pool.get().expect("valid connection");
+            let conn = pool.get().await.expect("valid connection");
 
             query(include_str!("../../tests/legacy-sqlx.sql"))
                 .expect("query")

--- a/crates/cdk-sqlite/src/mint/mod.rs
+++ b/crates/cdk-sqlite/src/mint/mod.rs
@@ -16,6 +16,7 @@ pub type MintSqliteAuthDatabase = SQLMintAuthDatabase<SqliteConnectionManager>;
 #[cfg(test)]
 mod test {
     use std::fs::remove_file;
+    use std::time::Duration;
 
     use cdk_common::mint_db_test;
     use cdk_sql_common::pool::Pool;
@@ -38,6 +39,17 @@ mod test {
         let db = pool.get().await;
         assert!(db.is_ok());
         let _ = remove_file("test.db");
+    }
+
+    #[tokio::test]
+    async fn exhausted_in_memory_pool_times_out() {
+        let config: Config = ":memory:".into();
+        let pool = Pool::<SqliteConnectionManager>::new(config);
+
+        let _conn = pool.get().await.expect("valid connection");
+        let result = pool.get_timeout(Duration::from_millis(10)).await;
+
+        assert!(matches!(result, Err(cdk_sql_common::pool::Error::Timeout)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
The SQLite connection pool used std::sync::Condvar to wait for free connections, which blocks the OS thread. Under the default pool size of 1, concurrent requests can block all Tokio worker threads, deadlocking the runtime the task holding the connection can never be scheduled to release it. Replace with tokio::sync::Semaphore so waiters yield to the async runtime instead of blocking.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
