### PR TITLE
fix(wallet): persist payment_proof when transitioning melt quote state

### DIFF
--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -964,6 +964,7 @@ impl Wallet {
         }
 
         quote.state = new_state;
+        quote.payment_proof = payment_proof;
 
         match self.localstore.add_melt_quote(quote.clone()).await {
             Ok(_) => Ok(()),
@@ -980,6 +981,7 @@ impl Wallet {
                         .ok_or(Error::UnknownQuote)?;
 
                     fresh_quote.state = new_state;
+                    fresh_quote.payment_proof = quote.payment_proof.clone();
 
                     match self.localstore.add_melt_quote(fresh_quote.clone()).await {
                         Ok(_) => (),


### PR DESCRIPTION
The wallet's update_melt_quote_state() was receiving the payment_proof parameter and forwarding it to add_transaction_for_pending_melt() but never writing it to the persisted quote record. As a result, the proof (lightning preimage / onchain outpoint) was never visible on the quote itself after a successful melt, only in the transaction log.

Assign payment_proof to quote.payment_proof before persistence, and carry it through the ConcurrentUpdate retry path.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
