### PR TITLE
feat(mint): add NUT-29 batch minting error codes

### DIFF
--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -235,6 +235,17 @@ pub enum Error {
         /// Maximum allowed outputs
         max: usize,
     },
+    /// Duplicate quote IDs provided in a batch request (NUT-29)
+    #[error("Duplicate quote IDs")]
+    DuplicateQuoteIds,
+    /// Maximum batch size exceeded (NUT-29)
+    #[error("Maximum batch size exceeded: {actual} provided, max {max}")]
+    BatchSizeExceeded {
+        /// Actual batch size provided
+        actual: usize,
+        /// Maximum allowed batch size
+        max: usize,
+    },
     /// Proof content too large (secret or witness exceeds max length)
     #[error("Proof content too large: {actual} bytes, max {max}")]
     ProofContentTooLarge {
@@ -581,6 +592,8 @@ impl Error {
             | Self::TransactionUnbalanced(_, _, _)
             | Self::DuplicateInputs
             | Self::DuplicateOutputs
+            | Self::DuplicateQuoteIds
+            | Self::BatchSizeExceeded { .. }
             | Self::MultipleUnits
             | Self::UnitMismatch
             | Self::SigAllUsedInMelt
@@ -1014,6 +1027,14 @@ impl From<Error> for ErrorResponse {
                 code: ErrorCode::MaxOutputsExceeded,
                 detail: err.to_string()
             },
+            Error::DuplicateQuoteIds => ErrorResponse {
+                code: ErrorCode::DuplicateQuoteIds,
+                detail: err.to_string(),
+            },
+            Error::BatchSizeExceeded { .. } => ErrorResponse {
+                code: ErrorCode::BatchSizeExceeded,
+                detail: err.to_string(),
+            },
             // Fallback for any remaining errors - use Unknown(99999) instead of TokenNotVerified
             _ => ErrorResponse {
                 code: ErrorCode::Unknown(50000),
@@ -1065,6 +1086,8 @@ impl From<ErrorResponse> for Error {
             }
             ErrorCode::DuplicateInputs => Self::DuplicateInputs,
             ErrorCode::DuplicateOutputs => Self::DuplicateOutputs,
+            ErrorCode::DuplicateQuoteIds => Self::DuplicateQuoteIds,
+            ErrorCode::BatchSizeExceeded => Self::BatchSizeExceeded { actual: 0, max: 0 },
             ErrorCode::MultipleUnits => Self::MultipleUnits,
             ErrorCode::UnitMismatch => Self::UnitMismatch,
             ErrorCode::AmountlessInvoiceNotSupported => Self::AmountLessNotAllowed,
@@ -1136,6 +1159,10 @@ pub enum ErrorCode {
     MaxInputsExceeded,
     /// The max number of outputs is exceeded
     MaxOutputsExceeded,
+    /// Duplicate quote IDs provided in a batch (11016)
+    DuplicateQuoteIds,
+    /// Batch size exceeds mint limit (11017)
+    BatchSizeExceeded,
     // 12xxx - Keyset errors
     /// Keyset is not known (12001)
     KeysetNotFound,
@@ -1209,6 +1236,8 @@ impl ErrorCode {
             11013 => Self::UnsupportedUnit,
             11014 => Self::MaxInputsExceeded,
             11015 => Self::MaxOutputsExceeded,
+            11016 => Self::DuplicateQuoteIds,
+            11017 => Self::BatchSizeExceeded,
             // 12xxx - Keyset errors
             12001 => Self::KeysetNotFound,
             12002 => Self::KeysetInactive,
@@ -1256,6 +1285,8 @@ impl ErrorCode {
             Self::UnsupportedUnit => 11013,
             Self::MaxInputsExceeded => 11014,
             Self::MaxOutputsExceeded => 11015,
+            Self::DuplicateQuoteIds => 11016,
+            Self::BatchSizeExceeded => 11017,
             // 12xxx - Keyset errors
             Self::KeysetNotFound => 12001,
             Self::KeysetInactive => 12002,

--- a/crates/cdk/src/mint/issue/mod.rs
+++ b/crates/cdk/src/mint/issue/mod.rs
@@ -59,7 +59,7 @@ impl MintInput {
 
                 let unique_ids: std::collections::HashSet<_> = batch.quotes.iter().collect();
                 if unique_ids.len() != batch.quotes.len() {
-                    return Err(Error::DuplicateInputs);
+                    return Err(Error::DuplicateQuoteIds);
                 }
 
                 if let Some(ref amounts) = batch.quote_amounts {
@@ -596,7 +596,7 @@ impl Mint {
 
             let unique_ids: std::collections::HashSet<_> = quote_ids.iter().collect();
             if unique_ids.len() != quote_ids.len() {
-                return Err(Error::DuplicateInputs);
+                return Err(Error::DuplicateQuoteIds);
             }
 
             let mut responses = Vec::with_capacity(quote_ids.len());
@@ -666,7 +666,7 @@ impl Mint {
                 if let Some(max_batch_size) = settings.max_batch_size {
                     let max = usize::try_from(max_batch_size).unwrap_or(usize::MAX);
                     if batch.quotes.len() > max {
-                        return Err(Error::MaxInputsExceeded {
+                        return Err(Error::BatchSizeExceeded {
                             actual: batch.quotes.len(),
                             max,
                         });
@@ -1337,7 +1337,7 @@ mod batch_mint_tests {
             .await;
 
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::DuplicateInputs));
+        assert!(matches!(result.unwrap_err(), Error::DuplicateQuoteIds));
     }
 
     #[tokio::test]
@@ -1605,7 +1605,7 @@ mod batch_mint_tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            Error::MaxInputsExceeded { actual: 2, max: 1 }
+            Error::BatchSizeExceeded { actual: 2, max: 1 }
         ));
     }
 


### PR DESCRIPTION
### Description

Implements the new NUT-29 batch minting error codes from [cashubtc/nuts#366](https://github.com/cashubtc/nuts/pull/366), replacing the incorrect reuse of generic input/output codes
Closes #1943

-----

### Notes to the reviewers

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

 - NUT-29 batch mint validation now returns DuplicateQuoteIds (11016) and BatchSizeExceeded (11017) instead of DuplicateInputs (11007) and MaxInputsExceeded (11014).

#### ADDED

  - Error::DuplicateQuoteIds and Error::BatchSizeExceeded  actual, max  variants.
  - ErrorCode::DuplicateQuoteIds (11016) and ErrorCode::BatchSizeExceeded (11017) variants.   

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
