### PR TITLE
feat(nix): add pre-commit package into nix build inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -760,6 +760,7 @@
           [
             # Add additional build inputs here
             git
+            pre-commit
             pkg-config
             curl
             just


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
Just added the `pre-commit` package in nix environment

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED
- `flake.nix`

#### ADDED
- Add `pre-commit` into nix flake

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
