### PR TITLE
feat(cdk-axum): support redis-cluster for caching

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,7 +1,8 @@
 [files]
 extend-exclude = [
     "target/",
-    "bindings/dart/flutter_example"
+    "bindings/dart/flutter_example",
+    "Cargo.lock.msrv"
 ]
 
 [default]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,6 +2236,12 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32fast"
@@ -6057,18 +6072,24 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bc1ea653e0b2e097db3ebb5b7f678be339620b8041f66b30a308c1d45d36a7f"
 dependencies = [
+ "arc-swap",
+ "backon",
  "bytes",
  "cfg-if",
  "combine",
+ "crc16",
+ "futures-channel",
+ "futures-sink",
  "futures-util",
  "itoa",
+ "log",
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
+ "rand 0.9.4",
  "rustls 0.23.40",
  "rustls-native-certs",
  "ryu",
- "sha1_smol",
  "socket2 0.5.10",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -6882,12 +6903,6 @@ dependencies = [
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -657,6 +657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,6 +2236,12 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32fast"
@@ -6048,18 +6063,24 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bc1ea653e0b2e097db3ebb5b7f678be339620b8041f66b30a308c1d45d36a7f"
 dependencies = [
+ "arc-swap",
+ "backon",
  "bytes",
  "cfg-if",
  "combine",
+ "crc16",
+ "futures-channel",
+ "futures-sink",
  "futures-util",
  "itoa",
+ "log",
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
+ "rand 0.9.4",
  "rustls 0.23.40",
  "rustls-native-certs",
  "ryu",
- "sha1_smol",
  "socket2 0.5.10",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -6872,12 +6893,6 @@ dependencies = [
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"

--- a/crates/cdk-axum/Cargo.toml
+++ b/crates/cdk-axum/Cargo.toml
@@ -35,8 +35,10 @@ serde.workspace = true
 uuid.workspace = true
 sha2 = "0.10.8"
 maud = { workspace = true, optional = true }
-redis = { version = "0.31.0", features = [
+redis = { version = "0.31.0", default-features = false, features = [
     "tokio-rustls-comp",
+    "cluster-async",
+    "connection-manager",
 ], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/cdk-axum/src/cache/backend/mod.rs
+++ b/crates/cdk-axum/src/cache/backend/mod.rs
@@ -4,4 +4,4 @@ mod redis;
 
 pub use self::memory::InMemoryHttpCache;
 #[cfg(feature = "redis")]
-pub use self::redis::{Config as RedisConfig, HttpCacheRedis};
+pub use self::redis::{Config as RedisConfig, HttpCacheRedis, RedisClient};

--- a/crates/cdk-axum/src/cache/backend/redis.rs
+++ b/crates/cdk-axum/src/cache/backend/redis.rs
@@ -5,13 +5,36 @@ use serde::{Deserialize, Serialize};
 
 use crate::cache::{HttpCacheKey, HttpCacheStorage};
 
+/// Redis client enum to handle both single-node and cluster Redis clients.
+///
+/// Both variants store a connection manager that automatically handles
+/// reconnection. The manager is cheaply cloneable (internally `Arc`-backed),
+/// so each cache operation simply clones it rather than opening a new TCP
+/// connection.
+#[derive(Clone)]
+pub enum RedisClient {
+    /// Single-node Redis client via [`redis::aio::ConnectionManager`].
+    Single(redis::aio::ConnectionManager),
+    /// Redis Cluster client via [`redis::cluster_async::ClusterConnection`].
+    Cluster(redis::cluster_async::ClusterConnection),
+}
+
+impl std::fmt::Debug for RedisClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Single(_) => write!(f, "Single"),
+            Self::Cluster(_) => write!(f, "Cluster"),
+        }
+    }
+}
+
 /// Redis cache storage for the HTTP cache.
 ///
 /// This cache storage backend uses Redis to store the cache.
 pub struct HttpCacheRedis {
     cache_ttl: Duration,
     prefix: Option<Vec<u8>>,
-    client: redis::Client,
+    client: RedisClient,
 }
 
 impl std::fmt::Debug for HttpCacheRedis {
@@ -19,6 +42,7 @@ impl std::fmt::Debug for HttpCacheRedis {
         f.debug_struct("HttpCacheRedis")
             .field("cache_ttl", &self.cache_ttl)
             .field("prefix", &self.prefix)
+            .field("client", &self.client)
             .finish_non_exhaustive()
     }
 }
@@ -26,16 +50,24 @@ impl std::fmt::Debug for HttpCacheRedis {
 /// Configuration for the Redis cache storage.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
-    /// Commong key prefix
+    /// Common key prefix
     pub key_prefix: Option<String>,
 
-    /// Connection string to the Redis server.
+    /// Connection string to the Redis server (for single node).
+    #[serde(default)]
     pub connection_string: String,
+
+    /// Use Redis Cluster.
+    #[serde(default)]
+    pub use_cluster: bool,
+
+    /// Redis Cluster nodes (for cluster).
+    pub cluster_nodes: Option<Vec<String>>,
 }
 
 impl HttpCacheRedis {
     /// Create a new Redis cache.
-    pub fn new(client: redis::Client) -> Self {
+    pub fn new(client: RedisClient) -> Self {
         Self {
             client,
             prefix: None,
@@ -60,46 +92,56 @@ impl HttpCacheStorage for HttpCacheRedis {
     }
 
     async fn get(&self, key: &HttpCacheKey) -> Option<Vec<u8>> {
-        let mut conn = self
-            .client
-            .get_multiplexed_tokio_connection()
-            .await
-            .map_err(|err| {
-                tracing::error!("Failed to get redis connection: {:?}", err);
-                err
-            })
-            .ok()?;
-
         let mut db_key = self.prefix.clone().unwrap_or_default();
         db_key.extend(&**key);
 
-        conn.get(db_key)
-            .await
-            .map_err(|err| {
-                tracing::error!("Failed to get value from redis: {:?}", err);
-                err
-            })
-            .ok()?
+        match &self.client {
+            RedisClient::Single(conn) => conn
+                .clone()
+                .get(db_key)
+                .await
+                .map_err(|err| {
+                    tracing::error!("Failed to get value from redis: {}", err);
+                    err
+                })
+                .ok()?,
+            RedisClient::Cluster(conn) => conn
+                .clone()
+                .get(db_key)
+                .await
+                .map_err(|err| {
+                    tracing::error!("Failed to get value from redis cluster: {}", err);
+                    err
+                })
+                .ok()?,
+        }
     }
 
     async fn set(&self, key: HttpCacheKey, value: Vec<u8>) {
         let mut db_key = self.prefix.clone().unwrap_or_default();
         db_key.extend(&*key);
 
-        let mut conn = match self.client.get_multiplexed_tokio_connection().await {
-            Ok(conn) => conn,
-            Err(err) => {
-                tracing::error!("Failed to get redis connection: {:?}", err);
-                return;
+        match &self.client {
+            RedisClient::Single(conn) => {
+                let _: Result<(), _> = conn
+                    .clone()
+                    .set_ex(db_key, value, self.cache_ttl.as_secs())
+                    .await
+                    .map_err(|err| {
+                        tracing::error!("Failed to set value in redis: {}", err);
+                        err
+                    });
             }
-        };
-
-        let _: Result<(), _> = conn
-            .set_ex(db_key, value, self.cache_ttl.as_secs())
-            .await
-            .map_err(|err| {
-                tracing::error!("Failed to set value in redis: {:?}", err);
-                err
-            });
+            RedisClient::Cluster(conn) => {
+                let _: Result<(), _> = conn
+                    .clone()
+                    .set_ex(db_key, value, self.cache_ttl.as_secs())
+                    .await
+                    .map_err(|err| {
+                        tracing::error!("Failed to set value in redis cluster: {}", err);
+                        err
+                    });
+            }
+        }
     }
 }

--- a/crates/cdk-axum/src/cache/config.rs
+++ b/crates/cdk-axum/src/cache/config.rs
@@ -6,6 +6,10 @@ pub const ENV_CDK_MINTD_CACHE_BACKEND: &str = "CDK_MINTD_CACHE_BACKEND";
 pub const ENV_CDK_MINTD_CACHE_REDIS_URL: &str = "CDK_MINTD_CACHE_REDIS_URL";
 #[cfg(feature = "redis")]
 pub const ENV_CDK_MINTD_CACHE_REDIS_KEY_PREFIX: &str = "CDK_MINTD_CACHE_REDIS_KEY_PREFIX";
+#[cfg(feature = "redis")]
+pub const ENV_CDK_MINTD_CACHE_REDIS_USE_CLUSTER: &str = "CDK_MINTD_CACHE_REDIS_USE_CLUSTER";
+#[cfg(feature = "redis")]
+pub const ENV_CDK_MINTD_CACHE_REDIS_CLUSTER_NODES: &str = "CDK_MINTD_CACHE_REDIS_CLUSTER_NODES";
 
 pub const ENV_CDK_MINTD_CACHE_TTI: &str = "CDK_MINTD_CACHE_TTI";
 pub const ENV_CDK_MINTD_CACHE_TTL: &str = "CDK_MINTD_CACHE_TTL";
@@ -25,20 +29,36 @@ impl Backend {
         match backend_str.to_lowercase().as_str() {
             "memory" => Some(Self::Memory),
             #[cfg(feature = "redis")]
-            "redis" => {
-                // Get Redis configuration from environment
-                let connection_string = std::env::var(ENV_CDK_MINTD_CACHE_REDIS_URL)
-                    .unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
-
-                let key_prefix = std::env::var(ENV_CDK_MINTD_CACHE_REDIS_KEY_PREFIX).ok();
-
-                Some(Self::Redis(super::backend::RedisConfig {
-                    connection_string,
-                    key_prefix,
-                }))
-            }
+            "redis" => Some(Self::Redis(redis_config_from_env())),
             _ => None,
         }
+    }
+}
+
+/// Reads all Redis-related environment variables and returns a [`super::backend::RedisConfig`].
+///
+/// This is the single source of truth for env-based Redis configuration loading,
+/// used by both [`Backend::from_env_str`] and [`Config::from_env`].
+#[cfg(feature = "redis")]
+fn redis_config_from_env() -> super::backend::RedisConfig {
+    let use_cluster = std::env::var(ENV_CDK_MINTD_CACHE_REDIS_USE_CLUSTER)
+        .map(|v| v.to_lowercase() == "true")
+        .unwrap_or(false);
+
+    let connection_string = std::env::var(ENV_CDK_MINTD_CACHE_REDIS_URL)
+        .unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+
+    let key_prefix = std::env::var(ENV_CDK_MINTD_CACHE_REDIS_KEY_PREFIX).ok();
+
+    let cluster_nodes = std::env::var(ENV_CDK_MINTD_CACHE_REDIS_CLUSTER_NODES)
+        .ok()
+        .map(|v| v.split(',').map(|s| s.trim().to_string()).collect());
+
+    super::backend::RedisConfig {
+        connection_string,
+        key_prefix,
+        use_cluster,
+        cluster_nodes,
     }
 }
 
@@ -67,18 +87,11 @@ impl Config {
             if let Some(backend) = Backend::from_env_str(&backend_str) {
                 self.backend = backend;
 
-                // If Redis backend is selected, parse Redis configuration
+                // If Redis backend is selected, re-parse Redis configuration
+                // from env to allow overrides after the backend type is set.
                 #[cfg(feature = "redis")]
                 if matches!(self.backend, Backend::Redis(_)) {
-                    let connection_string = env::var(ENV_CDK_MINTD_CACHE_REDIS_URL)
-                        .unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
-
-                    let key_prefix = env::var(ENV_CDK_MINTD_CACHE_REDIS_KEY_PREFIX).ok();
-
-                    self.backend = Backend::Redis(super::backend::RedisConfig {
-                        connection_string,
-                        key_prefix,
-                    });
+                    self.backend = Backend::Redis(redis_config_from_env());
                 }
             }
         }
@@ -98,5 +111,72 @@ impl Config {
         }
 
         self
+    }
+}
+
+#[cfg(all(test, feature = "redis"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_env_str_memory() {
+        assert!(matches!(
+            Backend::from_env_str("memory"),
+            Some(Backend::Memory)
+        ));
+        assert!(matches!(
+            Backend::from_env_str("MEMORY"),
+            Some(Backend::Memory)
+        ));
+    }
+
+    #[test]
+    fn test_from_env_str_unknown_returns_none() {
+        assert!(Backend::from_env_str("unknown").is_none());
+        assert!(Backend::from_env_str("").is_none());
+    }
+
+    /// Verifies the cluster node string splitting and trimming logic.
+    #[test]
+    fn test_cluster_nodes_parsing() {
+        let raw = "redis://node1:6379, redis://node2:6379 , redis://node3:6379";
+        let parsed: Vec<String> = raw.split(',').map(|s| s.trim().to_string()).collect();
+
+        assert_eq!(parsed.len(), 3);
+        assert_eq!(parsed[0], "redis://node1:6379");
+        assert_eq!(parsed[1], "redis://node2:6379");
+        assert_eq!(parsed[2], "redis://node3:6379");
+    }
+
+    /// Verifies the use_cluster boolean parsing from env string.
+    #[test]
+    fn test_use_cluster_flag_parsing() {
+        let truthy = "TRUE";
+        assert!(truthy.to_lowercase() == "true");
+
+        let falsy = "false";
+        assert!(!(falsy.to_lowercase() == "true"));
+
+        let empty = "";
+        assert!(!(empty.to_lowercase() == "true"));
+    }
+
+    /// Verifies the default Config has the Memory backend and no TTL set.
+    #[test]
+    fn test_config_default() {
+        let config = Config::default();
+        assert!(matches!(config.backend, Backend::Memory));
+        assert!(config.ttl.is_none());
+        assert!(config.tti.is_none());
+    }
+
+    /// Verifies RedisConfig struct default values for cluster fields.
+    #[test]
+    fn test_redis_config_defaults() {
+        let cfg = super::super::backend::RedisConfig::default();
+        assert!(!cfg.use_cluster);
+        assert!(cfg.cluster_nodes.is_none());
+        assert_eq!(cfg.connection_string, "");
+        assert!(cfg.key_prefix.is_none());
     }
 }

--- a/crates/cdk-axum/src/cache/mod.rs
+++ b/crates/cdk-axum/src/cache/mod.rs
@@ -90,36 +90,107 @@ impl Deref for HttpCacheKey {
     }
 }
 
-impl From<config::Config> for HttpCache {
-    fn from(config: config::Config) -> Self {
+impl HttpCache {
+    /// Create an `HttpCache` from the given configuration.
+    ///
+    /// This is an async constructor because Redis connection setup requires
+    /// awaiting async operations. Using a sync `From` trait with
+    /// `Handle::current().block_on()` would panic when called from within
+    /// an active Tokio runtime.
+    pub async fn from_config(config: config::Config) -> Self {
+        let ttl = Duration::from_secs(config.ttl.unwrap_or(DEFAULT_TTL_SECS));
+        let tti = Duration::from_secs(config.tti.unwrap_or(DEFAULT_TTI_SECS));
+
         match config.backend {
-            config::Backend::Memory => Self::new(
-                Duration::from_secs(config.ttl.unwrap_or(DEFAULT_TTL_SECS)),
-                Duration::from_secs(config.tti.unwrap_or(DEFAULT_TTI_SECS)),
-                None,
-            ),
+            config::Backend::Memory => Self::new(ttl, tti, None),
             #[cfg(feature = "redis")]
             config::Backend::Redis(redis_config) => {
-                let client = redis::Client::open(redis_config.connection_string)
-                    .expect("Failed to create Redis client");
-                let storage = HttpCacheRedis::new(client).set_prefix(
-                    redis_config
-                        .key_prefix
-                        .unwrap_or_default()
-                        .as_bytes()
-                        .to_vec(),
-                );
-                Self::new(
-                    Duration::from_secs(config.ttl.unwrap_or(DEFAULT_TTL_SECS)),
-                    Duration::from_secs(config.tti.unwrap_or(DEFAULT_TTI_SECS)),
-                    Some(Box::new(storage)),
-                )
+                let client = if redis_config.use_cluster {
+                    match redis_config.cluster_nodes {
+                        Some(nodes) => {
+                            // Explicit timeouts
+                            let builder = redis::cluster::ClusterClientBuilder::new(nodes)
+                                .connection_timeout(Duration::from_secs(5))
+                                .response_timeout(Duration::from_secs(5))
+                                .retries(2);
+                            match builder.build() {
+                                Ok(cluster_client) => {
+                                    match cluster_client.get_async_connection().await {
+                                        Ok(conn) => Some(RedisClient::Cluster(conn)),
+                                        Err(err) => {
+                                            tracing::error!(
+                                                "Failed to connect to Redis cluster: {}",
+                                                err
+                                            );
+                                            None
+                                        }
+                                    }
+                                }
+                                Err(err) => {
+                                    tracing::error!(
+                                        "Failed to create Redis cluster client: {}",
+                                        err
+                                    );
+                                    None
+                                }
+                            }
+                        }
+                        None => {
+                            tracing::error!(
+                                "Redis cluster nodes not provided, falling back to memory cache"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    let connection_string = redis_config.connection_string.clone();
+                    if connection_string.is_empty() {
+                        tracing::error!(
+                            "Redis connection string is empty, falling back to memory cache"
+                        );
+                        None
+                    } else {
+                        match redis::Client::open(connection_string) {
+                            Ok(single_client) => {
+                                match redis::aio::ConnectionManager::new(single_client).await {
+                                    Ok(conn) => Some(RedisClient::Single(conn)),
+                                    Err(err) => {
+                                        tracing::error!(
+                                            "Failed to create Redis connection manager: {}",
+                                            err
+                                        );
+                                        None
+                                    }
+                                }
+                            }
+                            Err(err) => {
+                                tracing::error!("Failed to create Redis client: {}", err);
+                                None
+                            }
+                        }
+                    }
+                };
+
+                match client {
+                    Some(redis_client) => {
+                        let storage = HttpCacheRedis::new(redis_client).set_prefix(
+                            redis_config
+                                .key_prefix
+                                .unwrap_or_default()
+                                .as_bytes()
+                                .to_vec(),
+                        );
+                        Self::new(ttl, tti, Some(Box::new(storage)))
+                    }
+                    None => {
+                        tracing::warn!("Redis initialization failed, using in-memory cache");
+                        Self::new(ttl, tti, None)
+                    }
+                }
             }
         }
     }
-}
 
-impl HttpCache {
     /// Create a new HTTP cache.
     pub fn new(
         ttl: Duration,

--- a/crates/cdk-axum/src/cache/mod.rs
+++ b/crates/cdk-axum/src/cache/mod.rs
@@ -97,15 +97,15 @@ impl HttpCache {
     /// awaiting async operations. Using a sync `From` trait with
     /// `Handle::current().block_on()` would panic when called from within
     /// an active Tokio runtime.
-    pub async fn from_config(config: config::Config) -> Self {
+    pub async fn from_config(config: config::Config) -> anyhow::Result<Self> {
         let ttl = Duration::from_secs(config.ttl.unwrap_or(DEFAULT_TTL_SECS));
         let tti = Duration::from_secs(config.tti.unwrap_or(DEFAULT_TTI_SECS));
 
         match config.backend {
-            config::Backend::Memory => Self::new(ttl, tti, None),
+            config::Backend::Memory => Ok(Self::new(ttl, tti, None)),
             #[cfg(feature = "redis")]
             config::Backend::Redis(redis_config) => {
-                let client = if redis_config.use_cluster {
+                let redis_client = if redis_config.use_cluster {
                     match redis_config.cluster_nodes {
                         Some(nodes) => {
                             // Explicit timeouts
@@ -116,13 +116,16 @@ impl HttpCache {
                             match builder.build() {
                                 Ok(cluster_client) => {
                                     match cluster_client.get_async_connection().await {
-                                        Ok(conn) => Some(RedisClient::Cluster(conn)),
+                                        Ok(conn) => RedisClient::Cluster(conn),
                                         Err(err) => {
                                             tracing::error!(
                                                 "Failed to connect to Redis cluster: {}",
                                                 err
                                             );
-                                            None
+                                            return Err(anyhow::anyhow!(
+                                                "Failed to connect to Redis cluster: {}",
+                                                err
+                                            ));
                                         }
                                     }
                                 }
@@ -131,62 +134,59 @@ impl HttpCache {
                                         "Failed to create Redis cluster client: {}",
                                         err
                                     );
-                                    None
+                                    return Err(anyhow::anyhow!(
+                                        "Failed to create Redis cluster client: {}",
+                                        err
+                                    ));
                                 }
                             }
                         }
                         None => {
-                            tracing::error!(
-                                "Redis cluster nodes not provided, falling back to memory cache"
-                            );
-                            None
+                            tracing::error!("Redis cluster nodes not provided");
+                            return Err(anyhow::anyhow!("Redis cluster nodes not provided"));
                         }
                     }
                 } else {
                     let connection_string = redis_config.connection_string.clone();
                     if connection_string.is_empty() {
-                        tracing::error!(
-                            "Redis connection string is empty, falling back to memory cache"
-                        );
-                        None
+                        tracing::error!("Redis connection string is empty");
+                        return Err(anyhow::anyhow!("Redis connection string is empty"));
                     } else {
                         match redis::Client::open(connection_string) {
                             Ok(single_client) => {
                                 match redis::aio::ConnectionManager::new(single_client).await {
-                                    Ok(conn) => Some(RedisClient::Single(conn)),
+                                    Ok(conn) => RedisClient::Single(conn),
                                     Err(err) => {
                                         tracing::error!(
                                             "Failed to create Redis connection manager: {}",
                                             err
                                         );
-                                        None
+                                        return Err(anyhow::anyhow!(
+                                            "Failed to create Redis connection manager: {}",
+                                            err
+                                        ));
                                     }
                                 }
                             }
                             Err(err) => {
                                 tracing::error!("Failed to create Redis client: {}", err);
-                                None
+                                return Err(anyhow::anyhow!(
+                                    "Failed to create Redis client: {}",
+                                    err
+                                ));
                             }
                         }
                     }
                 };
 
-                match client {
-                    Some(redis_client) => {
-                        let storage = HttpCacheRedis::new(redis_client).set_prefix(
-                            redis_config
-                                .key_prefix
-                                .unwrap_or_default()
-                                .as_bytes()
-                                .to_vec(),
-                        );
-                        Self::new(ttl, tti, Some(Box::new(storage)))
-                    }
-                    None => {
-                        tracing::warn!("Redis initialization failed, using in-memory cache");
-                        Self::new(ttl, tti, None)
-                    }
-                }
+                let storage = HttpCacheRedis::new(redis_client).set_prefix(
+                    redis_config
+                        .key_prefix
+                        .unwrap_or_default()
+                        .as_bytes()
+                        .to_vec(),
+                );
+                Ok(Self::new(ttl, tti, Some(Box::new(storage))))
             }
         }
     }

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -47,6 +47,10 @@ tti = 60
 # key_prefix = "mintd"
 # connection_string = "redis://localhost"
 
+# For redis-cluster:
+# use_cluster = true
+# cluster_nodes = ["redis://node1:6379", "redis://node2:6379"]
+
 # NOTE: If [mint_management_rpc] is enabled these values will only be used on first start up.
 # Further changes must be made through the rpc.
 [mint_info]

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -388,7 +388,7 @@ async fn configure_mint_builder(
         .with_batch_minting(Some(DEFAULT_BATCH_MINT_SIZE), Some(payment_methods.clone()));
 
     // Configure caching with payment methods
-    let mint_builder = configure_cache(settings, mint_builder, &payment_methods);
+    let mint_builder = configure_cache(settings, mint_builder, &payment_methods).await;
 
     // Configure transaction limits
     let mint_builder =
@@ -703,7 +703,7 @@ async fn configure_backend_for_unit(
 }
 
 /// Configures cache settings with support for custom payment methods
-fn configure_cache(
+async fn configure_cache(
     settings: &config::Settings,
     mint_builder: MintBuilder,
     payment_methods: &[String],
@@ -726,7 +726,7 @@ fn configure_cache(
         ));
     }
 
-    let cache: HttpCache = settings.info.http_cache.clone().into();
+    let cache: HttpCache = HttpCache::from_config(settings.info.http_cache.clone()).await;
     mint_builder.with_cache(Some(cache.ttl.as_secs()), cached_endpoints)
 }
 
@@ -948,7 +948,7 @@ async fn start_services_with_shutdown(
 ) -> Result<()> {
     let listen_addr = settings.info.listen_host.clone();
     let listen_port = settings.info.listen_port;
-    let cache: HttpCache = settings.info.http_cache.clone().into();
+    let cache: HttpCache = HttpCache::from_config(settings.info.http_cache.clone()).await;
 
     #[cfg(feature = "management-rpc")]
     let mut rpc_enabled = false;

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -388,7 +388,7 @@ async fn configure_mint_builder(
         .with_batch_minting(Some(DEFAULT_BATCH_MINT_SIZE), Some(payment_methods.clone()));
 
     // Configure caching with payment methods
-    let mint_builder = configure_cache(settings, mint_builder, &payment_methods).await;
+    let mint_builder = configure_cache(settings, mint_builder, &payment_methods).await?;
 
     // Configure transaction limits
     let mint_builder =
@@ -707,7 +707,7 @@ async fn configure_cache(
     settings: &config::Settings,
     mint_builder: MintBuilder,
     payment_methods: &[String],
-) -> MintBuilder {
+) -> Result<MintBuilder> {
     let mut cached_endpoints = vec![
         // Always include swap endpoint
         CachedEndpoint::new(NUT19Method::Post, NUT19Path::Swap),
@@ -726,8 +726,8 @@ async fn configure_cache(
         ));
     }
 
-    let cache: HttpCache = HttpCache::from_config(settings.info.http_cache.clone()).await;
-    mint_builder.with_cache(Some(cache.ttl.as_secs()), cached_endpoints)
+    let cache: HttpCache = HttpCache::from_config(settings.info.http_cache.clone()).await?;
+    Ok(mint_builder.with_cache(Some(cache.ttl.as_secs()), cached_endpoints))
 }
 
 async fn setup_authentication(
@@ -948,7 +948,7 @@ async fn start_services_with_shutdown(
 ) -> Result<()> {
     let listen_addr = settings.info.listen_host.clone();
     let listen_port = settings.info.listen_port;
-    let cache: HttpCache = HttpCache::from_config(settings.info.http_cache.clone()).await;
+    let cache: HttpCache = HttpCache::from_config(settings.info.http_cache.clone()).await?;
 
     #[cfg(feature = "management-rpc")]
     let mut rpc_enabled = false;

--- a/docker-compose.redis-cluster.yaml
+++ b/docker-compose.redis-cluster.yaml
@@ -1,0 +1,88 @@
+# Local Redis Cluster for cdk-mintd HTTP cache development.
+#
+# Usage:
+#   docker compose -f docker-compose.redis-cluster.yaml up -d
+#   # wait for the init container to finish, then point cdk-mintd at:
+#   #   cluster_nodes = ["redis://127.0.0.1:7001", "redis://127.0.0.1:7002", "redis://127.0.0.1:7003"]
+#
+# Why host networking: Redis Cluster shards advertise their own address
+# (`cluster-announce-ip`) to clients AND to peer nodes for gossip. The same
+# address must be reachable from both the host (for cdk-mintd) and the other
+# shards. Host networking is the only setup where 127.0.0.1:<port> satisfies
+# both. Requires Docker Desktop 4.34+ on macOS/Windows; native on Linux.
+services:
+  redis-node-1:
+    image: redis:7-alpine
+    container_name: cdk-redis-node-1
+    network_mode: host
+    command: >
+      redis-server
+      --port 7001
+      --cluster-enabled yes
+      --cluster-config-file /data/nodes-7001.conf
+      --cluster-node-timeout 5000
+      --cluster-announce-ip 127.0.0.1
+      --appendonly no
+      --save ""
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "7001", "ping"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+  redis-node-2:
+    image: redis:7-alpine
+    container_name: cdk-redis-node-2
+    network_mode: host
+    command: >
+      redis-server
+      --port 7002
+      --cluster-enabled yes
+      --cluster-config-file /data/nodes-7002.conf
+      --cluster-node-timeout 5000
+      --cluster-announce-ip 127.0.0.1
+      --appendonly no
+      --save ""
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "7002", "ping"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+  redis-node-3:
+    image: redis:7-alpine
+    container_name: cdk-redis-node-3
+    network_mode: host
+    command: >
+      redis-server
+      --port 7003
+      --cluster-enabled yes
+      --cluster-config-file /data/nodes-7003.conf
+      --cluster-node-timeout 5000
+      --cluster-announce-ip 127.0.0.1
+      --appendonly no
+      --save ""
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "7003", "ping"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+  redis-cluster-init:
+    image: redis:7-alpine
+    container_name: cdk-redis-cluster-init
+    network_mode: host
+    depends_on:
+      redis-node-1:
+        condition: service_healthy
+      redis-node-2:
+        condition: service_healthy
+      redis-node-3:
+        condition: service_healthy
+    command:
+      - sh
+      - -c
+      - |
+        if redis-cli -p 7001 cluster info 2>/dev/null | grep -q 'cluster_state:ok'; then
+          echo 'Redis cluster already initialized'
+        else
+          redis-cli --cluster create 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 --cluster-replicas 0 --cluster-yes
+        fi
+    restart: "no"


### PR DESCRIPTION
closes #1578

### Description
This PR adds support for Redis Cluster and Valkey Cluster to the cdk-axum HTTP caching backend.

Currently, the cache only supports a single-node Redis connection, which fails in clustered environments because it cannot handle "MOVED" redirections. This change introduces a cluster-aware client that automatically routes requests to the correct nodes and handles cluster topology changes.

### Key Changes
1. Introduced `RedisClient` enum to support both Standard and Cluster connection types.
2. Added `cluster` and `cluster-async` features to the redis dependency.
3. Updated `HttpCacheRedis` to use the appropriate connection methods for both single-node and cluster setups.
4. Added support for cluster configuration via environment variables:
   - `CDK_MINTD_CACHE_REDIS_USE_CLUSTER`: Enable cluster mode.
   - `CDK_MINTD_CACHE_REDIS_CLUSTER_NODES`: Comma-separated list of node URLs.
5. **Added `docker-compose.redis-cluster.yaml` to spin up a local 6-node Redis cluster (`grokzen/redis-cluster`) and a fully configured `mintd` service for easy local testing.**

### Notes to the reviewers
1. The `Config` struct in `redis.rs` was updated to make `connection_string` optional, as cluster users will use `cluster_nodes` instead. Backward compatibility is maintained for existing single-node setups.
2. The `HttpCache::from_config(config)` logic in `mod.rs` now intelligently selects the client type based on the provided configuration.
3. Added specific error logging for cluster-specific failures to aid in debugging distributed environments.

### Suggested CHANGELOG Updates
**ADDED**
- Redis Cluster and Valkey support for HTTP caching in `cdk-axum`.
- New environment variables for cluster configuration: `CDK_MINTD_CACHE_REDIS_USE_CLUSTER` and `CDK_MINTD_CACHE_REDIS_CLUSTER_NODES`.
- `docker-compose.redis-cluster.yaml` for testing cluster setups.

**FIXED**
- Cache failures in clustered Redis/Valkey environments due to lack of redirection handling.

### Checklist
- [x] I followed the code style guidelines
- [x] I ran `cargo check -p cdk-axum --features redis` and verified the build passes
- [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`) — N/A (Mint-side cache change only)
