### PR TITLE
Fix: Wallet can get mint info without specify `mint_url`

### DIFF
--- a/crates/cdk-cli/src/sub_commands/mint_info.rs
+++ b/crates/cdk-cli/src/sub_commands/mint_info.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use anyhow::Result;
 use cdk::mint_url::MintUrl;
 use cdk::wallet::WalletRepository;
@@ -5,17 +7,61 @@ use clap::Args;
 
 #[derive(Args)]
 pub struct MintInfoSubcommand {
-    mint_url: MintUrl,
+    mint_url: Option<MintUrl>,
 }
 
 pub async fn mint_info(
     wallet_repository: &WalletRepository,
     sub_command_args: &MintInfoSubcommand,
 ) -> Result<()> {
-    let mint_url = sub_command_args.mint_url.clone();
-    let info = wallet_repository.fetch_mint_info(&mint_url).await?;
+    if let Some(mint_url) = &sub_command_args.mint_url {
+        match wallet_repository.fetch_mint_info(mint_url).await {
+            Ok(info) => {
+                println!("{}", serde_json::to_string_pretty(&info)?);
+            }
+            Err(_) => {
+                let wallets = wallet_repository.get_wallets_for_mint(mint_url).await;
 
-    println!("{}", serde_json::to_string_pretty(&info)?);
+                if wallets.is_empty() {
+                    return Err(anyhow::anyhow!(
+                        "Cannot fetch mint info {mint_url}: No wallet found for this mint"
+                    ));
+                }
+
+                for (i, wallet) in wallets.iter().enumerate() {
+                    match wallet.load_mint_info().await {
+                        Ok(mint_info) => {
+                            println!("{i}: {mint_url}");
+                            println!("{}", serde_json::to_string_pretty(&mint_info)?);
+                        }
+                        Err(e) => {
+                            return Err(anyhow::anyhow!("Cannot fetch mint info {mint_url}: {e}"));
+                        }
+                    }
+                }
+            }
+        };
+    } else {
+        let mut seen = HashSet::new();
+        for (i, wallet) in wallet_repository
+            .get_wallets()
+            .await
+            .iter()
+            .filter(|w| seen.insert(w.mint_url.clone()))
+            .enumerate()
+        {
+            let mint_url = wallet.mint_url.clone();
+            match wallet.load_mint_info().await {
+                Ok(info) => {
+                    println!("{i}: {mint_url}");
+                    println!("{}", serde_json::to_string_pretty(&info)?);
+                }
+                Err(e) => {
+                    return Err(anyhow::anyhow!("Cannot fetch mint info {mint_url}: {e}"));
+                }
+            };
+        }
+    }
 
     Ok(())
 }

--- a/crates/cdk-cli/src/sub_commands/mint_info.rs
+++ b/crates/cdk-cli/src/sub_commands/mint_info.rs
@@ -1,25 +1,71 @@
+use std::collections::HashSet;
+
 use anyhow::Result;
 use cdk::mint_url::MintUrl;
-use cdk::wallet::WalletRepository;
+use cdk::wallet::{Wallet, WalletRepository};
 use clap::Args;
 
 use crate::terminal::escape_control;
 
 #[derive(Args)]
 pub struct MintInfoSubcommand {
-    mint_url: MintUrl,
+    mint_url: Option<MintUrl>,
 }
 
 pub async fn mint_info(
     wallet_repository: &WalletRepository,
     sub_command_args: &MintInfoSubcommand,
 ) -> Result<()> {
-    let mint_url = sub_command_args.mint_url.clone();
-    let info = wallet_repository.fetch_mint_info(&mint_url).await?;
+    if let Some(mint_url) = &sub_command_args.mint_url {
+        match wallet_repository.fetch_mint_info(mint_url).await {
+            Ok(info) => {
+                // Mint info is entirely mint-controlled (URLs, custom currency units,
+                // descriptions); escape control characters before printing.
+                println!("{}", escape_control(&serde_json::to_string_pretty(&info)?));
+            }
+            Err(fetch_err) => {
+                let wallets: Vec<Wallet> = wallet_repository.get_wallets_for_mint(mint_url).await;
 
-    // Mint info is entirely mint-controlled (URLs, custom currency units,
-    // descriptions); escape control characters before printing.
-    println!("{}", escape_control(&serde_json::to_string_pretty(&info)?));
+                if let Some(wallet) = wallets.first() {
+                    match wallet.load_mint_info().await {
+                        Ok(mint_info) => {
+                            println!(
+                                "{}",
+                                escape_control(&serde_json::to_string_pretty(&mint_info)?)
+                            );
+                        }
+                        Err(e) => {
+                            return Err(anyhow::anyhow!("Cannot fetch mint info {mint_url}: fetch failed {fetch_err}, cache failed {e}"));
+                        }
+                    }
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "Cannot fetch mint info {mint_url}: {fetch_err}"
+                    ));
+                }
+            }
+        };
+    } else {
+        let mut seen = HashSet::new();
+        for (i, wallet) in wallet_repository
+            .get_wallets()
+            .await
+            .iter()
+            .filter(|w| seen.insert(w.mint_url.clone()))
+            .enumerate()
+        {
+            let mint_url = wallet.mint_url.clone();
+            match wallet.load_mint_info().await {
+                Ok(info) => {
+                    println!("{i}: {}", escape_control(&mint_url.to_string()));
+                    println!("{}", escape_control(&serde_json::to_string_pretty(&info)?));
+                }
+                Err(e) => {
+                    return Err(anyhow::anyhow!("Cannot fetch mint info {mint_url}: {e}"));
+                }
+            };
+        }
+    }
 
     Ok(())
 }

--- a/crates/cdk/src/wallet/mint_metadata_cache.rs
+++ b/crates/cdk/src/wallet/mint_metadata_cache.rs
@@ -328,6 +328,7 @@ impl MintMetadataCache {
     /// // Load from database (no HTTP)
     /// let metadata = cache.load_from_db(&storage).await?;
     /// ```
+    #[inline(always)]
     async fn load_from_db(
         &self,
         storage: &Arc<dyn WalletDatabase<database::Error> + Send + Sync>,


### PR DESCRIPTION
### Description

Accept HTTP proxy on the CLI and ensure that the Wallet's can get mint info without specify `mint_url`.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

- 0a88ae65c98fe392dd624f3ec20ca448f4b8fbc2:  Get mint info from wallets on `cdk-cli mint-info` command without needing to specifying `mint_url` and define `danger_accept_invalid_certs` from `Wallet Repository` as public.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED
- `cdk-cli mint-info` command
- Mark `danger_accept_invalid_certs` as public

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
