### PR TITLE
fix(wallet): surface HTTP status code in Async transport

### DIFF
--- a/crates/cdk/src/wallet/mint_connector/transport.rs
+++ b/crates/cdk/src/wallet/mint_connector/transport.rs
@@ -170,14 +170,26 @@ impl Transport for Async {
         let response = request
             .send()
             .await
-            .map_err(|e| Error::HttpError(None, e.to_string()))?
+            .map_err(|e| Error::HttpError(None, e.to_string()))?;
+
+        let status = response.status();
+        let body = response
             .text()
             .await
             .map_err(|e| Error::HttpError(None, e.to_string()))?;
 
-        serde_json::from_str::<R>(&response).map_err(|err| {
+        if !(200..300).contains(&status) {
+            // Attempt to strictly parse as a Cashu ErrorResponse (requires the 'code' field).
+            // This avoids laundering generic errors into ErrorCode::Unknown(999).
+            if let Ok(err_resp) = serde_json::from_str::<ErrorResponse>(&body) {
+                return Err(err_resp.into());
+            }
+            return Err(Error::HttpError(Some(status), body));
+        }
+
+        serde_json::from_str::<R>(&body).map_err(|err| {
             tracing::warn!("Http Response error: {}", err);
-            match ErrorResponse::from_json(&response) {
+            match ErrorResponse::from_json(&body) {
                 Ok(ok) => <ErrorResponse as Into<Error>>::into(ok),
                 Err(err) => err.into(),
             }
@@ -206,15 +218,24 @@ impl Transport for Async {
             .await
             .map_err(|e| Error::HttpError(None, e.to_string()))?;
 
-        let response = response
+        let status = response.status();
+        let body = response
             .text()
             .await
             .map_err(|e| Error::HttpError(None, e.to_string()))?;
 
-        serde_json::from_str::<R>(&response).map_err(|err| {
+        if !(200..300).contains(&status) {
+            // Attempt to strictly parse as a Cashu ErrorResponse (requires the 'code' field).
+            // This avoids laundering generic errors into ErrorCode::Unknown(999).
+            if let Ok(err_resp) = serde_json::from_str::<ErrorResponse>(&body) {
+                return Err(err_resp.into());
+            }
+            return Err(Error::HttpError(Some(status), body));
+        }
+
+        serde_json::from_str::<R>(&body).map_err(|err| {
             tracing::warn!("Http Response error: {}", err);
-            tracing::debug!("{:?}", response);
-            match ErrorResponse::from_json(&response) {
+            match ErrorResponse::from_json(&body) {
                 Ok(ok) => <ErrorResponse as Into<Error>>::into(ok),
                 Err(err) => err.into(),
             }
@@ -224,3 +245,102 @@ impl Transport for Async {
 
 #[cfg(all(feature = "tor", not(target_arch = "wasm32")))]
 pub mod tor_transport;
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    /// Spawn a one-shot HTTP server that replies with the given status line and
+    /// body to the first request it receives. Returns the URL to connect to.
+    async fn spawn_canned_response(status_line: &'static str, body: &'static str) -> Url {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+
+        let response = format!(
+            "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+
+        tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let mut buf = [0u8; 2048];
+                let _ = socket.read(&mut buf).await;
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.shutdown().await;
+            }
+        });
+
+        Url::parse(&format!("http://{}/", addr)).expect("valid url")
+    }
+
+    /// Regression test for https://github.com/cashubtc/cdk/issues/1914
+    ///
+    /// A 429 response with a body that does not match the Cashu ErrorResponse
+    /// schema (e.g. nutshell's `{"detail":"Rate limit exceeded."}`) must surface
+    /// as `Error::HttpError(Some(429), body)` instead of being laundered into
+    /// `ErrorCode::Unknown(999)` by `ErrorResponse::from_value`.
+    #[tokio::test]
+    async fn http_post_surfaces_429_status() {
+        let url = spawn_canned_response(
+            "HTTP/1.1 429 Too Many Requests",
+            r#"{"detail":"Rate limit exceeded."}"#,
+        )
+        .await;
+
+        let transport = Async::default();
+        let result: Result<serde_json::Value, Error> =
+            transport.http_post(url, None, &serde_json::json!({})).await;
+
+        match result {
+            Err(Error::HttpError(Some(429), body)) => {
+                assert!(
+                    body.contains("Rate limit exceeded"),
+                    "body should be preserved, got: {body}"
+                );
+            }
+            other => panic!("expected HttpError(Some(429), _), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn http_get_surfaces_429_status() {
+        let url = spawn_canned_response(
+            "HTTP/1.1 429 Too Many Requests",
+            r#"{"detail":"Rate limit exceeded."}"#,
+        )
+        .await;
+
+        let transport = Async::default();
+        let result: Result<serde_json::Value, Error> = transport.http_get(url, None).await;
+
+        match result {
+            Err(Error::HttpError(Some(429), body)) => {
+                assert!(body.contains("Rate limit exceeded"));
+            }
+            other => panic!("expected HttpError(Some(429), _), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn http_post_surfaces_400_mint_error() {
+        let url = spawn_canned_response(
+            "HTTP/1.1 400 Bad Request",
+            r#"{"code": 1000, "detail": "Token already spent"}"#,
+        )
+        .await;
+
+        let transport = Async::default();
+        let result: Result<serde_json::Value, Error> =
+            transport.http_post(url, None, &serde_json::json!({})).await;
+
+        match result {
+            Err(Error::UnknownErrorResponse(msg)) if msg.contains("1000") => {}
+            other => panic!("expected Error::UnknownErrorResponse containing 1000, got {other:?}"),
+        }
+    }
+}

--- a/crates/cdk/src/wallet/mint_connector/transport/tor_transport.rs
+++ b/crates/cdk/src/wallet/mint_connector/transport/tor_transport.rs
@@ -207,6 +207,9 @@ impl TorAsync {
 
         if !(200..300).contains(&status) {
             let text = String::from_utf8_lossy(&bytes).to_string();
+            if let Ok(err_resp) = serde_json::from_str::<ErrorResponse>(&text) {
+                return Err(err_resp.into());
+            }
             return Err(Error::HttpError(Some(status), text));
         }
 


### PR DESCRIPTION
### Description

The Async transport in the wallet's mint connector was reading the response body without first checking the HTTP status code. Non-2xx responses whose body does not match the Cashu ErrorResponse schema for example nutshell's {"detail":"Rate limit exceeded."} on HTTP 429 fell into the fallback path in ErrorResponse::from_value (crates/cdk-common/src/error.rs:724-731) and were laundered into ErrorCode::Unknown(999). The original status was lost.                                                                                                                                                 

This meant that:
- Error::is_definitive_failure (which already handles 429 correctly at crates/cdk-common/src/error.rs:500-503) was unreachable from this path, so the error was classified as ambiguous and eligible for retry — the opposite of what you want on a rate-limited mint.
- retriable_http_request in http_client.rs:162-175 could not distinguish rate-limit errors from other failures. 

Only the Tor transport (tor_transport.rs:208-211) handled status correctly.

This PR aligns the Async transport with the Tor transport: check response.status() before consuming the body, and return Error::HttpError(Some(status), body) on non-2xx. The existing 2xx parsing path is preserved.

-----

### Notes to the reviewers


-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

- Async transport in cdk::wallet::mint_connector::transport now returns Error::HttpError(Some(status), body) on non-2xx HTTP responses, matching the  Tor transport's behavior.    

#### ADDED

#### REMOVED

#### FIXED

- HTTP 429 responses from rate-limited mints (e.g. nutshell with mint_global_rate_limit_per_minute) no longer surface as ErrorCode::Unknown(999) and are now correctly classified as definitive failures. Partial fix for #1914.   
----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
