### PR TITLE
fix(ldk-node): only include fee in amount if outbound tx

### DIFF
--- a/crates/cdk-ldk-node/src/web/handlers/payments.rs
+++ b/crates/cdk-ldk-node/src/web/handlers/payments.rs
@@ -160,8 +160,8 @@ pub async fn payments_page(
 
                     @let amount_str = {
                         match (payment.amount_msat, payment.fee_paid_msat) {
-                            (Some(amount), Some(fee)) => format_msats_as_btc(amount + fee),
-                            (Some(amount), None) => format_msats_as_btc(amount),
+                            (Some(amount), Some(fee)) if payment.direction == PaymentDirection::Outbound => format_msats_as_btc(amount + fee),
+                            (Some(amount), _) => format_msats_as_btc(amount),
                             _ => "Unknown".to_string()
                         }
                     };


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

closes: https://github.com/cashubtc/cdk/issues/1867

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
