### PR TITLE
feat: enforce keyset expiry

### DIFF
--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -207,6 +207,9 @@ pub enum Error {
     /// Inactive Keyset
     #[error("Inactive Keyset")]
     InactiveKeyset,
+    /// Keyset has expired
+    #[error("Keyset has expired")]
+    ExpiredKeyset,
     /// Transaction unbalanced
     #[error("Inputs: `{0}`, Outputs: `{1}`, Expected Fee: `{2}`")]
     TransactionUnbalanced(u64, u64, u64),
@@ -574,6 +577,7 @@ impl Error {
             | Self::UnknownKeySet
             | Self::BlindedMessageAlreadySigned
             | Self::InactiveKeyset
+            | Self::ExpiredKeyset
             | Self::TransactionUnbalanced(_, _, _)
             | Self::DuplicateInputs
             | Self::DuplicateOutputs
@@ -879,6 +883,10 @@ impl From<Error> for ErrorResponse {
                 code: ErrorCode::KeysetInactive,
                 detail: err.to_string(),
             },
+            Error::ExpiredKeyset => ErrorResponse {
+                code: ErrorCode::KeysetExpired,
+                detail: err.to_string(),
+            },
             Error::AmountLessNotAllowed => ErrorResponse {
                 code: ErrorCode::AmountlessInvoiceNotSupported,
                 detail: err.to_string(),
@@ -1065,6 +1073,7 @@ impl From<ErrorResponse> for Error {
             // 12xxx - Keyset errors
             ErrorCode::KeysetNotFound => Self::UnknownKeySet,
             ErrorCode::KeysetInactive => Self::InactiveKeyset,
+            ErrorCode::KeysetExpired => Self::ExpiredKeyset,
             // 20xxx - Quote/Payment errors
             ErrorCode::QuoteNotPaid => Self::UnpaidQuote,
             ErrorCode::TokensAlreadyIssued => Self::IssuedQuote,
@@ -1132,6 +1141,8 @@ pub enum ErrorCode {
     KeysetNotFound,
     /// Keyset is inactive, cannot sign messages (12002)
     KeysetInactive,
+    /// Keyset expired (12003)
+    KeysetExpired,
 
     // 20xxx - Quote/Payment errors
     /// Quote request is not paid (20001)
@@ -1201,6 +1212,7 @@ impl ErrorCode {
             // 12xxx - Keyset errors
             12001 => Self::KeysetNotFound,
             12002 => Self::KeysetInactive,
+            12003 => Self::KeysetExpired,
             // 20xxx - Quote/Payment errors
             20001 => Self::QuoteNotPaid,
             20002 => Self::TokensAlreadyIssued,
@@ -1247,6 +1259,7 @@ impl ErrorCode {
             // 12xxx - Keyset errors
             Self::KeysetNotFound => 12001,
             Self::KeysetInactive => 12002,
+            Self::KeysetExpired => 12003,
             // 20xxx - Quote/Payment errors
             Self::QuoteNotPaid => 20001,
             Self::TokensAlreadyIssued => 20002,

--- a/crates/cdk-common/src/mint.rs
+++ b/crates/cdk-common/src/mint.rs
@@ -1019,6 +1019,13 @@ pub struct MintKeySetInfo {
     pub issuer_version: Option<IssuerVersion>,
 }
 
+impl MintKeySetInfo {
+    /// Returns true if `final_expiry` is set and strictly in the past.
+    pub fn is_expired(&self) -> bool {
+        self.final_expiry.is_some_and(|expiry| expiry < unix_time())
+    }
+}
+
 /// Default fee
 pub fn default_fee() -> u64 {
     0
@@ -1375,5 +1382,52 @@ mod tests {
 
         assert_eq!(response.quote, melt_quote.id);
         assert_eq!(response.request, None);
+    }
+
+    fn dummy_mint_keyset_info(final_expiry: Option<u64>) -> MintKeySetInfo {
+        use std::str::FromStr;
+        MintKeySetInfo {
+            id: Id::from_str("009a1f293253e41e").unwrap(),
+            unit: CurrencyUnit::Sat,
+            active: true,
+            valid_from: 0,
+            derivation_path: "m/0'/0'/0'".parse().unwrap(),
+            derivation_path_index: Some(0),
+            amounts: vec![1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
+            input_fee_ppk: 0,
+            final_expiry,
+            issuer_version: None,
+        }
+    }
+
+    #[test]
+    fn test_is_expired_none() {
+        let info = dummy_mint_keyset_info(None);
+        assert!(!info.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_far_future() {
+        let info = dummy_mint_keyset_info(Some(unix_time() + 1_000_000));
+        assert!(!info.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_exactly_now_is_not_expired() {
+        // strict less-than: expiry == now is not yet expired
+        let info = dummy_mint_keyset_info(Some(unix_time()));
+        assert!(!info.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_one_second_ago() {
+        let info = dummy_mint_keyset_info(Some(unix_time() - 1));
+        assert!(info.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_zero() {
+        let info = dummy_mint_keyset_info(Some(0));
+        assert!(info.is_expired());
     }
 }

--- a/crates/cdk-integration-tests/tests/mint.rs
+++ b/crates/cdk-integration-tests/tests/mint.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use bip39::Mnemonic;
 use cashu::nut00::KnownMethod;
+use cashu::util::unix_time;
 use cashu::PaymentMethod;
 use cdk::mint::{MintBuilder, MintMeltLimits};
 use cdk::nuts::CurrencyUnit;
@@ -397,4 +398,103 @@ async fn test_rotate_keyset_with_expiry() {
     // Exactly one should be active
     let active_count = keysets.keysets.iter().filter(|k| k.active).count();
     assert_eq!(active_count, 1, "Exactly one keyset should be active");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_builder_does_not_replace_all_expired_keysets() {
+    use cdk_common::database::mint::KeysDatabase;
+
+    let mnemonic = Mnemonic::generate(12).unwrap();
+    let fee_reserve = FeeReserve {
+        min_fee_reserve: 1.into(),
+        percent_fee_reserve: 1.0,
+    };
+
+    let database = memory::empty().await.expect("valid db instance");
+    let localstore = Arc::new(database);
+
+    let fake_wallet1 = FakeWallet::new(
+        fee_reserve.clone(),
+        HashMap::default(),
+        HashSet::default(),
+        0,
+        CurrencyUnit::Sat,
+    );
+    let mut builder1 = MintBuilder::new(localstore.clone());
+    builder1 = builder1
+        .with_name("test mint".to_string())
+        .with_description("test mint".to_string());
+    builder1
+        .add_payment_processor(
+            CurrencyUnit::Sat,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+            MintMeltLimits::new(1, 5_000),
+            Arc::new(fake_wallet1),
+        )
+        .await
+        .unwrap();
+    let mint = builder1
+        .build_with_seed(localstore.clone(), &mnemonic.to_seed_normalized(""))
+        .await
+        .unwrap();
+    mint.set_quote_ttl(QuoteTTL::new(10000, 10000))
+        .await
+        .unwrap();
+
+    assert_eq!(mint.keysets().keysets.len(), 1);
+
+    let future_expiry = unix_time() + 1_000_000;
+    let new_keyset = mint
+        .rotate_keyset(
+            CurrencyUnit::Sat,
+            cdk_integration_tests::standard_keyset_amounts(32),
+            0,
+            true,
+            Some(future_expiry),
+        )
+        .await
+        .unwrap();
+
+    let count_before_rebuild = mint.keysets().keysets.len();
+    assert_eq!(count_before_rebuild, 2);
+
+    // Mutate final_expiry to be in the past via localstore upsert.
+    drop(mint);
+    {
+        let mut info = KeysDatabase::get_keyset_info(&*localstore, &new_keyset.id)
+            .await
+            .unwrap()
+            .expect("rotated keyset should be present in localstore");
+        info.final_expiry = Some(unix_time().saturating_sub(1));
+        let mut tx = KeysDatabase::begin_transaction(&*localstore).await.unwrap();
+        tx.add_keyset_info(info).await.unwrap();
+        tx.commit().await.unwrap();
+    }
+
+    let fake_wallet2 = FakeWallet::new(
+        fee_reserve,
+        HashMap::default(),
+        HashSet::default(),
+        0,
+        CurrencyUnit::Sat,
+    );
+    let mut builder2 = MintBuilder::new(localstore.clone());
+    builder2 = builder2
+        .with_name("test mint".to_string())
+        .with_description("test mint".to_string());
+    builder2
+        .add_payment_processor(
+            CurrencyUnit::Sat,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+            MintMeltLimits::new(1, 5_000),
+            Arc::new(fake_wallet2),
+        )
+        .await
+        .unwrap();
+    let mint2 = builder2
+        .build_with_seed(localstore.clone(), &mnemonic.to_seed_normalized(""))
+        .await
+        .unwrap();
+
+    assert_eq!(mint2.keysets().keysets.len(), count_before_rebuild);
 }

--- a/crates/cdk-signatory/src/common.rs
+++ b/crates/cdk-signatory/src/common.rs
@@ -34,6 +34,14 @@ pub async fn init_keysets(
             keysets.sort_by_key(|b| std::cmp::Reverse(b.derivation_path_index));
 
             if let Some(highest_index_keyset) = keysets.first() {
+                if highest_index_keyset.is_expired() {
+                    tracing::info!(
+                        "Highest index keyset for unit {} has expired, skipping reactivation",
+                        unit
+                    );
+                    continue;
+                }
+
                 // Check if it matches our criteria
                 if highest_index_keyset.input_fee_ppk == *input_fee_ppk
                     && highest_index_keyset.amounts == *amounts

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -138,6 +138,9 @@ impl Signatory for DbSignatory {
                 if !info.active {
                     return Err(Error::InactiveKeyset);
                 }
+                if info.is_expired() {
+                    return Err(Error::ExpiredKeyset);
+                }
 
                 let key_pair = key.keys.get(&amount).ok_or(Error::UnknownKeySet)?;
                 let c = sign_message(&key_pair.secret_key, &blinded_secret)?;
@@ -250,10 +253,52 @@ mod test {
 
     use bitcoin::key::Secp256k1;
     use bitcoin::Network;
+    use cdk_common::nuts::SecretKey;
     use cdk_common::util::hex;
+    use cdk_common::util::unix_time;
     use cdk_common::{Amount, MintKeySet, PublicKey};
 
     use super::*;
+
+    #[tokio::test]
+    async fn blind_sign_rejects_expired_keyset() {
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let signatory = DbSignatory::new(
+            store,
+            b"test-seed-for-unit-tests",
+            Default::default(),
+            Default::default(),
+        )
+        .await
+        .expect("DbSignatory::new");
+
+        let expired_keyset = signatory
+            .rotate_keyset(RotateKeyArguments {
+                unit: CurrencyUnit::Sat,
+                amounts: vec![1, 2, 4, 8],
+                input_fee_ppk: 0,
+                keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                final_expiry: Some(unix_time() - 1),
+            })
+            .await
+            .expect("rotate_keyset");
+
+        // Expiry check runs before crypto, so an unsigned blinded secret is fine here.
+        let blinded_secret = SecretKey::generate().public_key();
+        let msg = BlindedMessage::new(Amount::from(1), expired_keyset.id, blinded_secret);
+
+        let result = signatory.blind_sign(vec![msg]).await;
+
+        assert!(
+            matches!(result, Err(Error::ExpiredKeyset)),
+            "expected ExpiredKeyset error, got: {:?}",
+            result
+        );
+    }
 
     #[test]
     fn mint_mod_generate_keyset_from_seed() {

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -254,8 +254,7 @@ mod test {
     use bitcoin::key::Secp256k1;
     use bitcoin::Network;
     use cdk_common::nuts::SecretKey;
-    use cdk_common::util::hex;
-    use cdk_common::util::unix_time;
+    use cdk_common::util::{hex, unix_time};
     use cdk_common::{Amount, MintKeySet, PublicKey};
 
     use super::*;

--- a/crates/cdk-signatory/src/signatory.rs
+++ b/crates/cdk-signatory/src/signatory.rs
@@ -89,6 +89,14 @@ pub struct SignatoryKeySet {
     pub version: u32,
 }
 
+impl SignatoryKeySet {
+    /// Returns true if `final_expiry` is set and strictly in the past.
+    pub fn is_expired(&self) -> bool {
+        self.final_expiry
+            .is_some_and(|expiry| expiry < cdk_common::util::unix_time())
+    }
+}
+
 impl From<&SignatoryKeySet> for KeySet {
     fn from(val: &SignatoryKeySet) -> Self {
         val.to_owned().into()
@@ -171,4 +179,61 @@ pub trait Signatory {
     /// Add current keyset to inactive keysets
     /// Generate new keyset
     async fn rotate_keyset(&self, args: RotateKeyArguments) -> Result<SignatoryKeySet, Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::str::FromStr;
+
+    use cdk_common::nuts::nut01::Keys;
+    use cdk_common::util::unix_time;
+    use cdk_common::{CurrencyUnit, Id};
+
+    use super::*;
+
+    fn dummy_signatory_keyset(final_expiry: Option<u64>) -> SignatoryKeySet {
+        SignatoryKeySet {
+            id: Id::from_str("009a1f293253e41e").unwrap(),
+            unit: CurrencyUnit::Sat,
+            active: true,
+            keys: Keys::new(BTreeMap::new()),
+            amounts: vec![1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
+            input_fee_ppk: 0,
+            final_expiry,
+            issuer_version: None,
+            version: 0,
+        }
+    }
+
+    #[test]
+    fn test_is_expired_none() {
+        let ks = dummy_signatory_keyset(None);
+        assert!(!ks.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_far_future() {
+        let ks = dummy_signatory_keyset(Some(unix_time() + 1_000_000));
+        assert!(!ks.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_exactly_now_is_not_expired() {
+        // strict less-than: expiry == now is not yet expired
+        let ks = dummy_signatory_keyset(Some(unix_time()));
+        assert!(!ks.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_one_second_ago() {
+        let ks = dummy_signatory_keyset(Some(unix_time() - 1));
+        assert!(ks.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_zero() {
+        let ks = dummy_signatory_keyset(Some(0));
+        assert!(ks.is_expired());
+    }
 }

--- a/crates/cdk/src/mint/auth/mod.rs
+++ b/crates/cdk/src/mint/auth/mod.rs
@@ -54,6 +54,10 @@ impl Mint {
             return Err(Error::BlindAuthFailed);
         }
 
+        if keyset.is_expired() {
+            return Err(Error::ExpiredKeyset);
+        }
+
         self.signatory
             .verify_proofs(vec![token.auth_proof.clone().into()])
             .await

--- a/crates/cdk/src/mint/builder.rs
+++ b/crates/cdk/src/mint/builder.rs
@@ -540,6 +540,10 @@ impl MintBuilder {
             let mut rotate = false;
 
             if let Some(keyset) = keyset {
+                if keyset.is_expired() {
+                    tracing::warn!("Active keyset for unit {} has expired; not rotating", unit);
+                    continue;
+                }
                 // Check if fee matches
                 if keyset.input_fee_ppk != *fee {
                     tracing::info!(

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1198,6 +1198,15 @@ impl Mint {
                 request.outputs.into_iter().zip(blinded_signatures)
             {
                 if let Some(blinded_signature) = blinded_signature {
+                    if let Some(keyset_info) = self.get_keyset_info(&blinded_signature.keyset_id) {
+                        if keyset_info.is_expired() {
+                            tracing::debug!(
+                                "Skipping restore for expired keyset {}",
+                                blinded_signature.keyset_id
+                            );
+                            continue;
+                        }
+                    }
                     outputs.push(blinded_message);
                     signatures.push(blinded_signature);
                 }
@@ -1779,5 +1788,85 @@ mod tests {
             rotation_result,
             Err(Error::UnitStringCollision(_currency_unit))
         ));
+    }
+
+    #[tokio::test]
+    async fn verify_outputs_keyset_rejects_expired_keyset() {
+        use cdk_common::nuts::SecretKey;
+        use cdk_common::util::unix_time;
+
+        let mut supported_units = HashMap::new();
+        let amounts: Vec<u64> = (0..8).map(|i| 2u64.pow(i)).collect();
+        supported_units.insert(CurrencyUnit::default(), (0, amounts));
+
+        let config = MintConfig::<'_> {
+            supported_units,
+            ..Default::default()
+        };
+        let mint = create_mint(config).await;
+
+        let current_keysets: Vec<SignatoryKeySet> = mint.keysets.load().as_ref().clone();
+        let keyset_id = current_keysets[0].id;
+
+        let expired_keysets: Vec<SignatoryKeySet> = current_keysets
+            .into_iter()
+            .map(|mut ks| {
+                ks.final_expiry = Some(unix_time() - 1);
+                ks
+            })
+            .collect();
+        mint.keysets.store(Arc::new(expired_keysets));
+
+        let blinded_secret = SecretKey::generate().public_key();
+        let output = BlindedMessage::new(Amount::from(1), keyset_id, blinded_secret);
+
+        let result = mint.verify_outputs_keyset(&[output]);
+
+        assert!(
+            matches!(result, Err(Error::ExpiredKeyset)),
+            "expected ExpiredKeyset error, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_inputs_keyset_rejects_expired_keyset() {
+        use cdk_common::nuts::{Proof, SecretKey};
+        use cdk_common::secret::Secret;
+        use cdk_common::util::unix_time;
+
+        let mut supported_units = HashMap::new();
+        let amounts: Vec<u64> = (0..8).map(|i| 2u64.pow(i)).collect();
+        supported_units.insert(CurrencyUnit::default(), (0, amounts));
+
+        let config = MintConfig::<'_> {
+            supported_units,
+            ..Default::default()
+        };
+        let mint = create_mint(config).await;
+
+        let current_keysets: Vec<SignatoryKeySet> = mint.keysets.load().as_ref().clone();
+        let keyset_id = current_keysets[0].id;
+
+        let expired_keysets: Vec<SignatoryKeySet> = current_keysets
+            .into_iter()
+            .map(|mut ks| {
+                ks.final_expiry = Some(unix_time() - 1);
+                ks
+            })
+            .collect();
+        mint.keysets.store(Arc::new(expired_keysets));
+
+        // Expiry check runs before crypto, so an unsigned proof is fine here.
+        let c = SecretKey::generate().public_key();
+        let proof = Proof::new(Amount::from(1), keyset_id, Secret::generate(), c);
+
+        let result = mint.verify_inputs_keyset(&vec![proof]).await;
+
+        assert!(
+            matches!(result, Err(Error::ExpiredKeyset)),
+            "expected ExpiredKeyset error, got: {:?}",
+            result
+        );
     }
 }

--- a/crates/cdk/src/mint/verification.rs
+++ b/crates/cdk/src/mint/verification.rs
@@ -76,6 +76,13 @@ impl Mint {
                         );
                         return Err(Error::InactiveKeyset);
                     }
+                    if keyset.is_expired() {
+                        tracing::debug!(
+                            "Transaction attempted with expired keyset in outputs: {}.",
+                            id
+                        );
+                        return Err(Error::ExpiredKeyset);
+                    }
                     keyset_units.insert(keyset.unit);
                 }
                 None => {
@@ -114,6 +121,13 @@ impl Mint {
         for id in &inputs_keyset_ids {
             match self.get_keyset_info(id) {
                 Some(keyset) => {
+                    if keyset.is_expired() {
+                        tracing::debug!(
+                            "Transaction attempted with expired keyset in inputs: {}.",
+                            id
+                        );
+                        return Err(Error::ExpiredKeyset);
+                    }
                     keyset_units.insert(keyset.unit);
                 }
                 None => {


### PR DESCRIPTION
closes #1895

### Description

Enforces keyset expiry by rejecting inputs and outputs for an expired keyset. The expired keyset stays active.

-----

### Notes to the reviewers

This doesn't handle the wallet side of things. Also, while working on the tests I realized that the mint allows for keysets to be rotated with an expiry in the past, I created an issue for that #1945 

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
