### PR TITLE
Adding MacOS builds for releases

### DIFF
--- a/.github/workflows/static-build-publish.yml
+++ b/.github/workflows/static-build-publish.yml
@@ -100,10 +100,64 @@ jobs:
           name: binaries-aarch64
           path: ./static-bin/
 
+  build-macos:
+    name: "Build macOS binaries (${{ matrix.artifact }})"
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            artifact: binaries-macos-aarch64
+          - runner: macos-15-intel
+            artifact: binaries-macos-x86_64
+    timeout-minutes: 120
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v14
+
+      - name: Set up Cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: cashudevkit
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          useDaemon: false
+        continue-on-error: true
+
+      - name: Build cdk-mintd-darwin
+        run: |
+          nix build .#cdk-mintd-darwin -L
+          mkdir -p ./static-bin
+          cp -f ./result/bin/* ./static-bin/
+
+      - name: Build cdk-mintd-ldk-darwin
+        run: |
+          nix build .#cdk-mintd-ldk-darwin -L
+          cp -f ./result/bin/* ./static-bin/
+
+      - name: Build cdk-cli-darwin
+        run: |
+          nix build .#cdk-cli-darwin -L
+          cp -f ./result/bin/* ./static-bin/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ./static-bin/
+
   upload-release:
     name: "Upload binaries to release"
     runs-on: ubuntu-latest
-    needs: [build-x86_64, build-aarch64]
+    needs: [build-x86_64, build-aarch64, build-macos]
     timeout-minutes: 10
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- cdk: GitHub release workflow builds macOS binaries for Apple Silicon and Intel (`aarch64-apple-darwin`, `x86_64-apple-darwin`) (#1804).
+
 ## [0.16.0](https://github.com/cashubtc/cdk/releases/tag/v0.16.0)
 
 ### Summary

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -165,15 +165,25 @@ nix build .#checks.x86_64-linux.cashu
 
 ### Static Binaries
 
-CDK provides fully statically-linked Linux binaries built with [musl](https://musl.libc.org/). These binaries have zero runtime dependencies and run on any x86_64 Linux system.
+CDK publishes **fully statically-linked Linux binaries** built with [musl](https://musl.libc.org/). These have no libc or OpenSSL runtime dependencies and run on x86_64 and aarch64 Linux.
 
-**Available static build targets:**
+GitHub releases also include **macOS binaries** (`*-aarch64-apple-darwin`, `*-x86_64-apple-darwin`) built via Nix as native Mach-O executables. They are intended to run on stock macOS without Nix; system frameworks are linked normally.
+
+**Linux static build targets (musl):**
+
+| Target | Binary (per architecture) | Features |
+| :--- | :--- | :--- |
+| `cdk-mintd-static` | `cdk-mintd-{version}-x86_64`, `cdk-mintd-{version}-aarch64` | `postgres`, `prometheus`, `redis` |
+| `cdk-mintd-ldk-static` | `cdk-mintd-ldk-{version}-x86_64`, `cdk-mintd-ldk-{version}-aarch64` | `ldk-node`, `postgres`, `prometheus`, `redis` |
+| `cdk-cli-static` | `cdk-cli-{version}-x86_64`, `cdk-cli-{version}-aarch64` | default |
+
+**macOS release build targets (build on macOS only):**
 
 | Target | Binary | Features |
 | :--- | :--- | :--- |
-| `cdk-mintd-static` | `cdk-mintd-{version}-x86_64` | `postgres`, `prometheus`, `redis` |
-| `cdk-mintd-ldk-static` | `cdk-mintd-ldk-{version}-x86_64` | `ldk-node`, `postgres`, `prometheus`, `redis` |
-| `cdk-cli-static` | `cdk-cli-{version}-x86_64` | default |
+| `cdk-mintd-darwin` | `cdk-mintd-{version}-aarch64-apple-darwin`, `cdk-mintd-{version}-x86_64-apple-darwin` | same as `cdk-mintd-static` |
+| `cdk-mintd-ldk-darwin` | `cdk-mintd-ldk-{version}-aarch64-apple-darwin`, … | same as `cdk-mintd-ldk-static` |
+| `cdk-cli-darwin` | `cdk-cli-{version}-aarch64-apple-darwin`, … | default |
 
 **Building locally (requires Nix):**
 
@@ -195,11 +205,21 @@ Built binaries are placed in `./static-bin/`.
 
 When a GitHub release is published, the [`static-build-publish.yml`](.github/workflows/static-build-publish.yml) workflow automatically:
 
-1. Builds all three static binaries via Nix
-2. Generates a `SHA256SUMS` file with checksums for each binary
-3. Uploads the binaries and checksums to the GitHub release
+1. Builds the three **Linux musl** binaries on x86_64 and aarch64 (self-hosted / `ubuntu-24.04-arm`)
+2. Builds the three **macOS** binaries on `macos-15` (Apple Silicon) and `macos-15-intel` (x86_64)
+3. Generates a single `SHA256SUMS` file covering every uploaded binary
+4. Uploads all binaries and `SHA256SUMS` to the GitHub release
 
-The workflow can also be triggered manually via `workflow_dispatch` with a tag input. Pre-built static binaries are available on the [GitHub releases page](https://github.com/cashubtc/cdk/releases).
+The workflow can also be triggered manually via `workflow_dispatch` with a tag input (use the same tag as the release). Pre-built binaries are on the [GitHub releases page](https://github.com/cashubtc/cdk/releases).
+
+**If release uploads or macOS jobs fail**, check repository and organization settings:
+
+| Topic | What to check |
+| :--- | :--- |
+| **Actions enabled** | Repository *Settings* → *Actions* → *General*: Actions must be allowed (subject to organization policy). |
+| **`GITHUB_TOKEN` write access** | The workflow sets `permissions: contents: write` on the upload job. If the organization caps workflow permissions at read-only, an admin must allow `contents: write` for workflows. |
+| **Secrets** | `CACHIX_AUTH_TOKEN` is optional; without it, builds are slower but should still succeed. |
+| **macOS Intel runner** | Intel artifacts use `macos-15-intel`. If that job does not start, confirm the org/account can use GitHub-hosted macOS runners (avoid `macos-*-large` unless you intend billable larger runners). |
 
 **Reproducibility:**
 

--- a/crates/cdk-mintd/README.md
+++ b/crates/cdk-mintd/README.md
@@ -29,28 +29,47 @@ For detailed configuration of each Lightning backend, see:
 
 ### Option 1: Download Pre-built Binary
 
-Statically-linked x86_64 Linux binaries are published to each [GitHub release](https://github.com/cashubtc/cdk/releases). These have zero runtime dependencies and run on any x86_64 Linux system.
+Pre-built binaries are published on each [GitHub release](https://github.com/cashubtc/cdk/releases). Replace `{version}` with the release tag (for example `0.16.0` without a leading `v` in the filename—match the assets list for the release you use).
 
-Available binaries:
-- **`cdk-mintd-{version}-x86_64`** -- standard mint with `postgres`, `prometheus`, and `redis` support
-- **`cdk-mintd-ldk-{version}-x86_64`** -- mint with built-in `ldk-node` Lightning backend
+#### Linux (fully static musl)
 
-Each release also includes a `SHA256SUMS` file to verify downloads:
+These run on x86_64 and aarch64 Linux without extra runtime libraries.
+
+| Asset | Description |
+| :--- | :--- |
+| `cdk-mintd-{version}-x86_64` / `cdk-mintd-{version}-aarch64` | Standard mint (`postgres`, `prometheus`, `redis`) |
+| `cdk-mintd-ldk-{version}-x86_64` / `...-aarch64` | Mint with built-in `ldk-node` backend |
 
 ```bash
-# Download the binary and checksums
 curl -LO https://github.com/cashubtc/cdk/releases/latest/download/cdk-mintd-{version}-x86_64
 curl -LO https://github.com/cashubtc/cdk/releases/latest/download/SHA256SUMS
-
-# Verify the checksum
 sha256sum -c SHA256SUMS --ignore-missing
-
-# Make executable and run
 chmod +x cdk-mintd-*-x86_64
 ./cdk-mintd-*-x86_64 --help
 ```
 
-To build static binaries locally, see the [Static Binaries](../../DEVELOPMENT.md#static-binaries) section in the Development Guide.
+#### macOS (native Mach-O)
+
+Apple Silicon and Intel each have their own binary. You do not need Nix installed to run them; they use normal macOS system libraries.
+
+| Asset | Machine |
+| :--- | :--- |
+| `cdk-mintd-{version}-aarch64-apple-darwin` | Apple Silicon (M-series) |
+| `cdk-mintd-{version}-x86_64-apple-darwin` | Intel Mac |
+| `cdk-mintd-ldk-{version}-aarch64-apple-darwin` / `...-x86_64-apple-darwin` | Same with `ldk-node` |
+
+```bash
+# Example: Apple Silicon — pick the asset that matches your Mac
+curl -LO https://github.com/cashubtc/cdk/releases/latest/download/cdk-mintd-{version}-aarch64-apple-darwin
+curl -LO https://github.com/cashubtc/cdk/releases/latest/download/SHA256SUMS
+grep "cdk-mintd-{version}-aarch64-apple-darwin\$" SHA256SUMS | shasum -a 256 -c
+chmod +x cdk-mintd-*-apple-darwin
+./cdk-mintd-*-aarch64-apple-darwin --help
+```
+
+Each release includes a `SHA256SUMS` file listing all published binaries (Linux, macOS, and `cdk-cli`).
+
+To build release-style binaries locally with Nix, see [Static Binaries](../../DEVELOPMENT.md#static-binaries) in the Development Guide.
 
 ### Option 2: Build from Source
 

--- a/flake.nix
+++ b/flake.nix
@@ -1114,7 +1114,7 @@
             cargoExtraArgs = "--bin cdk-cli";
           };
         }
-        # macOS release binary packages (dynamically linked, Apple Silicon only)
+        # macOS release binary packages (dynamically linked; x86_64 and aarch64)
         // lib.optionalAttrs isDarwin {
           cdk-mintd-darwin = mkDarwinPackage {
             bin = "cdk-mintd";


### PR DESCRIPTION
### Description

Aiming to close #1804. The static-build-publish workflow now runs a build-macos job on GitHub-hosted macos-15 (Apple Silicon) and macos-15-intel (x86_64), using Nix to build cdk-mintd-darwin, cdk-mintd-ldk-darwin, and cdk-cli-darwin, and uploads artifacts as binaries-macos-aarch64 and binaries-macos-x86_64. The upload-release job waits on these jobs so published releases include Linux (musl) and macOS assets in one SHA256SUMS upload.

-----

### Notes to the reviewers

- Cachix on macOS uses continue-on-error: true, matching the idea that missing CACHIX_AUTH_TOKEN slows builds but should not fail them;
- Intel artifacts rely on the macos-15-intel label; worth confirming org billing/runner access if that job queues forever;
- CHANGELOG on the branch already includes an Unreleased bullet; the “Suggested CHANGELOG” section below mirrors that for reviewers who prefer the PR template.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED
None
#### ADDED
GitHub release workflow builds macOS binaries for Apple Silicon and Intel (aarch64-apple-darwin, x86_64-apple-darwin) and attaches them to releases alongside existing Linux musl artifacts.
#### REMOVED
None
#### FIXED
None
----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
