### PR TITLE
fix(cdk-lnd): honor mint quote TTL on LND invoices

### DIFF
--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -585,11 +585,15 @@ impl MintPayment for Cln {
                 let amount_msat =
                     AmountOrAny::Amount(CLN_Amount::from_msat(amount_converted.value()));
 
+                let expiry = unix_expiry
+                    .map(|t| t.checked_sub(time_now).ok_or(payment::Error::InvalidExpiry))
+                    .transpose()?;
+
                 let request = InvoiceRequest {
                     amount_msat,
                     description: description.unwrap_or_default(),
                     label: label.clone(),
-                    expiry: unix_expiry.map(|t| t - time_now),
+                    expiry,
                     fallbacks: None,
                     preimage: None,
                     cltv: None,

--- a/crates/cdk-common/src/payment.rs
+++ b/crates/cdk-common/src/payment.rs
@@ -40,6 +40,9 @@ pub enum Error {
     /// Amount mismatch
     #[error("Amount is not what is expected")]
     AmountMismatch,
+    /// Invalid expiry
+    #[error("Invalid expiry")]
+    InvalidExpiry,
     /// Lightning Error
     #[error(transparent)]
     Lightning(Box<dyn std::error::Error + Send + Sync>),

--- a/crates/cdk-ldk-node/src/lib.rs
+++ b/crates/cdk-ldk-node/src/lib.rs
@@ -539,10 +539,12 @@ impl MintPayment for CdkLdkNode {
                     .convert_to(&CurrencyUnit::Msat)?
                     .into();
                 let description = bolt11_options.description.unwrap_or_default();
-                let time = bolt11_options
-                    .unix_expiry
-                    .map(|t| t - unix_time())
-                    .unwrap_or(36000);
+                let time = match bolt11_options.unix_expiry {
+                    Some(t) => t
+                        .checked_sub(unix_time())
+                        .ok_or(payment::Error::InvalidExpiry)?,
+                    None => 36000,
+                };
 
                 let description = Bolt11InvoiceDescription::Direct(
                     Description::new(description).map_err(|_| Error::InvalidDescription)?,
@@ -575,7 +577,13 @@ impl MintPayment for CdkLdkNode {
                     unix_expiry,
                 } = *bolt12_options;
 
-                let time = unix_expiry.map(|t| (t - unix_time()) as u32);
+                let time = unix_expiry
+                    .map(|t| {
+                        t.checked_sub(unix_time())
+                            .ok_or(payment::Error::InvalidExpiry)
+                            .map(|t| t as u32)
+                    })
+                    .transpose()?;
 
                 let offer = match amount {
                     Some(amount) => {

--- a/crates/cdk-lnbits/src/lib.rs
+++ b/crates/cdk-lnbits/src/lib.rs
@@ -347,7 +347,9 @@ impl MintPayment for LNbits {
                 let unix_expiry = bolt11_options.unix_expiry;
 
                 let time_now = unix_time();
-                let expiry = unix_expiry.map(|t| t - time_now);
+                let expiry = unix_expiry
+                    .map(|t| t.checked_sub(time_now).ok_or(payment::Error::InvalidExpiry))
+                    .transpose()?;
 
                 let invoice_request = CreateInvoiceRequest {
                     amount: amount.to_sat()?,

--- a/crates/cdk-lnd/src/lib.rs
+++ b/crates/cdk-lnd/src/lib.rs
@@ -23,7 +23,7 @@ use cdk_common::payment::{
     MintPayment, OutgoingPaymentOptions, PaymentIdentifier, PaymentQuoteResponse, SettingsResponse,
     WaitPaymentResponse,
 };
-use cdk_common::util::hex;
+use cdk_common::util::{hex, unix_time};
 use cdk_common::Bolt11Invoice;
 use error::Error;
 use futures::{Stream, StreamExt};
@@ -634,6 +634,13 @@ impl MintPayment for Lnd {
                 let invoice_request = lnrpc::Invoice {
                     value_msat: u64::from(amount_msat) as i64,
                     memo: description,
+                    expiry: unix_expiry
+                        .map(|t| {
+                            t.checked_sub(unix_time())
+                                .ok_or(payment::Error::InvalidExpiry)
+                        })
+                        .transpose()?
+                        .unwrap_or_default() as i64,
                     ..Default::default()
                 };
 
@@ -651,10 +658,12 @@ impl MintPayment for Lnd {
                 let payment_identifier =
                     PaymentIdentifier::PaymentHash(*bolt11.payment_hash().as_ref());
 
+                let expiry = bolt11.expires_at().map(|t| t.as_secs());
+
                 Ok(CreateIncomingPaymentResponse {
                     request_lookup_id: payment_identifier,
                     request: bolt11.to_string(),
-                    expiry: unix_expiry,
+                    expiry,
                     extra_json: None,
                 })
             }


### PR DESCRIPTION
### Description

LND invoices were always created with the default 24h expiry, ignoring `mint_ttl`. Set `lnrpc::Invoice.expiry` from the quote TTL and read back the actual expiry from the bolt11, matching CLN/LNBits behavior.

-----

### Notes to the reviewers

The `lnrpc::Invoice.expiry` field expects a duration in seconds (not a unix timestamp). Since the mint passes an absolute unix timestamp (`unix_expiry`), we convert it to a relative duration via `saturating_sub(unix_time())`, same pattern CLN and LNBits already use.

-----

#### FIXED

- Fixed LND invoices ignoring `mint_ttl` and always using 24h default expiry


----

### Checklist

* [X] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [X] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
