### PR TITLE
chore: update Rust to 1.95.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -143,11 +143,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776309239,
-        "narHash": "sha256-XzTecca59093jBsVAE4PVAMcJO+PAYHYHBPRnOR8iWs=",
+        "lastModified": 1776827647,
+        "narHash": "sha256-sYixYhp5V8jCajO8TRorE4fzs7IkL4MZdfLTKgkPQBk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3717ee024da7b0a20744f12c39b41e27cbc12f2d",
+        "rev": "40e6ccc06e1245a4837cbbd6bdda64e21cc67379",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,7 @@
 
         # Toolchains
         # latest stable
-        stable_toolchain = pkgs.rust-bin.stable."1.94.1".default.override {
+        stable_toolchain = pkgs.rust-bin.stable."1.95.0".default.override {
           targets = [
             "wasm32-unknown-unknown"
             "aarch64-apple-ios"
@@ -169,7 +169,7 @@
         # Stable toolchain with musl target for static builds (Linux only)
         static_toolchain =
           if muslTarget != null then
-            pkgs.rust-bin.stable."1.94.0".default.override
+            pkgs.rust-bin.stable."1.95.0".default.override
               {
                 targets = [ muslTarget ];
               }

--- a/justfile
+++ b/justfile
@@ -421,7 +421,7 @@ update-msrv-lock:
 
     nix develop --ignore-environment .#stable --command bash -c '
         cargo update
-        echo "Updated Cargo.lock (stable 1.94.0)"
+        echo "Updated Cargo.lock (stable 1.95.0)"
     '
 
 itest db:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 
 targets = [


### PR DESCRIPTION
### Description

Bumps the Rust toolchain from 1.94.1 to 1.95.0, as tracked in issue #1912.

Changes:
- rust-toolchain.toml: channel 1.94.1 -> 1.95.0
- flake.nix: stable_toolchain (1.94.1) and static_toolchain (1.94.0) -> 1.95.0
- flake.lock: rust-overlay input updated via nix flake lock --update-input rust-overlay
-  justfile: update stale echo message in update-msrv-lock recipe to reference 1.95.0

Closes #1912
-----

### Notes to the reviewers

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

- Updated Rust toolchain from 1.94.1 to 1.95.0.

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
