### PR TITLE
fix(wallet): recover failed melt confirms via saga state

### DIFF
--- a/crates/cdk-integration-tests/tests/fake_wallet.rs
+++ b/crates/cdk-integration-tests/tests/fake_wallet.rs
@@ -1899,6 +1899,138 @@ async fn test_wallet_proof_recovery_after_failed_melt() {
     );
 }
 
+/// Regression test for cashubtc/cdk#1891.
+///
+/// Exercises the chained `prepare_melt(...).await?.confirm().await?` pattern
+/// where `PreparedMelt` is consumed on failure. The wallet should recover via
+/// the persisted melt saga without requiring `check_all_pending_proofs()`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_chained_confirm_auto_releases_proofs_on_failure() {
+    let wallet = Wallet::new(
+        MINT_URL,
+        CurrencyUnit::Sat,
+        Arc::new(memory::empty().await.unwrap()),
+        Mnemonic::generate(12).unwrap().to_seed_normalized(""),
+        None,
+    )
+    .expect("failed to create new wallet");
+
+    let mint_quote = wallet
+        .mint_quote(PaymentMethod::BOLT11, Some(100.into()), None, None)
+        .await
+        .unwrap();
+    let mut proof_streams = wallet.proof_stream(mint_quote.clone(), SplitTarget::default(), None);
+    proof_streams
+        .next()
+        .await
+        .expect("payment")
+        .expect("no error");
+
+    assert_eq!(wallet.total_balance().await.unwrap(), Amount::from(100));
+
+    let fake_description = FakeInvoiceDescription {
+        pay_invoice_state: MeltQuoteState::Failed,
+        check_payment_state: MeltQuoteState::Failed,
+        pay_err: false,
+        check_err: false,
+    };
+    let invoice = create_fake_invoice(1000, serde_json::to_string(&fake_description).unwrap());
+    let melt_quote = wallet
+        .melt_quote(PaymentMethod::BOLT11, invoice.to_string(), None, None)
+        .await
+        .unwrap();
+
+    let melt_result = wallet
+        .prepare_melt(&melt_quote.id, std::collections::HashMap::new())
+        .await
+        .unwrap()
+        .confirm()
+        .await;
+    assert!(melt_result.is_err(), "Melt should fail on Failed state");
+
+    let pending = wallet
+        .localstore
+        .get_proofs(None, None, Some(vec![State::Pending]), None)
+        .await
+        .unwrap();
+    assert!(
+        pending.is_empty(),
+        "no proofs should remain Pending after automatic saga recovery"
+    );
+
+    assert_eq!(
+        wallet.total_balance().await.unwrap(),
+        Amount::from(100),
+        "balance should be fully recovered without explicit recovery calls"
+    );
+}
+
+/// Regression test for the recovered-paid confirm path.
+///
+/// If the initial melt request errors locally but recovery sees the quote as
+/// `Paid`, chained `prepare_melt(...).confirm()` should still return success.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_chained_confirm_recovers_paid_melt() {
+    let wallet = Wallet::new(
+        MINT_URL,
+        CurrencyUnit::Sat,
+        Arc::new(memory::empty().await.unwrap()),
+        Mnemonic::generate(12).unwrap().to_seed_normalized(""),
+        None,
+    )
+    .expect("Failed to create new wallet");
+
+    let mint_quote = wallet
+        .mint_quote(PaymentMethod::BOLT11, Some(100.into()), None, None)
+        .await
+        .unwrap();
+    let mut proof_streams = wallet.proof_stream(mint_quote.clone(), SplitTarget::default(), None);
+    proof_streams
+        .next()
+        .await
+        .expect("payment")
+        .expect("no error");
+
+    let old_balance = wallet.total_balance().await.expect("balance");
+
+    let fake_description = FakeInvoiceDescription {
+        pay_invoice_state: MeltQuoteState::Failed,
+        check_payment_state: MeltQuoteState::Paid,
+        pay_err: true,
+        check_err: false,
+    };
+    let invoice = create_fake_invoice(7000, serde_json::to_string(&fake_description).unwrap());
+    let melt_quote = wallet
+        .melt_quote(PaymentMethod::BOLT11, invoice.to_string(), None, None)
+        .await
+        .unwrap();
+
+    let melt = wallet
+        .prepare_melt(&melt_quote.id, std::collections::HashMap::new())
+        .await
+        .unwrap()
+        .confirm()
+        .await
+        .expect("confirm should recover to Paid");
+
+    assert_eq!(melt.fee_paid(), Amount::ZERO);
+    assert_eq!(melt.amount(), Amount::from(7));
+    assert_eq!(
+        old_balance - melt.amount(),
+        wallet.total_balance().await.expect("new balance")
+    );
+
+    let pending = wallet
+        .localstore
+        .get_proofs(None, None, Some(vec![State::Pending]), None)
+        .await
+        .unwrap();
+    assert!(
+        pending.is_empty(),
+        "paid recovery should not leave pending proofs"
+    );
+}
+
 /// Tests that concurrent melt attempts for the same invoice result in exactly one success
 ///
 /// This test verifies the race condition protection: when multiple melt quotes exist for the

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -85,21 +85,22 @@ impl<'a> PendingMelt<'a> {
     async fn wait(self) -> Result<FinalizedMelt, Error> {
         let quote_id = self.saga.quote().id.clone();
         let wallet = self.saga.wallet;
+        let operation_id = self.saga.state_data.operation_id;
 
-        let mut subscription = match self.saga.quote().payment_method {
+        let subscribe_result = match self.saga.quote().payment_method {
             PaymentMethod::Known(KnownMethod::Bolt11) => {
                 wallet
                     .subscribe(WalletSubscription::Bolt11MeltQuoteState(vec![
                         quote_id.clone()
                     ]))
-                    .await?
+                    .await
             }
             PaymentMethod::Known(KnownMethod::Bolt12) => {
                 wallet
                     .subscribe(WalletSubscription::Bolt12MeltQuoteState(vec![
                         quote_id.clone()
                     ]))
-                    .await?
+                    .await
             }
             PaymentMethod::Custom(ref method) => {
                 wallet
@@ -107,7 +108,14 @@ impl<'a> PendingMelt<'a> {
                         method.to_string(),
                         vec![quote_id.clone()],
                     ))
-                    .await?
+                    .await
+            }
+        };
+
+        let mut subscription = match subscribe_result {
+            Ok(subscription) => subscription,
+            Err(err) => {
+                return wallet.recover_failed_melt_confirm(operation_id, err).await;
             }
         };
 
@@ -177,19 +185,27 @@ impl<'a> PendingMelt<'a> {
                                 change
                             };
 
-                            let finalized = self
+                            match self
                                 .saga
                                 .finalize(state, payment_proof, change, self.metadata)
-                                .await?;
-
-                            return Ok(FinalizedMelt::new(
-                                finalized.quote_id().to_string(),
-                                finalized.state(),
-                                finalized.payment_proof().map(|s| s.to_string()),
-                                finalized.amount(),
-                                finalized.fee_paid(),
-                                finalized.into_change(),
-                            ));
+                                .await
+                            {
+                                Ok(finalized) => {
+                                    return Ok(FinalizedMelt::new(
+                                        finalized.quote_id().to_string(),
+                                        finalized.state(),
+                                        finalized.payment_proof().map(|s| s.to_string()),
+                                        finalized.amount(),
+                                        finalized.fee_paid(),
+                                        finalized.into_change(),
+                                    ));
+                                }
+                                Err(err) => {
+                                    return wallet
+                                        .recover_failed_melt_confirm(operation_id, err)
+                                        .await;
+                                }
+                            }
                         }
                         MeltQuoteState::Failed
                         | MeltQuoteState::Unpaid
@@ -201,7 +217,8 @@ impl<'a> PendingMelt<'a> {
                     }
                 }
                 None => {
-                    return Err(Error::Custom("Subscription closed".to_string()));
+                    let err = Error::Custom("Subscription closed".to_string());
+                    return wallet.recover_failed_melt_confirm(operation_id, err).await;
                 }
             }
         }
@@ -287,7 +304,7 @@ impl MeltConfirmOptions {
 }
 
 /// A prepared melt operation that can be confirmed or cancelled.
-#[must_use = "must be confirmed or canceled to release reserved proofs"]
+#[must_use = "must be confirmed or canceled; confirm auto-recovers reserved proofs on failure"]
 pub struct PreparedMelt<'a> {
     /// The saga in the Prepared state
     saga: MeltSaga<'a, Prepared>,
@@ -377,6 +394,11 @@ impl<'a> PreparedMelt<'a> {
     /// If the mint supports async payments (NUT-05), this may complete faster by
     /// not blocking on the payment processing.
     ///
+    /// If the confirm path fails before returning a [`FinalizedMelt`], the wallet
+    /// runs melt saga recovery using the persisted saga state. If recovery shows
+    /// the melt actually completed, this method still returns the recovered melt.
+    /// Otherwise, the original confirm error or a recovery error is returned.
+    ///
     /// # Example
     ///
     /// ```rust,no_run
@@ -413,6 +435,12 @@ impl<'a> PreparedMelt<'a> {
     /// This method waits for the payment to complete and returns the finalized melt.
     /// If the mint supports async payments (NUT-05), this may complete faster by
     /// not blocking on the payment processing.
+    ///
+    /// If the confirm path fails before returning a [`FinalizedMelt`], the wallet
+    /// runs melt saga recovery using the persisted saga state so proofs do not
+    /// remain stuck in an intermediate state. If recovery determines the melt
+    /// actually completed, this method returns the recovered melt. Recovery
+    /// errors are surfaced directly.
     pub async fn confirm_with_options(
         self,
         options: MeltConfirmOptions,
@@ -504,13 +532,39 @@ impl<'a> PreparedMelt<'a> {
     /// Note: This waits for the mint's initial response, which may block if the mint
     /// does not support async payments. Only returns `Pending` if the mint explicitly
     /// supports and accepts async melt requests.
+    ///
+    /// If confirm fails before returning a [`MeltOutcome`], this method runs melt
+    /// saga recovery using the persisted saga state so proofs do not stay stuck
+    /// in an intermediate state. If recovery determines the melt actually
+    /// completed, this method returns `MeltOutcome::Paid`. Recovery errors are
+    /// surfaced directly.
     pub async fn confirm_prefer_async_with_options(
         self,
         options: MeltConfirmOptions,
     ) -> Result<MeltOutcome<'a>, Error> {
-        let melt_requested = self.saga.request_melt_with_options(options).await?;
+        let operation_id = self.saga.operation_id();
+        let wallet = self.saga.wallet;
+        let metadata = self.metadata;
 
-        let result = melt_requested.execute_async(self.metadata.clone()).await?;
+        let melt_requested = match self.saga.request_melt_with_options(options).await {
+            Ok(melt_requested) => melt_requested,
+            Err(err) => {
+                let finalized = wallet
+                    .recover_failed_melt_confirm(operation_id, err)
+                    .await?;
+                return Ok(MeltOutcome::Paid(finalized));
+            }
+        };
+
+        let result = match melt_requested.execute_async(metadata.clone()).await {
+            Ok(result) => result,
+            Err(err) => {
+                let finalized = wallet
+                    .recover_failed_melt_confirm(operation_id, err)
+                    .await?;
+                return Ok(MeltOutcome::Paid(finalized));
+            }
+        };
 
         match result {
             MeltSagaResult::Finalized(finalized) => Ok(MeltOutcome::Paid(FinalizedMelt::new(
@@ -523,7 +577,7 @@ impl<'a> PreparedMelt<'a> {
             ))),
             MeltSagaResult::Pending(pending_saga) => Ok(MeltOutcome::Pending(PendingMelt {
                 saga: pending_saga,
-                metadata: self.metadata,
+                metadata,
             })),
         }
     }
@@ -694,8 +748,15 @@ impl Wallet {
             db_saga,
         );
 
-        let melt_requested = saga.request_melt_with_options(options).await?;
-        let result = melt_requested.execute_async(metadata.clone()).await?;
+        let melt_requested = match saga.request_melt_with_options(options).await {
+            Ok(melt_requested) => melt_requested,
+            Err(err) => return self.recover_failed_melt_confirm(operation_id, err).await,
+        };
+
+        let result = match melt_requested.execute_async(metadata.clone()).await {
+            Ok(result) => result,
+            Err(err) => return self.recover_failed_melt_confirm(operation_id, err).await,
+        };
 
         match result {
             MeltSagaResult::Finalized(finalized) => Ok(FinalizedMelt::new(
@@ -716,6 +777,36 @@ impl Wallet {
         }
     }
 
+    /// Run melt recovery after a failed confirm path.
+    ///
+    /// This uses the persisted saga state as the source of truth, matching crash
+    /// recovery semantics. If recovery proves the melt actually completed, the
+    /// recovered [`FinalizedMelt`] is returned. If recovery compensates or leaves
+    /// the saga pending, the original confirm error is returned. Recovery errors
+    /// are surfaced directly so callers know cleanup did not complete.
+    #[instrument(skip(self))]
+    async fn recover_failed_melt_confirm(
+        &self,
+        operation_id: Uuid,
+        original_err: Error,
+    ) -> Result<FinalizedMelt, Error> {
+        let saga = match self.localstore.get_saga(&operation_id).await? {
+            Some(saga) => saga,
+            None => return Err(original_err),
+        };
+
+        match self.resume_melt_saga(&saga).await? {
+            Some(finalized) if finalized.state() == MeltQuoteState::Paid => {
+                tracing::info!(
+                    "Melt operation {} recovered to Paid after confirm error",
+                    operation_id
+                );
+                Ok(finalized)
+            }
+            Some(_) | None => Err(original_err),
+        }
+    }
+
     /// Internal method called by `PreparedMelt::cancel` with cached data.
     ///
     /// Not intended for direct use - use [`PreparedMelt::cancel`] instead.
@@ -733,9 +824,18 @@ impl Wallet {
         all_ys.extend(proofs_to_swap.ys()?);
 
         if !all_ys.is_empty() {
-            self.localstore
-                .update_proofs_state(all_ys, State::Unspent)
-                .await?;
+            let current = self.localstore.get_proofs_by_ys(all_ys).await?;
+            let ys_to_revert: Vec<_> = current
+                .into_iter()
+                .filter(|proof| proof.state == State::Reserved || proof.state == State::Pending)
+                .map(|proof| proof.y)
+                .collect();
+
+            if !ys_to_revert.is_empty() {
+                self.localstore
+                    .update_proofs_state(ys_to_revert, State::Unspent)
+                    .await?;
+            }
         }
 
         if let Err(e) = self.localstore.release_melt_quote(&operation_id).await {
@@ -1152,5 +1252,142 @@ impl Wallet {
         };
 
         Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use cdk_common::nuts::State;
+
+    use crate::wallet::saga::test_utils::{
+        create_test_db, test_keyset_id, test_mint_url, test_proof_info,
+    };
+    use crate::wallet::test_utils::{create_test_wallet_with_mock, MockMintConnector};
+
+    #[tokio::test]
+    async fn test_cancel_prepared_melt_reverts_reserved_proofs() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let operation_id = uuid::Uuid::new_v4();
+
+        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Reserved);
+        let proof_y = proof_info.y;
+        let proof = proof_info.proof.clone();
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        wallet
+            .cancel_prepared_melt(operation_id, vec![proof], vec![])
+            .await
+            .unwrap();
+
+        let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].state, State::Unspent);
+    }
+
+    #[tokio::test]
+    async fn test_cancel_prepared_melt_reverts_pending_proofs() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let operation_id = uuid::Uuid::new_v4();
+
+        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Pending);
+        let proof_y = proof_info.y;
+        let proof = proof_info.proof.clone();
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        wallet
+            .cancel_prepared_melt(operation_id, vec![proof], vec![])
+            .await
+            .unwrap();
+
+        let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].state, State::Unspent);
+    }
+
+    #[tokio::test]
+    async fn test_cancel_prepared_melt_preserves_spent_proofs() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let operation_id = uuid::Uuid::new_v4();
+
+        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Spent);
+        let proof_y = proof_info.y;
+        let proof = proof_info.proof.clone();
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        wallet
+            .cancel_prepared_melt(operation_id, vec![], vec![proof])
+            .await
+            .unwrap();
+
+        let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].state, State::Spent);
+    }
+
+    #[tokio::test]
+    async fn test_cancel_prepared_melt_mixed_states_only_reverts_reserved_and_pending() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let operation_id = uuid::Uuid::new_v4();
+
+        let reserved = test_proof_info(keyset_id, 100, mint_url.clone(), State::Reserved);
+        let pending = test_proof_info(keyset_id, 200, mint_url.clone(), State::Pending);
+        let spent = test_proof_info(keyset_id, 300, mint_url.clone(), State::Spent);
+
+        let reserved_y = reserved.y;
+        let pending_y = pending.y;
+        let spent_y = spent.y;
+
+        let reserved_proof = reserved.proof.clone();
+        let pending_proof = pending.proof.clone();
+        let spent_proof = spent.proof.clone();
+
+        db.update_proofs(vec![reserved, pending, spent], vec![])
+            .await
+            .unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        wallet
+            .cancel_prepared_melt(
+                operation_id,
+                vec![reserved_proof, pending_proof],
+                vec![spent_proof],
+            )
+            .await
+            .unwrap();
+
+        let stored = db
+            .get_proofs_by_ys(vec![reserved_y, pending_y, spent_y])
+            .await
+            .unwrap();
+        let state_for = |y| {
+            stored
+                .iter()
+                .find(|proof| proof.y == y)
+                .map(|proof| proof.state)
+        };
+        assert_eq!(state_for(reserved_y), Some(State::Unspent));
+        assert_eq!(state_for(pending_y), Some(State::Unspent));
+        assert_eq!(state_for(spent_y), Some(State::Spent));
     }
 }


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

closes: https://github.com/cashubtc/cdk/issues/1891

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
