### PR TITLE
feat(wallet): add offline ecash receiving with DLEQ verification

### DIFF
--- a/crates/cashu/src/nuts/nut07.rs
+++ b/crates/cashu/src/nuts/nut07.rs
@@ -37,6 +37,8 @@ pub enum State {
     Reserved,
     /// Pending spent (i.e., spent but not yet swapped by receiver)
     PendingSpent,
+    /// Pending receive (i.e. offline received but not yet swapped)
+    PendingReceive,
 }
 
 impl fmt::Display for State {
@@ -47,6 +49,7 @@ impl fmt::Display for State {
             Self::Pending => "PENDING",
             Self::Reserved => "RESERVED",
             Self::PendingSpent => "PENDING_SPENT",
+            Self::PendingReceive => "PENDING_RECEIVE",
         };
 
         write!(f, "{s}")
@@ -63,6 +66,7 @@ impl FromStr for State {
             "PENDING" => Ok(Self::Pending),
             "RESERVED" => Ok(Self::Reserved),
             "PENDING_SPENT" => Ok(Self::PendingSpent),
+            "PENDING_RECEIVE" => Ok(Self::PendingReceive),
             _ => Err(Error::UnknownState),
         }
     }

--- a/crates/cdk-cli/src/main.rs
+++ b/crates/cdk-cli/src/main.rs
@@ -96,6 +96,8 @@ enum Commands {
     Transfer(sub_commands::transfer::TransferSubCommand),
     /// Reclaim pending proofs that are no longer pending
     CheckPending,
+    /// Finalize pending receives by contacting the mint and swapping
+    FinalizeReceives(sub_commands::finalize_receives::FinalizeReceivesSubCommand),
     /// Check incoming payments for stored payment requests.
     CheckRequests,
     /// View mint info
@@ -297,6 +299,10 @@ async fn main() -> Result<()> {
         }
         Commands::CheckPending => {
             sub_commands::check_pending::check_pending(&wallet_repository).await
+        }
+        Commands::FinalizeReceives(sub_command_args) => {
+            sub_commands::finalize_receives::finalize_receives(&wallet_repository, sub_command_args)
+                .await
         }
         Commands::CheckRequests => {
             sub_commands::check_requests::check_requests(&wallet_repository).await

--- a/crates/cdk-cli/src/sub_commands/finalize_receives.rs
+++ b/crates/cdk-cli/src/sub_commands/finalize_receives.rs
@@ -1,0 +1,48 @@
+use anyhow::Result;
+use cdk::wallet::WalletRepository;
+
+#[derive(clap::Args, Clone)]
+pub struct FinalizeReceivesSubCommand {
+    /// Specify the mint url
+    #[arg(short, long)]
+    pub mint_url: Option<String>,
+}
+
+pub async fn finalize_receives(
+    wallet_repository: &WalletRepository,
+    sub_command_args: &FinalizeReceivesSubCommand,
+) -> Result<()> {
+    let wallets = wallet_repository.get_wallets().await;
+
+    let mut found_mint = false;
+    for wallet in wallets.iter() {
+        if let Some(mint_url) = &sub_command_args.mint_url {
+            if wallet.mint_url.to_string() != *mint_url {
+                continue;
+            }
+        }
+        found_mint = true;
+
+        match wallet.finalize_pending_receives().await {
+            Ok(amount) => {
+                println!(
+                    "Finalized pending receives for {}: {} {}",
+                    wallet.mint_url, amount, wallet.unit
+                );
+            }
+            Err(e) => {
+                println!("Error finalizing receives for {}: {}", wallet.mint_url, e);
+            }
+        }
+    }
+
+    if !found_mint {
+        if let Some(mint_url) = &sub_command_args.mint_url {
+            println!("No wallet found for mint: {}", mint_url);
+        } else {
+            println!("No wallets found.");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cdk-cli/src/sub_commands/mod.rs
+++ b/crates/cdk-cli/src/sub_commands/mod.rs
@@ -7,6 +7,7 @@ pub mod check_requests;
 pub mod create_request;
 pub mod decode_request;
 pub mod decode_token;
+pub mod finalize_receives;
 pub mod generate_public_key;
 pub mod get_public_keys;
 pub mod list_mint_proofs;

--- a/crates/cdk-cli/src/sub_commands/receive.rs
+++ b/crates/cdk-cli/src/sub_commands/receive.rs
@@ -37,6 +37,9 @@ pub struct ReceiveSubCommand {
     /// Allow receiving from untrusted mints (mints not already in the wallet)
     #[arg(long, default_value = "false")]
     allow_untrusted: bool,
+    /// Only accept the token offline and place it into PendingReceive state
+    #[arg(long, default_value = "false")]
+    offline: bool,
 }
 
 pub async fn receive(
@@ -72,6 +75,7 @@ pub async fn receive(
                 &signing_keys,
                 &sub_command_args.preimage,
                 sub_command_args.allow_untrusted,
+                sub_command_args.offline,
                 unit,
             )
             .await?
@@ -114,6 +118,7 @@ pub async fn receive(
                     &signing_keys,
                     &sub_command_args.preimage,
                     sub_command_args.allow_untrusted,
+                    sub_command_args.offline,
                     unit,
                 )
                 .await
@@ -142,6 +147,7 @@ async fn receive_token(
     signing_keys: &[SecretKey],
     preimage: &[String],
     allow_untrusted: bool,
+    offline: bool,
     unit: &CurrencyUnit,
 ) -> Result<Amount> {
     let token: Token = Token::from_str(token_str)?;
@@ -162,15 +168,22 @@ async fn receive_token(
     // Get or create wallet for the token's mint
     let wallet = get_or_create_wallet(wallet_repository, &mint_url, unit).await?;
 
-    // Create receive options
-    let receive_options = ReceiveOptions {
-        p2pk_signing_keys: signing_keys.to_vec(),
-        preimages: preimage.to_vec(),
-        ..Default::default()
-    };
+    if offline {
+        let options = cdk_common::wallet::OfflineReceiveOptions {
+            minimum_locktime: None,
+            require_locked: false,
+        };
+        Ok(wallet.receive_offline(token_str, options).await?)
+    } else {
+        // Create receive options
+        let receive_options = ReceiveOptions {
+            p2pk_signing_keys: signing_keys.to_vec(),
+            preimages: preimage.to_vec(),
+            ..Default::default()
+        };
 
-    let received = wallet.receive(token_str, receive_options).await?;
-    Ok(received)
+        Ok(wallet.receive(token_str, receive_options).await?)
+    }
 }
 
 /// Receive tokens sent to nostr pubkey via dm

--- a/crates/cdk-common/src/database/mint/test/proofs.rs
+++ b/crates/cdk-common/src/database/mint/test/proofs.rs
@@ -582,7 +582,8 @@ where
             | State::Reserved
             | State::Pending
             | State::Spent
-            | State::PendingSpent => {}
+            | State::PendingSpent
+            | State::PendingReceive => {}
         }
     }
     // It's OK if state is None for some implementations

--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -490,6 +490,22 @@ impl fmt::Debug for ReceiveOptions {
     }
 }
 
+/// Offline Receive options
+///
+/// DLEQ proof verification is always performed for offline receives
+/// since it is the only way to verify token authenticity without
+/// contacting the mint.
+///
+/// The wallet is already bound to a specific mint URL, so mint
+/// filtering is handled automatically.
+#[derive(Debug, Clone, Default)]
+pub struct OfflineReceiveOptions {
+    /// Optional minimum locktime required for the token
+    pub minimum_locktime: Option<u64>,
+    /// Require the token to be P2PK locked
+    pub require_locked: bool,
+}
+
 /// Send Kind
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum SendKind {
@@ -859,6 +875,12 @@ pub trait Wallet: Send + Sync {
     /// Total pending balance of the wallet
     async fn total_pending_balance(&self) -> Result<Self::Amount, Self::Error>;
 
+    /// Total pending-receive balance of the wallet
+    ///
+    /// Proofs in this state have been DLEQ-verified offline but not yet
+    /// swapped with the mint. Call `finalize_pending_receives` to settle them.
+    async fn total_pending_receive_balance(&self) -> Result<Self::Amount, Self::Error>;
+
     /// Total reserved balance of the wallet
     async fn total_reserved_balance(&self) -> Result<Self::Amount, Self::Error>;
 
@@ -970,6 +992,16 @@ pub trait Wallet: Send + Sync {
         memo: Option<String>,
         token: Option<String>,
     ) -> Result<Self::Amount, Self::Error>;
+
+    /// Receive an encoded token offline without contacting the mint
+    async fn receive_offline(
+        &self,
+        encoded_token: &str,
+        options: OfflineReceiveOptions,
+    ) -> Result<Self::Amount, Self::Error>;
+
+    /// Finalize pending offline receives by attempting to swap them
+    async fn finalize_pending_receives(&self) -> Result<Self::Amount, Self::Error>;
 
     /// Prepare a send transaction
     async fn prepare_send(

--- a/crates/cdk-common/src/wallet/saga/mod.rs
+++ b/crates/cdk-common/src/wallet/saga/mod.rs
@@ -84,6 +84,7 @@ impl WalletSagaState {
             WalletSagaState::Receive(s) => match s {
                 ReceiveSagaState::ProofsPending => "proofs_pending",
                 ReceiveSagaState::SwapRequested => "swap_requested",
+                ReceiveSagaState::OfflinePendingReceive => "offline_pending_receive",
             },
             WalletSagaState::Swap(s) => match s {
                 SwapSagaState::ProofsReserved => "proofs_reserved",

--- a/crates/cdk-common/src/wallet/saga/receive.rs
+++ b/crates/cdk-common/src/wallet/saga/receive.rs
@@ -13,6 +13,11 @@ pub enum ReceiveSagaState {
     ProofsPending,
     /// Swap request sent to mint, awaiting signatures for new proofs
     SwapRequested,
+    /// Proofs accepted offline (DLEQ-verified), stored as PendingReceive awaiting
+    /// `finalize_pending_receives`. This saga holds the original token string so
+    /// the memo and proof grouping survive until the wallet comes back online.
+    /// Recovery must NOT compensate this state — `finalize_pending_receives` owns it.
+    OfflinePendingReceive,
 }
 
 impl std::fmt::Display for ReceiveSagaState {
@@ -20,6 +25,7 @@ impl std::fmt::Display for ReceiveSagaState {
         match self {
             ReceiveSagaState::ProofsPending => write!(f, "proofs_pending"),
             ReceiveSagaState::SwapRequested => write!(f, "swap_requested"),
+            ReceiveSagaState::OfflinePendingReceive => write!(f, "offline_pending_receive"),
         }
     }
 }
@@ -30,6 +36,7 @@ impl std::str::FromStr for ReceiveSagaState {
         match s {
             "proofs_pending" => Ok(ReceiveSagaState::ProofsPending),
             "swap_requested" => Ok(ReceiveSagaState::SwapRequested),
+            "offline_pending_receive" => Ok(ReceiveSagaState::OfflinePendingReceive),
             _ => Err(Error::InvalidOperationState),
         }
     }

--- a/crates/cdk-ffi/src/types/proof.rs
+++ b/crates/cdk-ffi/src/types/proof.rs
@@ -17,6 +17,8 @@ pub enum ProofState {
     Spent,
     Reserved,
     PendingSpent,
+    /// Proofs received offline, verified via DLEQ, awaiting final swap
+    PendingReceive,
 }
 
 impl From<CdkState> for ProofState {
@@ -27,6 +29,7 @@ impl From<CdkState> for ProofState {
             CdkState::Spent => ProofState::Spent,
             CdkState::Reserved => ProofState::Reserved,
             CdkState::PendingSpent => ProofState::PendingSpent,
+            CdkState::PendingReceive => ProofState::PendingReceive,
         }
     }
 }
@@ -39,6 +42,7 @@ impl From<ProofState> for CdkState {
             ProofState::Spent => CdkState::Spent,
             ProofState::Reserved => CdkState::Reserved,
             ProofState::PendingSpent => CdkState::PendingSpent,
+            ProofState::PendingReceive => CdkState::PendingReceive,
         }
     }
 }

--- a/crates/cdk-ffi/src/types/wallet.rs
+++ b/crates/cdk-ffi/src/types/wallet.rs
@@ -457,6 +457,47 @@ pub fn encode_receive_options(options: ReceiveOptions) -> Result<String, FfiErro
     Ok(serde_json::to_string(&options)?)
 }
 
+/// FFI-compatible Offline Receive options
+///
+/// DLEQ proof verification is always performed for offline receives
+/// since it is the only way to verify token authenticity without
+/// contacting the mint.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, uniffi::Record)]
+pub struct OfflineReceiveOptions {
+    /// Optional minimum locktime required for the token (Unix timestamp)
+    pub minimum_locktime: Option<u64>,
+    /// Require the token to be P2PK locked
+    pub require_locked: bool,
+}
+
+impl From<OfflineReceiveOptions> for cdk_common::wallet::OfflineReceiveOptions {
+    fn from(opts: OfflineReceiveOptions) -> Self {
+        Self {
+            minimum_locktime: opts.minimum_locktime,
+            require_locked: opts.require_locked,
+        }
+    }
+}
+
+impl OfflineReceiveOptions {
+    /// Convert OfflineReceiveOptions to JSON string
+    pub fn to_json(&self) -> Result<String, FfiError> {
+        Ok(serde_json::to_string(self)?)
+    }
+}
+
+/// Decode OfflineReceiveOptions from JSON string
+#[uniffi::export]
+pub fn decode_offline_receive_options(json: String) -> Result<OfflineReceiveOptions, FfiError> {
+    Ok(serde_json::from_str(&json)?)
+}
+
+/// Encode OfflineReceiveOptions to JSON string
+#[uniffi::export]
+pub fn encode_offline_receive_options(options: OfflineReceiveOptions) -> Result<String, FfiError> {
+    Ok(serde_json::to_string(&options)?)
+}
+
 /// FFI-compatible NUT-13 restore options
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
 pub struct NUT13Options {

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -128,6 +128,12 @@ impl Wallet {
         Ok(balance.into())
     }
 
+    /// Get total pending receive balance
+    pub async fn total_pending_receive_balance(&self) -> Result<Amount, FfiError> {
+        let balance = self.inner.total_pending_receive_balance().await?;
+        Ok(balance.into())
+    }
+
     /// Get total reserved balance
     pub async fn total_reserved_balance(&self) -> Result<Amount, FfiError> {
         let balance = self.inner.total_reserved_balance().await?;
@@ -205,6 +211,32 @@ impl Wallet {
             .receive_proofs(cdk_proofs, options.try_into()?, memo, token)
             .await?;
         Ok(amount.into())
+    }
+
+    /// Receive an encoded token offline without contacting the mint
+    ///
+    /// Verifies the token's DLEQ proofs locally (no network call) and stores
+    /// the proofs as `PendingReceive` in the local database. Call
+    /// `finalize_pending_receives` once back online to settle them.
+    pub async fn receive_offline(
+        &self,
+        encoded_token: String,
+        options: OfflineReceiveOptions,
+    ) -> Result<Amount, FfiError> {
+        Ok(self
+            .inner
+            .receive_offline(&encoded_token, options.into())
+            .await?
+            .into())
+    }
+
+    /// Finalize pending offline receives by swapping with the mint
+    ///
+    /// Finds all proofs stored as `PendingReceive` (from prior calls to
+    /// `receive_offline`) and swaps them with the mint, making them fully
+    /// spendable. Requires an active network connection.
+    pub async fn finalize_pending_receives(&self) -> Result<Amount, FfiError> {
+        Ok(self.inner.finalize_pending_receives().await?.into())
     }
 
     /// Get all pending send operations
@@ -548,6 +580,11 @@ impl Wallet {
                 ProofState::Pending => self.inner.get_pending_proofs().await?,
                 ProofState::Reserved => self.inner.get_reserved_proofs().await?,
                 ProofState::PendingSpent => self.inner.get_pending_spent_proofs().await?,
+                ProofState::PendingReceive => {
+                    self.inner
+                        .get_proofs_by_states(vec![cdk::nuts::State::PendingReceive])
+                        .await?
+                }
                 ProofState::Spent => {
                     // CDK doesn't have a method to get spent proofs directly
                     // They are removed from the database when spent

--- a/crates/cdk-ffi/src/wallet_trait.rs
+++ b/crates/cdk-ffi/src/wallet_trait.rs
@@ -53,6 +53,11 @@ impl WalletTraitDef for Wallet {
         Ok(balance.into())
     }
 
+    async fn total_pending_receive_balance(&self) -> Result<Self::Amount, Self::Error> {
+        let balance = WalletTraitDef::total_pending_receive_balance(self.inner().as_ref()).await?;
+        Ok(balance.into())
+    }
+
     async fn total_reserved_balance(&self) -> Result<Self::Amount, Self::Error> {
         let balance = WalletTraitDef::total_reserved_balance(self.inner().as_ref()).await?;
         Ok(balance.into())
@@ -554,5 +559,22 @@ impl WalletTraitDef for Wallet {
     ) -> Result<Option<cdk::nuts::SecretKey>, Self::Error> {
         let signing_key = WalletTraitDef::get_signing_key(self.inner().as_ref(), pubkey).await?;
         Ok(signing_key)
+    }
+
+    /// Receive a token offline: verify DLEQ proofs and store in PendingReceive state.
+    async fn receive_offline(
+        &self,
+        encoded_token: &str,
+        options: cdk_common::wallet::OfflineReceiveOptions,
+    ) -> Result<Self::Amount, Self::Error> {
+        let amount =
+            WalletTraitDef::receive_offline(self.inner().as_ref(), encoded_token, options).await?;
+        Ok(amount.into())
+    }
+
+    /// Finalize all pending receives by swapping them with the mint.
+    async fn finalize_pending_receives(&self) -> Result<Self::Amount, Self::Error> {
+        let amount = WalletTraitDef::finalize_pending_receives(self.inner().as_ref()).await?;
+        Ok(amount.into())
     }
 }

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -3699,3 +3699,405 @@ async fn test_p2pk_signing_keys_mixed_locked_and_unlocked_proofs() {
         "Bob should receive exactly the send amount"
     );
 }
+
+/// Tests the full offline receive lifecycle:
+///
+/// 1. Alice funds herself online and sends 40 sats to Carol as a token string.
+/// 2. Carol calls `receive_offline()` — no swap request is made to the Mint.
+///    Instead, the proofs are verified via DLEQ and stored as `PendingReceive`.
+/// 3. We verify that Carol's spendable balance is zero (proofs are not yet spendable)
+///    but proofs exist in `PendingReceive` state in the database.
+/// 4. Carol calls `finalize_pending_receives()` which swaps the proofs online,
+///    moving them to `Unspent` and making them fully spendable.
+#[tokio::test]
+async fn test_receive_offline_pending_then_finalize() {
+    setup_tracing();
+
+    let mint_bob = create_and_start_test_mint()
+        .await
+        .expect("Failed to create test mint");
+
+    let wallet_alice = create_test_wallet_for_mint(mint_bob.clone())
+        .await
+        .expect("Failed to create Alice's wallet");
+
+    // Alice gets 64 sats online
+    fund_wallet(wallet_alice.clone(), 64, None)
+        .await
+        .expect("Failed to fund Alice");
+
+    assert_eq!(
+        Amount::from(64),
+        wallet_alice.total_balance().await.unwrap()
+    );
+
+    // Alice prepares and confirms a send of 40 sats
+    let prepared = wallet_alice
+        .prepare_send(Amount::from(40), SendOptions::default())
+        .await
+        .expect("Failed to prepare send");
+
+    let token = prepared
+        .confirm(None)
+        .await
+        .expect("Failed to confirm send");
+
+    let token_str = token.to_string();
+
+    // Carol's wallet is connected to the same mint, so it has the keyset cached
+    let wallet_carol = create_test_wallet_for_mint(mint_bob.clone())
+        .await
+        .expect("Failed to create Carol's wallet");
+
+    // Carol receives offline — no swap is performed with the mint
+    let pending_amount = wallet_carol
+        .receive_offline(
+            &token_str,
+            cdk_common::wallet::OfflineReceiveOptions::default(),
+        )
+        .await
+        .expect("receive_offline should succeed with valid DLEQ proofs");
+
+    assert_eq!(
+        Amount::from(40),
+        pending_amount,
+        "receive_offline should return the token amount"
+    );
+
+    // Carol's spendable balance should still be zero — proofs are PendingReceive
+    assert_eq!(
+        Amount::ZERO,
+        wallet_carol.total_balance().await.unwrap(),
+        "Spendable balance should be zero until proofs are finalized"
+    );
+
+    // Verify the proofs are in PendingReceive state
+    let pending_proofs = wallet_carol
+        .get_proofs_by_states(vec![State::PendingReceive])
+        .await
+        .expect("Failed to get pending proofs");
+
+    assert!(
+        !pending_proofs.is_empty(),
+        "Proofs should be stored in PendingReceive state after offline receive"
+    );
+
+    // Carol comes back online and finalizes the pending receives
+    let finalized_amount = wallet_carol
+        .finalize_pending_receives()
+        .await
+        .expect("finalize_pending_receives should succeed");
+
+    assert_eq!(
+        Amount::from(40),
+        finalized_amount,
+        "finalize_pending_receives should return the finalized amount"
+    );
+
+    // Now Carol's balance should reflect the received funds
+    assert_eq!(
+        Amount::from(40),
+        wallet_carol.total_balance().await.unwrap(),
+        "Carol's balance should be 40 after finalizing"
+    );
+
+    // No proofs should remain in PendingReceive state
+    let still_pending = wallet_carol
+        .get_proofs_by_states(vec![State::PendingReceive])
+        .await
+        .expect("Failed to get pending proofs after finalization");
+
+    assert!(
+        still_pending.is_empty(),
+        "No proofs should remain in PendingReceive state after finalization"
+    );
+}
+
+/// Tests that `receive_offline` rejects tokens that do not carry DLEQ proofs.
+///
+/// DLEQ proofs are the *only* cryptographic guarantee available when offline.
+/// Without them, the wallet cannot verify token authenticity. This test
+/// ensures the function fails with `DleqProofNotProvided`.
+#[tokio::test]
+async fn test_receive_offline_rejects_token_without_dleq() {
+    setup_tracing();
+
+    let mint_bob = create_and_start_test_mint()
+        .await
+        .expect("Failed to create test mint");
+
+    let wallet_alice = create_test_wallet_for_mint(mint_bob.clone())
+        .await
+        .expect("Failed to create Alice's wallet");
+
+    // Alice gets 64 sats online
+    fund_wallet(wallet_alice.clone(), 64, None)
+        .await
+        .expect("Failed to fund Alice");
+
+    // Alice prepares and confirms a send of 10 sats
+    let prepared = wallet_alice
+        .prepare_send(Amount::from(10), SendOptions::default())
+        .await
+        .expect("Failed to prepare send");
+
+    let token = prepared
+        .confirm(None)
+        .await
+        .expect("Failed to confirm send");
+
+    // Manually strip DLEQ proofs from the token
+    let keysets_info = to_keyset_infos(&wallet_alice.keysets(Default::default()).await.unwrap());
+
+    let mut proofs = token.proofs(&keysets_info).unwrap();
+    for proof in &mut proofs {
+        proof.dleq = None;
+    }
+
+    let stripped_token = cashu::Token::new(
+        wallet_alice.mint_url.clone(),
+        proofs,
+        token.memo().clone(),
+        CurrencyUnit::Sat,
+    );
+
+    let wallet_carol = create_test_wallet_for_mint(mint_bob.clone())
+        .await
+        .expect("Failed to create Carol's wallet");
+
+    // Carol tries to receive offline — must fail because DLEQ is missing
+    let result = wallet_carol
+        .receive_offline(
+            &stripped_token.to_string(),
+            cdk_common::wallet::OfflineReceiveOptions::default(),
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "receive_offline must reject tokens without DLEQ proofs"
+    );
+
+    match result.unwrap_err() {
+        cdk::Error::DleqProofNotProvided => {}
+        other => panic!("Expected DleqProofNotProvided error, got: {:?}", other),
+    }
+}
+
+/// Tests that `finalize_pending_receives` removes a double-spent proof.
+///
+/// If a sender gives Carol a token and then spends the same proofs before Carol
+/// finalises, the mint will definitively reject Carol's swap request. The saga's
+/// compensation step deletes the proof from Carol's database, and
+/// `finalize_pending_receives` must NOT re-store it — doing so would create an
+/// infinite retry loop on every subsequent call.
+///
+/// Scenario:
+/// 1. Alice sends a 40-sat token to Carol (Carol stores it as PendingReceive).
+/// 2. Bob receives the same token online, spending the proofs at the mint.
+/// 3. Carol calls `finalize_pending_receives()` — the mint rejects the swap.
+/// 4. Carol's PendingReceive proof is gone and her balance remains zero.
+#[tokio::test]
+async fn test_finalize_pending_receives_removes_double_spent_proof() {
+    setup_tracing();
+
+    let mint_bob = create_and_start_test_mint()
+        .await
+        .expect("Failed to create test mint");
+
+    let wallet_alice = create_test_wallet_for_mint(mint_bob.clone())
+        .await
+        .expect("Failed to create Alice's wallet");
+
+    fund_wallet(wallet_alice.clone(), 64, None)
+        .await
+        .expect("Failed to fund Alice");
+
+    // Alice creates a 40-sat token
+    let prepared = wallet_alice
+        .prepare_send(Amount::from(40), SendOptions::default())
+        .await
+        .expect("Failed to prepare send");
+
+    let token = prepared
+        .confirm(None)
+        .await
+        .expect("Failed to confirm send");
+
+    let token_str = token.to_string();
+
+    // Carol stores the token offline without contacting the mint
+    let wallet_carol = create_test_wallet_for_mint(mint_bob.clone())
+        .await
+        .expect("Failed to create Carol's wallet");
+
+    let pending_amount = wallet_carol
+        .receive_offline(
+            &token_str,
+            cdk_common::wallet::OfflineReceiveOptions::default(),
+        )
+        .await
+        .expect("receive_offline should accept token with valid DLEQ");
+
+    assert_eq!(Amount::from(40), pending_amount);
+
+    // Sanity: Carol has a PendingReceive proof before finalization
+    let pending_before = wallet_carol
+        .get_proofs_by_states(vec![State::PendingReceive])
+        .await
+        .expect("Failed to get proofs");
+    assert!(
+        !pending_before.is_empty(),
+        "Should have PendingReceive proof"
+    );
+
+    // Bob spends the same proofs at the mint — simulates sender double-spending
+    let wallet_bob = create_test_wallet_for_mint(mint_bob.clone())
+        .await
+        .expect("Failed to create Bob's wallet");
+
+    wallet_bob
+        .receive(&token_str, ReceiveOptions::default())
+        .await
+        .expect("Bob should successfully receive the token first");
+
+    // Carol now tries to finalize — the mint will reject her swap (already spent)
+    let finalized = wallet_carol
+        .finalize_pending_receives()
+        .await
+        .expect("finalize_pending_receives should not return Err for definitive failures");
+
+    assert_eq!(
+        Amount::ZERO,
+        finalized,
+        "No amount should be finalized when proofs are double-spent"
+    );
+
+    // Carol's balance must be zero
+    assert_eq!(
+        Amount::ZERO,
+        wallet_carol.total_balance().await.unwrap(),
+        "Carol's balance should remain zero after a failed finalization"
+    );
+
+    // The PendingReceive proof must have been removed — not re-stored
+    let pending_after = wallet_carol
+        .get_proofs_by_states(vec![State::PendingReceive])
+        .await
+        .expect("Failed to get proofs after finalization");
+
+    assert!(
+        pending_after.is_empty(),
+        "Definitively rejected proof must be removed, not re-stored as PendingReceive"
+    );
+}
+
+/// Tests that `finalize_pending_receives` preserves the token memo and emits a
+/// single transaction record for a multi-proof token.
+///
+/// Without the fix, each proof from the same token would be swapped individually
+/// and produce multiple context-less transaction records with no memo.
+///
+/// Scenario:
+/// 1. Alice sends a 40-sat token to Carol with memo "coffee money". The mint
+///    splits 40 into at least two proofs (e.g. 32 + 8), so this exercises the
+///    grouping path.
+/// 2. Carol stores the token offline (DLEQ verified, no network needed).
+/// 3. Carol calls `finalize_pending_receives()` — exactly one incoming
+///    transaction must appear, carrying the original memo.
+#[tokio::test]
+async fn test_finalize_pending_receives_preserves_memo_and_groups_proofs() {
+    setup_tracing();
+
+    let mint_bob = create_and_start_test_mint()
+        .await
+        .expect("Failed to create test mint");
+
+    let wallet_alice = create_test_wallet_for_mint(mint_bob.clone())
+        .await
+        .expect("Failed to create Alice's wallet");
+
+    fund_wallet(wallet_alice.clone(), 64, None)
+        .await
+        .expect("Failed to fund Alice");
+
+    // Alice sends 40 sats with a memo attached to the token.
+    // The mint represents 40 as 32+8, so the token has at least two proofs —
+    // enough to exercise the grouping-under-one-transaction requirement.
+    let prepared = wallet_alice
+        .prepare_send(Amount::from(40), SendOptions::default())
+        .await
+        .expect("Failed to prepare send");
+
+    let token = prepared
+        .confirm(Some(SendMemo::for_token("coffee money")))
+        .await
+        .expect("Failed to confirm send");
+
+    let token_str = token.to_string();
+    assert_eq!(token.memo().as_deref(), Some("coffee money"));
+
+    let wallet_carol = create_test_wallet_for_mint(mint_bob.clone())
+        .await
+        .expect("Failed to create Carol's wallet");
+
+    // Carol stores offline — proofs are PendingReceive, no transaction yet.
+    let pending_amount = wallet_carol
+        .receive_offline(
+            &token_str,
+            cdk_common::wallet::OfflineReceiveOptions::default(),
+        )
+        .await
+        .expect("receive_offline should accept token with valid DLEQ");
+
+    assert_eq!(Amount::from(40), pending_amount);
+    assert!(
+        wallet_carol
+            .list_transactions(None)
+            .await
+            .unwrap()
+            .is_empty(),
+        "No transaction should be recorded until finalization"
+    );
+
+    // Carol comes online and finalizes.
+    let finalized = wallet_carol
+        .finalize_pending_receives()
+        .await
+        .expect("finalize_pending_receives should not error");
+
+    assert!(
+        finalized > Amount::ZERO,
+        "Carol should have received some sats after finalization"
+    );
+
+    // Exactly one incoming transaction — not one per proof.
+    let txs = wallet_carol
+        .list_transactions(Some(TransactionDirection::Incoming))
+        .await
+        .expect("Failed to list transactions");
+
+    assert_eq!(
+        1,
+        txs.len(),
+        "Multi-proof token must produce exactly one transaction, not one per proof (got {})",
+        txs.len()
+    );
+
+    // The memo from the original token must survive through finalization.
+    assert_eq!(
+        Some("coffee money".to_string()),
+        txs[0].memo,
+        "Transaction memo must match the sender's original token memo"
+    );
+
+    // No proofs left stuck in PendingReceive.
+    let pending_after = wallet_carol
+        .get_proofs_by_states(vec![State::PendingReceive])
+        .await
+        .expect("Failed to get proofs");
+    assert!(
+        pending_after.is_empty(),
+        "No PendingReceive proofs should remain after finalization"
+    );
+}

--- a/crates/cdk-sql-common/src/wallet/migrations/postgres/20260423000000_allow_pending_receive.sql
+++ b/crates/cdk-sql-common/src/wallet/migrations/postgres/20260423000000_allow_pending_receive.sql
@@ -1,0 +1,12 @@
+-- Migration to add PENDING_RECEIVE to the proof state check constraint
+-- Since the constraint is anonymous in initial migration, we drop and recreate it with a name
+
+-- Drop potential anonymous constraints (Postgres generates names like proof_state_check)
+DO $$ 
+BEGIN 
+    ALTER TABLE proof DROP CONSTRAINT IF EXISTS proof_state_check;
+EXCEPTION 
+    WHEN undefined_object THEN null; 
+END $$;
+
+ALTER TABLE proof ADD CONSTRAINT proof_state_check CHECK (state IN ('SPENT', 'UNSPENT', 'PENDING', 'RESERVED', 'PENDING_SPENT', 'PENDING_RECEIVE'));

--- a/crates/cdk-sql-common/src/wallet/migrations/sqlite/20260423000000_allow_pending_receive.sql
+++ b/crates/cdk-sql-common/src/wallet/migrations/sqlite/20260423000000_allow_pending_receive.sql
@@ -1,0 +1,39 @@
+-- Create a new table with the updated CHECK constraint
+CREATE TABLE IF NOT EXISTS proof_new (
+    y BLOB PRIMARY KEY,
+    mint_url TEXT NOT NULL,
+    state TEXT CHECK ( state IN ('SPENT', 'UNSPENT', 'PENDING', 'RESERVED', 'PENDING_SPENT', 'PENDING_RECEIVE' ) ) NOT NULL,
+    spending_condition TEXT,
+    unit TEXT NOT NULL,
+    amount INTEGER NOT NULL,
+    keyset_id TEXT NOT NULL,
+    secret TEXT NOT NULL,
+    c BLOB NOT NULL,
+    witness TEXT,
+    dleq_e BLOB,
+    dleq_s BLOB,
+    dleq_r BLOB,
+    used_by_operation TEXT,
+    created_by_operation TEXT,
+    p2pk_e BLOB
+);
+
+CREATE INDEX IF NOT EXISTS secret_index ON proof_new(secret);
+CREATE INDEX IF NOT EXISTS state_index ON proof_new(state);
+CREATE INDEX IF NOT EXISTS spending_condition_index ON proof_new(spending_condition);
+CREATE INDEX IF NOT EXISTS unit_index ON proof_new(unit);
+CREATE INDEX IF NOT EXISTS amount_index ON proof_new(amount);
+CREATE INDEX IF NOT EXISTS mint_url_index ON proof_new(mint_url);
+CREATE INDEX IF NOT EXISTS proof_used_by_operation_index ON proof_new(used_by_operation);
+CREATE INDEX IF NOT EXISTS proof_created_by_operation_index ON proof_new(created_by_operation);
+
+-- Copy data from old proof table to new proof table
+INSERT INTO proof_new (y, mint_url, state, spending_condition, unit, amount, keyset_id, secret, c, witness, dleq_e, dleq_s, dleq_r, used_by_operation, created_by_operation, p2pk_e)
+SELECT y, mint_url, state, spending_condition, unit, amount, keyset_id, secret, c, witness, dleq_e, dleq_s, dleq_r, used_by_operation, created_by_operation, p2pk_e
+FROM proof;
+
+-- Drop the old proof table
+DROP TABLE proof;
+
+-- Rename the new proof table to proof
+ALTER TABLE proof_new RENAME TO proof;

--- a/crates/cdk/src/mint/check_spendable.rs
+++ b/crates/cdk/src/mint/check_spendable.rs
@@ -128,7 +128,7 @@ mod tests {
                     .unwrap();
                 tx.commit().await.unwrap();
             }
-            State::Reserved | State::PendingSpent => {
+            State::Reserved | State::PendingSpent | State::PendingReceive => {
                 panic!("mint proof state is not valid for check_state witness tests");
             }
         }

--- a/crates/cdk/src/wallet/balance.rs
+++ b/crates/cdk/src/wallet/balance.rs
@@ -26,6 +26,16 @@ impl Wallet {
         Ok(self.get_pending_proofs().await?.total_amount()?)
     }
 
+    /// Total pending-receive balance
+    ///
+    /// Returns the sum of proofs that have been verified offline (DLEQ) and
+    /// stored as [`State::PendingReceive`], but have not yet been swapped with
+    /// the mint. Call [`Wallet::finalize_pending_receives`] to settle them.
+    #[instrument(skip(self))]
+    pub async fn total_pending_receive_balance(&self) -> Result<Amount, Error> {
+        Ok(self.get_pending_receive_proofs().await?.total_amount()?)
+    }
+
     /// Total reserved balance
     #[instrument(skip(self))]
     pub async fn total_reserved_balance(&self) -> Result<Amount, Error> {

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -39,6 +39,17 @@ impl Wallet {
             .await
     }
 
+    /// Get pending receive [`Proofs`]
+    ///
+    /// These proofs have been verified offline (DLEQ) and stored locally, but
+    /// have not yet been swapped with the mint.  Call
+    /// [`Wallet::finalize_pending_receives`] to settle them.
+    #[instrument(skip(self))]
+    pub async fn get_pending_receive_proofs(&self) -> Result<Proofs, Error> {
+        self.get_proofs_with(Some(vec![State::PendingReceive]), None)
+            .await
+    }
+
     /// Get proofs filtered by states
     #[instrument(skip(self))]
     pub async fn get_proofs_by_states(&self, states: Vec<State>) -> Result<Proofs, Error> {

--- a/crates/cdk/src/wallet/receive/mod.rs
+++ b/crates/cdk/src/wallet/receive/mod.rs
@@ -2,9 +2,12 @@
 //!
 //! This module provides functionality for receiving ecash tokens and proofs.
 
+use std::collections::HashMap;
 use std::str::FromStr;
 
+use cdk_common::wallet::KeysetLoadPolicy;
 use tracing::instrument;
+use uuid::Uuid;
 
 use crate::nuts::{Proofs, Token};
 use crate::{ensure_cdk, Amount, Error, Wallet};
@@ -127,5 +130,373 @@ impl Wallet {
     ) -> Result<Amount, Error> {
         let token_str = Token::try_from(binary_token)?.to_string();
         self.receive(token_str.as_str(), opts).await
+    }
+
+    /// Receive an encoded token offline without contacting the mint
+    #[instrument(skip_all)]
+    pub async fn receive_offline(
+        &self,
+        encoded_token: &str,
+        opts: cdk_common::wallet::OfflineReceiveOptions,
+    ) -> Result<Amount, Error> {
+        let token = Token::from_str(encoded_token)?;
+
+        let unit = token.unit().unwrap_or_default();
+        ensure_cdk!(unit == self.unit, Error::UnsupportedUnit);
+
+        let mint_url = token.mint_url()?;
+        ensure_cdk!(self.mint_url == mint_url, Error::IncorrectMint);
+
+        if let Token::TokenV3(token) = &token {
+            ensure_cdk!(!token.is_multi_mint(), Error::MultiMintTokenNotSupported);
+        }
+
+        // token_proofs loads ALL keysets (active + inactive) so tokens from
+        // rotated keysets are decoded correctly — the same helper used by
+        // online receive(), keeping the two paths consistent.
+        let mut proofs = self.token_proofs(&token).await?;
+
+        let mut total_amount = Amount::ZERO;
+
+        for proof in &mut proofs {
+            // DLEQ verification is always required for offline receive
+            ensure_cdk!(proof.dleq.is_some(), Error::DleqProofNotProvided);
+
+            // CacheOnly so offline receive never contacts the mint — the
+            // default policy (CacheThenNetwork) would silently go online.
+            let keys = self
+                .keyset_with_policy(proof.keyset_id, KeysetLoadPolicy::CacheOnly)
+                .await?
+                .keys;
+            let key = keys.amount_key(proof.amount).ok_or_else(|| {
+                Error::Custom(format!(
+                    "keyset {} not in local cache — connect to the mint once to sync keysets",
+                    proof.keyset_id
+                ))
+            })?;
+            proof.verify_dleq(key)?;
+
+            if opts.require_locked {
+                let secret: crate::nuts::nut10::Secret =
+                    proof.secret.clone().try_into().map_err(|_| {
+                        Error::InvalidSpendConditions("Token must be P2PK locked".to_string())
+                    })?;
+                ensure_cdk!(
+                    matches!(secret.kind(), crate::nuts::nut10::Kind::P2PK),
+                    Error::InvalidSpendConditions("Token must be P2PK locked".to_string())
+                );
+            }
+
+            if let Some(min_locktime) = opts.minimum_locktime {
+                let secret: crate::nuts::nut10::Secret = proof
+                    .secret
+                    .clone()
+                    .try_into()
+                    .map_err(|_| Error::LocktimeNotProvided)?;
+                let conditions: crate::nuts::Conditions = secret
+                    .secret_data()
+                    .tags()
+                    .cloned()
+                    .unwrap_or_default()
+                    .try_into()
+                    .map_err(|_| Error::LocktimeNotProvided)?;
+                let locktime = conditions.locktime.ok_or(Error::LocktimeNotProvided)?;
+                ensure_cdk!(
+                    locktime >= min_locktime,
+                    Error::InvalidSpendConditions(format!(
+                        "Locktime {} is less than required {}",
+                        locktime, min_locktime
+                    ))
+                );
+            }
+
+            total_amount += proof.amount;
+        }
+
+        use cdk_common::wallet::{
+            OperationData, ReceiveOperationData, ReceiveSagaState, WalletSaga, WalletSagaState,
+        };
+
+        use crate::nuts::State;
+        use crate::wallet::ProofInfo;
+
+        // One UUID ties all proofs from this token together so finalize_pending_receives
+        // can process them as a single receive operation and recover the memo.
+        let operation_id = Uuid::now_v7();
+
+        let proofs_info = proofs
+            .clone()
+            .into_iter()
+            .map(|p| {
+                ProofInfo::new_with_operations(
+                    p,
+                    self.mint_url.clone(),
+                    State::PendingReceive,
+                    self.unit.clone(),
+                    None,
+                    Some(operation_id),
+                )
+            })
+            .collect::<Result<Vec<ProofInfo>, _>>()?;
+
+        // Store proofs as PendingReceive — no transaction is recorded here.
+        // The transaction will be recorded by the ReceiveSaga when
+        // `finalize_pending_receives` completes the swap with the mint.
+        self.localstore.update_proofs(proofs_info, vec![]).await?;
+
+        // Write a saga entry to preserve the original token string (and its memo)
+        // until finalization. The OfflinePendingReceive state tells crash recovery
+        // to skip this saga — finalize_pending_receives owns it.
+        let saga = WalletSaga::new(
+            operation_id,
+            WalletSagaState::Receive(ReceiveSagaState::OfflinePendingReceive),
+            total_amount,
+            self.mint_url.clone(),
+            self.unit.clone(),
+            OperationData::Receive(ReceiveOperationData {
+                token: Some(encoded_token.to_string()),
+                counter_start: None,
+                counter_end: None,
+                amount: Some(total_amount),
+                blinded_messages: None,
+            }),
+        );
+        self.localstore.add_saga(saga).await?;
+
+        Ok(total_amount)
+    }
+
+    /// Finalize pending offline receives by attempting to swap them with the mint.
+    ///
+    /// Proofs that were stored via [`Wallet::receive_offline`] are processed in
+    /// their original token groups so that a multi-proof token produces a single
+    /// transaction record and the sender's memo is preserved.
+    ///
+    /// Each group (and any ungrouped legacy proofs) is processed independently so
+    /// that one bad token cannot block valid ones:
+    ///
+    /// - **Success**: all proofs in the group are swapped for fresh `Unspent`
+    ///   proofs and one transaction record is written with the original memo.
+    /// - **Definitive failure** (e.g. the sender double-spent the token): the
+    ///   saga's compensation step removes the proofs from the database. The proof
+    ///   Y values and error are logged at `WARN` level for diagnostics.
+    /// - **Transient failure** (e.g. mint unreachable): the proofs are left in
+    ///   `Pending` state with a `SwapRequested` saga entry. Call
+    ///   [`Wallet::recover_incomplete_sagas`] once back online to retry.
+    #[instrument(skip_all)]
+    pub async fn finalize_pending_receives(&self) -> Result<Amount, Error> {
+        use cdk_common::wallet::OperationData;
+
+        use crate::nuts::State;
+
+        let proofs_info = self
+            .localstore
+            .get_proofs(
+                Some(self.mint_url.clone()),
+                Some(self.unit.clone()),
+                Some(vec![State::PendingReceive]),
+                None,
+            )
+            .await?;
+
+        if proofs_info.is_empty() {
+            return Ok(Amount::ZERO);
+        }
+
+        let mut total = Amount::ZERO;
+
+        // Group proofs by their offline-receive operation ID (created_by_operation).
+        // Proofs without an ID were stored before this grouping was introduced and
+        // are processed individually as a backward-compatible fallback.
+        let mut grouped: HashMap<Uuid, Vec<_>> = HashMap::new();
+        let mut ungrouped: Vec<_> = Vec::new();
+
+        for proof_info in proofs_info {
+            match proof_info.created_by_operation {
+                Some(op_id) => grouped.entry(op_id).or_default().push(proof_info),
+                None => ungrouped.push(proof_info),
+            }
+        }
+
+        // Process each group as one receive operation, recovering the memo from
+        // the OfflinePendingReceive saga written at receive_offline time.
+        for (op_id, proof_infos) in grouped {
+            let (memo, token_str) = match self.localstore.get_saga(&op_id).await? {
+                Some(saga) => {
+                    if let OperationData::Receive(ref data) = saga.data {
+                        let token_str = data.token.clone();
+                        let memo = token_str
+                            .as_deref()
+                            .and_then(|t| Token::from_str(t).ok())
+                            .and_then(|tok| tok.memo().clone());
+                        (memo, token_str)
+                    } else {
+                        (None, None)
+                    }
+                }
+                None => (None, None),
+            };
+
+            let proof_ys: Vec<_> = proof_infos.iter().map(|p| p.y).collect();
+            let proofs: Vec<_> = proof_infos.into_iter().map(|p| p.proof).collect();
+
+            let result = self
+                .receive_proofs(proofs, ReceiveOptions::default(), memo, token_str)
+                .await;
+
+            // Only drop the OfflinePendingReceive saga once the proofs have actually
+            // been taken over. `receive_proofs` runs prepare() (no DB changes) before
+            // execute() (which moves the proofs to Pending under a SwapRequested saga
+            // and registers compensation). If it fails inside prepare() the proofs are
+            // still in PendingReceive and this saga is the only record of their memo,
+            // so deleting it here would lose the memo (transient) or strand the proofs
+            // forever (definitive). Detect that by checking whether the proofs are
+            // still PendingReceive under this operation.
+            match result {
+                Ok(amount) => {
+                    total += amount;
+                    self.delete_offline_receive_saga(op_id).await;
+                }
+                Err(e) => {
+                    let still_pending = self
+                        .localstore
+                        .get_proofs(
+                            Some(self.mint_url.clone()),
+                            Some(self.unit.clone()),
+                            Some(vec![State::PendingReceive]),
+                            None,
+                        )
+                        .await?
+                        .iter()
+                        .any(|p| p.created_by_operation == Some(op_id));
+
+                    if !still_pending {
+                        // execute() took ownership: the proofs are now Pending under a
+                        // SwapRequested saga (transient) or were removed by compensation
+                        // (definitive). Either way the offline saga is redundant.
+                        self.delete_offline_receive_saga(op_id).await;
+                        if e.is_definitive_failure() {
+                            tracing::warn!(
+                                ys = ?proof_ys,
+                                error = %e,
+                                "Mint definitively rejected a pending offline receive; \
+                                 proofs removed (token was double-spent or invalid)"
+                            );
+                        } else {
+                            tracing::warn!(
+                                ys = ?proof_ys,
+                                error = %e,
+                                "Transient failure finalizing pending offline receive; \
+                                 will retry via recover_incomplete_sagas()"
+                            );
+                        }
+                    } else if e.is_definitive_failure() {
+                        // prepare() rejected the token for good; the proofs are orphaned
+                        // in PendingReceive. Remove them, then drop the offline saga.
+                        self.localstore
+                            .update_proofs(vec![], proof_ys.clone())
+                            .await?;
+                        self.delete_offline_receive_saga(op_id).await;
+                        tracing::warn!(
+                            ys = ?proof_ys,
+                            error = %e,
+                            "Mint definitively rejected a pending offline receive; \
+                             proofs removed (token was double-spent or invalid)"
+                        );
+                    } else {
+                        // prepare() failed transiently: keep both the proofs and the
+                        // saga so the next finalize_pending_receives retains the memo
+                        // and can retry.
+                        tracing::warn!(
+                            ys = ?proof_ys,
+                            error = %e,
+                            "Transient failure finalizing pending offline receive; \
+                             will retry on next finalize_pending_receives()"
+                        );
+                    }
+                }
+            }
+        }
+
+        // Backward-compatible path: proofs stored without a created_by_operation
+        // (written before this fix) are processed one at a time with no memo.
+        for proof_info in ungrouped {
+            let proof_y = proof_info.y;
+
+            let result = self
+                .receive_proofs(
+                    vec![proof_info.proof],
+                    ReceiveOptions::default(),
+                    None,
+                    None,
+                )
+                .await;
+
+            match result {
+                Ok(amount) => total += amount,
+                Err(e) => {
+                    // Same prepare()-vs-execute() reasoning as the grouped path: if
+                    // the proof is still PendingReceive the failure was in prepare()
+                    // before execute() took ownership, so a definitive failure here
+                    // left it orphaned and a transient one must be left for retry.
+                    let still_pending = self
+                        .localstore
+                        .get_proofs(
+                            Some(self.mint_url.clone()),
+                            Some(self.unit.clone()),
+                            Some(vec![State::PendingReceive]),
+                            None,
+                        )
+                        .await?
+                        .iter()
+                        .any(|p| p.y == proof_y);
+
+                    if still_pending && e.is_definitive_failure() {
+                        self.localstore.update_proofs(vec![], vec![proof_y]).await?;
+                        tracing::warn!(
+                            y = %proof_y,
+                            error = %e,
+                            "Mint definitively rejected a pending offline receive; \
+                             proof removed (token was double-spent or invalid)"
+                        );
+                    } else if e.is_definitive_failure() {
+                        tracing::warn!(
+                            y = %proof_y,
+                            error = %e,
+                            "Mint definitively rejected a pending offline receive; \
+                             proof removed (token was double-spent or invalid)"
+                        );
+                    } else if still_pending {
+                        tracing::warn!(
+                            y = %proof_y,
+                            error = %e,
+                            "Transient failure finalizing pending offline receive; \
+                             will retry on next finalize_pending_receives()"
+                        );
+                    } else {
+                        tracing::warn!(
+                            y = %proof_y,
+                            error = %e,
+                            "Transient failure finalizing pending offline receive; \
+                             will retry via recover_incomplete_sagas()"
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(total)
+    }
+
+    /// Delete an `OfflinePendingReceive` saga, logging (but not failing) on error.
+    /// An orphaned saga is harmless and cleaned up on recovery.
+    async fn delete_offline_receive_saga(&self, op_id: Uuid) {
+        if let Err(e) = self.localstore.delete_saga(&op_id).await {
+            tracing::warn!(
+                "Failed to delete offline pending receive saga {}: {}",
+                op_id,
+                e
+            );
+        }
     }
 }

--- a/crates/cdk/src/wallet/receive/saga/resume.rs
+++ b/crates/cdk/src/wallet/receive/saga/resume.rs
@@ -66,6 +66,17 @@ impl Wallet {
                 );
                 self.recover_or_compensate_receive(&saga.id, data).await
             }
+            ReceiveSagaState::OfflinePendingReceive => {
+                // This saga is metadata storage for an offline receive that has not yet
+                // been finalized. The proofs are in PendingReceive state and are owned
+                // by `finalize_pending_receives`. Do not compensate — doing so would
+                // silently delete valid proofs the user hasn't collected yet.
+                tracing::debug!(
+                    "Receive saga {} is an offline pending receive — skipping recovery",
+                    saga.id
+                );
+                Ok(RecoveryAction::Skipped)
+            }
         }
     }
 

--- a/crates/cdk/src/wallet/wallet_trait.rs
+++ b/crates/cdk/src/wallet/wallet_trait.rs
@@ -62,6 +62,11 @@ impl WalletTrait for super::Wallet {
     }
 
     #[instrument(skip(self))]
+    async fn total_pending_receive_balance(&self) -> Result<Amount, Self::Error> {
+        self.total_pending_receive_balance().await
+    }
+
+    #[instrument(skip(self))]
     async fn total_reserved_balance(&self) -> Result<Amount, Self::Error> {
         self.total_reserved_balance().await
     }
@@ -204,6 +209,20 @@ impl WalletTrait for super::Wallet {
         token: Option<String>,
     ) -> Result<Amount, Self::Error> {
         self.receive_proofs(proofs, options, memo, token).await
+    }
+
+    #[instrument(skip(self, encoded_token, options))]
+    async fn receive_offline(
+        &self,
+        encoded_token: &str,
+        options: cdk_common::wallet::OfflineReceiveOptions,
+    ) -> Result<Amount, Self::Error> {
+        self.receive_offline(encoded_token, options).await
+    }
+
+    #[instrument(skip(self))]
+    async fn finalize_pending_receives(&self) -> Result<Amount, Self::Error> {
+        self.finalize_pending_receives().await
     }
 
     #[instrument(skip(self, options))]


### PR DESCRIPTION
## Description
Closes #1927

Currently, receiving in the CDK wallet requires the wallet to be online to perform a swap. However, Cashu enables offline receiving pending DLEQ verification and locking conditions. This PR adds that capability end-to-end across the core library, mobile FFI bindings, and CLI.

`receive_offline()` accepts a token and an `OfflineReceiveOptions` struct containing:
- `min_locktime` — the minimum locktime required on the token
- `require_locked` — whether the token must be P2PK locked to protect against double-spend by the sender while offline

The wallet verifies the token's DLEQ proof and checks these conditions entirely offline. Upon successful verification, the proofs are added to the database in the new `PendingReceive` state. Wallets should display these with a warning that they must be swapped for final settlement.

`finalize_pending_receives()` checks for all proofs in `PendingReceive` state and executes the swaps with the mint. This should be called whenever the wallet comes back online.

## What was added

### Core Protocol
- Adds `PendingReceive` state to the `State` enum in `cashu/nut07`
- Adds `OfflineReceiveOptions` struct (`min_locktime`, `require_locked`)
- Adds `receive_offline()` method to the `Wallet` trait and core implementation:
  - Verifies DLEQ proofs on all tokens without going online
  - Validates locking conditions (locktime, P2PK)
  - Stores verified proofs in `PendingReceive` state in the database
- Adds `finalize_pending_receives()` to swap pending proofs with the mint
- Adds `total_pending_receive_balance()` to query the total amount sitting in the pending offline queue
- Fixes offline receive finalization losing the sender's memo and splitting one token into per-proof transactions. Proofs are now grouped by a UUID stamped at `receive_offline` time; `finalize_pending_receives` processes each group as a single receive operation and recovers the memo from the `OfflinePendingReceive` saga entry

### Database
- Adds SQLite and Postgres migrations to add `PENDING_RECEIVE` to the proof state `CHECK` constraint

### FFI Layer (cdk-ffi)
- Exposes `receive_offline()`, `finalize_pending_receives()`, and `total_pending_receive_balance()` over the UniFFI boundary so Swift/Kotlin consumers can use the full offline receive lifecycle
- Exposes `ProofState::PendingReceive` as a UniFFI enum variant
- Adds JSON encode/decode helpers for `OfflineReceiveOptions` for mobile callers
- Handles `PendingReceive` in all exhaustive match sites (test utils, FFI)

### CLI (cdk-cli)
- Adds `--offline` flag to the receive subcommand — routes the token to `receive_offline` instead of the standard online swap
- Adds new `finalize-receives` subcommand — sweeps all `PendingReceive` proofs and swaps them with the mint when the user is back online

### Bug Fix
- Fixes a non-exhaustive match compiler error in `check_spendable.rs` that was introduced when `PendingReceive` was added to the `State` enum

## Known limitations

- `receive_offline` depends on the keyset for the incoming token having been synced during a prior online session. This relies on #1957's `load_from_db` fallback in `MintMetadataCache::load()`.

  `is_populated` is a coarse boolean — it returns `true` if *any* keyset is cached, not specifically the one the incoming token uses. If the wallet has never seen that keyset (e.g. the mint rotated keys between the sender minting and the receiver syncing), `load_keyset_keys` returns `None`. Scoped fix in this PR: improved error message at the `load_keyset_keys` call site directing the user to go online once to sync. Follow-up: `is_populated` should be keyset-id-aware rather than a global boolean.

- Atomic offline receive: `receive_offline` does two DB writes with no transaction between them — a crash between them loses the memo but not funds. Needs a DB transaction API to fix properly.

- No dismissal API for stuck pending receives — UI wallets have no way to let users clear a `PendingReceive` proof they know is gone.

## Notes to reviewers
- `PendingReceive` is kept intentionally separate from `Pending` (used for in-flight send/melt) to avoid ambiguity in state machine transitions and to make it easy to display pending offline receives distinctly in wallet UIs.
- Database migrations update the `CHECK (state IN (...))` constraint on the proof table to include `PENDING_RECEIVE`, preventing constraint violations at runtime.
- The FFI layer is fully updated: `ProofState::PendingReceive` is exposed as a UniFFI enum variant, and all three new methods are callable from mobile/desktop consumers.
- The CLI `--offline` flag requires users to explicitly opt-in to offline receives, as bearer tokens accepted offline carry a double-spend risk unless `require_locked` is set.

## Changelog

### Added
- `State::PendingReceive` — new proof state for offline-received ecash awaiting final swap
- `Wallet::receive_offline(token, options)` — verify a token's DLEQ proof offline and store proofs in `PendingReceive` state
- `Wallet::finalize_pending_receives()` — sweep all `PendingReceive` proofs and swap them with the mint
- `Wallet::total_pending_receive_balance()` — query the total pending offline balance
- `OfflineReceiveOptions` struct with `min_locktime` and `require_locked` fields
- SQLite and Postgres DB migrations to add `PENDING_RECEIVE` to the proof state constraint
- FFI bindings for all of the above via `cdk-ffi`
- `cdk-cli` `receive --offline` flag
- `cdk-cli` `finalize-receives` subcommand

## Checklist
- [x] followed the code style guidelines
- [x] ran `just quick-check` before committing
- [x] wallet API changes are reflected in FFI bindings