### PR TITLE
feat: add Go bindings build and tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,6 +516,25 @@ jobs:
       - name: Run Kotlin tests
         run: nix develop -L .#bindings --command just test-kotlin
 
+  go-binding-tests:
+    name: "Go binding tests"
+    runs-on: self-hosted
+    timeout-minutes: 30
+    needs: pre-commit-checks
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: cachix/cachix-action@v16
+        with:
+          name: cashudevkit
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          useDaemon: false
+        continue-on-error: true
+      - name: Build native library and generate bindings
+        run: nix develop -L .#bindings --command just binding-go
+      - name: Run Go tests
+        run: nix develop -L .#bindings --command just test-go
+
   swift-binding-tests:
     name: "Swift binding tests"
     runs-on: macos-latest

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ bindings/kotlin/cdk-jvm/src/main/kotlin/uniffi/
 bindings/kotlin/cdk-jvm/src/main/resources/*.so
 bindings/kotlin/cdk-jvm/src/main/resources/*.dylib
 
+# Go bindings
+bindings/go/cdkffi/
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,6 +1426,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cdk-ffi-go"
+version = "0.16.0"
+dependencies = [
+ "cdk-ffi",
+ "uniffi",
+]
+
+[[package]]
 name = "cdk-ffi-kotlin"
 version = "0.16.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "bindings/dart/rust",
     "bindings/swift/rust",
     "bindings/kotlin/rust",
+    "bindings/go/rust",
 ]
 exclude = [
     "fuzz",

--- a/bindings/go/generate-bindings.sh
+++ b/bindings/go/generate-bindings.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+UNIFFI_BINDGEN_GO_TAG="${UNIFFI_BINDGEN_GO_TAG:-v0.6.0+v0.30.0}"
+UNIFFI_BINDGEN_GO_REPO="${UNIFFI_BINDGEN_GO_REPO:-https://github.com/NordSecurity/uniffi-bindgen-go}"
+
+# Install uniffi-bindgen-go if not already available at the right version
+if command -v uniffi-bindgen-go >/dev/null 2>&1; then
+    INSTALLED_VERSION="$(uniffi-bindgen-go --version 2>/dev/null | awk '{print $2}')"
+    REQUESTED_VERSION="${UNIFFI_BINDGEN_GO_TAG#v}"
+
+    if [ "${INSTALLED_VERSION}" != "${REQUESTED_VERSION}" ]; then
+        echo "Updating uniffi-bindgen-go from ${INSTALLED_VERSION:-unknown} to ${UNIFFI_BINDGEN_GO_TAG}"
+        cargo install uniffi-bindgen-go \
+            --git "${UNIFFI_BINDGEN_GO_REPO}" \
+            --tag "${UNIFFI_BINDGEN_GO_TAG}" \
+            --locked --force
+    fi
+else
+    echo "Installing uniffi-bindgen-go ${UNIFFI_BINDGEN_GO_TAG}..."
+    cargo install uniffi-bindgen-go \
+        --git "${UNIFFI_BINDGEN_GO_REPO}" \
+        --tag "${UNIFFI_BINDGEN_GO_TAG}" \
+        --locked
+fi
+
+# Platform detection
+if [[ "${OSTYPE:-}" == darwin* ]]; then
+    LIB_EXT="dylib"
+    PLATFORM_OS="darwin"
+else
+    LIB_EXT="so"
+    PLATFORM_OS="linux"
+fi
+
+UNAME_ARCH="$(uname -m)"
+case "${UNAME_ARCH}" in
+    x86_64)         PLATFORM_ARCH="amd64" ;;
+    aarch64|arm64)  PLATFORM_ARCH="arm64" ;;
+    *)
+        echo "Unsupported architecture: ${UNAME_ARCH}" >&2
+        exit 1
+        ;;
+esac
+
+PLATFORM_KEY="${PLATFORM_OS}_${PLATFORM_ARCH}"
+PACKAGE_DIR="${SCRIPT_DIR}/cdkffi"
+
+# Build the cdk-ffi-go cdylib
+pushd "${ROOT_DIR}" >/dev/null
+cargo build --release -p cdk-ffi-go
+popd >/dev/null
+
+LIB_FILE="${ROOT_DIR}/target/release/libcdk_ffi_go.${LIB_EXT}"
+if [ ! -f "${LIB_FILE}" ]; then
+    echo "ERROR: Could not find ${LIB_FILE}"
+    ls -la "${ROOT_DIR}/target/release/libcdk_ffi_go"* || true
+    exit 1
+fi
+
+# Clean previous generation
+rm -rf "${PACKAGE_DIR}"
+
+# Generate Go bindings using uniffi-bindgen-go
+pushd "${ROOT_DIR}" >/dev/null
+uniffi-bindgen-go "${LIB_FILE}" \
+    --library \
+    --config bindings/go/rust/uniffi.toml \
+    --out-dir bindings/go
+popd >/dev/null
+
+# Copy native library to platform-specific directory
+NATIVE_DIR="${PACKAGE_DIR}/native/${PLATFORM_KEY}"
+mkdir -p "${NATIVE_DIR}"
+cp "${LIB_FILE}" "${NATIVE_DIR}/libcdk_ffi_go.${LIB_EXT}"
+
+if [[ "${PLATFORM_OS}" == "darwin" ]]; then
+    install_name_tool -id "@rpath/libcdk_ffi_go.dylib" "${NATIVE_DIR}/libcdk_ffi_go.dylib"
+fi
+
+# Create CGO link file for the current platform
+if [[ "${PLATFORM_OS}" == "linux" ]]; then
+    EXTRA_LIBS="-lm -ldl"
+else
+    EXTRA_LIBS="-lm"
+fi
+
+cat > "${PACKAGE_DIR}/link_${PLATFORM_KEY}.go" <<GOEOF
+//go:build ${PLATFORM_OS} && ${PLATFORM_ARCH}
+
+package cdk_ffi
+
+// #cgo LDFLAGS: -L\${SRCDIR}/native/${PLATFORM_KEY} -lcdk_ffi_go -Wl,-rpath,\${SRCDIR}/native/${PLATFORM_KEY} ${EXTRA_LIBS}
+import "C"
+GOEOF
+
+echo "Generated Go bindings in ${PACKAGE_DIR} (${PLATFORM_KEY})"

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/cashubtc/cdk/bindings/go
+
+go 1.22

--- a/bindings/go/rust/Cargo.toml
+++ b/bindings/go/rust/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "cdk-ffi-go"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+version.workspace = true
+readme.workspace = true
+
+[lib]
+crate-type = ["staticlib", "cdylib"]
+name = "cdk_ffi_go"
+
+[dependencies]
+cdk-ffi.workspace = true
+uniffi = { workspace = true }
+
+[build-dependencies]
+uniffi = { workspace = true, features = ["build"] }
+
+[lints]
+workspace = true

--- a/bindings/go/rust/src/lib.rs
+++ b/bindings/go/rust/src/lib.rs
@@ -1,0 +1,2 @@
+//! CDK FFI bindings for Go
+pub use cdk_ffi::*;

--- a/bindings/go/rust/uniffi.toml
+++ b/bindings/go/rust/uniffi.toml
@@ -1,0 +1,4 @@
+[bindings.go]
+go_mod = "github.com/cashubtc/cdk/bindings/go"
+package_name = "cdkffi"
+c_module_filename = "cdk_ffi"

--- a/flake.nix
+++ b/flake.nix
@@ -371,7 +371,7 @@
           commonCraneArgsMsrv
           // {
             pname = "cdk-deps-msrv";
-            cargoExtraArgs = "--workspace --exclude cdk-redb --exclude cdk-integration-tests --exclude cdk-ffi-dart --exclude cdk-ffi-swift --exclude cdk-ffi-kotlin";
+            cargoExtraArgs = "--workspace --exclude cdk-redb --exclude cdk-integration-tests --exclude cdk-ffi-dart --exclude cdk-ffi-swift --exclude cdk-ffi-kotlin --exclude cdk-ffi-go";
           }
         );
 
@@ -1324,7 +1324,7 @@
               // envVars
             );
 
-            # Shell for bindings development (Dart + Swift + Kotlin FFI)
+            # Shell for bindings development (Dart + Swift + Kotlin + Go FFI)
             bindings = pkgs.mkShell (
               {
                 shellHook = commonShellHook;
@@ -1334,6 +1334,7 @@
                   dartpkgs.default
                   pkgs.openssl
                   pkgs.jdk17
+                  pkgs.go
                 ];
                 nativeBuildInputs = [
                   pkgs.pkg-config

--- a/justfile
+++ b/justfile
@@ -902,6 +902,20 @@ test-kotlin:
   cd "{{justfile_directory()}}/bindings/kotlin"
   ./gradlew :cdk-jvm:test
 
+# Generate Go FFI bindings
+binding-go:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd "{{justfile_directory()}}"
+  bindings/go/generate-bindings.sh
+
+# Run Go binding tests
+test-go:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd "{{justfile_directory()}}/bindings/go"
+  CGO_ENABLED=1 go test ./cdkffi/...
+
 # Generate Swift FFI bindings and XCFramework
 binding-swift:
   #!/usr/bin/env bash


### PR DESCRIPTION
### Description

Add Go bindings build and tests to CDK CI, following the same pattern used by Dart, Kotlin, and Swift bindings.

- Create `cdk-ffi-go` wrapper crate in `bindings/go/rust/`
- Add `generate-bindings.sh` script using `uniffi-bindgen-go` (v0.6.0+v0.30.0)
- Add `binding-go` and `test-go` justfile recipes
- Add `go-binding-tests` job to CI workflow
- Add Go (`pkgs.go`) to the Nix `#bindings` dev shell
- Exclude `cdk-ffi-go` from MSRV builds

Closes #1860

-----

### Notes to the reviewers

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates


#### CHANGED

#### ADDED

- Added Go FFI bindings (`cdk-ffi-go`) and CI job to build and verify them

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
