### PR TITLE
feat(wallet): add RestoreOptions to tune Wallet::restore batching

### DIFF
--- a/bindings/dart/rust/uniffi-bindgen.rs
+++ b/bindings/dart/rust/uniffi-bindgen.rs
@@ -74,6 +74,9 @@ fn main() {
 /// 5. **P2PKSigningKey casing** – uniffi-dart generates the Record class as `P2pkSigningKey`
 ///    (camelCase) but references it as `P2PKSigningKey` in callback interface method signatures and
 ///    sequence/optional converters. All occurrences are normalized to `P2pkSigningKey`.
+///
+/// 6. **NUT13Options casing** – same issue as above. The generated Record class is `Nut13Options`
+///    while some references use `NUT13Options`. All occurrences are normalized to `Nut13Options`.
 fn patch_generated(path: &camino::Utf8Path) {
     let content =
         std::fs::read_to_string(path).unwrap_or_else(|e| panic!("Failed to read {}: {}", path, e));
@@ -144,7 +147,13 @@ class _RustOwnedWalletDatabase implements WalletDatabase {
     // Normalize all occurrences to P2pkSigningKey.
     content = content.replace("P2PKSigningKey", "P2pkSigningKey");
 
-    // 6. Patch lower() to handle _RustOwnedWalletDatabase
+    // 6. Fix NUT13Options casing inconsistency.
+    // uniffi-dart generates the class as Nut13Options (camelCase) but references
+    // it as NUT13Options in some generated signatures and converters.
+    // Normalize all occurrences to Nut13Options.
+    content = content.replace("NUT13Options", "Nut13Options");
+
+    // 7. Patch lower() to handle _RustOwnedWalletDatabase
     content = content.replace(
         "  static Pointer<Void> lower(WalletDatabase value) {\n    _ensureVTableInitialized();\n    final handle = _handleMap.insert(value);\n    return Pointer<Void>.fromAddress(handle);\n  }",
         "  static Pointer<Void> lower(WalletDatabase value) {\n    if (value is _RustOwnedWalletDatabase) {\n      return value.clonePointer();\n    }\n    _ensureVTableInitialized();\n    final handle = _handleMap.insert(value);\n    return Pointer<Void>.fromAddress(handle);\n  }",

--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -369,6 +369,14 @@ pub enum Error {
     /// Max Fee Ecxeded
     #[error("Max fee exceeded")]
     MaxFeeExceeded,
+    /// Invalid NUT-13 restore options
+    #[error("Invalid NUT-13 restore options: `{field}` {reason}")]
+    InvalidNut13Options {
+        /// Invalid option field.
+        field: &'static str,
+        /// Reason the option value is invalid.
+        reason: &'static str,
+    },
     /// Url path segments could not be joined
     #[error("Url path segments could not be joined")]
     UrlPathSegments,
@@ -663,6 +671,7 @@ impl Error {
             | Self::InvalidSpendConditions(_)
             | Self::IncorrectWallet(_)
             | Self::MaxFeeExceeded
+            | Self::InvalidNut13Options { .. }
             | Self::DleqProofNotProvided
             | Self::IncorrectMint
             | Self::MultiMintTokenNotSupported

--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -328,6 +328,30 @@ pub struct Restored {
     pub pending: Amount,
 }
 
+/// Options for [`crate::wallet::Wallet::restore_with_opts`].
+///
+/// Defaults match the NUT-13 spec recommendation
+/// (<https://github.com/cashubtc/nuts/blob/main/13.md#generate-blindedmessages>):
+/// a batch of 100 blinded messages and three consecutive empty batches to
+/// signal end-of-history. Callers that need more conservative pacing or
+/// different gap tolerance can override either field.
+#[derive(Debug, Clone)]
+pub struct NUT13Options {
+    /// Number of blinded messages to request per batch.
+    pub batch_size: u32,
+    /// Number of consecutive empty batches that terminate the scan.
+    pub max_gap: u32,
+}
+
+impl Default for NUT13Options {
+    fn default() -> Self {
+        Self {
+            batch_size: 100,
+            max_gap: 3,
+        }
+    }
+}
+
 /// Send options
 #[derive(Clone, Default)]
 pub struct SendOptions {
@@ -984,6 +1008,9 @@ pub trait Wallet: Send + Sync {
     /// Restore wallet from seed
     async fn restore(&self) -> Result<Restored, Self::Error>;
 
+    /// Restore wallet from seed with custom [`NUT13Options`]
+    async fn restore_with_opts(&self, opts: NUT13Options) -> Result<Restored, Self::Error>;
+
     /// Verify DLEQ proofs in a token
     async fn verify_token_dleq(&self, token_str: &str) -> Result<(), Self::Error>;
 
@@ -1246,5 +1273,25 @@ mod tests {
         assert!(send_debug.contains("[redacted]"));
         assert!(!receive_debug.contains(&secret_hex));
         assert!(receive_debug.contains("[redacted]"));
+    }
+
+    #[test]
+    fn nut13_options_defaults_match_nut13_spec() {
+        // NUT-13 recommends batch_size=100 and gap_limit=3.
+        // https://github.com/cashubtc/nuts/blob/main/13.md#generate-blindedmessages
+        let opts = NUT13Options::default();
+        assert_eq!(opts.batch_size, 100);
+        assert_eq!(opts.max_gap, 3);
+    }
+
+    #[test]
+    fn nut13_options_custom_values_round_trip() {
+        let opts = NUT13Options {
+            batch_size: 25,
+            max_gap: 2,
+        };
+        let cloned = opts.clone();
+        assert_eq!(cloned.batch_size, 25);
+        assert_eq!(cloned.max_gap, 2);
     }
 }

--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -346,9 +346,45 @@ pub struct NUT13Options {
 impl Default for NUT13Options {
     fn default() -> Self {
         Self {
-            batch_size: 100,
-            max_gap: 3,
+            batch_size: Self::DEFAULT_BATCH_SIZE,
+            max_gap: Self::DEFAULT_MAX_GAP,
         }
+    }
+}
+
+impl NUT13Options {
+    /// NUT-13 default restore batch size.
+    pub const DEFAULT_BATCH_SIZE: u32 = 100;
+
+    /// NUT-13 default restore gap limit.
+    pub const DEFAULT_MAX_GAP: u32 = 3;
+
+    /// Create new NUT-13 restore options.
+    pub fn new(batch_size: u32, max_gap: u32) -> Result<Self, Error> {
+        let opts = Self {
+            batch_size,
+            max_gap,
+        };
+        opts.validate()?;
+        Ok(opts)
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), Error> {
+        if self.batch_size == 0 {
+            return Err(Error::InvalidNut13Options {
+                field: "batch_size",
+                reason: "must be greater than zero",
+            });
+        }
+
+        if self.max_gap == 0 {
+            return Err(Error::InvalidNut13Options {
+                field: "max_gap",
+                reason: "must be greater than zero",
+            });
+        }
+
+        Ok(())
     }
 }
 
@@ -1280,18 +1316,39 @@ mod tests {
         // NUT-13 recommends batch_size=100 and gap_limit=3.
         // https://github.com/cashubtc/nuts/blob/main/13.md#generate-blindedmessages
         let opts = NUT13Options::default();
-        assert_eq!(opts.batch_size, 100);
-        assert_eq!(opts.max_gap, 3);
+        assert_eq!(opts.batch_size, NUT13Options::DEFAULT_BATCH_SIZE);
+        assert_eq!(opts.max_gap, NUT13Options::DEFAULT_MAX_GAP);
     }
 
     #[test]
-    fn nut13_options_custom_values_round_trip() {
-        let opts = NUT13Options {
-            batch_size: 25,
-            max_gap: 2,
-        };
+    fn nut13_options_new_accepts_custom_values() {
+        let opts = NUT13Options::new(25, 2).unwrap();
         let cloned = opts.clone();
         assert_eq!(cloned.batch_size, 25);
         assert_eq!(cloned.max_gap, 2);
+    }
+
+    #[test]
+    fn nut13_options_reject_zero_batch_size() {
+        let err = NUT13Options::new(0, 2).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::InvalidNut13Options {
+                field: "batch_size",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn nut13_options_reject_zero_max_gap() {
+        let err = NUT13Options::new(25, 0).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::InvalidNut13Options {
+                field: "max_gap",
+                ..
+            }
+        ));
     }
 }

--- a/crates/cdk-ffi/src/types/wallet.rs
+++ b/crates/cdk-ffi/src/types/wallet.rs
@@ -418,6 +418,39 @@ pub fn encode_receive_options(options: ReceiveOptions) -> Result<String, FfiErro
     Ok(serde_json::to_string(&options)?)
 }
 
+/// FFI-compatible NUT-13 restore options
+#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+pub struct NUT13Options {
+    /// Number of blinded messages to request per batch
+    pub batch_size: u32,
+    /// Number of consecutive empty batches that terminate the scan
+    pub max_gap: u32,
+}
+
+impl Default for NUT13Options {
+    fn default() -> Self {
+        cdk::wallet::NUT13Options::default().into()
+    }
+}
+
+impl From<NUT13Options> for cdk::wallet::NUT13Options {
+    fn from(opts: NUT13Options) -> Self {
+        cdk::wallet::NUT13Options {
+            batch_size: opts.batch_size,
+            max_gap: opts.max_gap,
+        }
+    }
+}
+
+impl From<cdk::wallet::NUT13Options> for NUT13Options {
+    fn from(opts: cdk::wallet::NUT13Options) -> Self {
+        NUT13Options {
+            batch_size: opts.batch_size,
+            max_gap: opts.max_gap,
+        }
+    }
+}
+
 /// FFI-compatible PreparedSend
 ///
 /// This wraps the data from a prepared send operation along with a reference

--- a/crates/cdk-ffi/src/types/wallet.rs
+++ b/crates/cdk-ffi/src/types/wallet.rs
@@ -433,12 +433,14 @@ impl Default for NUT13Options {
     }
 }
 
-impl From<NUT13Options> for cdk::wallet::NUT13Options {
-    fn from(opts: NUT13Options) -> Self {
-        cdk::wallet::NUT13Options {
-            batch_size: opts.batch_size,
-            max_gap: opts.max_gap,
-        }
+impl TryFrom<NUT13Options> for cdk::wallet::NUT13Options {
+    type Error = FfiError;
+
+    fn try_from(opts: NUT13Options) -> Result<Self, Self::Error> {
+        Ok(cdk::wallet::NUT13Options::new(
+            opts.batch_size,
+            opts.max_gap,
+        )?)
     }
 }
 

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -155,6 +155,12 @@ impl Wallet {
         Ok(restored.into())
     }
 
+    /// Restore wallet from seed with custom NUT-13 options
+    pub async fn restore_with_opts(&self, opts: NUT13Options) -> Result<Restored, FfiError> {
+        let restored = self.inner.restore_with_opts(opts.into()).await?;
+        Ok(restored.into())
+    }
+
     /// Verify token DLEQ proofs
     pub async fn verify_token_dleq(&self, token: std::sync::Arc<Token>) -> Result<(), FfiError> {
         let cdk_token = token.inner.clone();

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -157,7 +157,7 @@ impl Wallet {
 
     /// Restore wallet from seed with custom NUT-13 options
     pub async fn restore_with_opts(&self, opts: NUT13Options) -> Result<Restored, FfiError> {
-        let restored = self.inner.restore_with_opts(opts.into()).await?;
+        let restored = self.inner.restore_with_opts(opts.try_into()?).await?;
         Ok(restored.into())
     }
 

--- a/crates/cdk-ffi/src/wallet_trait.rs
+++ b/crates/cdk-ffi/src/wallet_trait.rs
@@ -408,6 +408,14 @@ impl WalletTraitDef for Wallet {
         Ok(restored)
     }
 
+    async fn restore_with_opts(
+        &self,
+        opts: cdk_common::wallet::NUT13Options,
+    ) -> Result<cdk_common::wallet::Restored, Self::Error> {
+        let restored = WalletTraitDef::restore_with_opts(self.inner().as_ref(), opts).await?;
+        Ok(restored)
+    }
+
     async fn verify_token_dleq(&self, token_str: &str) -> Result<(), Self::Error> {
         WalletTraitDef::verify_token_dleq(self.inner().as_ref(), token_str).await?;
         Ok(())

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -553,12 +553,10 @@ impl Wallet {
     ///
     /// Scans each keyset in batches of `opts.batch_size` blinded messages
     /// and stops after `opts.max_gap` consecutive empty batches. Lowering
-    /// `batch_size` trades scan latency for a gentler request pattern; the
-    /// mint's rate limit and the wallet's configured
-    /// [`RateLimiter`](crate::wallet::RateLimiter) are orthogonal pacing
-    /// controls that still apply.
+    /// `batch_size` trades scan latency for a gentler request pattern.
     #[instrument(skip(self))]
     pub async fn restore_with_opts(&self, opts: NUT13Options) -> Result<Restored, Error> {
+        let opts = NUT13Options::new(opts.batch_size, opts.max_gap)?;
         let batch_size = opts.batch_size;
         let max_gap = opts.max_gap;
 

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -79,7 +79,9 @@ pub use bip321::{
 };
 pub use builder::WalletBuilder;
 pub use cdk_common::wallet as types;
-pub use cdk_common::wallet::{P2PKLockedProofSendMode, ReceiveOptions, SendMemo, SendOptions};
+pub use cdk_common::wallet::{
+    NUT13Options, P2PKLockedProofSendMode, ReceiveOptions, SendMemo, SendOptions,
+};
 pub use keysets::KeysetFilter;
 pub use melt::{MeltConfirmOptions, MeltOutcome, PendingMelt, PreparedMelt};
 pub use mint_connector::transport::Transport as HttpTransport;
@@ -537,9 +539,29 @@ impl Wallet {
         Ok(SplitTarget::Values(values))
     }
 
-    /// Restore
-    #[instrument(skip(self))]
+    /// Restore proofs from the mint using the NUT-13 spec defaults (batch
+    /// size 100, gap 3).
+    ///
+    /// This is a thin wrapper over
+    /// [`Wallet::restore_with_opts`](Self::restore_with_opts). Call that
+    /// directly if you need to override the batch size or gap limit.
     pub async fn restore(&self) -> Result<Restored, Error> {
+        self.restore_with_opts(NUT13Options::default()).await
+    }
+
+    /// Restore proofs from the mint using the given [`NUT13Options`].
+    ///
+    /// Scans each keyset in batches of `opts.batch_size` blinded messages
+    /// and stops after `opts.max_gap` consecutive empty batches. Lowering
+    /// `batch_size` trades scan latency for a gentler request pattern; the
+    /// mint's rate limit and the wallet's configured
+    /// [`RateLimiter`](crate::wallet::RateLimiter) are orthogonal pacing
+    /// controls that still apply.
+    #[instrument(skip(self))]
+    pub async fn restore_with_opts(&self, opts: NUT13Options) -> Result<Restored, Error> {
+        let batch_size = opts.batch_size;
+        let max_gap = opts.max_gap;
+
         // Check that mint is in store of mints
         if self
             .localstore
@@ -556,23 +578,20 @@ impl Wallet {
 
         for keyset in keysets {
             let keys = self.load_keyset_keys(keyset.id).await?;
-            let mut empty_batch = 0;
-            let mut start_counter = 0;
+            let mut empty_batch: u32 = 0;
+            let mut start_counter: u32 = 0;
             // Track the highest counter value that had a signature
             let mut highest_counter: Option<u32> = None;
 
-            while empty_batch.lt(&3) {
-                let premint_secrets = PreMintSecrets::restore_batch(
-                    keyset.id,
-                    &self.seed,
-                    start_counter,
-                    start_counter + 100,
-                )?;
+            while empty_batch < max_gap {
+                let batch_end = start_counter.saturating_add(batch_size);
+                let premint_secrets =
+                    PreMintSecrets::restore_batch(keyset.id, &self.seed, start_counter, batch_end)?;
 
                 tracing::debug!(
                     "Attempting to restore counter {}-{} for mint {} keyset {}",
                     start_counter,
-                    start_counter + 100,
+                    batch_end,
                     self.mint_url,
                     keyset.id
                 );
@@ -585,7 +604,7 @@ impl Wallet {
 
                 if response.signatures.is_empty() {
                     empty_batch += 1;
-                    start_counter += 100;
+                    start_counter = start_counter.saturating_add(batch_size);
                     continue;
                 }
 
@@ -687,7 +706,7 @@ impl Wallet {
                     .await?;
 
                 empty_batch = 0;
-                start_counter += 100;
+                start_counter = start_counter.saturating_add(batch_size);
             }
 
             if let Some(highest) = highest_counter {

--- a/crates/cdk/src/wallet/wallet_trait.rs
+++ b/crates/cdk/src/wallet/wallet_trait.rs
@@ -343,6 +343,14 @@ impl WalletTrait for super::Wallet {
         self.restore().await
     }
 
+    #[instrument(skip(self))]
+    async fn restore_with_opts(
+        &self,
+        opts: cdk_common::wallet::NUT13Options,
+    ) -> Result<Restored, Self::Error> {
+        self.restore_with_opts(opts).await
+    }
+
     #[instrument(skip(self, token_str))]
     async fn verify_token_dleq(&self, token_str: &str) -> Result<(), Self::Error> {
         let token = cdk_common::nuts::nut00::token::Token::from_str(token_str)?;


### PR DESCRIPTION
### Description

Makes Wallet::restore()'s batch size and gap limit configurable via a new RestoreOptions struct, as requested by @thesimplekid in the thread on #1914. Defaults match the NUT-13 spec recommendation (100 / 3), so existing callers see no behavior change.

Partial fix for #1914

-----

### Notes to the reviewers

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

- nostr_backup::RestoreOptions (feature nostr) renamed to BackupRestoreOptions to free the RestoreOptions name for the main wallet API.
- Wallet::restore() is now a thin wrapper over the new Wallet::restore_with_opts(RestoreOptions::default()).


#### ADDED

- cdk::wallet::RestoreOptions (re-exported from cdk_common::wallet) with tunable batch_size and max_gap.
- Wallet::restore_with_opts(opts) for callers that want to override the NUT-13 defaults.

#### REMOVED

#### FIXED

- Callers can now shrink batch_size to be gentler on rate-limited mints while the wallet is being restored.

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
