### PR TITLE
feat(wallet): preemptive client-side rate limiter

### DIFF
--- a/crates/cdk/src/wallet/auth/auth_wallet.rs
+++ b/crates/cdk/src/wallet/auth/auth_wallet.rs
@@ -17,7 +17,7 @@ use crate::nuts::{
     nut12, AuthRequired, AuthToken, BlindAuthToken, CurrencyUnit, KeySetInfo, PreMintSecrets,
     Proofs, ProtectedEndpoint, State,
 };
-use crate::wallet::mint_connector::AuthHttpClient;
+use crate::wallet::mint_connector::{AuthHttpClient, RateLimiter};
 use crate::wallet::mint_metadata_cache::MintMetadataCache;
 use crate::{Amount, Error, OidcClient};
 
@@ -52,7 +52,11 @@ pub struct AuthWallet {
 }
 
 impl AuthWallet {
-    /// Create a new [`AuthWallet`] instance
+    /// Create a new [`AuthWallet`] instance.
+    ///
+    /// The inner [`AuthHttpClient`] gets its own default [`RateLimiter`],
+    /// independent from any limiter attached to the wallet's regular
+    /// [`HttpClient`]. Use [`AuthWallet::with_rate_limiter`] to share one.
     pub fn new(
         mint_url: MintUrl,
         cat: Option<AuthToken>,
@@ -62,13 +66,59 @@ impl AuthWallet {
         oidc_client: Option<OidcClient>,
     ) -> Self {
         let http_client = Arc::new(AuthHttpClient::new(mint_url.clone(), cat));
+        Self::from_parts(
+            mint_url,
+            localstore,
+            metadata_cache,
+            protected_endpoints,
+            http_client,
+            oidc_client,
+        )
+    }
+
+    /// Create a new [`AuthWallet`] sharing a [`RateLimiter`] with the
+    /// wallet's regular HTTP client.
+    ///
+    /// Pass `None` to disable rate limiting on the blind-auth path entirely.
+    pub fn with_rate_limiter(
+        mint_url: MintUrl,
+        cat: Option<AuthToken>,
+        localstore: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
+        metadata_cache: Arc<MintMetadataCache>,
+        protected_endpoints: HashMap<ProtectedEndpoint, AuthRequired>,
+        oidc_client: Option<OidcClient>,
+        rate_limiter: Option<Arc<RateLimiter>>,
+    ) -> Self {
+        let http_client = Arc::new(AuthHttpClient::with_rate_limiter(
+            mint_url.clone(),
+            cat,
+            rate_limiter,
+        ));
+        Self::from_parts(
+            mint_url,
+            localstore,
+            metadata_cache,
+            protected_endpoints,
+            http_client,
+            oidc_client,
+        )
+    }
+
+    fn from_parts(
+        mint_url: MintUrl,
+        localstore: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
+        metadata_cache: Arc<MintMetadataCache>,
+        protected_endpoints: HashMap<ProtectedEndpoint, AuthRequired>,
+        auth_client: Arc<dyn AuthMintConnector + Send + Sync>,
+        oidc_client: Option<OidcClient>,
+    ) -> Self {
         Self {
             mint_url,
             localstore,
             metadata_cache,
             protected_endpoints: Arc::new(RwLock::new(protected_endpoints)),
             refresh_token: Arc::new(RwLock::new(None)),
-            auth_client: http_client,
+            auth_client,
             oidc_client: Arc::new(RwLock::new(oidc_client)),
         }
     }

--- a/crates/cdk/src/wallet/builder.rs
+++ b/crates/cdk/src/wallet/builder.rs
@@ -11,6 +11,8 @@ use crate::error::Error;
 use crate::mint_url::MintUrl;
 use crate::nuts::CurrencyUnit;
 use crate::wallet::auth::AuthWallet;
+use crate::wallet::mint_connector::rate_limiter::RateLimiter;
+use crate::wallet::mint_connector::transport::Async;
 use crate::wallet::mint_metadata_cache::MintMetadataCache;
 use crate::wallet::{HttpClient, MintConnector, SubscriptionManager, Wallet};
 
@@ -27,6 +29,8 @@ pub struct WalletBuilder {
     metadata_cache_ttl: Option<Duration>,
     metadata_cache: Option<Arc<MintMetadataCache>>,
     metadata_caches: HashMap<MintUrl, Arc<MintMetadataCache>>,
+    rate_limiter: Option<Option<Arc<RateLimiter>>>,
+    pending_auth_cat: Option<String>,
 }
 
 impl std::fmt::Debug for WalletBuilder {
@@ -53,6 +57,8 @@ impl Default for WalletBuilder {
             use_http_subscription: false,
             metadata_cache: None,
             metadata_caches: HashMap::new(),
+            rate_limiter: None,
+            pending_auth_cat: None,
         }
     }
 }
@@ -119,6 +125,8 @@ impl WalletBuilder {
     /// Set the auth wallet
     pub fn auth_wallet(mut self, auth_wallet: AuthWallet) -> Self {
         self.auth_wallet = Some(auth_wallet);
+        // `auth_wallet` and `set_auth_cat` are mutually exclusive; last call wins.
+        self.pending_auth_cat = None;
         self
     }
 
@@ -162,39 +170,48 @@ impl WalletBuilder {
         self
     }
 
-    /// Set auth CAT (Clear Auth Token)
+    /// Set the client-side rate limiter for HTTP requests to the mint.
+    ///
+    /// Pass `Some(limiter)` to share a limiter across multiple wallets
+    /// targeting the same mint (recommended for apps with separate wallets
+    /// per unit), or `None` to disable client-side rate limiting entirely.
+    ///
+    /// If this method is never called, a default [`RateLimiter`] is
+    /// installed automatically and shared between the built-in HTTP client
+    /// and the blind-auth client (when auth is configured via
+    /// [`set_auth_cat`](Self::set_auth_cat)).
+    ///
+    /// Scope: this setting applies to the built-in connector and to a NUT-22
+    /// [`AuthWallet`] materialized from [`set_auth_cat`](Self::set_auth_cat).
+    /// It has no effect on a custom connector passed via
+    /// [`client`](Self::client), nor on a user-supplied
+    /// [`AuthWallet`](Self::auth_wallet) — those carry their own pacing.
+    pub fn rate_limiter(mut self, rate_limiter: Option<Arc<RateLimiter>>) -> Self {
+        self.rate_limiter = Some(rate_limiter);
+        self
+    }
+
+    /// Set auth CAT (Clear Auth Token).
+    ///
+    /// The [`AuthWallet`] is not constructed until [`build`](Self::build) is
+    /// called, so the order in which you call [`set_auth_cat`](Self::set_auth_cat)
+    /// and [`rate_limiter`](Self::rate_limiter) does not matter — both will
+    /// share the same limiter.
     ///
     /// # Errors
     ///
     /// Returns an error if `mint_url` or `localstore` have not been set on the builder.
     pub fn set_auth_cat(mut self, cat: String) -> Result<Self, Error> {
-        let mint_url = self
-            .mint_url
-            .clone()
+        self.mint_url
+            .as_ref()
             .ok_or_else(|| Error::Custom("Mint URL required".to_string()))?;
-        let localstore = self
-            .localstore
-            .clone()
+        self.localstore
+            .as_ref()
             .ok_or_else(|| Error::Custom("Localstore required".to_string()))?;
 
-        let metadata_cache = self.metadata_cache.clone().unwrap_or_else(|| {
-            // Check if we already have a cache for this mint in the HashMap
-            if let Some(cache) = self.metadata_caches.get(&mint_url) {
-                cache.clone()
-            } else {
-                // Create a new one
-                Arc::new(MintMetadataCache::new(mint_url.clone()))
-            }
-        });
-
-        self.auth_wallet = Some(AuthWallet::new(
-            mint_url,
-            Some(AuthToken::ClearAuth(cat)),
-            localstore,
-            metadata_cache,
-            HashMap::new(),
-            None,
-        ));
+        self.pending_auth_cat = Some(cat);
+        // `auth_wallet` and `set_auth_cat` are mutually exclusive; last call wins.
+        self.auth_wallet = None;
         Ok(self)
     }
 
@@ -213,13 +230,14 @@ impl WalletBuilder {
             .seed
             .ok_or(Error::Custom("Seed required".to_string()))?;
 
-        let client = match self.client {
-            Some(client) => client,
-            None => Arc::new(HttpClient::new(mint_url.clone(), self.auth_wallet.clone()))
-                as Arc<dyn MintConnector + Send + Sync>,
+        // Resolve the effective rate limiter so both the `HttpClient` and a
+        // deferred `AuthWallet` share the same `Arc<RateLimiter>`. If the
+        // caller gave an explicit preference (including `None` to opt out),
+        // honor it; otherwise default to one shared instance.
+        let effective_rate_limiter: Option<Arc<RateLimiter>> = match self.rate_limiter {
+            Some(explicit) => explicit,
+            None => Some(Arc::new(RateLimiter::default())),
         };
-
-        let metadata_cache_ttl = self.metadata_cache_ttl;
 
         let metadata_cache = self.metadata_cache.unwrap_or_else(|| {
             // Check if we already have a cache for this mint in the HashMap
@@ -231,6 +249,36 @@ impl WalletBuilder {
             }
         });
 
+        // Materialize the `AuthWallet` from a pending `set_auth_cat` call,
+        // threading the effective rate limiter. A user-provided `auth_wallet`
+        // wins over `pending_auth_cat`.
+        let auth_wallet = match self.auth_wallet {
+            Some(aw) => Some(aw),
+            None => self.pending_auth_cat.map(|cat| {
+                AuthWallet::with_rate_limiter(
+                    mint_url.clone(),
+                    Some(AuthToken::ClearAuth(cat)),
+                    localstore.clone(),
+                    metadata_cache.clone(),
+                    HashMap::new(),
+                    None,
+                    effective_rate_limiter.clone(),
+                )
+            }),
+        };
+
+        let client = match self.client {
+            Some(client) => client,
+            None => Arc::new(HttpClient::with_rate_limiter(
+                mint_url.clone(),
+                Async::default(),
+                auth_wallet.clone(),
+                effective_rate_limiter,
+            )) as Arc<dyn MintConnector + Send + Sync>,
+        };
+
+        let metadata_cache_ttl = self.metadata_cache_ttl;
+
         Ok(Wallet {
             mint_url,
             unit,
@@ -238,7 +286,7 @@ impl WalletBuilder {
             metadata_cache,
             metadata_cache_ttl: Arc::new(RwLock::new(metadata_cache_ttl)),
             target_proof_count: self.target_proof_count.unwrap_or(3),
-            auth_wallet: Arc::new(TokioRwLock::new(self.auth_wallet)),
+            auth_wallet: Arc::new(TokioRwLock::new(auth_wallet)),
             #[cfg(feature = "npubcash")]
             npubcash_client: Arc::new(TokioRwLock::new(None)),
             seed,

--- a/crates/cdk/src/wallet/mint_connector/http_client.rs
+++ b/crates/cdk/src/wallet/mint_connector/http_client.rs
@@ -15,6 +15,7 @@ use tracing::instrument;
 use url::Url;
 use web_time::{Duration, Instant};
 
+use super::rate_limiter::RateLimiter;
 use super::transport::Transport;
 use super::{Error, MintConnector};
 use crate::mint_url::MintUrl;
@@ -39,6 +40,7 @@ where
     mint_url: MintUrl,
     cache_support: Arc<StdRwLock<Cache>>,
     auth_wallet: Arc<RwLock<Option<AuthWallet>>>,
+    rate_limiter: Option<Arc<RateLimiter>>,
 }
 
 impl<T> HttpClient<T>
@@ -46,6 +48,10 @@ where
     T: Transport + Send + Sync + 'static,
 {
     /// Create new [`HttpClient`] with a provided transport implementation.
+    ///
+    /// A default [`RateLimiter`] is installed to avoid triggering mint-side
+    /// rate limits. Use [`HttpClient::with_rate_limiter`] to share a limiter
+    /// across clients, or pass `None` to disable it entirely.
     pub fn with_transport(
         mint_url: MintUrl,
         transport: T,
@@ -56,6 +62,27 @@ where
             mint_url,
             auth_wallet: Arc::new(RwLock::new(auth_wallet)),
             cache_support: Default::default(),
+            rate_limiter: Some(Arc::new(RateLimiter::default())),
+        }
+    }
+
+    /// Create new [`HttpClient`] with an explicit [`RateLimiter`].
+    ///
+    /// Pass `None` to opt out of client-side rate limiting. To share pacing
+    /// across multiple wallets targeting the same mint, pass the same
+    /// `Arc<RateLimiter>` to each client.
+    pub fn with_rate_limiter(
+        mint_url: MintUrl,
+        transport: T,
+        auth_wallet: Option<AuthWallet>,
+        rate_limiter: Option<Arc<RateLimiter>>,
+    ) -> Self {
+        Self {
+            transport: transport.into(),
+            mint_url,
+            auth_wallet: Arc::new(RwLock::new(auth_wallet)),
+            cache_support: Default::default(),
+            rate_limiter,
         }
     }
 
@@ -66,7 +93,38 @@ where
             mint_url,
             auth_wallet: Arc::new(RwLock::new(auth_wallet)),
             cache_support: Default::default(),
+            rate_limiter: Some(Arc::new(RateLimiter::default())),
         }
+    }
+
+    async fn rate_limit(&self) {
+        if let Some(limiter) = &self.rate_limiter {
+            limiter.acquire().await;
+        }
+    }
+
+    /// HTTP GET gated by this client's rate limiter.
+    async fn http_get<R>(&self, url: Url, auth: Option<AuthToken>) -> Result<R, Error>
+    where
+        R: DeserializeOwned,
+    {
+        self.rate_limit().await;
+        self.transport.http_get(url, auth).await
+    }
+
+    /// HTTP POST gated by this client's rate limiter.
+    async fn http_post<P, R>(
+        &self,
+        url: Url,
+        auth: Option<AuthToken>,
+        payload: &P,
+    ) -> Result<R, Error>
+    where
+        P: Serialize + ?Sized + Send + Sync,
+        R: DeserializeOwned,
+    {
+        self.rate_limit().await;
+        self.transport.http_post(url, auth, payload).await
     }
 
     /// Get auth token for a protected endpoint
@@ -103,6 +161,7 @@ where
             mint_url,
             auth_wallet: Arc::new(RwLock::new(None)),
             cache_support: Default::default(),
+            rate_limiter: Some(Arc::new(RateLimiter::default())),
         })
     }
 
@@ -136,7 +195,6 @@ where
             .map(Duration::from_secs)
             .unwrap_or_default();
 
-        let transport = self.transport.clone();
         loop {
             let url = match &path {
                 nut19::Path::Swap => self.mint_url.join_paths(&["v1", "swap"])?,
@@ -150,8 +208,8 @@ where
             };
 
             let result = match method {
-                nut19::Method::Get => transport.http_get(url, auth_token.clone()).await,
-                nut19::Method::Post => transport.http_post(url, auth_token.clone(), payload).await,
+                nut19::Method::Get => self.http_get(url, auth_token.clone()).await,
+                nut19::Method::Post => self.http_post(url, auth_token.clone(), payload).await,
             };
 
             if result.is_ok() {
@@ -192,7 +250,10 @@ where
         self.transport.resolve_dns_txt(domain).await
     }
 
-    /// Fetch Lightning address pay request data
+    /// Fetch Lightning address pay request data.
+    ///
+    /// LNURL endpoints are third-party Lightning address servers, not the
+    /// mint, so this call bypasses the client's rate limiter.
     #[instrument(skip(self))]
     async fn fetch_lnurl_pay_request(
         &self,
@@ -203,7 +264,10 @@ where
         self.transport.http_get(parsed_url, None).await
     }
 
-    /// Fetch invoice from Lightning address callback
+    /// Fetch invoice from Lightning address callback.
+    ///
+    /// LNURL endpoints are third-party Lightning address servers, not the
+    /// mint, so this call bypasses the client's rate limiter.
     #[instrument(skip(self))]
     async fn fetch_lnurl_invoice(
         &self,
@@ -218,9 +282,8 @@ where
     #[instrument(skip(self), fields(mint_url = %self.mint_url))]
     async fn get_mint_keys(&self) -> Result<Vec<KeySet>, Error> {
         let url = self.mint_url.join_paths(&["v1", "keys"])?;
-        let transport = self.transport.clone();
 
-        Ok(transport.http_get::<KeysResponse>(url, None).await?.keysets)
+        Ok(self.http_get::<KeysResponse>(url, None).await?.keysets)
     }
 
     /// Get Keyset Keys [NUT-01]
@@ -230,8 +293,7 @@ where
             .mint_url
             .join_paths(&["v1", "keys", &keyset_id.to_string()])?;
 
-        let transport = self.transport.clone();
-        let keys_response = transport.http_get::<KeysResponse>(url, None).await?;
+        let keys_response = self.http_get::<KeysResponse>(url, None).await?;
 
         Ok(keys_response
             .keysets
@@ -244,8 +306,7 @@ where
     #[instrument(skip(self), fields(mint_url = %self.mint_url))]
     async fn get_mint_keysets(&self) -> Result<KeysetResponse, Error> {
         let url = self.mint_url.join_paths(&["v1", "keysets"])?;
-        let transport = self.transport.clone();
-        transport.http_get(url, None).await
+        self.http_get(url, None).await
     }
 
     /// Mint Quote [NUT-04, NUT-23, NUT-25]
@@ -271,17 +332,17 @@ where
         match &request {
             MintQuoteRequest::Bolt11(req) => {
                 let response: cdk_common::nut23::MintQuoteBolt11Response<String> =
-                    self.transport.http_post(url, auth_token, req).await?;
+                    self.http_post(url, auth_token, req).await?;
                 Ok(MintQuoteResponse::Bolt11(response))
             }
             MintQuoteRequest::Bolt12(req) => {
                 let response: cdk_common::nut25::MintQuoteBolt12Response<String> =
-                    self.transport.http_post(url, auth_token, req).await?;
+                    self.http_post(url, auth_token, req).await?;
                 Ok(MintQuoteResponse::Bolt12(response))
             }
             MintQuoteRequest::Custom { request: req, .. } => {
                 let response: cdk_common::nut04::MintQuoteCustomResponse<String> =
-                    self.transport.http_post(url, auth_token, req).await?;
+                    self.http_post(url, auth_token, req).await?;
                 Ok(MintQuoteResponse::Custom {
                     method: request.method(),
                     response,
@@ -311,7 +372,7 @@ where
                     .await?;
 
                 let response: MintQuoteBolt11Response<String> =
-                    self.transport.http_get(url, auth_token).await?;
+                    self.http_get(url, auth_token).await?;
 
                 Ok(MintQuoteResponse::Bolt11(response))
             }
@@ -328,7 +389,7 @@ where
                     .await?;
 
                 let response: MintQuoteBolt12Response<String> =
-                    self.transport.http_get(url, auth_token).await?;
+                    self.http_get(url, auth_token).await?;
 
                 Ok(MintQuoteResponse::Bolt12(response))
             }
@@ -342,7 +403,7 @@ where
                     .await?;
 
                 let response: MintQuoteCustomResponse<String> =
-                    self.transport.http_get(url, auth_token).await?;
+                    self.http_get(url, auth_token).await?;
 
                 Ok(MintQuoteResponse::Custom { method, response })
             }
@@ -389,7 +450,7 @@ where
             .get_auth_token(Method::Post, RoutePath::MintQuote(method.to_string()))
             .await?;
 
-        self.transport.http_post(url, auth_token, &request).await
+        self.http_post(url, auth_token, &request).await
     }
 
     /// Batch mint tokens [NUT-29]
@@ -428,17 +489,17 @@ where
         match &request {
             MeltQuoteRequest::Bolt11(req) => {
                 let response: cdk_common::nut23::MeltQuoteBolt11Response<String> =
-                    self.transport.http_post(url, auth_token, req).await?;
+                    self.http_post(url, auth_token, req).await?;
                 Ok(MeltQuoteCreateResponse::Bolt11(response))
             }
             MeltQuoteRequest::Bolt12(req) => {
                 let response: cdk_common::nut25::MeltQuoteBolt12Response<String> =
-                    self.transport.http_post(url, auth_token, req).await?;
+                    self.http_post(url, auth_token, req).await?;
                 Ok(MeltQuoteCreateResponse::Bolt12(response))
             }
             MeltQuoteRequest::Custom(req) => {
                 let response: cdk_common::nut05::MeltQuoteCustomResponse<String> =
-                    self.transport.http_post(url, auth_token, req).await?;
+                    self.http_post(url, auth_token, req).await?;
                 Ok(MeltQuoteCreateResponse::Custom((
                     request.method(),
                     response,
@@ -468,7 +529,7 @@ where
                     .await?;
 
                 let response: cdk_common::nut23::MeltQuoteBolt11Response<String> =
-                    self.transport.http_get(url, auth_token).await?;
+                    self.http_get(url, auth_token).await?;
 
                 Ok(MeltQuoteResponse::Bolt11(response))
             }
@@ -485,7 +546,7 @@ where
                     .await?;
 
                 let response: cdk_common::nut25::MeltQuoteBolt12Response<String> =
-                    self.transport.http_get(url, auth_token).await?;
+                    self.http_get(url, auth_token).await?;
 
                 Ok(MeltQuoteResponse::Bolt12(response))
             }
@@ -499,7 +560,7 @@ where
                     .await?;
 
                 let response: cdk_common::nut05::MeltQuoteCustomResponse<String> =
-                    self.transport.http_get(url, auth_token).await?;
+                    self.http_get(url, auth_token).await?;
 
                 Ok(MeltQuoteResponse::Custom((method.clone(), response)))
             }
@@ -567,8 +628,7 @@ where
     /// Helper to get mint info
     async fn get_mint_info(&self) -> Result<MintInfo, Error> {
         let url = self.mint_url.join_paths(&["v1", "info"])?;
-        let transport = self.transport.clone();
-        let info: MintInfo = transport.http_get(url, None).await?;
+        let info: MintInfo = self.http_get(url, None).await?;
 
         if let Ok(mut cache_support) = self.cache_support.write() {
             *cache_support = (
@@ -605,7 +665,7 @@ where
             .get_auth_token(Method::Post, RoutePath::Checkstate)
             .await?;
 
-        self.transport.http_post(url, auth_token, &request).await
+        self.http_post(url, auth_token, &request).await
     }
 
     /// Restore request [NUT-13]
@@ -616,12 +676,11 @@ where
             .get_auth_token(Method::Post, RoutePath::Restore)
             .await?;
 
-        self.transport.http_post(url, auth_token, &request).await
+        self.http_post(url, auth_token, &request).await
     }
 }
 
 /// Http Client
-
 #[derive(Debug, Clone)]
 pub struct AuthHttpClient<T>
 where
@@ -630,21 +689,70 @@ where
     transport: Arc<T>,
     mint_url: MintUrl,
     cat: Arc<RwLock<AuthToken>>,
+    rate_limiter: Option<Arc<RateLimiter>>,
 }
 
 impl<T> AuthHttpClient<T>
 where
     T: Transport + Send + Sync + 'static,
 {
-    /// Create new [`AuthHttpClient`]
+    /// Create new [`AuthHttpClient`].
+    ///
+    /// A default [`RateLimiter`] is installed. Note that this limiter is
+    /// independent of the one used by [`HttpClient`]: a wallet that performs
+    /// both regular and NUT-22 blind-auth requests will draw from two
+    /// separate budgets unless the caller shares one via
+    /// [`AuthHttpClient::with_rate_limiter`].
     pub fn new(mint_url: MintUrl, cat: Option<AuthToken>) -> Self {
+        Self::with_rate_limiter(mint_url, cat, Some(Arc::new(RateLimiter::default())))
+    }
+
+    /// Create new [`AuthHttpClient`] with an explicit [`RateLimiter`].
+    ///
+    /// Pass `None` to disable client-side rate limiting. Pass the same
+    /// `Arc<RateLimiter>` used by the wallet's [`HttpClient`] to share a
+    /// single budget across regular and blind-auth traffic.
+    pub fn with_rate_limiter(
+        mint_url: MintUrl,
+        cat: Option<AuthToken>,
+        rate_limiter: Option<Arc<RateLimiter>>,
+    ) -> Self {
         Self {
             transport: T::default().into(),
             mint_url,
             cat: Arc::new(RwLock::new(
                 cat.unwrap_or(AuthToken::ClearAuth("".to_string())),
             )),
+            rate_limiter,
         }
+    }
+
+    async fn rate_limit(&self) {
+        if let Some(limiter) = &self.rate_limiter {
+            limiter.acquire().await;
+        }
+    }
+
+    async fn http_get<R>(&self, url: Url, auth: Option<AuthToken>) -> Result<R, Error>
+    where
+        R: DeserializeOwned,
+    {
+        self.rate_limit().await;
+        self.transport.http_get(url, auth).await
+    }
+
+    async fn http_post<P, R>(
+        &self,
+        url: Url,
+        auth: Option<AuthToken>,
+        payload: &P,
+    ) -> Result<R, Error>
+    where
+        P: Serialize + ?Sized + Send + Sync,
+        R: DeserializeOwned,
+    {
+        self.rate_limit().await;
+        self.transport.http_post(url, auth, payload).await
     }
 }
 
@@ -666,7 +774,7 @@ where
     /// Get Mint Info [NUT-06]
     async fn get_mint_info(&self) -> Result<MintInfo, Error> {
         let url = self.mint_url.join_paths(&["v1", "info"])?;
-        let mint_info: MintInfo = self.transport.http_get::<MintInfo>(url, None).await?;
+        let mint_info: MintInfo = self.http_get::<MintInfo>(url, None).await?;
 
         Ok(mint_info)
     }
@@ -678,7 +786,7 @@ where
             self.mint_url
                 .join_paths(&["v1", "auth", "blind", "keys", &keyset_id.to_string()])?;
 
-        let mut keys_response = self.transport.http_get::<KeysResponse>(url, None).await?;
+        let mut keys_response = self.http_get::<KeysResponse>(url, None).await?;
 
         let keyset = keys_response
             .keysets
@@ -696,15 +804,14 @@ where
             .mint_url
             .join_paths(&["v1", "auth", "blind", "keysets"])?;
 
-        self.transport.http_get(url, None).await
+        self.http_get(url, None).await
     }
 
     /// Mint Tokens [NUT-22]
     #[instrument(skip(self, request), fields(mint_url = %self.mint_url))]
     async fn post_mint_blind_auth(&self, request: MintAuthRequest) -> Result<MintResponse, Error> {
         let url = self.mint_url.join_paths(&["v1", "auth", "blind", "mint"])?;
-        self.transport
-            .http_post(url, Some(self.cat.read().await.clone()), &request)
+        self.http_post(url, Some(self.cat.read().await.clone()), &request)
             .await
     }
 }
@@ -858,5 +965,84 @@ mod tests {
         let parsed = parsed.expect("already checked");
         assert_eq!(parsed.amount, cdk_common::Amount::from(1000));
         assert_eq!(parsed.unit, cdk_common::CurrencyUnit::Sat);
+    }
+
+    /// When a rate limiter is attached, consecutive requests beyond its burst
+    /// must wait for refill; when `None`, they must not.
+    #[tokio::test]
+    async fn http_client_respects_attached_rate_limiter() {
+        use std::time::Instant;
+
+        use cdk_common::nuts::nut23::QuoteState;
+
+        let canned = MintQuoteCustomResponse::<String> {
+            quote: "q".to_string(),
+            request: "x".to_string(),
+            amount: Some(cdk_common::Amount::from(1)),
+            unit: Some(cdk_common::CurrencyUnit::Sat),
+            state: QuoteState::Unpaid,
+            expiry: Some(1),
+            pubkey: None,
+            extra: serde_json::Value::Null,
+        };
+        let canned_json = serde_json::to_string(&canned).expect("serialize");
+
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let make_request = || MintQuoteRequest::Custom {
+            method: PaymentMethod::Custom("paypal".to_string()),
+            request: MintQuoteCustomRequest {
+                amount: cdk_common::Amount::from(1),
+                unit: cdk_common::CurrencyUnit::Sat,
+                description: None,
+                pubkey: None,
+                extra: serde_json::Value::Null,
+            },
+        };
+
+        // Burst capacity 1, 60/min = 1 token per second. Second call waits ~1s.
+        let limiter = Arc::new(RateLimiter::new(1, 60));
+        let transport = MockTransport {
+            captured_payload: Arc::new(Mutex::new(None)),
+            post_response: Arc::new(Mutex::new(Some(canned_json.clone()))),
+        };
+        let client =
+            HttpClient::with_rate_limiter(mint_url.clone(), transport, None, Some(limiter.clone()));
+        client
+            .post_mint_quote(make_request())
+            .await
+            .expect("first ok");
+        let start = Instant::now();
+        client
+            .post_mint_quote(make_request())
+            .await
+            .expect("second ok");
+        let gated = start.elapsed();
+        assert!(
+            gated >= std::time::Duration::from_millis(800),
+            "second call should wait ~1s for refill, waited {:?}",
+            gated
+        );
+
+        // With rate_limiter = None the second call must not wait.
+        let transport = MockTransport {
+            captured_payload: Arc::new(Mutex::new(None)),
+            post_response: Arc::new(Mutex::new(Some(canned_json))),
+        };
+        let client = HttpClient::with_rate_limiter(mint_url, transport, None, None);
+        client
+            .post_mint_quote(make_request())
+            .await
+            .expect("first ok");
+        let start = Instant::now();
+        client
+            .post_mint_quote(make_request())
+            .await
+            .expect("second ok");
+        let ungated = start.elapsed();
+        assert!(
+            ungated < std::time::Duration::from_millis(100),
+            "without limiter the call should be essentially instant, took {:?}",
+            ungated
+        );
     }
 }

--- a/crates/cdk/src/wallet/mint_connector/mod.rs
+++ b/crates/cdk/src/wallet/mint_connector/mod.rs
@@ -19,7 +19,10 @@ use crate::nuts::{
 use crate::wallet::AuthWallet;
 
 pub mod http_client;
+pub mod rate_limiter;
 pub mod transport;
+
+pub use rate_limiter::RateLimiter;
 
 /// Auth HTTP Client with async transport
 pub type AuthHttpClient = http_client::AuthHttpClient<transport::Async>;

--- a/crates/cdk/src/wallet/mint_connector/rate_limiter.rs
+++ b/crates/cdk/src/wallet/mint_connector/rate_limiter.rs
@@ -1,0 +1,222 @@
+//! Preemptive client-side rate limiter for wallet HTTP requests.
+//!
+//! Wraps every request the wallet sends to a mint with a token-bucket so that
+//! the wallet stays under the mint's advertised (or assumed) rate limit and
+//! avoids triggering server-side 429s. Modeled after Coco's
+//! `RequestRateLimiter` — shared FIFO queue per limiter instance, no reactive
+//! handling of server responses.
+//!
+//! See: <https://github.com/cashubtc/cdk/issues/1642>.
+
+use std::fmt;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+use web_time::Instant;
+
+/// Default burst capacity, matching Coco's WalletService defaults.
+pub const DEFAULT_CAPACITY: u32 = 20;
+/// Default sustained rate (requests per minute), matching Coco's WalletService defaults.
+pub const DEFAULT_REFILL_PER_MINUTE: u32 = 20;
+
+/// Token bucket rate limiter.
+///
+/// Tokens refill continuously at `refill_per_minute / 60` tokens per second,
+/// capped at `capacity`. [`RateLimiter::acquire`] consumes one token; when
+/// none are available it awaits until the next token is produced. Waiters are
+/// served in roughly arrival order via `tokio::sync::Mutex` lock ordering.
+pub struct RateLimiter {
+    capacity: f64,
+    refill_per_second: f64,
+    state: Mutex<State>,
+}
+
+struct State {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl fmt::Debug for RateLimiter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RateLimiter")
+            .field("capacity", &self.capacity)
+            .field("refill_per_second", &self.refill_per_second)
+            .finish()
+    }
+}
+
+impl RateLimiter {
+    /// Build a limiter with the given burst capacity and sustained rate.
+    ///
+    /// `capacity` is the number of tokens available at start and the ceiling
+    /// the bucket refills to. `refill_per_minute` is the sustained rate.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` or `refill_per_minute` is zero. A zero capacity
+    /// would deadlock every caller, and a zero refill rate yields a
+    /// non-finite wait duration. Both are programmer errors; to opt out of
+    /// rate limiting pass `None` where an `Option<Arc<RateLimiter>>` is
+    /// accepted.
+    pub fn new(capacity: u32, refill_per_minute: u32) -> Self {
+        assert!(capacity > 0, "RateLimiter capacity must be > 0");
+        assert!(
+            refill_per_minute > 0,
+            "RateLimiter refill_per_minute must be > 0"
+        );
+        let capacity = capacity as f64;
+        Self {
+            capacity,
+            refill_per_second: (refill_per_minute as f64) / 60.0,
+            state: Mutex::new(State {
+                tokens: capacity,
+                last_refill: Instant::now(),
+            }),
+        }
+    }
+
+    /// Acquire one token, awaiting if the bucket is empty.
+    ///
+    /// Safe to call concurrently; waiters are served in roughly the order
+    /// they arrived.
+    ///
+    /// Each call consumes one token on success. Retry loops (for example
+    /// `HttpClient::retriable_http_request`) therefore consume one token per
+    /// attempt — this is intentional and prevents a failing endpoint from
+    /// being hammered.
+    pub async fn acquire(&self) {
+        loop {
+            let wait = {
+                let mut state = self.state.lock().await;
+                let now = Instant::now();
+                let elapsed = now.duration_since(state.last_refill).as_secs_f64();
+                state.tokens = (state.tokens + elapsed * self.refill_per_second).min(self.capacity);
+                state.last_refill = now;
+
+                if state.tokens >= 1.0 {
+                    state.tokens -= 1.0;
+                    return;
+                }
+
+                // Duration until the bucket reaches one token.
+                let needed = 1.0 - state.tokens;
+                Duration::from_secs_f64(needed / self.refill_per_second)
+            };
+            tokio::time::sleep(wait).await;
+        }
+    }
+}
+
+impl Default for RateLimiter {
+    /// Defaults matching Coco's WalletService: 20 capacity, 20 req/min.
+    fn default() -> Self {
+        Self::new(DEFAULT_CAPACITY, DEFAULT_REFILL_PER_MINUTE)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn burst_consumes_capacity_without_waiting() {
+        let limiter = RateLimiter::new(5, 1); // 1/min = very slow refill
+        let start = Instant::now();
+        for _ in 0..5 {
+            limiter.acquire().await;
+        }
+        assert!(
+            start.elapsed() < Duration::from_millis(100),
+            "burst should be essentially instant, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[tokio::test]
+    async fn sixth_request_waits_for_refill() {
+        // 600/min = 10 tokens/s = one token every 100ms.
+        let limiter = RateLimiter::new(5, 600);
+        for _ in 0..5 {
+            limiter.acquire().await;
+        }
+        let start = Instant::now();
+        limiter.acquire().await;
+        let waited = start.elapsed();
+        assert!(
+            waited >= Duration::from_millis(80),
+            "sixth should wait ~100ms, waited {:?}",
+            waited
+        );
+        assert!(
+            waited < Duration::from_millis(300),
+            "sixth should not wait much more than one refill interval, waited {:?}",
+            waited
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity must be > 0")]
+    fn zero_capacity_panics() {
+        let _ = RateLimiter::new(0, 20);
+    }
+
+    #[test]
+    #[should_panic(expected = "refill_per_minute must be > 0")]
+    fn zero_refill_panics() {
+        let _ = RateLimiter::new(20, 0);
+    }
+
+    #[tokio::test]
+    async fn concurrent_acquires_are_serialized() {
+        // 1200/min = 20/s = 50ms/token. Capacity 2, so 5 concurrent requests
+        // drain the burst and must wait at least 3 * 50ms = 150ms in total.
+        let limiter = Arc::new(RateLimiter::new(2, 1200));
+        let completed = Arc::new(AtomicUsize::new(0));
+
+        let start = Instant::now();
+        let mut handles = Vec::new();
+        for _ in 0..5 {
+            let l = limiter.clone();
+            let c = completed.clone();
+            handles.push(tokio::spawn(async move {
+                l.acquire().await;
+                c.fetch_add(1, Ordering::SeqCst);
+            }));
+        }
+        for h in handles {
+            h.await.expect("join");
+        }
+        let elapsed = start.elapsed();
+
+        assert_eq!(completed.load(Ordering::SeqCst), 5);
+        assert!(
+            elapsed >= Duration::from_millis(130),
+            "5 requests with cap=2, rate=20/s should take ~150ms, took {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test]
+    async fn refill_is_capped_at_capacity() {
+        // 100/s, saturates the bucket instantly. Let elapsed time pile up so
+        // the bucket would mathematically hold more than `capacity` tokens.
+        let limiter = RateLimiter::new(3, 6000);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Should still only have 3 tokens available in burst.
+        let start = Instant::now();
+        for _ in 0..3 {
+            limiter.acquire().await;
+        }
+        assert!(start.elapsed() < Duration::from_millis(50));
+        // Fourth acquire must wait for a fresh token.
+        let start = Instant::now();
+        limiter.acquire().await;
+        assert!(
+            start.elapsed() >= Duration::from_millis(5),
+            "fourth should have waited for a refill tick"
+        );
+    }
+}

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -85,6 +85,7 @@ pub use melt::{MeltConfirmOptions, MeltOutcome, PendingMelt, PreparedMelt};
 pub use mint_connector::transport::Transport as HttpTransport;
 pub use mint_connector::{
     AuthHttpClient, HttpClient, LnurlPayInvoiceResponse, LnurlPayResponse, MintConnector,
+    RateLimiter,
 };
 #[cfg(feature = "nostr")]
 pub use nostr_backup::{BackupOptions, BackupResult, RestoreOptions, RestoreResult};


### PR DESCRIPTION
### Description

Adds a preemptive token-bucket rate limiter to the wallet's HTTP client, so the wallet stays under the mint's advertised (or assumed) rate limit and avoids triggering server-side 429s in the first place.  

Modeled after Coco's RequestRateLimiter:

- Token bucket with continuous refill, capped at capacity.  
- Defaults match Coco's WalletService: capacity=20, refill=20/min. Safely under nutshell's default global 60/min.
- FIFO ordering via tokio::sync::Mutex lock ordering.
- Waits (awaits) when tokens are exhausted  never rejects.
- No reactive handling of 429s  surfacing those correctly is handled by the companion transport fix.
- Asserts on zero capacity or zero refill in RateLimiter::new — both are configuration bugs (zero capacity would deadlock, zero refill would yield a non-finite wait).                                                                                                                                     

wallet.restore() against a nutshell mint with mint_global_rate_limit_per_minute=60 (the upstream default since 44f0abd) reliably trips the limit on  mints with a few keysets × units, because the scan fires dozens of /v1/restore + /v1/checkstate requests in a tight loop. 

- cdk::wallet::RateLimiter (re-exported from cdk::wallet::mint_connector).
- RateLimiter::new(capacity, refill_per_minute), RateLimiter::default(), pub async fn acquire(&self).
- HttpClient::with_rate_limiter(...); HttpClient::new / with_transport / with_proxy install RateLimiter::default() automatically.                     
- AuthHttpClient::with_rate_limiter(...) and AuthWallet::with_rate_limiter(...) so NUT-22 blind-auth traffic can share the same limiter.
- WalletBuilder::rate_limiter(Option<Arc<RateLimiter>>) for app-level sharing or opt-out.   

-----

### Notes to the reviewers


-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

- HttpClient, AuthHttpClient, and wallets built via WalletBuilder now install a default client-side RateLimiter (20 req/min, burst 20). Pass None via  HttpClient::with_rate_limiter / WalletBuilder::rate_limiter to opt out.
- WalletBuilder::set_auth_cat now defers AuthWallet construction to build(). Public signature unchanged. 

#### ADDED

- cdk::wallet::RateLimiter — preemptive token-bucket limiter for wallet HTTP requests.
- HttpClient::with_rate_limiter, AuthHttpClient::with_rate_limiter, AuthWallet::with_rate_limiter.
- WalletBuilder::rate_limiter to share a limiter across wallets targeting the same mint or opt out. 

#### REMOVED

#### FIXED

- Preemptive pacing avoids triggering mint-side 429s during bursty workloads like Wallet::restore(). Partial fix for #1914.

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
