### PR TITLE
Migrate Swift tests from XCTest to Swift Testing

### DIFF
--- a/bindings/swift/Tests/CdkTests.swift
+++ b/bindings/swift/Tests/CdkTests.swift
@@ -1,12 +1,13 @@
-import XCTest
+import Testing
+import Foundation
 @testable import Cdk
 
-final class CdkTests: XCTestCase {
-    private var wallet: Wallet!
-    private var dbPath: String!
+@Suite("Cdk Wallet Tests")
+struct CdkTests {
+    private let wallet: Wallet
+    private let dbPath: String
 
-    override func setUp() async throws {
-        try await super.setUp()
+    init() async throws {
         let tempDir = FileManager.default.temporaryDirectory
         dbPath = tempDir.appendingPathComponent(UUID().uuidString + ".sqlite").path
         wallet = try Wallet(
@@ -18,20 +19,14 @@ final class CdkTests: XCTestCase {
         )
     }
 
-    override func tearDown() async throws {
-        wallet = nil
-        if let path = dbPath {
-            try? FileManager.default.removeItem(atPath: path)
-        }
-        try await super.tearDown()
-    }
-
-    func testInitialBalanceIsZero() async throws {
+    @Test("Initial balance is zero")
+    func initialBalanceIsZero() async throws {
         let balance = try await wallet.totalBalance()
-        XCTAssertEqual(balance.value, 0, "New wallet should have zero balance")
+        #expect(balance.value == 0, "New wallet should have zero balance")
     }
 
-    func testMintFlow() async throws {
+    @Test("Mint flow completes successfully")
+    func mintFlow() async throws {
         let quote = try await wallet.mintQuote(
             paymentMethod: .bolt11,
             amount: Amount(value: 100),
@@ -39,8 +34,8 @@ final class CdkTests: XCTestCase {
             extra: nil
         )
 
-        XCTAssertFalse(quote.id.isEmpty, "Quote should have a non-empty id")
-        XCTAssertFalse(quote.request.isEmpty, "Quote should have a non-empty payment request")
+        #expect(!quote.id.isEmpty, "Quote should have a non-empty id")
+        #expect(!quote.request.isEmpty, "Quote should have a non-empty payment request")
 
         // testnut pays quotes automatically, wait briefly for payment to settle
         try await Task.sleep(nanoseconds: 3_000_000_000)
@@ -51,9 +46,9 @@ final class CdkTests: XCTestCase {
             spendingConditions: nil
         )
 
-        XCTAssertFalse(proofs.isEmpty, "Should have received proofs")
+        #expect(!proofs.isEmpty, "Should have received proofs")
 
         let balance = try await wallet.totalBalance()
-        XCTAssertEqual(balance.value, 100, "Balance should be 100 after minting")
+        #expect(balance.value == 100, "Balance should be 100 after minting")
     }
 }


### PR DESCRIPTION

### Description

Bump swift-tools-version to 6.0 and rewrite CdkTests using @Suite struct, @Test macros, and #expect() assertions. Added swiftLanguageMode v5 to avoid strict concurrency errors from generated FFI bindings.

Fixes #1818

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
