### PR TITLE
Feat/prepare melt token

### DIFF
--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -868,6 +868,18 @@ pub trait Wallet: Send + Sync {
         metadata: HashMap<String, String>,
     ) -> Result<Self::PreparedMelt<'_>, Self::Error>;
 
+    /// Prepare a melt operation from an encoded token
+    ///
+    /// Decodes the token, extracts proofs (handling keyset state internally),
+    /// and prepares the melt. This is useful when the caller has a token and
+    /// wants to skip manual decoding, which requires keyset state for v2 keysets.
+    async fn prepare_melt_token(
+        &self,
+        quote_id: &str,
+        encoded_token: &str,
+        metadata: HashMap<String, String>,
+    ) -> Result<Self::PreparedMelt<'_>, Self::Error>;
+
     /// Swap proofs
     async fn swap(
         &self,

--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -870,6 +870,18 @@ pub trait Wallet: Send + Sync {
         metadata: HashMap<String, String>,
     ) -> Result<Self::PreparedMelt<'_>, Self::Error>;
 
+    /// Prepare a melt operation from an encoded token
+    ///
+    /// Decodes the token, extracts proofs (handling keyset state internally),
+    /// and prepares the melt. This is useful when the caller has a token and
+    /// wants to skip manual decoding, which requires keyset state for v2 keysets.
+    async fn prepare_melt_token(
+        &self,
+        quote_id: &str,
+        encoded_token: &str,
+        metadata: HashMap<String, String>,
+    ) -> Result<Self::PreparedMelt<'_>, Self::Error>;
+
     /// Swap proofs
     async fn swap(
         &self,

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -344,6 +344,35 @@ impl Wallet {
         Ok(PreparedMelt::new(Arc::clone(&self.inner), &prepared))
     }
 
+    /// Prepare a melt operation from an encoded token
+    ///
+    /// Decodes the token internally (handling keyset state for v2 keysets),
+    /// extracts proofs, and prepares the melt operation.
+    ///
+    /// # Arguments
+    ///
+    /// * `quote_id` - The melt quote ID (obtained from `melt_quote`)
+    /// * `encoded_token` - The encoded token string (cashuA or cashuB format)
+    ///
+    /// # Returns
+    ///
+    /// A `PreparedMelt` that can be confirmed or cancelled
+    pub async fn prepare_melt_token(
+        &self,
+        quote_id: String,
+        encoded_token: String,
+    ) -> Result<PreparedMelt, FfiError> {
+        let prepared = self
+            .inner
+            .prepare_melt_token(
+                &quote_id,
+                &encoded_token,
+                std::collections::HashMap::new(),
+            )
+            .await?;
+        Ok(PreparedMelt::new(Arc::clone(&self.inner), &prepared))
+    }
+
     pub async fn mint_unified(
         &self,
         quote_id: String,

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -344,6 +344,31 @@ impl Wallet {
         Ok(PreparedMelt::new(Arc::clone(&self.inner), &prepared))
     }
 
+    /// Prepare a melt operation from an encoded token
+    ///
+    /// Decodes the token internally (handling keyset state for v2 keysets),
+    /// extracts proofs, and prepares the melt operation.
+    ///
+    /// # Arguments
+    ///
+    /// * `quote_id` - The melt quote ID (obtained from `melt_quote`)
+    /// * `encoded_token` - The encoded token string (cashuA or cashuB format)
+    ///
+    /// # Returns
+    ///
+    /// A `PreparedMelt` that can be confirmed or cancelled
+    pub async fn prepare_melt_token(
+        &self,
+        quote_id: String,
+        encoded_token: String,
+    ) -> Result<PreparedMelt, FfiError> {
+        let prepared = self
+            .inner
+            .prepare_melt_token(&quote_id, &encoded_token, std::collections::HashMap::new())
+            .await?;
+        Ok(PreparedMelt::new(Arc::clone(&self.inner), &prepared))
+    }
+
     pub async fn mint_unified(
         &self,
         quote_id: String,

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -364,11 +364,7 @@ impl Wallet {
     ) -> Result<PreparedMelt, FfiError> {
         let prepared = self
             .inner
-            .prepare_melt_token(
-                &quote_id,
-                &encoded_token,
-                std::collections::HashMap::new(),
-            )
+            .prepare_melt_token(&quote_id, &encoded_token, std::collections::HashMap::new())
             .await?;
         Ok(PreparedMelt::new(Arc::clone(&self.inner), &prepared))
     }

--- a/crates/cdk-ffi/src/wallet_trait.rs
+++ b/crates/cdk-ffi/src/wallet_trait.rs
@@ -332,6 +332,19 @@ impl WalletTraitDef for Wallet {
         Ok(PreparedMelt::new(self.inner().clone(), &prepared))
     }
 
+    async fn prepare_melt_token(
+        &self,
+        quote_id: &str,
+        encoded_token: &str,
+        metadata: HashMap<String, String>,
+    ) -> Result<PreparedMelt, Self::Error> {
+        let prepared = self
+            .inner()
+            .prepare_melt_token(quote_id, encoded_token, metadata)
+            .await?;
+        Ok(PreparedMelt::new(self.inner().clone(), &prepared))
+    }
+
     async fn swap(
         &self,
         amount: Option<Self::Amount>,

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -654,6 +654,7 @@ impl Wallet {
         ensure_cdk!(self.mint_url == token.mint_url()?, Error::IncorrectMint);
 
         let keysets_info = self.load_mint_keysets().await?;
+        println!("{:?}", keysets_info);
         let proofs = token.proofs(&keysets_info)?;
 
         self.prepare_melt_proofs(quote_id, proofs, metadata).await
@@ -1281,14 +1282,20 @@ impl Wallet {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::str::FromStr;
     use std::sync::Arc;
 
-    use cdk_common::nuts::State;
+    use cdk_common::nuts::{CurrencyUnit, State};
+    use cdk_common::Id;
 
+    use super::*;
     use crate::wallet::saga::test_utils::{
         create_test_db, test_keyset_id, test_mint_url, test_proof_info,
     };
-    use crate::wallet::test_utils::{create_test_wallet_with_mock, MockMintConnector};
+    use crate::wallet::test_utils::{
+        create_test_wallet_with_mock, test_melt_quote, test_proof, MockMintConnector,
+    };
 
     #[tokio::test]
     async fn test_cancel_prepared_melt_reverts_reserved_proofs() {
@@ -1413,5 +1420,80 @@ mod tests {
         assert_eq!(state_for(reserved_y), Some(State::Unspent));
         assert_eq!(state_for(pending_y), Some(State::Unspent));
         assert_eq!(state_for(spent_y), Some(State::Spent));
+    }
+
+    async fn create_test_wallet_with_quote() -> (Wallet, String) {
+        let db = create_test_db().await;
+        let quote = test_melt_quote();
+        let quote_id = quote.id.clone();
+        db.add_melt_quote(quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.reset_default_mint_state();
+        let wallet = create_test_wallet_with_mock(db, mock_client).await;
+
+        (wallet, quote_id)
+    }
+
+    fn build_token(mint_url: cdk_common::mint_url::MintUrl, unit: CurrencyUnit) -> String {
+        let proofs = vec![test_proof(test_keyset_id(), 1000)];
+        Token::new(mint_url, proofs, None, unit).to_string()
+    }
+
+    #[tokio::test]
+    async fn test_prepare_melt_token_rejects_wrong_unit() {
+        let (wallet, quote_id) = create_test_wallet_with_quote().await;
+        let encoded_token = build_token(test_mint_url(), CurrencyUnit::Usd);
+
+        let result = wallet
+            .prepare_melt_token(&quote_id, &encoded_token, HashMap::new())
+            .await;
+
+        assert!(matches!(result, Err(Error::UnsupportedUnit)));
+    }
+
+    #[tokio::test]
+    async fn test_prepare_melt_token_rejects_wrong_mint() {
+        let (wallet, quote_id) = create_test_wallet_with_quote().await;
+        let encoded_token = build_token(
+            cdk_common::mint_url::MintUrl::from_str("https://other-mint.example.com").unwrap(),
+            CurrencyUnit::Sat,
+        );
+
+        let result = wallet
+            .prepare_melt_token(&quote_id, &encoded_token, HashMap::new())
+            .await;
+
+        assert!(matches!(result, Err(Error::IncorrectMint)));
+    }
+
+    #[tokio::test]
+    async fn test_prepare_melt_token_accepts_valid_token() {
+        let db = create_test_db().await;
+        let quote = test_melt_quote();
+        let quote_id = quote.id.clone();
+        db.add_melt_quote(quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.reset_default_mint_state();
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        let proof = test_proof(Id::from_str("0094d5a774c40a32").unwrap(), 1010);
+        let encoded_token =
+            Token::new(test_mint_url(), vec![proof], None, CurrencyUnit::Sat).to_string();
+
+        let prepared = wallet
+            .prepare_melt_token(&quote_id, &encoded_token, HashMap::new())
+            .await
+            .unwrap();
+
+        let reserved = db
+            .get_reserved_proofs(&prepared.operation_id())
+            .await
+            .unwrap();
+
+        assert_eq!(reserved.len(), 1);
+        assert_eq!(reserved[0].state, State::Reserved);
+        assert_eq!(reserved[0].proof.amount, Amount::from(1010_u64));
     }
 }

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -38,6 +38,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::future::{Future, IntoFuture};
 use std::pin::Pin;
+use std::str::FromStr;
 
 use cdk_common::util::unix_time;
 use cdk_common::wallet::{MeltQuote, Transaction, TransactionDirection};
@@ -46,11 +47,11 @@ use tracing::instrument;
 use uuid::Uuid;
 
 use crate::nuts::nut00::KnownMethod;
-use crate::nuts::{MeltOptions, Proofs};
+use crate::nuts::{MeltOptions, Proofs, Token};
 use crate::types::FinalizedMelt;
 use crate::wallet::subscription::NotificationPayload;
 use crate::wallet::WalletSubscription;
-use crate::{Amount, Wallet};
+use crate::{ensure_cdk, Amount, Wallet};
 
 mod bolt11;
 mod bolt12;
@@ -633,6 +634,29 @@ impl Wallet {
             saga: prepared_saga,
             metadata,
         })
+    }
+
+    /// Prepare a melt operation from an encoded token.
+    ///
+    /// Decodes the token, validates unit and mint URL, extracts proofs,
+    /// and delegates to [`prepare_melt_proofs`](Wallet::prepare_melt_proofs).
+    #[instrument(skip(self, encoded_token, metadata))]
+    pub async fn prepare_melt_token(
+        &self,
+        quote_id: &str,
+        encoded_token: &str,
+        metadata: HashMap<String, String>,
+    ) -> Result<PreparedMelt<'_>, Error> {
+        let token = Token::from_str(encoded_token)?;
+
+        let unit = token.unit().unwrap_or_default();
+        ensure_cdk!(unit == self.unit, Error::UnsupportedUnit);
+        ensure_cdk!(self.mint_url == token.mint_url()?, Error::IncorrectMint);
+
+        let keysets_info = self.load_mint_keysets().await?;
+        let proofs = token.proofs(&keysets_info)?;
+
+        self.prepare_melt_proofs(quote_id, proofs, metadata).await
     }
 
     /// Finalize pending melt operations.

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -38,6 +38,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::future::{Future, IntoFuture};
 use std::pin::Pin;
+use std::str::FromStr;
 
 use cdk_common::util::unix_time;
 use cdk_common::wallet::{MeltQuote, Transaction, TransactionDirection};
@@ -46,11 +47,11 @@ use tracing::instrument;
 use uuid::Uuid;
 
 use crate::nuts::nut00::KnownMethod;
-use crate::nuts::{MeltOptions, Proofs};
+use crate::nuts::{MeltOptions, Proofs, Token};
 use crate::types::FinalizedMelt;
 use crate::wallet::subscription::NotificationPayload;
 use crate::wallet::WalletSubscription;
-use crate::{Amount, Wallet};
+use crate::{ensure_cdk, Amount, Wallet};
 
 mod bolt11;
 mod bolt12;
@@ -579,6 +580,29 @@ impl Wallet {
             saga: prepared_saga,
             metadata,
         })
+    }
+
+    /// Prepare a melt operation from an encoded token.
+    ///
+    /// Decodes the token, validates unit and mint URL, extracts proofs,
+    /// and delegates to [`prepare_melt_proofs`](Wallet::prepare_melt_proofs).
+    #[instrument(skip(self, encoded_token, metadata))]
+    pub async fn prepare_melt_token(
+        &self,
+        quote_id: &str,
+        encoded_token: &str,
+        metadata: HashMap<String, String>,
+    ) -> Result<PreparedMelt<'_>, Error> {
+        let token = Token::from_str(encoded_token)?;
+
+        let unit = token.unit().unwrap_or_default();
+        ensure_cdk!(unit == self.unit, Error::UnsupportedUnit);
+        ensure_cdk!(self.mint_url == token.mint_url()?, Error::IncorrectMint);
+
+        let keysets_info = self.load_mint_keysets().await?;
+        let proofs = token.proofs(&keysets_info)?;
+
+        self.prepare_melt_proofs(quote_id, proofs, metadata).await
     }
 
     /// Finalize pending melt operations.

--- a/crates/cdk/src/wallet/wallet_trait.rs
+++ b/crates/cdk/src/wallet/wallet_trait.rs
@@ -275,6 +275,17 @@ impl WalletTrait for super::Wallet {
         self.prepare_melt_proofs(quote_id, proofs, metadata).await
     }
 
+    #[instrument(skip(self, encoded_token, metadata))]
+    async fn prepare_melt_token(
+        &self,
+        quote_id: &str,
+        encoded_token: &str,
+        metadata: HashMap<String, String>,
+    ) -> Result<super::melt::PreparedMelt<'_>, Self::Error> {
+        self.prepare_melt_token(quote_id, encoded_token, metadata)
+            .await
+    }
+
     #[instrument(skip(self, input_proofs, spending_conditions))]
     async fn swap(
         &self,


### PR DESCRIPTION
### Description

Adds `prepare_melt_token` to the `Wallet` trait, core implementation, and FFI bindings.
 
Currently CDK has `prepare_melt` (auto-selects proofs) and `prepare_melt_proofs` (accepts raw proofs), but there's no way to pass an encoded token  directly. 

This new method internalizes that complexity, following the same pattern as `receive()`.                                                                                                            
                                                          
Closes #1888 

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

#### ADDED

- Added `prepare_melt_token` to `Wallet` trait and FFI bindings, allowing callers to pass an encoded token (cashuA/cashuB) directly for melt operations 

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
