### PR TITLE
feat: add mints field to CreateRequestParams (NUT-18)

### DIFF
--- a/crates/cdk-cli/src/sub_commands/create_request.rs
+++ b/crates/cdk-cli/src/sub_commands/create_request.rs
@@ -55,6 +55,9 @@ pub struct CreateRequestSubCommand {
     /// If not provided, defaults to standard relays
     #[arg(long, action = clap::ArgAction::Append)]
     nostr_relay: Option<Vec<String>>,
+    /// Mint URLs the receiver trusts. Can be specified multiple times.
+    #[arg(long, action = clap::ArgAction::Append)]
+    mints: Option<Vec<String>>,
     /// Use bech32 encoding (CREQ-B)
     #[arg(short, long)]
     bech32: bool,
@@ -77,6 +80,7 @@ pub async fn create_request(
         transport: sub_command_args.transport.to_lowercase(),
         http_url: sub_command_args.http_url.clone(),
         nostr_relays: sub_command_args.nostr_relay.clone(),
+        mints: sub_command_args.mints.clone(),
     };
 
     let (req, nostr_wait) = wallet_repository.create_request(params).await?;

--- a/crates/cdk-ffi/src/types/payment_request.rs
+++ b/crates/cdk-ffi/src/types/payment_request.rs
@@ -198,6 +198,8 @@ pub struct CreateRequestParams {
     pub http_url: Option<String>,
     /// Nostr relay URLs (required if transport is "nostr")
     pub nostr_relays: Option<Vec<String>>,
+    /// Optional list of mint URLs the receiver trusts. If not provided, the wallet's current mints for the requested unit will be used.
+    pub mints: Option<Vec<String>>,
 }
 
 impl Default for CreateRequestParams {
@@ -213,6 +215,7 @@ impl Default for CreateRequestParams {
             transport: "none".to_string(),
             http_url: None,
             nostr_relays: None,
+            mints: None,
         }
     }
 }
@@ -230,6 +233,7 @@ impl From<CreateRequestParams> for cdk::wallet::payment_request::CreateRequestPa
             transport: params.transport,
             http_url: params.http_url,
             nostr_relays: params.nostr_relays,
+            mints: params.mints,
         }
     }
 }
@@ -247,6 +251,7 @@ impl From<cdk::wallet::payment_request::CreateRequestParams> for CreateRequestPa
             transport: params.transport,
             http_url: params.http_url,
             nostr_relays: params.nostr_relays,
+            mints: params.mints,
         }
     }
 }

--- a/crates/cdk/examples/payment_request.rs
+++ b/crates/cdk/examples/payment_request.rs
@@ -130,6 +130,7 @@ async fn main() -> anyhow::Result<()> {
             "wss://relay.damus.io".to_string(),
             "wss://nos.lol".to_string(),
         ]),
+        mints: None,
     };
 
     let (payment_request, nostr_wait_info) = wallet.create_request(nostr_params).await?;
@@ -185,6 +186,7 @@ async fn main() -> anyhow::Result<()> {
         transport: "http".to_string(),
         http_url: Some("https://example.com/cashu/callback".to_string()),
         nostr_relays: None,
+        mints: None,
     };
 
     let (http_request, _) = wallet.create_request(http_params).await?;
@@ -228,6 +230,7 @@ async fn main() -> anyhow::Result<()> {
         transport: "nostr".to_string(),
         http_url: None,
         nostr_relays: Some(vec!["wss://relay.damus.io".to_string()]),
+        mints: None,
     };
 
     let (p2pk_request, _) = wallet.create_request(p2pk_params).await?;

--- a/crates/cdk/src/wallet/payment_request.rs
+++ b/crates/cdk/src/wallet/payment_request.rs
@@ -220,6 +220,8 @@ pub struct CreateRequestParams {
     pub http_url: Option<String>, // when transport == http
     /// List of Nostr relay URLs to include in the nprofile (used if `transport == nostr`)
     pub nostr_relays: Option<Vec<String>>, // when transport == nostr
+    /// Optional list of mint URLs the receiver trusts. If not provided, the wallet's current mints for the requested unit will be used.
+    pub mints: Option<Vec<String>>,
 }
 
 /// Extra information needed to wait for an incoming Nostr payment
@@ -467,13 +469,12 @@ impl WalletRepository {
     ) -> Result<(PaymentRequest, Option<NostrWaitInfo>), Error> {
         // Collect available mints for the selected unit
         // Filter by the requested unit and extract unique mint URLs
-        let requested_unit = CurrencyUnit::from_str(&params.unit)?;
-        let mints: Vec<MintUrl> = self
-            .get_balances()
-            .await?
-            .keys()
-            .filter(|key| key.unit == requested_unit)
-            .map(|key| key.mint_url.clone())
+        let mints: Vec<MintUrl> = params
+            .mints
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|url| MintUrl::from_str(&url).ok())
             .collect();
 
         // Transports
@@ -572,13 +573,12 @@ impl WalletRepository {
     ) -> Result<PaymentRequest, Error> {
         // Collect available mints for the selected unit
         // Filter by the requested unit and extract unique mint URLs
-        let requested_unit = CurrencyUnit::from_str(&params.unit)?;
-        let mints: Vec<MintUrl> = self
-            .get_balances()
-            .await?
-            .keys()
-            .filter(|key| key.unit == requested_unit)
-            .map(|key| key.mint_url.clone())
+        let mints: Vec<MintUrl> = params
+            .mints
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|url| MintUrl::from_str(&url).ok())
             .collect();
 
         // Transports


### PR DESCRIPTION
## Summary
* Added `mints: Option<Vec<String>>` to `CreateRequestParams` in CDK wallet `payment_request` to align with the NUT-18 spec.
* Exposed the `mints` field in the FFI bindings.
* Added the `--mint` flag to `cdk-cli` for `create-request`.
* Updated examples.