### PR TITLE
fix(wallet): auto-release reserved proofs when melt confirm fails

### DIFF
--- a/crates/cdk-integration-tests/tests/fake_wallet.rs
+++ b/crates/cdk-integration-tests/tests/fake_wallet.rs
@@ -1819,13 +1819,11 @@ async fn test_fake_mint_duplicate_proofs_melt() {
     }
 }
 
-/// Regression test for cashubtc/cdk#1891.
-///
 /// Exercises the chained `prepare_melt(...).await?.confirm().await?` pattern
-/// that forced consumers to reach for `check_all_pending_proofs()` when the
-/// melt failed. After the fix, confirm() must auto-release reserved proofs on
-/// any failure path, so balance should be fully recovered without any
-/// explicit recovery call.
+/// that used to force consumers to reach for `check_all_pending_proofs()` when
+/// the melt failed. confirm() must auto-release reserved proofs on any failure
+/// path, so balance should be fully recovered without any explicit recovery
+/// call.
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_chained_confirm_auto_releases_proofs_on_failure() {
     let wallet = Wallet::new(

--- a/crates/cdk-integration-tests/tests/fake_wallet.rs
+++ b/crates/cdk-integration-tests/tests/fake_wallet.rs
@@ -1819,6 +1819,79 @@ async fn test_fake_mint_duplicate_proofs_melt() {
     }
 }
 
+/// Regression test for cashubtc/cdk#1891.
+///
+/// Exercises the chained `prepare_melt(...).await?.confirm().await?` pattern
+/// that forced consumers to reach for `check_all_pending_proofs()` when the
+/// melt failed. After the fix, confirm() must auto-release reserved proofs on
+/// any failure path, so balance should be fully recovered without any
+/// explicit recovery call.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_chained_confirm_auto_releases_proofs_on_failure() {
+    let wallet = Wallet::new(
+        MINT_URL,
+        CurrencyUnit::Sat,
+        Arc::new(memory::empty().await.unwrap()),
+        Mnemonic::generate(12).unwrap().to_seed_normalized(""),
+        None,
+    )
+    .expect("failed to create new wallet");
+
+    // Mint 100 sats
+    let mint_quote = wallet
+        .mint_quote(PaymentMethod::BOLT11, Some(100.into()), None, None)
+        .await
+        .unwrap();
+    let mut proof_streams = wallet.proof_stream(mint_quote.clone(), SplitTarget::default(), None);
+    proof_streams
+        .next()
+        .await
+        .expect("payment")
+        .expect("no error");
+
+    assert_eq!(wallet.total_balance().await.unwrap(), Amount::from(100));
+
+    let fake_description = FakeInvoiceDescription {
+        pay_invoice_state: MeltQuoteState::Failed,
+        check_payment_state: MeltQuoteState::Failed,
+        pay_err: false,
+        check_err: false,
+    };
+    let invoice = create_fake_invoice(1000, serde_json::to_string(&fake_description).unwrap());
+    let melt_quote = wallet
+        .melt_quote(PaymentMethod::BOLT11, invoice.to_string(), None, None)
+        .await
+        .unwrap();
+
+    // Chained pattern: if confirm fails, PreparedMelt is consumed and there is
+    // no handle to cancel. Auto-compensation must still run inside confirm().
+    let melt_result = wallet
+        .prepare_melt(&melt_quote.id, std::collections::HashMap::new())
+        .await
+        .unwrap()
+        .confirm()
+        .await;
+    assert!(melt_result.is_err(), "Melt should fail on Failed state");
+
+    // Do NOT call check_all_pending_proofs here — the whole point is that the
+    // wallet self-heals so consumers don't need to.
+    let pending = wallet
+        .localstore
+        .get_proofs(None, None, Some(vec![State::Pending]), None)
+        .await
+        .unwrap();
+    assert!(
+        pending.is_empty(),
+        "no proofs should remain Pending after auto-compensation"
+    );
+
+    assert_eq!(
+        wallet.total_balance().await.unwrap(),
+        Amount::from(100),
+        "balance should be fully recovered without explicit recovery calls"
+    );
+}
+
 /// Tests that wallet automatically recovers proofs after a failed melt operation
 /// by swapping them to new proofs, preventing loss of funds
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -85,21 +85,22 @@ impl<'a> PendingMelt<'a> {
     async fn wait(self) -> Result<FinalizedMelt, Error> {
         let quote_id = self.saga.quote().id.clone();
         let wallet = self.saga.wallet;
+        let operation_id = self.saga.state_data.operation_id;
 
-        let mut subscription = match self.saga.quote().payment_method {
+        let subscribe_result = match self.saga.quote().payment_method {
             PaymentMethod::Known(KnownMethod::Bolt11) => {
                 wallet
                     .subscribe(WalletSubscription::Bolt11MeltQuoteState(vec![
                         quote_id.clone()
                     ]))
-                    .await?
+                    .await
             }
             PaymentMethod::Known(KnownMethod::Bolt12) => {
                 wallet
                     .subscribe(WalletSubscription::Bolt12MeltQuoteState(vec![
                         quote_id.clone()
                     ]))
-                    .await?
+                    .await
             }
             PaymentMethod::Custom(ref method) => {
                 wallet
@@ -107,7 +108,16 @@ impl<'a> PendingMelt<'a> {
                         method.to_string(),
                         vec![quote_id.clone()],
                     ))
-                    .await?
+                    .await
+            }
+        };
+
+        let mut subscription = match subscribe_result {
+            Ok(s) => s,
+            Err(err) => {
+                return wallet
+                    .compensate_failed_melt_confirm(operation_id, err)
+                    .await;
             }
         };
 
@@ -177,19 +187,27 @@ impl<'a> PendingMelt<'a> {
                                 change
                             };
 
-                            let finalized = self
+                            match self
                                 .saga
                                 .finalize(state, payment_proof, change, self.metadata)
-                                .await?;
-
-                            return Ok(FinalizedMelt::new(
-                                finalized.quote_id().to_string(),
-                                finalized.state(),
-                                finalized.payment_proof().map(|s| s.to_string()),
-                                finalized.amount(),
-                                finalized.fee_paid(),
-                                finalized.into_change(),
-                            ));
+                                .await
+                            {
+                                Ok(finalized) => {
+                                    return Ok(FinalizedMelt::new(
+                                        finalized.quote_id().to_string(),
+                                        finalized.state(),
+                                        finalized.payment_proof().map(|s| s.to_string()),
+                                        finalized.amount(),
+                                        finalized.fee_paid(),
+                                        finalized.into_change(),
+                                    ));
+                                }
+                                Err(err) => {
+                                    return wallet
+                                        .compensate_failed_melt_confirm(operation_id, err)
+                                        .await;
+                                }
+                            }
                         }
                         MeltQuoteState::Failed
                         | MeltQuoteState::Unpaid
@@ -201,7 +219,10 @@ impl<'a> PendingMelt<'a> {
                     }
                 }
                 None => {
-                    return Err(Error::Custom("Subscription closed".to_string()));
+                    let err = Error::Custom("Subscription closed".to_string());
+                    return wallet
+                        .compensate_failed_melt_confirm(operation_id, err)
+                        .await;
                 }
             }
         }
@@ -287,7 +308,7 @@ impl MeltConfirmOptions {
 }
 
 /// A prepared melt operation that can be confirmed or cancelled.
-#[must_use = "must be confirmed or canceled to release reserved proofs"]
+#[must_use = "must be confirmed or canceled; confirm auto-releases reserved proofs on failure"]
 pub struct PreparedMelt<'a> {
     /// The saga in the Prepared state
     saga: MeltSaga<'a, Prepared>,
@@ -413,14 +434,21 @@ impl<'a> PreparedMelt<'a> {
     /// This method waits for the payment to complete and returns the finalized melt.
     /// If the mint supports async payments (NUT-05), this may complete faster by
     /// not blocking on the payment processing.
+    ///
+    /// If the confirm fails, this method automatically runs saga compensation so
+    /// reserved proofs do not stay stuck in `Pending`. Compensation consults the
+    /// mint to avoid reverting proofs the mint already spent. See
+    /// [`Wallet::resume_melt_saga`].
     pub async fn confirm_with_options(
         self,
         options: MeltConfirmOptions,
     ) -> Result<FinalizedMelt, Error> {
-        self.saga
-            .wallet
+        let operation_id = self.saga.operation_id();
+        let wallet = self.saga.wallet;
+
+        let result = wallet
             .confirm_prepared_melt_with_options(
-                self.saga.operation_id(),
+                operation_id,
                 self.saga.quote().clone(),
                 self.saga.proofs().clone(),
                 self.saga.proofs_to_swap().clone(),
@@ -429,7 +457,12 @@ impl<'a> PreparedMelt<'a> {
                 self.metadata,
                 options,
             )
-            .await
+            .await;
+
+        match result {
+            Ok(finalized) => Ok(finalized),
+            Err(err) => wallet.compensate_failed_melt_confirm(operation_id, err).await,
+        }
     }
 
     /// Confirm the prepared melt using async support (NUT-05).
@@ -504,13 +537,43 @@ impl<'a> PreparedMelt<'a> {
     /// Note: This waits for the mint's initial response, which may block if the mint
     /// does not support async payments. Only returns `Pending` if the mint explicitly
     /// supports and accepts async melt requests.
+    ///
+    /// If the confirm fails before returning a `MeltOutcome`, this method
+    /// automatically runs saga compensation so reserved proofs do not stay
+    /// stuck in `Pending`. See [`Wallet::resume_melt_saga`].
     pub async fn confirm_prefer_async_with_options(
         self,
         options: MeltConfirmOptions,
     ) -> Result<MeltOutcome<'a>, Error> {
-        let melt_requested = self.saga.request_melt_with_options(options).await?;
+        let operation_id = self.saga.operation_id();
+        let wallet = self.saga.wallet;
+        let metadata = self.metadata;
 
-        let result = melt_requested.execute_async(self.metadata.clone()).await?;
+        let melt_requested = match self.saga.request_melt_with_options(options).await {
+            Ok(r) => r,
+            Err(err) => {
+                let recovered = wallet
+                    .compensate_failed_melt_confirm(operation_id, err)
+                    .await;
+                return match recovered {
+                    Ok(finalized) => Ok(MeltOutcome::Paid(finalized)),
+                    Err(e) => Err(e),
+                };
+            }
+        };
+
+        let result = match melt_requested.execute_async(metadata.clone()).await {
+            Ok(r) => r,
+            Err(err) => {
+                let recovered = wallet
+                    .compensate_failed_melt_confirm(operation_id, err)
+                    .await;
+                return match recovered {
+                    Ok(finalized) => Ok(MeltOutcome::Paid(finalized)),
+                    Err(e) => Err(e),
+                };
+            }
+        };
 
         match result {
             MeltSagaResult::Finalized(finalized) => Ok(MeltOutcome::Paid(FinalizedMelt::new(
@@ -523,7 +586,7 @@ impl<'a> PreparedMelt<'a> {
             ))),
             MeltSagaResult::Pending(pending_saga) => Ok(MeltOutcome::Pending(PendingMelt {
                 saga: pending_saga,
-                metadata: self.metadata,
+                metadata,
             })),
         }
     }
@@ -716,6 +779,59 @@ impl Wallet {
         }
     }
 
+    /// Run saga compensation after a failed melt confirm.
+    ///
+    /// Looks up the saga by `operation_id` and delegates to
+    /// [`Wallet::resume_melt_saga`], which safely handles every saga state
+    /// (`ProofsReserved`, `MeltRequested`, `PaymentPending`) by consulting the
+    /// mint when needed so proofs the mint already spent are not reverted.
+    ///
+    /// If resume determines the payment actually completed (state `Paid`), the
+    /// recovered [`FinalizedMelt`] is returned as `Ok` so the caller sees the
+    /// success. In every other case (`Unpaid`/`Failed`/`Pending`, saga missing,
+    /// or cleanup error) the original error is propagated.
+    ///
+    /// Note: when a `Paid` state is recovered here, no `Transaction` record is
+    /// emitted (that is a side-effect of `finalize_melt_common` and is skipped
+    /// on this rare path). Callers that reconcile transaction history may need
+    /// to call `check_melt_quote_status` or `finalize_pending_melts` afterwards.
+    #[instrument(skip(self))]
+    async fn compensate_failed_melt_confirm(
+        &self,
+        operation_id: Uuid,
+        original_err: Error,
+    ) -> Result<FinalizedMelt, Error> {
+        match self.localstore.get_saga(&operation_id).await {
+            Ok(Some(saga)) => match self.resume_melt_saga(&saga).await {
+                Ok(Some(finalized)) if finalized.state() == MeltQuoteState::Paid => {
+                    tracing::info!(
+                        "Melt operation {} recovered to Paid after confirm error",
+                        operation_id
+                    );
+                    Ok(finalized)
+                }
+                Ok(_) => Err(original_err),
+                Err(cleanup_err) => {
+                    tracing::warn!(
+                        "Melt compensation failed for operation {} after confirm error: {}",
+                        operation_id,
+                        cleanup_err
+                    );
+                    Err(original_err)
+                }
+            },
+            Ok(None) => Err(original_err),
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to look up saga {} for compensation: {}",
+                    operation_id,
+                    e
+                );
+                Err(original_err)
+            }
+        }
+    }
+
     /// Internal method called by `PreparedMelt::cancel` with cached data.
     ///
     /// Not intended for direct use - use [`PreparedMelt::cancel`] instead.
@@ -733,9 +849,20 @@ impl Wallet {
         all_ys.extend(proofs_to_swap.ys()?);
 
         if !all_ys.is_empty() {
-            self.localstore
-                .update_proofs_state(all_ys, State::Unspent)
-                .await?;
+            // Fetch current states to avoid reverting proofs that were already
+            // spent (e.g. by a successful internal swap before this cancel).
+            let current = self.localstore.get_proofs_by_ys(all_ys).await?;
+            let ys_to_revert: Vec<_> = current
+                .into_iter()
+                .filter(|p| p.state == State::Reserved || p.state == State::Pending)
+                .map(|p| p.y)
+                .collect();
+
+            if !ys_to_revert.is_empty() {
+                self.localstore
+                    .update_proofs_state(ys_to_revert, State::Unspent)
+                    .await?;
+            }
         }
 
         if let Err(e) = self.localstore.release_melt_quote(&operation_id).await {
@@ -1152,5 +1279,150 @@ impl Wallet {
         };
 
         Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use cdk_common::nuts::State;
+
+    use crate::wallet::saga::test_utils::{
+        create_test_db, test_keyset_id, test_mint_url, test_proof_info,
+    };
+    use crate::wallet::test_utils::{create_test_wallet_with_mock, MockMintConnector};
+
+    /// cancel_prepared_melt should revert Reserved proofs to Unspent.
+    #[tokio::test]
+    async fn test_cancel_prepared_melt_reverts_reserved_proofs() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let operation_id = uuid::Uuid::new_v4();
+
+        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Reserved);
+        let proof_y = proof_info.y;
+        let proof = proof_info.proof.clone();
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        wallet
+            .cancel_prepared_melt(operation_id, vec![proof], vec![])
+            .await
+            .unwrap();
+
+        let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].state, State::Unspent);
+    }
+
+    /// cancel_prepared_melt should revert Pending proofs to Unspent.
+    #[tokio::test]
+    async fn test_cancel_prepared_melt_reverts_pending_proofs() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let operation_id = uuid::Uuid::new_v4();
+
+        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Pending);
+        let proof_y = proof_info.y;
+        let proof = proof_info.proof.clone();
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        wallet
+            .cancel_prepared_melt(operation_id, vec![proof], vec![])
+            .await
+            .unwrap();
+
+        let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].state, State::Unspent);
+    }
+
+    /// cancel_prepared_melt must NOT revert proofs that are already Spent.
+    /// This matters after a swap step has already consumed the originals:
+    /// reverting them to Unspent would cause the wallet to believe it holds
+    /// funds the mint already spent, leading to double-spend attempts.
+    #[tokio::test]
+    async fn test_cancel_prepared_melt_preserves_spent_proofs() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let operation_id = uuid::Uuid::new_v4();
+
+        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Spent);
+        let proof_y = proof_info.y;
+        let proof = proof_info.proof.clone();
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        // Pass the already-Spent proofs in the proofs_to_swap slot (mimicking
+        // the post-swap case where originals moved to Spent).
+        wallet
+            .cancel_prepared_melt(operation_id, vec![], vec![proof])
+            .await
+            .unwrap();
+
+        let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(
+            stored[0].state,
+            State::Spent,
+            "Spent proofs must not be reverted by cancel"
+        );
+    }
+
+    /// Mixed states: Reserved and Pending get reverted; Spent is preserved.
+    #[tokio::test]
+    async fn test_cancel_prepared_melt_mixed_states_only_reverts_reserved_and_pending() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let operation_id = uuid::Uuid::new_v4();
+
+        let reserved = test_proof_info(keyset_id, 100, mint_url.clone(), State::Reserved);
+        let pending = test_proof_info(keyset_id, 200, mint_url.clone(), State::Pending);
+        let spent = test_proof_info(keyset_id, 300, mint_url.clone(), State::Spent);
+
+        let reserved_y = reserved.y;
+        let pending_y = pending.y;
+        let spent_y = spent.y;
+
+        let reserved_proof = reserved.proof.clone();
+        let pending_proof = pending.proof.clone();
+        let spent_proof = spent.proof.clone();
+
+        db.update_proofs(vec![reserved, pending, spent], vec![])
+            .await
+            .unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        wallet
+            .cancel_prepared_melt(
+                operation_id,
+                vec![reserved_proof, pending_proof],
+                vec![spent_proof],
+            )
+            .await
+            .unwrap();
+
+        let stored = db
+            .get_proofs_by_ys(vec![reserved_y, pending_y, spent_y])
+            .await
+            .unwrap();
+        let state_for = |y| stored.iter().find(|p| p.y == y).map(|p| p.state);
+        assert_eq!(state_for(reserved_y), Some(State::Unspent));
+        assert_eq!(state_for(pending_y), Some(State::Unspent));
+        assert_eq!(state_for(spent_y), Some(State::Spent));
     }
 }

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -461,7 +461,11 @@ impl<'a> PreparedMelt<'a> {
 
         match result {
             Ok(finalized) => Ok(finalized),
-            Err(err) => wallet.compensate_failed_melt_confirm(operation_id, err).await,
+            Err(err) => {
+                wallet
+                    .compensate_failed_melt_confirm(operation_id, err)
+                    .await
+            }
         }
     }
 


### PR DESCRIPTION
### Description
                                                                                                                                                      
When `PreparedMelt::confirm()` failed, reserved proofs were left stuck in the `Pending` state with no automatic compensation. The only prior recovery path `reclaim_pending_proofs()` is unsafe because it also revokes unclaimed                                                                            
sent tokens. Consumers were forced to call `check_all_pending_proofs()` manually or reach into raw DB state.                                                                                                                  

This PR wires saga compensation into the error path of `PreparedMelt::confirm`, `confirm_prefer_async_with_options`, and `PendingMelt::wait`, so the chained `wallet.prepare_melt(...).await?.confirm().await?` pattern self-heals on failure. Compensation delegates to `resume_melt_saga`, which consults the mint before acting this prevents the double-spend edge case where a pre-melt swap has already consumed proofs (the naive "unreserve everything" approach would                                                                          
have reverted `Spent` - `Unspent`).

Additionally, `cancel_prepared_melt` is hardened: it now filters by the proof's current state and only reverts `Reserved` / `Pending` - `Unspent`, mirroring the `RevertProofReservation` compensation pattern. Proofs a successful swap step already moved to `Spent` are preserved.

Closes #1891

-----

### Notes to the reviewers

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

- `Wallet::cancel_prepared_melt` now filters by current proof state (only reverts `Reserved`/`Pending` - `Unspent`). Proofs already `Spent` (e.g. by a prior swap) are preserved, preventing a double-spend vector.
- `PreparedMelt`'s `#[must_use]` message updated to reflect auto-release on confirm failure. 

#### ADDED
        
- Private helper `Wallet::compensate_failed_melt_confirm` that delegates to `resume_melt_saga` for safe error-path compensation, including mint status check before reverting proofs.                                                                                                               
- Auto-compensation on failure for `PreparedMelt::confirm_with_options`, `PreparedMelt::confirm_prefer_async_with_options`, and `PendingMelt::wait` — reserved proofs no longer stay stuck in `Pending` when these methods return `Err`.

#### REMOVED

#### FIXED

- Reserved proofs no longer leak into `Pending` state when `PreparedMelt::confirm()` fails via the chained `prepare_melt().await?.confirm().await?`      
----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
