### PR TITLE
fix: remove state from MintQuoteCustomResponse and update default extra

### DIFF
--- a/crates/cashu/src/nuts/nut04.rs
+++ b/crates/cashu/src/nuts/nut04.rs
@@ -377,6 +377,7 @@ pub struct MintQuoteCustomResponse<Q> {
     /// Currency unit
     pub unit: Option<CurrencyUnit>,
     /// Quote State
+    #[serde(default)]
     pub state: QuoteState,
     /// Unix timestamp until the quote is valid
     pub expiry: Option<u64>,

--- a/crates/cashu/src/nuts/nut04.rs
+++ b/crates/cashu/src/nuts/nut04.rs
@@ -13,7 +13,6 @@ use thiserror::Error;
 
 use super::nut00::{BlindSignature, BlindedMessage, CurrencyUnit, PaymentMethod};
 use crate::nut00::KnownMethod;
-use crate::nut23::QuoteState;
 #[cfg(feature = "mint")]
 use crate::quote_id::QuoteId;
 #[cfg(feature = "mint")]
@@ -350,15 +349,16 @@ pub struct MintQuoteCustomRequest {
 /// ```json
 /// {
 ///   "quote": "abc123",
-///   "state": "UNPAID",
 ///   "amount": 1000,
+///   "amount_paid": 0,
+///   "amount_issued": 0,
 ///   "paypal_link": "https://paypal.me/merchant",
 ///   "paypal_email": "merchant@example.com"
 /// }
 /// ```
 ///
 /// This separation enables proper validation layering: the mint verifies
-/// well-defined fields (amount, unit, state, etc.) while passing extra through
+/// well-defined fields (amount, unit, etc.) while passing extra through
 /// to the gRPC payment processor for method-specific validation.
 ///
 /// It also provides a clean upgrade path: when a payment method becomes speced,
@@ -374,10 +374,12 @@ pub struct MintQuoteCustomResponse<Q> {
     pub request: String,
     /// Amount
     pub amount: Option<Amount>,
+    /// Amount that has been paid
+    pub amount_paid: Amount,
+    /// Amount that has been issued
+    pub amount_issued: Amount,
     /// Currency unit
     pub unit: Option<CurrencyUnit>,
-    /// Quote State
-    pub state: QuoteState,
     /// Unix timestamp until the quote is valid
     pub expiry: Option<u64>,
     /// NUT-19 Pubkey
@@ -404,7 +406,8 @@ impl<Q: ToString> MintQuoteCustomResponse<Q> {
             quote: self.quote.to_string(),
             request: self.request.clone(),
             amount: self.amount,
-            state: self.state,
+            amount_paid: self.amount_paid,
+            amount_issued: self.amount_issued,
             unit: self.unit.clone(),
             expiry: self.expiry,
             pubkey: self.pubkey,
@@ -420,9 +423,10 @@ impl From<MintQuoteCustomResponse<QuoteId>> for MintQuoteCustomResponse<String> 
             quote: value.quote.to_string(),
             request: value.request,
             amount: value.amount,
+            amount_paid: value.amount_paid,
+            amount_issued: value.amount_issued,
             unit: value.unit,
             expiry: value.expiry,
-            state: value.state,
             pubkey: value.pubkey,
             extra: value.extra,
         }
@@ -781,5 +785,27 @@ mod tests {
             }
             _ => panic!("Expected Bolt11 options with description = true"),
         }
+    }
+
+    #[test]
+    fn custom_mint_quote_response_has_no_typed_state() {
+        let response = MintQuoteCustomResponse {
+            quote: "abc123".to_string(),
+            request: "paypal://pay?id=123".to_string(),
+            amount: Some(Amount::from(1000)),
+            amount_paid: Amount::ZERO,
+            amount_issued: Amount::ZERO,
+            unit: Some(CurrencyUnit::Sat),
+            expiry: Some(9999999),
+            pubkey: None,
+            extra: serde_json::Value::Null,
+        };
+
+        let serialized = to_string(&response).unwrap();
+        let parsed: serde_json::Value = from_str(&serialized).unwrap();
+
+        assert!(parsed.get("state").is_none());
+        assert_eq!(parsed["amount_paid"], json!(0));
+        assert_eq!(parsed["amount_issued"], json!(0));
     }
 }

--- a/crates/cashu/src/nuts/nut05.rs
+++ b/crates/cashu/src/nuts/nut05.rs
@@ -478,8 +478,8 @@ pub struct MeltQuoteCustomRequest {
 /// ```
 ///
 /// This separation enables proper validation layering: the mint verifies
-/// well-defined fields (amount, fee_reserve, state, etc.) while passing extra
-/// through to the gRPC payment processor for method-specific validation.
+/// well-defined fields (amount, optional fee_reserve, state, etc.) while
+/// passing extra through to the gRPC payment processor for method-specific validation.
 ///
 /// It also provides a clean upgrade path: when a payment method becomes speced,
 /// its fields can be promoted from `extra` to well-defined struct fields without
@@ -492,8 +492,9 @@ pub struct MeltQuoteCustomResponse<Q> {
     pub quote: Q,
     /// Amount to be melted
     pub amount: Amount,
-    /// Fee reserve required
-    pub fee_reserve: Amount,
+    /// Fee reserve required, if provided
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fee_reserve: Option<Amount>,
     /// Quote State
     pub state: QuoteState,
     /// Unix timestamp until the quote is valid
@@ -621,5 +622,47 @@ mod tests {
             }
             _ => panic!("Expected Bolt11 options with amountless = true"),
         }
+    }
+
+    #[test]
+    fn test_melt_quote_custom_response_fee_reserve_optional() {
+        let json_str = r#"{
+            "quote": "abc123",
+            "state": "UNPAID",
+            "amount": 1000,
+            "expiry": 1234567890,
+            "custom_field": "value"
+        }"#;
+
+        let response: MeltQuoteCustomResponse<String> = from_str(json_str).unwrap();
+
+        assert_eq!(response.fee_reserve, None);
+        assert_eq!(response.extra["custom_field"], json!("value"));
+
+        let serialized = to_string(&response).unwrap();
+        let parsed: serde_json::Value = from_str(&serialized).unwrap();
+
+        assert!(parsed.get("fee_reserve").is_none());
+    }
+
+    #[test]
+    fn test_melt_quote_custom_response_serializes_fee_reserve_when_present() {
+        let response = MeltQuoteCustomResponse {
+            quote: "abc123".to_string(),
+            amount: Amount::from(1000),
+            fee_reserve: Some(Amount::from(10)),
+            state: QuoteState::Unpaid,
+            expiry: 1234567890,
+            payment_preimage: None,
+            change: None,
+            request: None,
+            unit: None,
+            extra: serde_json::Value::Null,
+        };
+
+        let serialized = to_string(&response).unwrap();
+        let parsed: serde_json::Value = from_str(&serialized).unwrap();
+
+        assert_eq!(parsed["fee_reserve"], json!(10));
     }
 }

--- a/crates/cdk-axum/src/custom_handlers.rs
+++ b/crates/cdk-axum/src/custom_handlers.rs
@@ -239,6 +239,7 @@ pub async fn get_check_mint_custom_quote(
                 cdk::mint::MintQuoteResponse::Custom {
                     method: quote_method,
                     response,
+                    ..
                 } => {
                     if quote_method.to_string() != method {
                         return Err(into_response(cdk::Error::InvalidPaymentMethod));

--- a/crates/cdk-common/src/melt.rs
+++ b/crates/cdk-common/src/melt.rs
@@ -109,7 +109,7 @@ impl<Q> MeltQuoteResponse<Q> {
         match self {
             Self::Bolt11(r) => r.fee_reserve,
             Self::Bolt12(r) => r.fee_reserve,
-            Self::Custom((_, r)) => r.fee_reserve,
+            Self::Custom((_, r)) => r.fee_reserve.unwrap_or_default(),
         }
     }
 
@@ -227,7 +227,7 @@ mod tests {
         MeltQuoteCustomResponse {
             quote: quote.to_string(),
             amount: Amount::from(300),
-            fee_reserve: Amount::from(3),
+            fee_reserve: Some(Amount::from(3)),
             state: MeltQuoteState::Paid,
             expiry: 3000,
             payment_preimage: Some("outpoint-abc".to_string()),

--- a/crates/cdk-common/src/mint.rs
+++ b/crates/cdk-common/src/mint.rs
@@ -1094,7 +1094,9 @@ impl TryFrom<MintQuote> for MintQuoteCustomResponse<QuoteId> {
     type Error = Error;
 
     fn try_from(quote: MintQuote) -> Result<Self, Self::Error> {
-        let state = quote.state();
+        let amount_paid = quote.amount_paid().into();
+        let amount_issued = quote.amount_issued().into();
+
         Ok(MintQuoteCustomResponse {
             quote: quote.id,
             request: quote.request,
@@ -1102,7 +1104,8 @@ impl TryFrom<MintQuote> for MintQuoteCustomResponse<QuoteId> {
             expiry: Some(quote.expiry),
             pubkey: quote.pubkey,
             amount: quote.amount.map(Into::into),
-            state,
+            amount_paid,
+            amount_issued,
             extra: quote.extra_json.unwrap_or_default(),
         })
     }
@@ -1127,7 +1130,7 @@ impl From<MeltQuote> for crate::nuts::MeltQuoteCustomResponse<QuoteId> {
         Self {
             quote: melt_quote.id,
             amount: melt_quote.amount.into(),
-            fee_reserve: melt_quote.fee_reserve.into(),
+            fee_reserve: Some(melt_quote.fee_reserve.into()),
             state: melt_quote.state,
             expiry: melt_quote.expiry,
             payment_preimage: melt_quote.payment_proof,
@@ -1178,6 +1181,19 @@ impl TryFrom<MintQuote> for MintQuoteResponse<QuoteId> {
                 method,
                 response: custom_response,
             })
+        }
+    }
+}
+
+impl From<MintQuoteResponse<QuoteId>> for MintQuoteResponse<String> {
+    fn from(response: MintQuoteResponse<QuoteId>) -> Self {
+        match response {
+            MintQuoteResponse::Bolt11(response) => MintQuoteResponse::Bolt11(response.into()),
+            MintQuoteResponse::Bolt12(response) => MintQuoteResponse::Bolt12(response.into()),
+            MintQuoteResponse::Custom { method, response } => MintQuoteResponse::Custom {
+                method,
+                response: response.into(),
+            },
         }
     }
 }
@@ -1320,7 +1336,7 @@ mod tests {
 
         assert_eq!(response.quote, melt_quote.id);
         assert_eq!(response.amount, 100.into());
-        assert_eq!(response.fee_reserve, 2.into());
+        assert_eq!(response.fee_reserve, Some(2.into()));
         assert_eq!(response.state, melt_quote.state);
         assert_eq!(response.expiry, melt_quote.expiry);
         assert_eq!(response.payment_preimage, melt_quote.payment_proof);

--- a/crates/cdk-common/src/mint_quote.rs
+++ b/crates/cdk-common/src/mint_quote.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::nuts::nut00::KnownMethod;
 use crate::nuts::nut04::{MintQuoteCustomRequest, MintQuoteCustomResponse};
-use crate::nuts::nut23::{MintQuoteBolt11Request, MintQuoteBolt11Response};
+use crate::nuts::nut23::{MintQuoteBolt11Request, MintQuoteBolt11Response, QuoteState};
 use crate::nuts::nut25::{MintQuoteBolt12Request, MintQuoteBolt12Response};
 use crate::{Amount, CurrencyUnit, PaymentMethod, PublicKey};
 
@@ -125,20 +125,15 @@ impl<Q> MintQuoteResponse<Q> {
         }
     }
 
-    /// Returns the quote state.
-    pub fn state(&self) -> crate::nuts::nut23::QuoteState {
+    /// Returns the quote state derived from the response data.
+    pub fn state(&self) -> Option<QuoteState> {
         match self {
-            Self::Bolt11(r) => r.state,
-            Self::Bolt12(r) => {
-                if r.amount_issued > Amount::ZERO {
-                    crate::nuts::nut23::QuoteState::Issued
-                } else if r.amount_paid >= r.amount.unwrap_or(Amount::ZERO) {
-                    crate::nuts::nut23::QuoteState::Paid
-                } else {
-                    crate::nuts::nut23::QuoteState::Unpaid
-                }
-            }
-            Self::Custom { response: r, .. } => r.state,
+            Self::Bolt11(r) => Some(r.state),
+            Self::Bolt12(r) => Some(quote_state_from_amounts(r.amount_paid, r.amount_issued)),
+            Self::Custom { response, .. } => Some(quote_state_from_amounts(
+                response.amount_paid,
+                response.amount_issued,
+            )),
         }
     }
 
@@ -149,5 +144,73 @@ impl<Q> MintQuoteResponse<Q> {
             Self::Bolt12(r) => r.expiry,
             Self::Custom { response: r, .. } => r.expiry,
         }
+    }
+}
+
+pub(crate) fn quote_state_from_amounts(amount_paid: Amount, amount_issued: Amount) -> QuoteState {
+    if amount_paid == Amount::ZERO && amount_issued == Amount::ZERO {
+        return QuoteState::Unpaid;
+    }
+
+    match amount_paid.cmp(&amount_issued) {
+        std::cmp::Ordering::Less | std::cmp::Ordering::Equal => QuoteState::Issued,
+        std::cmp::Ordering::Greater => QuoteState::Paid,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn custom_response(amount_paid: Amount, amount_issued: Amount) -> MintQuoteResponse<String> {
+        MintQuoteResponse::Custom {
+            method: PaymentMethod::Custom("custom".to_string()),
+            response: MintQuoteCustomResponse {
+                quote: "quote".to_string(),
+                request: "custom-request".to_string(),
+                amount: Some(Amount::from(100)),
+                amount_paid,
+                amount_issued,
+                unit: Some(CurrencyUnit::Sat),
+                expiry: None,
+                pubkey: None,
+                extra: serde_json::Value::Null,
+            },
+        }
+    }
+
+    #[test]
+    fn custom_state_is_derived_from_amount_counters() {
+        assert_eq!(
+            custom_response(Amount::ZERO, Amount::ZERO).state(),
+            Some(QuoteState::Unpaid)
+        );
+        assert_eq!(
+            custom_response(Amount::from(100), Amount::ZERO).state(),
+            Some(QuoteState::Paid)
+        );
+        assert_eq!(
+            custom_response(Amount::from(100), Amount::from(100)).state(),
+            Some(QuoteState::Issued)
+        );
+    }
+
+    #[test]
+    fn bolt12_state_uses_unissued_amount() {
+        let response = MintQuoteResponse::Bolt12(MintQuoteBolt12Response {
+            quote: "quote".to_string(),
+            request: "bolt12-request".to_string(),
+            amount: Some(Amount::from(100)),
+            unit: CurrencyUnit::Sat,
+            expiry: None,
+            pubkey: PublicKey::from_hex(
+                "02a8cda4cf448bfce9a9e46e588c06ea1780fcb94e3bbdf3277f42995d403a8b0c",
+            )
+            .expect("valid public key"),
+            amount_paid: Amount::from(100),
+            amount_issued: Amount::from(40),
+        });
+
+        assert_eq!(response.state(), Some(QuoteState::Paid));
     }
 }

--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -16,6 +16,7 @@ use cashu::{nut00, PaymentMethod, Proof, Proofs, PublicKey};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::mint_quote::quote_state_from_amounts;
 use crate::mint_url::MintUrl;
 use crate::nuts::{
     CurrencyUnit, Id, MeltQuoteState, MintQuoteState, SecretKey, SpendingConditions, State,
@@ -269,6 +270,16 @@ impl MintQuote {
     /// Calculate the total amount including any fees
     pub fn total_amount(&self) -> Amount {
         self.amount_paid
+    }
+
+    /// Derive quote state from the tracked payment and issuance counters.
+    pub fn state_from_amounts(&self) -> MintQuoteState {
+        quote_state_from_amounts(self.amount_paid, self.amount_issued)
+    }
+
+    /// Update quote state from the tracked payment and issuance counters.
+    pub fn update_state_from_amounts(&mut self) {
+        self.state = self.state_from_amounts();
     }
 
     /// Check if the quote has expired

--- a/crates/cdk-ffi/src/types/quote.rs
+++ b/crates/cdk-ffi/src/types/quote.rs
@@ -177,12 +177,14 @@ pub struct MintQuoteCustomResponse {
     pub quote: String,
     /// Request string
     pub request: String,
-    /// State of the quote
-    pub state: QuoteState,
     /// Expiry timestamp (optional)
     pub expiry: Option<u64>,
     /// Amount (optional)
     pub amount: Option<Amount>,
+    /// Amount paid
+    pub amount_paid: Amount,
+    /// Amount issued
+    pub amount_issued: Amount,
     /// Unit (optional)
     pub unit: Option<CurrencyUnit>,
     /// Pubkey (optional)
@@ -205,9 +207,10 @@ impl From<cdk::nuts::MintQuoteCustomResponse<String>> for MintQuoteCustomRespons
         Self {
             quote: response.quote,
             request: response.request,
-            state: response.state.into(),
             expiry: response.expiry,
             amount: response.amount.map(Into::into),
+            amount_paid: response.amount_paid.into(),
+            amount_issued: response.amount_issued.into(),
             unit: response.unit.map(Into::into),
             pubkey: response.pubkey.map(|p| p.to_string()),
             extra,
@@ -262,7 +265,7 @@ pub struct MeltQuoteCustomResponse {
     /// Amount
     pub amount: Amount,
     /// Fee reserve
-    pub fee_reserve: Amount,
+    pub fee_reserve: Option<Amount>,
     /// State of the quote
     pub state: QuoteState,
     /// Expiry timestamp
@@ -291,7 +294,7 @@ impl From<cdk::nuts::MeltQuoteCustomResponse<String>> for MeltQuoteCustomRespons
         Self {
             quote: response.quote,
             amount: response.amount.into(),
-            fee_reserve: response.fee_reserve.into(),
+            fee_reserve: response.fee_reserve.map(Into::into),
             state: response.state.into(),
             expiry: response.expiry,
             payment_proof: response.payment_preimage,

--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -16,9 +16,8 @@ use cdk::mint::{MintBuilder, MintMeltLimits};
 use cdk::nuts::nut00::ProofsMethods;
 use cdk::nuts::{
     BatchCheckMintQuoteRequest, BatchMintRequest, CheckStateRequest, CheckStateResponse,
-    CurrencyUnit, Id, KeySet, KeysetResponse, MeltRequest, MintInfo, MintQuoteBolt11Response,
-    MintRequest, MintResponse, PaymentMethod, RestoreRequest, RestoreResponse, SwapRequest,
-    SwapResponse,
+    CurrencyUnit, Id, KeySet, KeysetResponse, MeltRequest, MintInfo, MintRequest, MintResponse,
+    PaymentMethod, RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
 };
 use cdk::types::{FeeReserve, QuoteTTL};
 use cdk::util::unix_time;
@@ -158,7 +157,7 @@ impl MintConnector for DirectMintConnection {
         &self,
         _method: &PaymentMethod,
         request: BatchCheckMintQuoteRequest<String>,
-    ) -> Result<Vec<MintQuoteBolt11Response<String>>, Error> {
+    ) -> Result<Vec<MintQuoteResponse<String>>, Error> {
         let quote_ids: Vec<QuoteId> = request
             .quotes
             .iter()

--- a/crates/cdk-payment-processor/src/proto/mod.rs
+++ b/crates/cdk-payment-processor/src/proto/mod.rs
@@ -202,7 +202,7 @@ impl TryFrom<CreatePaymentResponse> for CreateIncomingPaymentResponse {
             request: value.request,
             expiry: value.expiry,
             extra_json: Some(
-                serde_json::from_str(value.extra_json.unwrap_or_default().as_str())
+                serde_json::from_str(value.extra_json.as_deref().unwrap_or("{}"))
                     .unwrap_or_default(),
             ),
         })

--- a/crates/cdk-payment-processor/src/proto/mod.rs
+++ b/crates/cdk-payment-processor/src/proto/mod.rs
@@ -194,7 +194,7 @@ impl TryFrom<CreatePaymentResponse> for CreateIncomingPaymentResponse {
             request: value.request,
             expiry: value.expiry,
             extra_json: Some(
-                serde_json::from_str(value.extra_json.unwrap_or_default().as_str())
+                serde_json::from_str(value.extra_json.as_deref().unwrap_or("{}"))
                     .unwrap_or_default(),
             ),
         })

--- a/crates/cdk/src/wallet/issue/mod.rs
+++ b/crates/cdk/src/wallet/issue/mod.rs
@@ -76,7 +76,7 @@ impl Wallet {
                         unit: unit.clone(),
                         description,
                         pubkey: Some(secret_key.public_key()),
-                        extra: serde_json::from_str(&extra.unwrap_or_default())?,
+                        extra: serde_json::from_str(extra.as_deref().unwrap_or("{}"))?,
                     },
                 }
             }

--- a/crates/cdk/src/wallet/issue/mod.rs
+++ b/crates/cdk/src/wallet/issue/mod.rs
@@ -17,6 +17,35 @@ use crate::wallet::recovery::RecoveryAction;
 use crate::wallet::{MintQuote, MintQuoteState};
 use crate::{Amount, Error, Wallet};
 
+fn apply_mint_quote_response(quote: &mut MintQuote, response: &MintQuoteResponse<String>) {
+    match response {
+        MintQuoteResponse::Bolt11(response) => {
+            quote.state = response.state;
+            match response.state {
+                MintQuoteState::Paid => {
+                    quote.amount_paid = response.amount.unwrap_or_default();
+                }
+                MintQuoteState::Issued => {
+                    let amount = response.amount.unwrap_or_default();
+                    quote.amount_paid = amount;
+                    quote.amount_issued = amount;
+                }
+                MintQuoteState::Unpaid => (),
+            }
+        }
+        MintQuoteResponse::Bolt12(response) => {
+            quote.amount_paid = response.amount_paid;
+            quote.amount_issued = response.amount_issued;
+            quote.update_state_from_amounts();
+        }
+        MintQuoteResponse::Custom { response, .. } => {
+            quote.amount_paid = response.amount_paid;
+            quote.amount_issued = response.amount_issued;
+            quote.update_state_from_amounts();
+        }
+    }
+}
+
 impl Wallet {
     /// Create a mint quote for the given payment method and amount
     #[instrument(skip(self, method))]
@@ -76,7 +105,7 @@ impl Wallet {
                         unit: unit.clone(),
                         description,
                         pubkey: Some(secret_key.public_key()),
-                        extra: serde_json::from_str(&extra.unwrap_or_default())?,
+                        extra: serde_json::from_str(extra.as_deref().unwrap_or("{}"))?,
                     },
                 }
             }
@@ -87,7 +116,7 @@ impl Wallet {
         let request_str = response.request().to_string();
         let expiry = response.expiry();
 
-        let quote = MintQuote::new(
+        let mut quote = MintQuote::new(
             quote_id,
             mint_url,
             method.clone(),
@@ -97,6 +126,7 @@ impl Wallet {
             expiry.unwrap_or(0),
             Some(secret_key),
         );
+        apply_mint_quote_response(&mut quote, &response);
 
         self.localstore.add_mint_quote(quote.clone()).await?;
 
@@ -109,34 +139,7 @@ impl Wallet {
             .client
             .get_mint_quote_status(mint_quote.payment_method.clone(), &mint_quote.id)
             .await?;
-        mint_quote.state = mint_quote_response.state();
-
-        match &mint_quote_response {
-            MintQuoteResponse::Bolt11(response) => match response.state {
-                MintQuoteState::Paid => {
-                    mint_quote.amount_paid = mint_quote.amount.unwrap_or_default();
-                }
-                MintQuoteState::Issued => {
-                    mint_quote.amount_paid = mint_quote.amount.unwrap_or_default();
-                    mint_quote.amount_issued = mint_quote.amount.unwrap_or_default();
-                }
-                MintQuoteState::Unpaid => (),
-            },
-            MintQuoteResponse::Bolt12(response) => {
-                mint_quote.amount_issued = response.amount_issued;
-                mint_quote.amount_paid = response.amount_paid;
-            }
-            MintQuoteResponse::Custom { response, .. } => match response.state {
-                MintQuoteState::Paid => {
-                    mint_quote.amount_paid = response.amount.unwrap_or_default();
-                }
-                MintQuoteState::Issued => {
-                    mint_quote.amount_paid = response.amount.unwrap_or_default();
-                    mint_quote.amount_issued = response.amount.unwrap_or_default();
-                }
-                MintQuoteState::Unpaid => (),
-            },
-        }
+        apply_mint_quote_response(mint_quote, &mint_quote_response);
 
         Ok(())
     }
@@ -419,25 +422,7 @@ impl Wallet {
 
         let quote = match existing_quote {
             Some(mut existing) => {
-                // Update the existing quote with new state
-                existing.state = response.state();
-                match &response {
-                    MintQuoteResponse::Bolt12(r) => {
-                        existing.amount_paid = r.amount_paid;
-                        existing.amount_issued = r.amount_issued;
-                    }
-                    MintQuoteResponse::Bolt11(r) => {
-                        if let Some(amount) = r.amount {
-                            existing.amount_paid = amount;
-                        }
-                    }
-                    MintQuoteResponse::Custom { response: r, .. } => {
-                        if let Some(amount) = r.amount {
-                            existing.amount_paid = amount;
-                            existing.amount_issued = amount;
-                        }
-                    }
-                }
+                apply_mint_quote_response(&mut existing, &response);
                 existing
             }
             None => {
@@ -452,7 +437,7 @@ impl Wallet {
                     MintQuoteResponse::Bolt12(r) => Some(r.unit.clone()),
                     MintQuoteResponse::Custom { response: r, .. } => r.unit.clone(),
                 };
-                MintQuote::new(
+                let mut quote = MintQuote::new(
                     quote_id.to_string(),
                     self.mint_url.clone(),
                     method,
@@ -461,7 +446,9 @@ impl Wallet {
                     response.request().to_string(),
                     response.expiry().unwrap_or(0),
                     None,
-                )
+                );
+                apply_mint_quote_response(&mut quote, &response);
+                quote
             }
         };
 
@@ -516,15 +503,7 @@ impl Wallet {
 
         // Update local quotes with response data
         for (quote, response) in quotes.iter_mut().zip(responses.iter()) {
-            quote.state = response.state;
-            if let Some(amount) = response.amount {
-                if quote.state == MintQuoteState::Issued {
-                    quote.amount_paid = amount;
-                    quote.amount_issued = amount;
-                } else if quote.state == MintQuoteState::Paid {
-                    quote.amount_paid = amount;
-                }
-            }
+            apply_mint_quote_response(quote, response);
             self.localstore.add_mint_quote(quote.clone()).await?;
         }
 

--- a/crates/cdk/src/wallet/melt/custom.rs
+++ b/crates/cdk/src/wallet/melt/custom.rs
@@ -49,7 +49,7 @@ impl Wallet {
             amount: quote_res.amount,
             request: quote_request_str,
             unit: self.unit.clone(),
-            fee_reserve: quote_res.fee_reserve,
+            fee_reserve: quote_res.fee_reserve.unwrap_or_default(),
             state: quote_res.state,
             expiry: quote_res.expiry,
             payment_proof: quote_res.payment_preimage,

--- a/crates/cdk/src/wallet/mint_connector/http_client.rs
+++ b/crates/cdk/src/wallet/mint_connector/http_client.rs
@@ -380,7 +380,7 @@ where
         &self,
         method: &PaymentMethod,
         request: BatchCheckMintQuoteRequest<String>,
-    ) -> Result<Vec<MintQuoteBolt11Response<String>>, Error> {
+    ) -> Result<Vec<MintQuoteResponse<String>>, Error> {
         let url =
             self.mint_url
                 .join_paths(&["v1", "mint", "quote", &method.to_string(), "check"])?;
@@ -389,7 +389,35 @@ where
             .get_auth_token(Method::Post, RoutePath::MintQuote(method.to_string()))
             .await?;
 
-        self.transport.http_post(url, auth_token, &request).await
+        match method {
+            PaymentMethod::Known(KnownMethod::Bolt11) => {
+                let responses: Vec<MintQuoteBolt11Response<String>> =
+                    self.transport.http_post(url, auth_token, &request).await?;
+                Ok(responses
+                    .into_iter()
+                    .map(MintQuoteResponse::Bolt11)
+                    .collect())
+            }
+            PaymentMethod::Known(KnownMethod::Bolt12) => {
+                let responses: Vec<MintQuoteBolt12Response<String>> =
+                    self.transport.http_post(url, auth_token, &request).await?;
+                Ok(responses
+                    .into_iter()
+                    .map(MintQuoteResponse::Bolt12)
+                    .collect())
+            }
+            PaymentMethod::Custom(method_name) => {
+                let responses: Vec<MintQuoteCustomResponse<String>> =
+                    self.transport.http_post(url, auth_token, &request).await?;
+                Ok(responses
+                    .into_iter()
+                    .map(|response| MintQuoteResponse::Custom {
+                        method: PaymentMethod::Custom(method_name.clone()),
+                        response,
+                    })
+                    .collect())
+            }
+        }
     }
 
     /// Batch mint tokens [NUT-29]
@@ -716,6 +744,7 @@ mod tests {
     use std::sync::Mutex;
 
     use async_trait::async_trait;
+    use cdk_common::MintQuoteState;
     use serde::de::DeserializeOwned;
 
     use super::*;
@@ -730,6 +759,8 @@ mod tests {
         captured_payload: Arc<Mutex<Option<serde_json::Value>>>,
         /// Canned JSON string returned by `http_post`.
         post_response: Arc<Mutex<Option<String>>>,
+        /// Canned JSON string returned by `http_get`.
+        get_response: Arc<Mutex<Option<String>>>,
     }
 
     impl fmt::Debug for MockTransport {
@@ -759,7 +790,13 @@ mod tests {
         where
             R: DeserializeOwned,
         {
-            unimplemented!()
+            let json = self
+                .get_response
+                .lock()
+                .expect("lock")
+                .clone()
+                .expect("no mock response set");
+            serde_json::from_str(&json).map_err(|e| Error::Custom(e.to_string()))
         }
 
         async fn http_post<P, R>(
@@ -793,15 +830,14 @@ mod tests {
     /// serializes as a JSON array.
     #[tokio::test]
     async fn test_post_mint_quote_custom_sends_request_object() {
-        use cdk_common::nuts::nut23::QuoteState;
-
         // Build a canned MintQuoteCustomResponse<String> for the mock
         let canned_response = MintQuoteCustomResponse::<String> {
             quote: "test-quote-id".to_string(),
             request: "paypal://pay?id=123".to_string(),
             amount: Some(cdk_common::Amount::from(1000)),
+            amount_paid: cdk_common::Amount::ZERO,
+            amount_issued: cdk_common::Amount::ZERO,
             unit: Some(cdk_common::CurrencyUnit::Sat),
-            state: QuoteState::Unpaid,
             expiry: Some(9999999),
             pubkey: None,
             extra: serde_json::Value::Null,
@@ -811,6 +847,7 @@ mod tests {
         let transport = MockTransport {
             captured_payload: Arc::new(Mutex::new(None)),
             post_response: Arc::new(Mutex::new(Some(canned_json))),
+            get_response: Arc::new(Mutex::new(None)),
         };
         let captured = transport.captured_payload.clone();
 
@@ -858,5 +895,75 @@ mod tests {
         let parsed = parsed.expect("already checked");
         assert_eq!(parsed.amount, cdk_common::Amount::from(1000));
         assert_eq!(parsed.unit, cdk_common::CurrencyUnit::Sat);
+    }
+
+    #[tokio::test]
+    async fn test_get_mint_quote_custom_derives_state_from_amounts() {
+        let canned_json = serde_json::json!({
+            "quote": "test-quote-id",
+            "request": "paypal://pay?id=123",
+            "amount": 1000,
+            "amount_paid": 1000,
+            "amount_issued": 0,
+            "unit": "sat"
+        })
+        .to_string();
+
+        let transport = MockTransport {
+            get_response: Arc::new(Mutex::new(Some(canned_json))),
+            ..Default::default()
+        };
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let client = HttpClient::with_transport(mint_url, transport, None);
+
+        let response = client
+            .get_mint_quote_status(PaymentMethod::Custom("paypal".to_string()), "test-quote-id")
+            .await
+            .expect("custom quote status");
+
+        assert_eq!(response.state(), Some(MintQuoteState::Paid));
+        match response {
+            MintQuoteResponse::Custom { response, .. } => {
+                assert_eq!(response.amount_paid, cdk_common::Amount::from(1000));
+                assert_eq!(response.amount_issued, cdk_common::Amount::ZERO);
+            }
+            _ => panic!("expected custom response"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_batch_check_mint_quote_custom_parses_custom_responses() {
+        let canned_json = serde_json::json!([
+            {
+                "quote": "test-quote-id",
+                "request": "paypal://pay?id=123",
+                "amount": 1000,
+                "amount_paid": 1000,
+                "amount_issued": 1000,
+                "unit": "sat"
+            }
+        ])
+        .to_string();
+
+        let transport = MockTransport {
+            post_response: Arc::new(Mutex::new(Some(canned_json))),
+            ..Default::default()
+        };
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let client = HttpClient::with_transport(mint_url, transport, None);
+
+        let responses = client
+            .post_batch_check_mint_quote_status(
+                &PaymentMethod::Custom("paypal".to_string()),
+                BatchCheckMintQuoteRequest {
+                    quotes: vec!["test-quote-id".to_string()],
+                },
+            )
+            .await
+            .expect("custom batch quote status");
+
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0].state(), Some(MintQuoteState::Issued));
+        assert!(matches!(responses[0], MintQuoteResponse::Custom { .. }));
     }
 }

--- a/crates/cdk/src/wallet/mint_connector/mod.rs
+++ b/crates/cdk/src/wallet/mint_connector/mod.rs
@@ -13,8 +13,8 @@ use super::Error;
 pub use crate::lightning_address::{LnurlPayInvoiceResponse, LnurlPayResponse};
 use crate::nuts::{
     BatchCheckMintQuoteRequest, BatchMintRequest, CheckStateRequest, CheckStateResponse, Id,
-    KeySet, KeysetResponse, MeltRequest, MintInfo, MintQuoteBolt11Response, MintRequest,
-    MintResponse, PaymentMethod, RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
+    KeySet, KeysetResponse, MeltRequest, MintInfo, MintRequest, MintResponse, PaymentMethod,
+    RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
 };
 use crate::wallet::AuthWallet;
 
@@ -70,13 +70,11 @@ pub trait MintConnector: Debug {
     /// Batch check mint quote status [NUT-29]
     ///
     /// Checks the status of multiple mint quotes in a single request.
-    /// The response type is `Vec<MintQuoteBolt11Response>` for bolt11 quotes.
-    /// For other payment methods, the response is method-specific.
     async fn post_batch_check_mint_quote_status(
         &self,
         method: &PaymentMethod,
         request: BatchCheckMintQuoteRequest<String>,
-    ) -> Result<Vec<MintQuoteBolt11Response<String>>, Error>;
+    ) -> Result<Vec<MintQuoteResponse<String>>, Error>;
 
     /// Batch mint tokens [NUT-29]
     ///

--- a/crates/cdk/src/wallet/subscription.rs
+++ b/crates/cdk/src/wallet/subscription.rs
@@ -716,7 +716,8 @@ mod tests {
             "request": "custom-request",
             "amount": 42,
             "unit": "sat",
-            "state": "UNPAID",
+            "amount_paid": 0,
+            "amount_issued": 0,
             "expiry": 1234,
             "pubkey": null,
             "extra_field": "value"

--- a/crates/cdk/src/wallet/test_utils.rs
+++ b/crates/cdk/src/wallet/test_utils.rs
@@ -23,8 +23,7 @@ use cdk_common::{
 
 use crate::nuts::{
     nut17, nut19, BatchCheckMintQuoteRequest, BatchMintRequest, MeltQuoteBolt11Response,
-    MeltQuoteState, MintQuoteBolt11Response, NUT04Settings, NUT05Settings, PaymentMethod,
-    SecretKey, State,
+    MeltQuoteState, NUT04Settings, NUT05Settings, PaymentMethod, SecretKey, State,
 };
 use crate::secret::Secret;
 use crate::wallet::{MintConnector, Wallet};
@@ -717,7 +716,7 @@ impl MintConnector for MockMintConnector {
         &self,
         _method: &PaymentMethod,
         _request: BatchCheckMintQuoteRequest<String>,
-    ) -> Result<Vec<MintQuoteBolt11Response<String>>, Error> {
+    ) -> Result<Vec<MintQuoteResponse<String>>, Error> {
         unimplemented!()
     }
 


### PR DESCRIPTION
… quote

- Add #[serde(default)] to MintQuoteCustomResponse::state so mints that omit the field (returning amount_paid/amount_issued instead) deserialize correctly, defaulting to QuoteState::Unpaid instead of failing
- Replace extra.unwrap_or_default() (empty string) with extra.as_deref().unwrap_or("{}") in wallet/issue and cdk-payment-processor so serde_json::from_str never receives an empty string, which caused an EOF parse error when extra was None

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
