### PR TITLE
Move empty IN clause guard into bind_vec

### DIFF
--- a/crates/cdk-common/src/database/mint/test/mint.rs
+++ b/crates/cdk-common/src/database/mint/test/mint.rs
@@ -1684,8 +1684,8 @@ where
     assert_eq!(quotes[2].as_ref().unwrap().id, quote2.id);
 
     // 3. Test empty list
-    let quotes = db.get_mint_quotes_by_ids(&[]).await.unwrap();
-    assert!(quotes.is_empty());
+    let quotes = db.get_mint_quotes_by_ids(&[]).await;
+    assert!(quotes.is_err());
 
     // 4. Test within transaction (with locking)
     let mut tx = Database::begin_transaction(&db).await.unwrap();

--- a/crates/cdk-common/src/database/mod.rs
+++ b/crates/cdk-common/src/database/mod.rs
@@ -197,6 +197,10 @@ pub enum Error {
     #[error("Missing placeholder value {0}")]
     MissingPlaceholder(String),
 
+    /// Empty IN clause
+    #[error("Empty IN clause for placeholder: {0}")]
+    EmptyInClause(String),
+
     /// Unknown quote ttl
     #[error("Unknown quote ttl")]
     UnknownQuoteTTL,

--- a/crates/cdk-ffi/tests/test_transactions.py
+++ b/crates/cdk-ffi/tests/test_transactions.py
@@ -20,7 +20,7 @@ lib_file = "libcdk_ffi.dylib" if sys.platform == "darwin" else "libcdk_ffi.so"
 src_lib = lib_path / lib_file
 dst_lib = bindings_path / lib_file
 
-if src_lib.exists() and not dst_lib.exists():
+if src_lib.exists():
     shutil.copy2(src_lib, dst_lib)
 
 # Add target/bindings/python to path to load cdk_ffi module
@@ -212,8 +212,33 @@ async def test_wallet_quotes():
             os.unlink(db_path)
 
 
+async def test_wallet_proofs_by_ys_empty_errors():
+    """Test that get_proofs_by_ys errors with empty list"""
+    print("\n=== Test: Wallet Get Proofs by Y Values (Empty Errors) ===")
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+
+    try:
+        backend = cdk_ffi.WalletDbBackend.SQLITE(path=db_path)
+        db = cdk_ffi.create_wallet_db(backend)
+
+        try:
+            await db.get_proofs_by_ys([])
+            assert False, "Expected error for empty ys but got success"
+        except Exception as e:
+            assert "Empty IN clause" in str(e), f"Expected EmptyInClause error, got: {e}"
+            print("✓ get_proofs_by_ys errors on empty input")
+
+        print("✓ Test passed")
+
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
 async def test_wallet_proofs_by_ys():
-    """Test retrieving proofs by Y values"""
+    """Test retrieving proofs by Y values from the database"""
     print("\n=== Test: Wallet Get Proofs by Y Values ===")
 
     with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
@@ -223,12 +248,69 @@ async def test_wallet_proofs_by_ys():
         backend = cdk_ffi.WalletDbBackend.SQLITE(path=db_path)
         db = cdk_ffi.create_wallet_db(backend)
 
-        # Test with empty list
-        proofs = await db.get_proofs_by_ys([])
-        assert len(proofs) == 0, f"Expected 0 proofs, got {len(proofs)}"
-        print("✓ get_proofs_by_ys returns empty for empty input")
+        # Build test proofs using JSON decode helpers
+        import json
+        import hashlib
+        import secrets as secrets_mod
 
-        print("✓ Test passed: get_proofs_by_ys works")
+        mint_url = "https://example.com"
+        keyset_id = "00deadbeef123456"
+
+        proof_infos = []
+        expected_ys = []
+
+        for i in range(3):
+            # Generate a random secret string (matching cashu secret format)
+            random_hex = secrets_mod.token_hex(32)
+            secret_str = json.dumps(["P2PK", {"nonce": random_hex, "data": random_hex}])
+
+            # Use a valid secp256k1 generator point as C (just needs to be a valid pubkey)
+            # secp256k1 generator point G
+            c_hex = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+            proof = cdk_ffi.Proof(
+                amount=cdk_ffi.Amount(value=64),
+                secret=secret_str,
+                c=c_hex,
+                keyset_id=keyset_id,
+                witness=None,
+                dleq=None,
+                p2pk_e=None,
+            )
+
+            # Calculate Y from the proof
+            y_hex = cdk_ffi.proof_y(proof)
+            y = cdk_ffi.PublicKey(hex=y_hex)
+
+            proof_info = cdk_ffi.ProofInfo(
+                proof=proof,
+                y=y,
+                mint_url=cdk_ffi.MintUrl(url=mint_url),
+                state=cdk_ffi.ProofState.UNSPENT,
+                spending_condition=None,
+                unit=cdk_ffi.CurrencyUnit.SAT(),
+                used_by_operation=None,
+                created_by_operation=None,
+            )
+            proof_infos.append(proof_info)
+            expected_ys.append(y)
+
+        # Store proofs
+        await db.update_proofs(proof_infos, [])
+        print("✓ Stored 3 proofs")
+
+        # Retrieve all by Y values
+        retrieved = await db.get_proofs_by_ys(expected_ys)
+        assert len(retrieved) == 3, f"Expected 3 proofs, got {len(retrieved)}"
+        print("✓ Retrieved all 3 proofs by Y values")
+
+        # Retrieve subset
+        subset = await db.get_proofs_by_ys([expected_ys[0]])
+        assert len(subset) == 1, f"Expected 1 proof, got {len(subset)}"
+        assert subset[0].y.hex == expected_ys[0].hex
+        print("✓ Retrieved single proof by Y value")
+
+        print("✓ Test passed")
 
     finally:
         if os.path.exists(db_path):
@@ -246,6 +328,7 @@ async def main():
         ("Wallet Keyset Management", test_wallet_keyset_management),
         ("Wallet Keyset Counter", test_wallet_keyset_counter),
         ("Wallet Quote Operations", test_wallet_quotes),
+        ("Wallet Get Proofs by Y Values (Empty Errors)", test_wallet_proofs_by_ys_empty_errors),
         ("Wallet Get Proofs by Y Values", test_wallet_proofs_by_ys),
     ]
 

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -883,8 +883,12 @@ async fn setup_authentication(
 
         let mut tx = auth_localstore.begin_transaction().await?;
 
-        tx.remove_protected_endpoints(unprotected_endpoints).await?;
-        tx.add_protected_endpoints(protected_endpoints).await?;
+        if !unprotected_endpoints.is_empty() {
+            tx.remove_protected_endpoints(unprotected_endpoints).await?;
+        }
+        if !protected_endpoints.is_empty() {
+            tx.add_protected_endpoints(protected_endpoints).await?;
+        }
         tx.commit().await?;
 
         Ok((mint_builder, Some(auth_localstore)))

--- a/crates/cdk-sql-common/src/mint/auth/mod.rs
+++ b/crates/cdk-sql-common/src/mint/auth/mod.rs
@@ -224,10 +224,6 @@ where
         &mut self,
         protected_endpoints: Vec<ProtectedEndpoint>,
     ) -> Result<(), database::Error> {
-        if protected_endpoints.is_empty() {
-            return Ok(());
-        }
-
         query(r#"DELETE FROM protected_endpoints WHERE endpoint IN (:endpoints)"#)?
             .bind_vec(
                 "endpoints",
@@ -235,7 +231,7 @@ where
                     .iter()
                     .map(serde_json::to_string)
                     .collect::<Result<_, _>>()?,
-            )
+            )?
             .execute(&self.inner)
             .await?;
         Ok(())
@@ -329,12 +325,9 @@ where
     }
 
     async fn get_proofs_states(&self, ys: &[PublicKey]) -> Result<Vec<Option<State>>, Self::Err> {
-        if ys.is_empty() {
-            return Ok(vec![]);
-        }
         let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
         let mut current_states = query(r#"SELECT y, state FROM proof WHERE y IN (:ys)"#)?
-            .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
+            .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
             .fetch_all(&*conn)
             .await?
             .into_iter()
@@ -353,10 +346,6 @@ where
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
-        if blinded_messages.is_empty() {
-            return Ok(vec![]);
-        }
-
         let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
         let mut blinded_signatures = query(
             r#"SELECT
@@ -377,7 +366,7 @@ where
                 .iter()
                 .map(|bm| bm.to_bytes().to_vec())
                 .collect(),
-        )
+        )?
         .fetch_all(&*conn)
         .await?
         .into_iter()

--- a/crates/cdk-sql-common/src/mint/proofs.rs
+++ b/crates/cdk-sql-common/src/mint/proofs.rs
@@ -27,16 +27,13 @@ pub(super) async fn get_current_states<C>(
 where
     C: DatabaseExecutor + Send + Sync,
 {
-    if ys.is_empty() {
-        return Ok(Default::default());
-    }
     let for_update_clause = if for_update { "FOR UPDATE" } else { "" };
 
     query(&format!(
         r#"SELECT y, state FROM proof WHERE y IN (:ys) {}"#,
         for_update_clause
     ))?
-    .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
+    .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
     .fetch_all(conn)
     .await?
     .into_iter()
@@ -135,10 +132,6 @@ where
         quote_id: Option<QuoteId>,
         operation: &Operation,
     ) -> Result<Acquired<ProofsWithState>, Self::Err> {
-        if proofs.is_empty() {
-            return Ok(ProofsWithState::new(proofs, State::Unspent).into());
-        }
-
         let current_time = unix_time();
 
         // Check any previous proof, this query should return None in order to proceed storing
@@ -150,7 +143,7 @@ where
                     .iter()
                     .map(|y| y.y().map(|y| y.to_bytes().to_vec()))
                     .collect::<Result<_, _>>()?,
-            )
+            )?
             .pluck(&self.inner)
             .await?
             .map(|state| Ok::<_, Error>(column_as_string!(&state, State::from_str)))
@@ -212,14 +205,9 @@ where
     ) -> Result<(), Self::Err> {
         let ys = proofs.ys()?;
 
-        if ys.is_empty() {
-            proofs.state = new_state;
-            return Ok(());
-        }
-
         query(r#"UPDATE proof SET state = :new_state WHERE y IN (:ys)"#)?
             .bind("new_state", new_state.to_string())
-            .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
+            .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
             .execute(&self.inner)
             .await?;
 
@@ -235,7 +223,7 @@ where
                     DO UPDATE SET total_redeemed = keyset_amounts.total_redeemed + EXCLUDED.total_redeemed
                     "#,
                 )?
-                .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
+                .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
                 .execute(&self.inner)
                 .await?;
         }
@@ -250,16 +238,13 @@ where
         ys: &[PublicKey],
         _quote_id: Option<QuoteId>,
     ) -> Result<(), Self::Err> {
-        if ys.is_empty() {
-            return Ok(());
-        }
         let total_deleted = query(
             r#"
             DELETE FROM proof WHERE y IN (:ys) AND state NOT IN (:exclude_state)
             "#,
         )?
-        .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
-        .bind_vec("exclude_state", vec![State::Spent.to_string()])
+        .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
+        .bind_vec("exclude_state", vec![State::Spent.to_string()])?
         .execute(&self.inner)
         .await?;
 
@@ -363,10 +348,6 @@ where
         &mut self,
         ys: &[PublicKey],
     ) -> Result<Acquired<ProofsWithState>, Self::Err> {
-        if ys.is_empty() {
-            return Err(database::Error::ProofNotFound);
-        }
-
         let rows = query(
             r#"
              SELECT
@@ -383,7 +364,7 @@ where
              FOR UPDATE
              "#,
         )?
-        .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
+        .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
         .fetch_all(&self.inner)
         .await?;
 
@@ -426,10 +407,6 @@ where
     type Err = Error;
 
     async fn get_proofs_by_ys(&self, ys: &[PublicKey]) -> Result<Vec<Option<Proof>>, Self::Err> {
-        if ys.is_empty() {
-            return Ok(vec![]);
-        }
-
         let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
         let mut proofs = query(
             r#"
@@ -446,7 +423,7 @@ where
                 y IN (:ys)
             "#,
         )?
-        .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
+        .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
         .fetch_all(&*conn)
         .await?
         .into_iter()

--- a/crates/cdk-sql-common/src/mint/quotes.rs
+++ b/crates/cdk-sql-common/src/mint/quotes.rs
@@ -304,18 +304,6 @@ pub(super) async fn get_mint_quotes_inner<T>(
 where
     T: DatabaseExecutor,
 {
-    if quote_ids.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    // Build placeholders for IN clause: :id0, :id1, :id2, ...
-    let placeholders: Vec<String> = quote_ids
-        .iter()
-        .enumerate()
-        .map(|(i, _)| format!(":id{i}"))
-        .collect();
-    let in_clause = placeholders.join(", ");
-
     let for_update_clause = if for_update { "FOR UPDATE" } else { "" };
     let query_str = format!(
         r#"
@@ -335,17 +323,18 @@ where
             extra_json
         FROM
             mint_quote
-        WHERE id IN ({in_clause})
+        WHERE id IN (:quote_ids)
         {for_update_clause}
         "#
     );
 
-    let mut stmt = query(&query_str)?;
-    for (i, id) in quote_ids.iter().enumerate() {
-        stmt = stmt.bind(format!("id{i}"), id.to_string());
-    }
-
-    let rows = stmt.fetch_all(executor).await?;
+    let rows = query(&query_str)?
+        .bind_vec(
+            "quote_ids",
+            quote_ids.iter().map(|x| x.to_string()).collect(),
+        )?
+        .fetch_all(executor)
+        .await?;
 
     // Build a map from quote ID to MintQuote (without payments/issuance yet)
     let mut quote_map: HashMap<String, MintQuote> = HashMap::with_capacity(rows.len());
@@ -710,10 +699,6 @@ where
         &mut self,
         blinded_secrets: &[PublicKey],
     ) -> Result<(), Self::Err> {
-        if blinded_secrets.is_empty() {
-            return Ok(());
-        }
-
         // Delete blinded messages from blind_signature table where c IS NULL
         // (only delete unsigned blinded messages)
         query(
@@ -728,7 +713,7 @@ where
                 .iter()
                 .map(|secret| secret.to_bytes().to_vec())
                 .collect(),
-        )
+        )?
         .execute(&self.inner)
         .await?;
 

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -58,10 +58,6 @@ where
     ) -> Result<(), Self::Err> {
         let current_time = unix_time();
 
-        if blinded_messages.is_empty() {
-            return Ok(());
-        }
-
         if blinded_messages.len() != blind_signatures.len() {
             return Err(database::Error::Internal(
                 "Mismatched array lengths for blinded messages and blind signatures".to_string(),
@@ -83,7 +79,7 @@ where
                 .iter()
                 .map(|message| message.to_bytes().to_vec())
                 .collect(),
-        )
+        )?
         .fetch_all(&self.inner)
         .await?
         .into_iter()
@@ -213,10 +209,6 @@ where
         &mut self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
-        if blinded_messages.is_empty() {
-            return Ok(vec![]);
-        }
-
         let mut blinded_signatures = query(
             r#"SELECT
                 keyset_id,
@@ -236,7 +228,7 @@ where
                 .iter()
                 .map(|b| b.to_bytes().to_vec())
                 .collect(),
-        )
+        )?
         .fetch_all(&self.inner)
         .await?
         .into_iter()
@@ -269,10 +261,6 @@ where
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
-        if blinded_messages.is_empty() {
-            return Ok(vec![]);
-        }
-
         let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
         let mut blinded_signatures = query(
             r#"SELECT
@@ -293,7 +281,7 @@ where
                 .iter()
                 .map(|b_| b_.to_bytes().to_vec())
                 .collect(),
-        )
+        )?
         .fetch_all(&*conn)
         .await?
         .into_iter()

--- a/crates/cdk-sql-common/src/stmt.rs
+++ b/crates/cdk-sql-common/src/stmt.rs
@@ -327,13 +327,20 @@ impl Statement {
     ///
     /// This will rewrite the function from `:foo` (where value is vec![1, 2, 3]) to `:foo0, :foo1,
     /// :foo2` and binds each value from the value vector accordingly.
+    ///
+    /// Returns an error if the vector is empty, as empty `IN` clauses produce invalid SQL.
     #[inline]
-    pub fn bind_vec<C, V>(mut self, name: C, value: Vec<V>) -> Self
+    pub fn bind_vec<C, V>(mut self, name: C, value: Vec<V>) -> Result<Self, Error>
     where
         C: ToString,
         V: Into<Value>,
     {
         let name = name.to_string();
+
+        if value.is_empty() {
+            return Err(Error::EmptyInClause(name));
+        }
+
         let value: PlaceholderValue = value
             .into_iter()
             .map(|x| x.into())
@@ -348,7 +355,7 @@ impl Statement {
             }
         }
 
-        self
+        Ok(self)
     }
 
     /// Executes a query and returns the affected rows
@@ -397,4 +404,17 @@ impl Statement {
 pub fn query(sql: &str) -> Result<Statement, Error> {
     static CACHE: Lazy<Arc<RwLock<Cache>>> = Lazy::new(|| Arc::new(RwLock::new(HashMap::new())));
     Statement::new(sql, CACHE.clone()).map_err(|e| Error::Database(Box::new(e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bind_vec_errors_on_empty_vec() {
+        let stmt = query("SELECT * FROM foo WHERE id IN (:ids)").unwrap();
+        let result = stmt.bind_vec("ids", Vec::<Vec<u8>>::new());
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::EmptyInClause(name) if name == "ids"));
+    }
 }

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -506,10 +506,6 @@ where
         &self,
         ys: Vec<PublicKey>,
     ) -> Result<Vec<ProofInfo>, database::Error> {
-        if ys.is_empty() {
-            return Ok(Vec::new());
-        }
-
         let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
@@ -534,7 +530,7 @@ where
             WHERE y IN (:ys)
         "#,
         )?
-        .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
+        .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
         .fetch_all(&*conn)
         .await?
         .into_iter()
@@ -583,7 +579,7 @@ where
         }
 
         if !states.is_empty() {
-            q = q.bind_vec("states", states);
+            q = q.bind_vec("states", states)?;
         }
 
         let balance = q
@@ -773,7 +769,7 @@ where
                 .bind_vec(
                     "ys",
                     removed_ys.iter().map(|y| y.to_bytes().to_vec()).collect(),
-                )
+                )?
                 .execute(&tx)
                 .await?;
         }
@@ -789,14 +785,10 @@ where
         ys: Vec<PublicKey>,
         state: State,
     ) -> Result<(), database::Error> {
-        if ys.is_empty() {
-            return Ok(());
-        }
-
         let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
 
         query("UPDATE proof SET state = :state WHERE y IN (:ys)")?
-            .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())
+            .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
             .bind("state", state.to_string())
             .execute(&*conn)
             .await?;

--- a/crates/cdk-sqlite/src/mint/memory.rs
+++ b/crates/cdk-sqlite/src/mint/memory.rs
@@ -56,18 +56,20 @@ pub async fn new_with_state(
         tx.add_melt_quote(quote).await?;
     }
 
-    tx.add_proofs(
-        pending_proofs,
-        None,
-        &Operation::new_swap(Default::default(), Default::default(), Default::default()),
-    )
-    .await?;
-    tx.add_proofs(
-        spent_proofs,
-        None,
-        &Operation::new_swap(Default::default(), Default::default(), Default::default()),
-    )
-    .await?;
+    if !spent_proofs.is_empty() {
+        tx.add_proofs(
+            pending_proofs,
+            None,
+            &Operation::new_swap(Default::default(), Default::default(), Default::default()),
+        )
+        .await?;
+        tx.add_proofs(
+            spent_proofs,
+            None,
+            &Operation::new_swap(Default::default(), Default::default(), Default::default()),
+        )
+        .await?;
+    }
     let mint_info_bytes = serde_json::to_vec(&mint_info)?;
     tx.kv_write(
         CDK_MINT_PRIMARY_NAMESPACE,

--- a/crates/cdk-sqlite/src/wallet/mod.rs
+++ b/crates/cdk-sqlite/src/wallet/mod.rs
@@ -193,13 +193,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_proofs_by_ys_empty_errors() {
+        use cdk_common::database::Error;
+
+        let path = std::env::temp_dir().to_path_buf().join(format!(
+            "cdk-test-proofs-by-ys-empty-{}.sqlite",
+            uuid::Uuid::new_v4()
+        ));
+
+        #[cfg(feature = "sqlcipher")]
+        let db = WalletSqliteDatabase::new((path, "password".to_string()))
+            .await
+            .unwrap();
+
+        #[cfg(not(feature = "sqlcipher"))]
+        let db = WalletSqliteDatabase::new(path).await.unwrap();
+
+        let result = db.get_proofs_by_ys(vec![]).await;
+        assert!(matches!(result, Err(Error::EmptyInClause(_))));
+    }
+
+    #[tokio::test]
     async fn test_get_proofs_by_ys() {
         use cdk_common::mint_url::MintUrl;
         use cdk_common::nuts::{CurrencyUnit, Id, Proof, SecretKey};
         use cdk_common::wallet::ProofInfo;
         use cdk_common::Amount;
 
-        // Create a temporary database
         let path = std::env::temp_dir().to_path_buf().join(format!(
             "cdk-test-proofs-by-ys-{}.sqlite",
             uuid::Uuid::new_v4()
@@ -213,23 +233,17 @@ mod tests {
         #[cfg(not(feature = "sqlcipher"))]
         let db = WalletSqliteDatabase::new(path).await.unwrap();
 
-        // Create multiple proofs
         let keyset_id = Id::from_str("00deadbeef123456").unwrap();
         let mint_url = MintUrl::from_str("https://example.com").unwrap();
 
         let mut proof_infos = vec![];
         let mut expected_ys = vec![];
 
-        // Generate valid public keys using SecretKey
         for _i in 0..5 {
             let secret = Secret::generate();
-
-            // Generate a valid public key from a secret key
             let secret_key = SecretKey::generate();
             let c = secret_key.public_key();
-
             let proof = Proof::new(Amount::from(64), keyset_id, secret, c);
-
             let proof_info =
                 ProofInfo::new(proof, mint_url.clone(), State::Unspent, CurrencyUnit::Sat).unwrap();
 
@@ -237,43 +251,33 @@ mod tests {
             proof_infos.push(proof_info);
         }
 
-        // Store all proofs in the database
         db.update_proofs(proof_infos.clone(), vec![]).await.unwrap();
 
-        // Test 1: Retrieve all proofs by their Y values
+        // Retrieve all proofs by their Y values
         let retrieved_proofs = db.get_proofs_by_ys(expected_ys.clone()).await.unwrap();
-
         assert_eq!(retrieved_proofs.len(), 5);
         for retrieved_proof in &retrieved_proofs {
             assert!(expected_ys.contains(&retrieved_proof.y));
         }
 
-        // Test 2: Retrieve subset of proofs (first 3)
+        // Retrieve subset of proofs (first 3)
         let subset_ys = expected_ys[0..3].to_vec();
         let subset_proofs = db.get_proofs_by_ys(subset_ys.clone()).await.unwrap();
-
         assert_eq!(subset_proofs.len(), 3);
         for retrieved_proof in &subset_proofs {
             assert!(subset_ys.contains(&retrieved_proof.y));
         }
 
-        // Test 3: Retrieve with non-existent Y values
+        // Retrieve with non-existent Y values returns only existing ones
         let non_existent_secret_key = SecretKey::generate();
         let non_existent_y = non_existent_secret_key.public_key();
         let mixed_ys = vec![expected_ys[0], non_existent_y, expected_ys[1]];
         let mixed_proofs = db.get_proofs_by_ys(mixed_ys).await.unwrap();
-
-        // Should only return the 2 that exist
         assert_eq!(mixed_proofs.len(), 2);
 
-        // Test 4: Empty input returns empty result
-        let empty_result = db.get_proofs_by_ys(vec![]).await.unwrap();
-        assert_eq!(empty_result.len(), 0);
-
-        // Test 5: Verify retrieved proof data matches original
+        // Verify retrieved proof data matches original
         let single_y = vec![expected_ys[2]];
         let single_proof = db.get_proofs_by_ys(single_y).await.unwrap();
-
         assert_eq!(single_proof.len(), 1);
         assert_eq!(single_proof[0].y, proof_infos[2].y);
         assert_eq!(single_proof[0].proof.amount, proof_infos[2].proof.amount);

--- a/crates/cdk/src/wallet/saga/mod.rs
+++ b/crates/cdk/src/wallet/saga/mod.rs
@@ -102,11 +102,14 @@ impl CompensatingAction for RevertProofReservation {
 
         // Fetch current states to avoid reverting proofs that were already spent
         // (e.g. by a successful internal swap that occurred before a crash)
-        let current_proofs = self
-            .localstore
-            .get_proofs_by_ys(self.proof_ys.clone())
-            .await
-            .map_err(Error::Database)?;
+        let current_proofs = if self.proof_ys.is_empty() {
+            vec![]
+        } else {
+            self.localstore
+                .get_proofs_by_ys(self.proof_ys.clone())
+                .await
+                .map_err(Error::Database)?
+        };
 
         let ys_to_revert: Vec<_> = current_proofs
             .into_iter()


### PR DESCRIPTION

### Description

Instead of scattering empty-vec checks at each call site, bind_vec now returns Result and errors with EmptyInClause when given an empty vector.  This prevents invalid SQL from being generated at the source.

Fixes #1858 and #1813

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
