### PR TITLE
Feat/relax active keyset requirement

### DIFF
--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -129,6 +129,9 @@ pub trait KeysDatabaseTransaction<'a, Error>: DbTransactionFinalizer<Err = Error
     /// Add Active Keyset
     async fn set_active_keyset(&mut self, unit: CurrencyUnit, id: Id) -> Result<(), Error>;
 
+    /// Deactivate a specific keyset by ID without activating a replacement
+    async fn deactivate_keyset(&mut self, id: Id) -> Result<(), Error>;
+
     /// Add [`MintKeySetInfo`]
     async fn add_keyset_info(&mut self, keyset: MintKeySetInfo) -> Result<(), Error>;
 }

--- a/crates/cdk-integration-tests/tests/mint.rs
+++ b/crates/cdk-integration-tests/tests/mint.rs
@@ -398,3 +398,176 @@ async fn test_rotate_keyset_with_expiry() {
     let active_count = keysets.keysets.iter().filter(|k| k.active).count();
     assert_eq!(active_count, 1, "Exactly one keyset should be active");
 }
+
+/// Test that rebuilding a mint from the same database after deactivating a keyset
+/// does NOT auto-create a replacement keyset. The builder should respect the
+/// deliberate deactivation because inactive keysets exist for that unit.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_builder_respects_deactivation_across_restart() {
+    let mnemonic = Mnemonic::generate(12).unwrap();
+    let fee_reserve = FeeReserve {
+        min_fee_reserve: 1.into(),
+        percent_fee_reserve: 1.0,
+    };
+
+    let database = memory::empty().await.expect("valid db instance");
+
+    let fake_wallet = FakeWallet::new(
+        fee_reserve.clone(),
+        HashMap::default(),
+        HashSet::default(),
+        0,
+        CurrencyUnit::Sat,
+    );
+
+    let localstore = Arc::new(database);
+    let mut mint_builder = MintBuilder::new(localstore.clone());
+
+    mint_builder = mint_builder
+        .with_name("regtest mint".to_string())
+        .with_description("regtest mint".to_string());
+
+    mint_builder
+        .add_payment_processor(
+            CurrencyUnit::Sat,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+            MintMeltLimits::new(1, 5_000),
+            Arc::new(fake_wallet),
+        )
+        .await
+        .unwrap();
+
+    let mint = mint_builder
+        .build_with_seed(localstore.clone(), &mnemonic.to_seed_normalized(""))
+        .await
+        .unwrap();
+
+    // Verify an active Sat keyset exists
+    let active = mint.get_active_keysets();
+    let keyset_id = *active
+        .get(&CurrencyUnit::Sat)
+        .expect("should have active keyset");
+
+    // Deactivate the keyset
+    mint.deactivate_keyset(keyset_id).await.unwrap();
+
+    // Verify no active Sat keyset
+    let active = mint.get_active_keysets();
+    assert!(!active.contains_key(&CurrencyUnit::Sat));
+
+    // Drop the first mint
+    drop(mint);
+
+    // Build a NEW mint from the same localstore (simulates restart)
+    let fake_wallet2 = FakeWallet::new(
+        fee_reserve,
+        HashMap::default(),
+        HashSet::default(),
+        0,
+        CurrencyUnit::Sat,
+    );
+
+    let mut mint_builder2 = MintBuilder::new(localstore.clone());
+
+    mint_builder2 = mint_builder2
+        .with_name("regtest mint".to_string())
+        .with_description("regtest mint".to_string());
+
+    mint_builder2
+        .add_payment_processor(
+            CurrencyUnit::Sat,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+            MintMeltLimits::new(1, 5_000),
+            Arc::new(fake_wallet2),
+        )
+        .await
+        .unwrap();
+
+    let mint2 = mint_builder2
+        .build_with_seed(localstore.clone(), &mnemonic.to_seed_normalized(""))
+        .await
+        .unwrap();
+
+    // The new mint should have NO active Sat keyset
+    let active = mint2.get_active_keysets();
+    assert!(
+        !active.contains_key(&CurrencyUnit::Sat),
+        "Builder should not auto-create a keyset when inactive keysets exist for the unit"
+    );
+
+    // The inactive keyset should still be visible
+    let all_keysets = mint2.keysets();
+    let sat_keysets: Vec<_> = all_keysets
+        .keysets
+        .iter()
+        .filter(|k| k.unit == CurrencyUnit::Sat)
+        .collect();
+    assert_eq!(sat_keysets.len(), 1, "Should have exactly one Sat keyset");
+    assert!(!sat_keysets[0].active, "The Sat keyset should be inactive");
+    assert_eq!(
+        sat_keysets[0].id, keyset_id,
+        "The inactive keyset should be the same one we deactivated"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_deactivate_keyset() {
+    let mnemonic = Mnemonic::generate(12).unwrap();
+    let fee_reserve = FeeReserve {
+        min_fee_reserve: 1.into(),
+        percent_fee_reserve: 1.0,
+    };
+
+    let database = memory::empty().await.expect("valid db instance");
+
+    let fake_wallet = FakeWallet::new(
+        fee_reserve,
+        HashMap::default(),
+        HashSet::default(),
+        0,
+        CurrencyUnit::Sat,
+    );
+
+    let localstore = Arc::new(database);
+    let mut mint_builder = MintBuilder::new(localstore.clone());
+
+    mint_builder = mint_builder
+        .with_name("regtest mint".to_string())
+        .with_description("regtest mint".to_string());
+
+    mint_builder
+        .add_payment_processor(
+            CurrencyUnit::Sat,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+            MintMeltLimits::new(1, 5_000),
+            Arc::new(fake_wallet),
+        )
+        .await
+        .unwrap();
+
+    let mint = mint_builder
+        .build_with_seed(localstore.clone(), &mnemonic.to_seed_normalized(""))
+        .await
+        .unwrap();
+
+    // Verify we start with an active keyset
+    let active = mint.get_active_keysets();
+    let keyset_id = *active
+        .get(&CurrencyUnit::Sat)
+        .expect("should have active keyset");
+
+    // Deactivate by ID
+    mint.deactivate_keyset(keyset_id).await.unwrap();
+
+    // Verify no active keysets
+    let active = mint.get_active_keysets();
+    assert!(!active.contains_key(&CurrencyUnit::Sat));
+
+    // pubkeys endpoint returns empty (no active non-Auth keysets)
+    assert!(mint.pubkeys().keysets.is_empty());
+
+    // keysets endpoint still returns the keyset but marked inactive
+    let all_keysets = mint.keysets();
+    assert!(!all_keysets.keysets.is_empty());
+    assert!(all_keysets.keysets.iter().all(|k| !k.active));
+}

--- a/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
+++ b/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
@@ -102,6 +102,8 @@ enum Commands {
     UpdateNut04QuoteState(subcommands::UpdateNut04QuoteCommand),
     /// Rotate next keyset
     RotateNextKeyset(subcommands::RotateNextKeysetCommand),
+    /// Deactivate a keyset by ID
+    DeactivateKeyset(subcommands::DeactivateKeysetCommand),
 }
 
 #[tokio::main]
@@ -233,6 +235,9 @@ async fn main() -> Result<()> {
         }
         Commands::RotateNextKeyset(sub_command_args) => {
             subcommands::rotate_next_keyset(&mut client, &sub_command_args).await?;
+        }
+        Commands::DeactivateKeyset(sub_command_args) => {
+            subcommands::deactivate_keyset(&mut client, &sub_command_args).await?;
         }
     }
 

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/deactivate_keyset.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/deactivate_keyset.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::Request;
+
+use crate::{DeactivateKeysetRequest, InterceptedCdkMintClient};
+
+/// Command to deactivate a specific keyset by ID
+///
+/// This deactivates the specified keyset without creating a replacement.
+/// The mint will no longer issue new tokens for this keyset.
+/// Existing tokens can still be spent (swapped or melted).
+#[derive(Args, Debug)]
+pub struct DeactivateKeysetCommand {
+    /// The keyset ID to deactivate
+    #[arg(short, long)]
+    id: String,
+}
+
+/// Executes the deactivate_keyset command against the mint server
+pub async fn deactivate_keyset(
+    client: &mut InterceptedCdkMintClient,
+    sub_command_args: &DeactivateKeysetCommand,
+) -> Result<()> {
+    client
+        .deactivate_keyset(Request::new(DeactivateKeysetRequest {
+            id: sub_command_args.id.clone(),
+        }))
+        .await?;
+
+    println!("Deactivated keyset {}", sub_command_args.id);
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
@@ -1,5 +1,7 @@
 //! Subcommands for the mint RPC CLI
 
+/// Module for deactivating a keyset
+mod deactivate_keyset;
 /// Module for rotating to the next keyset
 mod rotate_next_keyset;
 /// Module for updating mint contact information
@@ -25,6 +27,7 @@ mod update_ttl;
 /// Module for managing mint URLs
 mod update_urls;
 
+pub use deactivate_keyset::{deactivate_keyset, DeactivateKeysetCommand};
 pub use rotate_next_keyset::{rotate_next_keyset, RotateNextKeysetCommand};
 pub use update_contact::{add_contact, remove_contact, AddContactCommand, RemoveContactCommand};
 pub use update_icon_url::{update_icon_url, UpdateIconUrlCommand};

--- a/crates/cdk-mint-rpc/src/proto/cdk-mint-rpc.proto
+++ b/crates/cdk-mint-rpc/src/proto/cdk-mint-rpc.proto
@@ -19,6 +19,7 @@ service CdkMint {
     rpc GetQuoteTtl(GetQuoteTtlRequest) returns (GetQuoteTtlResponse) {}
     rpc UpdateNut04Quote(UpdateNut04QuoteRequest) returns (UpdateNut04QuoteRequest) {}
     rpc RotateNextKeyset(RotateNextKeysetRequest) returns (RotateNextKeysetResponse) {}
+    rpc DeactivateKeyset(DeactivateKeysetRequest) returns (UpdateResponse) {}
 }
 
 message GetInfoRequest {
@@ -134,4 +135,8 @@ message RotateNextKeysetResponse {
     string unit = 2;
     repeated uint64 amounts = 3;
     uint64 input_fee_ppk = 4;
+}
+
+message DeactivateKeysetRequest {
+    string id = 1;
 }

--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use cdk::mint::{Mint, MintQuote};
 use cdk::nuts::nut04::MintMethodSettings;
 use cdk::nuts::nut05::MeltMethodSettings;
-use cdk::nuts::{CurrencyUnit, MintQuoteState, PaymentMethod};
+use cdk::nuts::{CurrencyUnit, Id, MintQuoteState, PaymentMethod};
 use cdk::types::QuoteTTL;
 use cdk::Amount;
 use cdk_common::grpc::create_version_check_interceptor;
@@ -20,8 +20,8 @@ use tonic::{Request, Response, Status};
 
 use crate::cdk_mint_server::{CdkMint, CdkMintServer};
 use crate::{
-    ContactInfo, GetInfoRequest, GetInfoResponse, GetQuoteTtlRequest, GetQuoteTtlResponse,
-    RotateNextKeysetRequest, RotateNextKeysetResponse, UpdateContactRequest,
+    ContactInfo, DeactivateKeysetRequest, GetInfoRequest, GetInfoResponse, GetQuoteTtlRequest,
+    GetQuoteTtlResponse, RotateNextKeysetRequest, RotateNextKeysetResponse, UpdateContactRequest,
     UpdateDescriptionRequest, UpdateIconUrlRequest, UpdateMotdRequest, UpdateNameRequest,
     UpdateNut04QuoteRequest, UpdateNut04Request, UpdateNut05Request, UpdateQuoteTtlRequest,
     UpdateResponse, UpdateUrlRequest,
@@ -788,5 +788,23 @@ impl CdkMint for MintRPCServer {
             amounts: keyset_info.amounts,
             input_fee_ppk: keyset_info.input_fee_ppk,
         }))
+    }
+
+    /// Deactivates a specific keyset by ID
+    async fn deactivate_keyset(
+        &self,
+        request: Request<DeactivateKeysetRequest>,
+    ) -> Result<Response<UpdateResponse>, Status> {
+        let request = request.into_inner();
+
+        let id = Id::from_str(&request.id)
+            .map_err(|_| Status::invalid_argument("Invalid keyset id".to_string()))?;
+
+        self.mint
+            .deactivate_keyset(id)
+            .await
+            .map_err(|err| Status::internal(format!("Could not deactivate keyset: {err}")))?;
+
+        Ok(Response::new(UpdateResponse {}))
     }
 }

--- a/crates/cdk-signatory/src/common.rs
+++ b/crates/cdk-signatory/src/common.rs
@@ -30,6 +30,16 @@ pub async fn init_keysets(
     for (unit, keysets) in keysets_by_unit {
         // We only care about units that are supported
         if let Some((input_fee_ppk, amounts)) = supported_units.get(&unit) {
+            // If no keyset is currently active for this unit, the operator
+            // deliberately deactivated it. Respect that and skip reactivation.
+            if !keysets.iter().any(|k| k.active) {
+                tracing::info!(
+                    "No active keyset for unit {}, respecting deliberate deactivation",
+                    unit
+                );
+                continue;
+            }
+
             let mut keysets = keysets;
             keysets.sort_by_key(|b| std::cmp::Reverse(b.derivation_path_index));
 

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -242,6 +242,17 @@ impl Signatory for DbSignatory {
 
         Ok((&(info, keyset)).into())
     }
+
+    #[tracing::instrument(skip(self))]
+    async fn deactivate_keyset(&self, id: Id) -> Result<(), Error> {
+        let mut tx = self.localstore.begin_transaction().await?;
+        tx.deactivate_keyset(id).await?;
+        tx.commit().await?;
+
+        self.reload_keys_from_db().await?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/cdk-signatory/src/embedded.rs
+++ b/crates/cdk-signatory/src/embedded.rs
@@ -2,7 +2,7 @@
 //! run the Signatory in another thread, isolated form the main CDK, communicating through messages
 use std::sync::Arc;
 
-use cdk_common::{BlindSignature, BlindedMessage, Error, Proof};
+use cdk_common::{BlindSignature, BlindedMessage, Error, Id, Proof};
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 
@@ -23,6 +23,7 @@ enum Request {
             oneshot::Sender<Result<SignatoryKeySet, Error>>,
         ),
     ),
+    DeactivateKeyset((Id, oneshot::Sender<Result<(), Error>>)),
 }
 
 /// Creates a service-like to wrap an implementation of the Signatory
@@ -88,6 +89,12 @@ impl Service {
                         tracing::error!("Error sending response: {:?}", err);
                     }
                 }
+                Request::DeactivateKeyset((id, response)) => {
+                    let output = handler.deactivate_keyset(id).await;
+                    if let Err(err) = response.send(output) {
+                        tracing::error!("Error sending response: {:?}", err);
+                    }
+                }
             }
         }
     }
@@ -140,6 +147,17 @@ impl Signatory for Service {
         let (tx, rx) = oneshot::channel();
         self.pipeline
             .send(Request::RotateKeyset((args, tx)))
+            .await
+            .map_err(|e| Error::SendError(e.to_string()))?;
+
+        rx.await.map_err(|e| Error::RecvError(e.to_string()))?
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn deactivate_keyset(&self, id: Id) -> Result<(), Error> {
+        let (tx, rx) = oneshot::channel();
+        self.pipeline
+            .send(Request::DeactivateKeyset((id, tx)))
             .await
             .map_err(|e| Error::SendError(e.to_string()))?;
 

--- a/crates/cdk-signatory/src/proto/client.rs
+++ b/crates/cdk-signatory/src/proto/client.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use cdk_common::error::Error;
 use cdk_common::grpc::{VersionInterceptor, VERSION_SIGNATORY_HEADER};
-use cdk_common::{BlindSignature, BlindedMessage, Proof};
+use cdk_common::{BlindSignature, BlindedMessage, Id, Proof};
 use tonic::codegen::InterceptedService;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
 
@@ -166,6 +166,24 @@ impl Signatory for SignatoryRpcClient {
             .rotate_keyset(tonic::Request::new(req))
             .await
             .map(|response| handle_error!(response, keyset).try_into())
+            .map_err(|e| Error::Custom(e.to_string()))?
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn deactivate_keyset(&self, id: Id) -> Result<(), Error> {
+        self.client
+            .clone()
+            .deactivate_keyset(tonic::Request::new(super::DeactivateKeysetRequest {
+                id: id.to_string(),
+            }))
+            .await
+            .map(|response| {
+                if handle_error!(response, success, scalar) {
+                    Ok(())
+                } else {
+                    Err(Error::Custom("Deactivation failed".to_string()))
+                }
+            })
             .map_err(|e| Error::Custom(e.to_string()))?
     }
 }

--- a/crates/cdk-signatory/src/proto/server.rs
+++ b/crates/cdk-signatory/src/proto/server.rs
@@ -1,9 +1,11 @@
 //! This module contains the generated gRPC server code for the Signatory service.
 use std::net::SocketAddr;
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use cdk_common::grpc::create_version_check_interceptor;
+use cdk_common::Id;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_stream::Stream;
 use tonic::metadata::MetadataMap;
@@ -158,6 +160,29 @@ where
         };
 
         Ok(Response::new(mint_keyset_info))
+    }
+
+    async fn deactivate_keyset(
+        &self,
+        request: Request<proto::DeactivateKeysetRequest>,
+    ) -> Result<Response<proto::BooleanResponse>, Status> {
+        let metadata = request.metadata();
+        let signatory = self.load_signatory(metadata).await?;
+        let id = Id::from_str(&request.into_inner().id)
+            .map_err(|_| Status::invalid_argument("Invalid keyset id"))?;
+
+        let result = match signatory.deactivate_keyset(id).await {
+            Ok(()) => proto::BooleanResponse {
+                success: true,
+                ..Default::default()
+            },
+            Err(err) => proto::BooleanResponse {
+                error: Some(err.into()),
+                ..Default::default()
+            },
+        };
+
+        Ok(Response::new(result))
     }
 }
 

--- a/crates/cdk-signatory/src/proto/signatory.proto
+++ b/crates/cdk-signatory/src/proto/signatory.proto
@@ -9,6 +9,8 @@ service Signatory {
   rpc Keysets(EmptyRequest) returns (KeysResponse);
   // rotates the keysets
   rpc RotateKeyset(RotationRequest) returns (KeyRotationResponse);
+  // deactivates a specific keyset by id
+  rpc DeactivateKeyset(DeactivateKeysetRequest) returns (BooleanResponse);
 }
 
 enum Constants {
@@ -141,6 +143,10 @@ enum ErrorCode {
 message Error {
   ErrorCode code = 1;
   string detail = 2;
+}
+
+message DeactivateKeysetRequest {
+  string id = 1;
 }
 
 message EmptyRequest {}

--- a/crates/cdk-signatory/src/signatory.rs
+++ b/crates/cdk-signatory/src/signatory.rs
@@ -171,4 +171,7 @@ pub trait Signatory {
     /// Add current keyset to inactive keysets
     /// Generate new keyset
     async fn rotate_keyset(&self, args: RotateKeyArguments) -> Result<SignatoryKeySet, Error>;
+
+    /// Deactivate a specific keyset by ID without creating a replacement
+    async fn deactivate_keyset(&self, id: Id) -> Result<(), Error>;
 }

--- a/crates/cdk-sql-common/src/mint/keys.rs
+++ b/crates/cdk-sql-common/src/mint/keys.rs
@@ -127,6 +127,15 @@ where
 
         Ok(())
     }
+
+    async fn deactivate_keyset(&mut self, id: Id) -> Result<(), Error> {
+        query(r#"UPDATE keyset SET active=FALSE WHERE id = :id"#)?
+            .bind("id", id.to_string())
+            .execute(&self.inner)
+            .await?;
+
+        Ok(())
+    }
 }
 
 #[async_trait]

--- a/crates/cdk/src/mint/builder.rs
+++ b/crates/cdk/src/mint/builder.rs
@@ -570,9 +570,23 @@ impl MintBuilder {
                     }
                 }
             } else {
-                // No active keyset for this unit
-                tracing::info!("Rotating keyset for unit {} (no active keyset found)", unit);
-                rotate = true;
+                // No active keyset for this unit. Check if any keyset (active or not) has
+                // ever existed. If inactive keysets exist, this is a deliberate deactivation
+                // and we should respect it. Only auto-create on first-time bootstrap.
+                let unit_has_history = active_keysets.keysets.iter().any(|k| k.unit == *unit);
+
+                if unit_has_history {
+                    tracing::info!(
+                        "No active keyset for unit {}, inactive keysets exist (respecting deliberate deactivation)",
+                        unit
+                    );
+                } else {
+                    tracing::info!(
+                        "No keyset history for unit {}, bootstrapping initial keyset",
+                        unit
+                    );
+                    rotate = true;
+                }
             }
 
             if rotate {

--- a/crates/cdk/src/mint/keysets/mod.rs
+++ b/crates/cdk/src/mint/keysets/mod.rs
@@ -99,4 +99,15 @@ impl Mint {
 
         Ok(result.into())
     }
+
+    /// Deactivate a specific keyset by ID without creating a replacement
+    #[instrument(skip(self))]
+    pub async fn deactivate_keyset(&self, id: Id) -> Result<(), Error> {
+        self.signatory.deactivate_keyset(id).await?;
+
+        let new_keyset = self.signatory.keysets().await?;
+        self.keysets.store(new_keyset.keysets.into());
+
+        Ok(())
+    }
 }

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -150,13 +150,6 @@ impl Mint {
         max_outputs: usize,
     ) -> Result<Self, Error> {
         let keysets = signatory.keysets().await?;
-        if !keysets
-            .keysets
-            .iter()
-            .any(|keyset| keyset.active && keyset.unit != CurrencyUnit::Auth)
-        {
-            return Err(Error::NoActiveKeyset);
-        }
 
         tracing::info!(
             "Using Signatory {} with {} active keys",
@@ -1334,6 +1327,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mint_starts_with_no_active_keysets() {
+        // Empty supported_units means no keysets will be created
+        let supported_units = HashMap::new();
+        let config = MintConfig::<'_> {
+            supported_units,
+            ..Default::default()
+        };
+        // This should NOT error, a mint with no active keysets is valid
+        let mint = create_mint(config).await;
+        assert!(mint.get_active_keysets().is_empty());
+        // pubkeys endpoint returns empty
+        assert!(mint.pubkeys().keysets.is_empty());
+        // keysets endpoint returns empty
+        assert!(mint.keysets().keysets.is_empty());
+    }
+
+    #[tokio::test]
     async fn mint_unit_string_collision() {
         let mut supported_units = HashMap::new();
         let amounts: Vec<u64> = (0..32).map(|i| 2_u64.pow(i as u32)).collect();
@@ -1360,5 +1370,33 @@ mod tests {
             rotation_result,
             Err(Error::UnitStringCollision(_currency_unit))
         ));
+    }
+
+    #[tokio::test]
+    async fn builder_respects_deactivated_keysets() {
+        let mut supported_units = HashMap::new();
+        let amounts: Vec<u64> = (0..32).map(|i| 2u64.pow(i)).collect();
+        supported_units.insert(CurrencyUnit::default(), (0, amounts.clone()));
+
+        let config = MintConfig::<'_> {
+            supported_units: supported_units.clone(),
+            ..Default::default()
+        };
+        let mint = create_mint(config).await;
+
+        // Verify we start with an active keyset
+        let active = mint.get_active_keysets();
+        let keyset_id = *active
+            .get(&CurrencyUnit::default())
+            .expect("should have active keyset");
+        assert!(!active.is_empty());
+
+        // Deactivate the keyset by ID
+        mint.deactivate_keyset(keyset_id)
+            .await
+            .expect("deactivate should work");
+
+        // Verify no active keysets
+        assert!(mint.get_active_keysets().is_empty());
     }
 }


### PR DESCRIPTION
### Description

This is the first phase of #1895. In this PR I make it so that a mint operator can deactivate a keyset by ID and allow the mint to start with no active keysets. The mint will still auto-rotate when no keysets for a unit exist or when the config changes compared to an active keyset. Rotation will not occur only if the keyset was explicitly deactivated.

-----

### Notes to the reviewers

I did this separate from enforcing expiry so that a mint operator can simply deactivate a keyset without an expiry and then leave the mint up until they feel like rugging. I could see an argument for only allowing no active keysets if they were deactivated due to expiry, but imo a mint should be able to run with no active keysets regardless of expiry.

If this is approved, then I will open a followup that adds expiry enforcement by disabling expired keysets and then extending input/output validation to disallow any operations for expired keysets 

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

Keyset rotation no longer happens automatically if keysets are deliberately deactivated

#### ADDED

Ability to deactivate keysets

#### REMOVED

Startup validation that checks for active keysets

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
