### PR TITLE
fix(cdk-cli): quiet saga recovery output

### DIFF
--- a/crates/cdk-cli/src/main.rs
+++ b/crates/cdk-cli/src/main.rs
@@ -242,10 +242,20 @@ async fn main() -> Result<()> {
     for wallet in wallets {
         // Recover from incomplete operations (required after wallet creation)
         let recovery = wallet.recover_incomplete_sagas().await?;
-        println!(
-            "Recovered {} operations, {} compensated, {} skipped, {} failed",
-            recovery.recovered, recovery.compensated, recovery.skipped, recovery.failed
-        );
+        if recovery.recovered != 0
+            || recovery.compensated != 0
+            || recovery.skipped != 0
+            || recovery.failed != 0
+        {
+            eprintln!(
+                "Recovery {}: {} recovered, {} compensated, {} skipped, {} failed",
+                wallet.mint_url,
+                recovery.recovered,
+                recovery.compensated,
+                recovery.skipped,
+                recovery.failed
+            );
+        }
     }
 
     match &args.command {


### PR DESCRIPTION
- Skip printing saga recovery stats when all counts are zero (normal startup).
- When recovery did something, print a one-line summary per wallet with the mint URL.
- Send that line to **stderr** (`eprintln!`) so primary command output stays on **stdout** for piping/scripts.

### Motivation
Every CLI run was printing `Recovered 0 operations, …` per wallet even when there was nothing to recover. Recovery status is also ancillary to subcommands like `balance`, so it belongs on stderr.

Before:
```
 cdk balance --unit sat
Recovered 0 operations, 0 compensated, 0 skipped, 0 failed
Recovered 6 operations, 0 compensated, 0 skipped, 0 failed
0: http://127.0.0.1:8085 100 sat
1: https://fake.thesimplekid.dev 79 sat

Total balance across all wallets: 179 sat
```

```
cdk balance 2>/dev/null
Recovered 0 operations, 0 compensated, 0 skipped, 0 failed
Recovered 6 operations, 0 compensated, 0 skipped, 0 failed
0: http://127.0.0.1:8085 100 sat
1: https://fake.thesimplekid.dev 79 sat

Total balance across all wallets: 179 sat
```

after:
```
cdk balance
Recovery https://fake.thesimplekid.dev: 6 recovered, 0 compensated, 0 skipped, 0 failed
0: http://127.0.0.1:8085 100 sat
1: https://fake.thesimplekid.dev 79 sat

Total balance across all wallets: 179 sat
```

```
cdk balance 2>/dev/null
0: http://127.0.0.1:8085 100 sat
1: https://fake.thesimplekid.dev 79 sat

Total balance across all wallets: 179 sat
```