### PR TITLE
fix(cdk-cli): parse --unit consistently and scope balance by currency

### DIFF
--- a/crates/cdk-cli/src/main.rs
+++ b/crates/cdk-cli/src/main.rs
@@ -56,9 +56,10 @@ struct Cli {
     /// NWS Proxy
     #[arg(short, long)]
     proxy: Option<Url>,
-    /// Currency unit to use for the wallet
-    #[arg(short, long, default_value = "sat")]
-    unit: String,
+    /// Currency unit (default `sat` when omitted). Standard: sat, msat, usd, eur, auth; other values are custom.
+    /// `cdk --unit usd balance` and `cdk balance --unit usd` are equivalent. `cdk --unit balance` parses `balance` as the unit value, not the subcommand.
+    #[arg(short, long, global = true)]
+    unit: Option<String>,
     /// NpubCash API URL
     #[cfg(feature = "npubcash")]
     #[arg(long, default_value = "https://npubx.cash")]
@@ -215,9 +216,10 @@ async fn main() -> Result<()> {
     };
     let seed = mnemonic.to_seed_normalized("");
 
-    // Parse currency unit from args
-    let currency_unit = CurrencyUnit::from_str(&args.unit)
-        .unwrap_or_else(|_| CurrencyUnit::Custom(args.unit.clone()));
+    let currency_unit = match &args.unit {
+        Some(s) => utils::parse_cli_currency_unit(s)?,
+        None => CurrencyUnit::Sat,
+    };
 
     // Create WalletRepository using builder pattern
     let wallet_repository = {
@@ -252,7 +254,9 @@ async fn main() -> Result<()> {
         Commands::DecodeToken(sub_command_args) => {
             sub_commands::decode_token::decode_token(sub_command_args)
         }
-        Commands::Balance => sub_commands::balance::balance(&wallet_repository).await,
+        Commands::Balance => {
+            sub_commands::balance::balance(&wallet_repository, &currency_unit).await
+        }
         Commands::Melt(sub_command_args) => {
             sub_commands::melt::pay(&wallet_repository, sub_command_args, &currency_unit).await
         }

--- a/crates/cdk-cli/src/sub_commands/balance.rs
+++ b/crates/cdk-cli/src/sub_commands/balance.rs
@@ -7,9 +7,13 @@ use cdk::wallet::WalletRepository;
 use cdk::Amount;
 use cdk_common::wallet::WalletKey;
 
-pub async fn balance(wallet_repository: &WalletRepository) -> Result<()> {
-    // Show individual mint balances
-    let mint_balances = mint_balances(wallet_repository).await?;
+/// Print balances for each mint for the given [`CurrencyUnit`] (e.g. sat from `cdk balance`, or
+/// `--unit usd` for USD-only wallets).
+pub async fn balance(
+    wallet_repository: &WalletRepository,
+    filter_unit: &CurrencyUnit,
+) -> Result<()> {
+    let mint_balances = mint_balances(wallet_repository, filter_unit).await?;
 
     if !mint_balances.is_empty() {
         // Aggregate totals per currency unit
@@ -29,6 +33,8 @@ pub async fn balance(wallet_repository: &WalletRepository) -> Result<()> {
                 println!("  {} {}", total, unit);
             }
         }
+    } else {
+        println!("No balance for unit {filter_unit}.");
     }
 
     Ok(())
@@ -36,6 +42,7 @@ pub async fn balance(wallet_repository: &WalletRepository) -> Result<()> {
 
 pub async fn mint_balances(
     wallet_repository: &WalletRepository,
+    filter_unit: &CurrencyUnit,
 ) -> Result<Vec<(MintUrl, CurrencyUnit, Amount)>> {
     let wallets = wallet_repository.get_balances().await?;
 
@@ -44,6 +51,7 @@ pub async fn mint_balances(
     for (i, (wallet_key, amount)) in wallets
         .iter()
         .filter(|(_, a)| a > &&Amount::ZERO)
+        .filter(|(wk, _)| wk.unit == *filter_unit)
         .enumerate()
     {
         let WalletKey { mint_url, unit } = wallet_key.clone();

--- a/crates/cdk-cli/src/utils.rs
+++ b/crates/cdk-cli/src/utils.rs
@@ -1,10 +1,39 @@
 use std::io::{self, Write};
 use std::str::FromStr;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use cdk::mint_url::MintUrl;
 use cdk::nuts::CurrencyUnit;
 use cdk::wallet::WalletRepository;
+
+/// Parse global `--unit`: trim, plural aliases (`sats`→`sat`, …), then [`CurrencyUnit::from_str`].
+pub fn parse_cli_currency_unit(s: &str) -> Result<CurrencyUnit> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        bail!("Currency unit must not be empty (omit `--unit` to use the default `sat`)");
+    }
+
+    if trimmed.eq_ignore_ascii_case("satt") {
+        bail!("Unknown currency unit '{trimmed}'. Did you mean 'sat'?");
+    }
+
+    let normalized: &str = match trimmed.to_ascii_lowercase().as_str() {
+        "sats" => "sat",
+        "msats" => "msat",
+        "usds" => "usd",
+        "eurs" => "eur",
+        "auths" => "auth",
+        _ => trimmed,
+    };
+
+    let unit = CurrencyUnit::from_str(normalized).map_err(|e| anyhow::anyhow!(e))?;
+    if let CurrencyUnit::Custom(ref name) = unit {
+        tracing::info!(
+            "Using custom currency unit '{name}' (not one of sat, msat, usd, eur, auth)"
+        );
+    }
+    Ok(unit)
+}
 
 /// Helper function to get user input with a prompt
 pub fn get_user_input(prompt: &str) -> Result<String> {


### PR DESCRIPTION

This PR improves how the global `--unit` flag is parsed and how `balance` uses it, so the CLI no longer misleads users about which currency unit they are acting on. Plural aliases and a typo check align input with Cashu’s standard units; `--unit` is global so it works both before and after the subcommand.

### issues i faced 

**Ambiguous or misleading unit handling**

A typo or odd string could still parse as a custom unit, so what i typed did not match what i saw on the screen. For example, a mistyped unit could still show **sat** balances as if nothing was wrong:

```text
cdk --unit satt balance
 http://127.0.0.1:8085 100 sat

Total balance across all wallets: 179 sat
```

**`balance` and `--unit`**

`--unit` did not line up with what i expected for `balance`. Asking for non-matching unit could still show **sat** totals. And putting `--unit` after the subcommand failed entirely:

```text
cdk --unit dollarz balance
 http://127.0.0.1:8085 100 sat

Total balance across all wallets: 179 sat
```

```text
cdk balance --unit usd
error: unexpected argument '--unit' found

Usage: cdk-cli balance

For more information, try '--help'.
```

Whereas putting `--unit` before the command still did not filter to that unit when you only held sat:

```text
cdk --unit usd balance
0: http://127.0.0.1:8085 100 sat
1: https://fake.thesimplekid.dev 79 sat

Total balance across all wallets: 179 sat
```

**Empty `--unit`**

Passing an empty value looked like “no unit,” but the tool still behaved like a normal **sat** run, which is not the same as omitting `--unit` on purpose:

```text
cdk --unit "" balance
0: http://127.0.0.1:8085 100 sat

Total balance across all wallets: 179 sat
```

### What this PR changes

- Stricter parsing: plural aliases, explicit error for `satt`, clear error for empty `--unit` (omit the flag for default `sat`).
- `balance` respects the resolved unit (default `sat` when `--unit` is omitted).
- `global = true` on `--unit` so `cdk balance --unit usd` and `cdk --unit usd balance` are equivalent.