### PR TITLE
fix: create melt quote kind index on melt table

### DIFF
--- a/crates/cdk-sql-common/src/mint/migrations/postgres/1_initial.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/postgres/1_initial.sql
@@ -95,6 +95,6 @@ CREATE TABLE mint_quote_issued (
   FOREIGN KEY (quote_id) REFERENCES mint_quote(id)
 );
 CREATE INDEX idx_mint_quote_issued_quote_id ON mint_quote_issued(quote_id);
-CREATE INDEX idx_melt_quote_request_lookup_id_and_kind ON mint_quote(
+CREATE INDEX idx_melt_quote_request_lookup_id_and_kind ON melt_quote(
   request_lookup_id, request_lookup_id_kind
 );

--- a/crates/cdk-sql-common/src/mint/migrations/postgres/20260427000000_fix_melt_quote_kind_index.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/postgres/20260427000000_fix_melt_quote_kind_index.sql
@@ -1,0 +1,5 @@
+-- Fix idx_melt_quote_request_lookup_id_and_kind if it was created on mint_quote.
+DROP INDEX IF EXISTS idx_melt_quote_request_lookup_id_and_kind;
+
+CREATE INDEX IF NOT EXISTS idx_melt_quote_request_lookup_id_and_kind
+ON melt_quote(request_lookup_id, request_lookup_id_kind);

--- a/crates/cdk-sql-common/src/mint/migrations/sqlite/20250706101057_bolt12.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/sqlite/20250706101057_bolt12.sql
@@ -76,6 +76,6 @@ ALTER TABLE melt_quote ADD COLUMN payment_method TEXT NOT NULL DEFAULT 'bolt11';
 ALTER TABLE melt_quote ADD COLUMN options TEXT;
 ALTER TABLE melt_quote ADD COLUMN request_lookup_id_kind TEXT NOT NULL DEFAULT 'payment_hash';
 
-CREATE INDEX IF NOT EXISTS idx_melt_quote_request_lookup_id_and_kind ON mint_quote(request_lookup_id, request_lookup_id_kind);
+CREATE INDEX IF NOT EXISTS idx_melt_quote_request_lookup_id_and_kind ON melt_quote(request_lookup_id, request_lookup_id_kind);
 
 ALTER TABLE melt_quote DROP COLUMN msat_to_pay;

--- a/crates/cdk-sql-common/src/mint/migrations/sqlite/20260427000000_fix_melt_quote_kind_index.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/sqlite/20260427000000_fix_melt_quote_kind_index.sql
@@ -1,0 +1,5 @@
+-- Fix idx_melt_quote_request_lookup_id_and_kind if it was created on mint_quote.
+DROP INDEX IF EXISTS idx_melt_quote_request_lookup_id_and_kind;
+
+CREATE INDEX IF NOT EXISTS idx_melt_quote_request_lookup_id_and_kind
+ON melt_quote(request_lookup_id, request_lookup_id_kind);


### PR DESCRIPTION
### Description



<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

idx_melt_quote_request_lookup_id_and_kind must be created on the melt quote table 

idx_mint_quote_request_lookup_id_and_kind is already present in the mint_quote table

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
