### PR TITLE
Make connection pool fully async to prevent tokio runtime starvation

### DIFF
--- a/crates/cdk-sql-common/src/keyvalue.rs
+++ b/crates/cdk-sql-common/src/keyvalue.rs
@@ -162,7 +162,7 @@ where
     // Validate parameters according to KV store requirements
     validate_kvstore_params(primary_namespace, secondary_namespace, Some(key))?;
 
-    let conn = pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+    let conn = pool.get().await.map_err(|e| Error::Database(Box::new(e)))?;
     Ok(query(
         r#"
         SELECT value
@@ -195,7 +195,7 @@ where
     // Validate namespace parameters according to KV store requirements
     validate_kvstore_params(primary_namespace, secondary_namespace, None)?;
 
-    let conn = pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+    let conn = pool.get().await.map_err(|e| Error::Database(Box::new(e)))?;
     query(
         r#"
         SELECT key

--- a/crates/cdk-sql-common/src/mint/auth/mod.rs
+++ b/crates/cdk-sql-common/src/mint/auth/mod.rs
@@ -42,7 +42,7 @@ where
         X: Into<RM::Config>,
     {
         let pool = Pool::new(db.into());
-        Self::migrate(pool.get().map_err(|e| Error::Database(Box::new(e)))?).await?;
+        Self::migrate(pool.get().await.map_err(|e| Error::Database(Box::new(e)))?).await?;
         Ok(Self { pool })
     }
 
@@ -251,14 +251,21 @@ where
     {
         Ok(Box::new(SQLTransaction {
             inner: ConnectionWithTransaction::new(
-                self.pool.get().map_err(|e| Error::Database(Box::new(e)))?,
+                self.pool
+                    .get()
+                    .await
+                    .map_err(|e| Error::Database(Box::new(e)))?,
             )
             .await?,
         }))
     }
 
     async fn get_active_keyset_id(&self) -> Result<Option<Id>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -277,7 +284,11 @@ where
     }
 
     async fn get_keyset_info(&self, id: &Id) -> Result<Option<MintKeySetInfo>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"SELECT
                 id,
@@ -301,7 +312,11 @@ where
     }
 
     async fn get_keyset_infos(&self) -> Result<Vec<MintKeySetInfo>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"SELECT
                 id,
@@ -325,7 +340,11 @@ where
     }
 
     async fn get_proofs_states(&self, ys: &[PublicKey]) -> Result<Vec<Option<State>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut current_states = query(r#"SELECT y, state FROM proof WHERE y IN (:ys)"#)?
             .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
             .fetch_all(&*conn)
@@ -346,7 +365,11 @@ where
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut blinded_signatures = query(
             r#"SELECT
                 keyset_id,
@@ -391,7 +414,11 @@ where
         &self,
         protected_endpoint: ProtectedEndpoint,
     ) -> Result<Option<AuthRequired>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(
             query(r#"SELECT auth FROM protected_endpoints WHERE endpoint = :endpoint"#)?
                 .bind("endpoint", serde_json::to_string(&protected_endpoint)?)
@@ -411,7 +438,11 @@ where
     async fn get_auth_for_endpoints(
         &self,
     ) -> Result<HashMap<ProtectedEndpoint, Option<AuthRequired>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(r#"SELECT endpoint, auth FROM protected_endpoints"#)?
             .fetch_all(&*conn)
             .await?

--- a/crates/cdk-sql-common/src/mint/completed_operations.rs
+++ b/crates/cdk-sql-common/src/mint/completed_operations.rs
@@ -124,7 +124,11 @@ where
         &self,
         operation_id: &uuid::Uuid,
     ) -> Result<Option<mint::Operation>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -152,7 +156,11 @@ where
         &self,
         operation_kind: mint::OperationKind,
     ) -> Result<Vec<mint::Operation>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -179,7 +187,11 @@ where
     }
 
     async fn get_completed_operations(&self) -> Result<Vec<mint::Operation>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/keys.rs
+++ b/crates/cdk-sql-common/src/mint/keys.rs
@@ -141,7 +141,10 @@ where
     ) -> Result<Box<dyn MintKeyDatabaseTransaction<'a, Error> + Send + Sync + 'a>, Error> {
         let tx = SQLTransaction {
             inner: ConnectionWithTransaction::new(
-                self.pool.get().map_err(|e| Error::Database(Box::new(e)))?,
+                self.pool
+                    .get()
+                    .await
+                    .map_err(|e| Error::Database(Box::new(e)))?,
             )
             .await?,
         };
@@ -150,7 +153,11 @@ where
     }
 
     async fn get_active_keyset_id(&self, unit: &CurrencyUnit) -> Result<Option<Id>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(
             query(r#" SELECT id FROM keyset WHERE active = :active AND unit = :unit"#)?
                 .bind("active", true)
@@ -167,7 +174,11 @@ where
     }
 
     async fn get_active_keysets(&self) -> Result<HashMap<CurrencyUnit, Id>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(
             query(r#"SELECT id, unit FROM keyset WHERE active = :active"#)?
                 .bind("active", true)
@@ -185,7 +196,11 @@ where
     }
 
     async fn get_keyset_info(&self, id: &Id) -> Result<Option<MintKeySetInfo>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"SELECT
                 id,
@@ -210,7 +225,11 @@ where
     }
 
     async fn get_keyset_infos(&self) -> Result<Vec<MintKeySetInfo>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"SELECT
                 id,

--- a/crates/cdk-sql-common/src/mint/keyvalue.rs
+++ b/crates/cdk-sql-common/src/mint/keyvalue.rs
@@ -105,7 +105,10 @@ where
     {
         Ok(Box::new(SQLTransaction {
             inner: ConnectionWithTransaction::new(
-                self.pool.get().map_err(|e| Error::Database(Box::new(e)))?,
+                self.pool
+                    .get()
+                    .await
+                    .map_err(|e| Error::Database(Box::new(e)))?,
             )
             .await?,
         }))

--- a/crates/cdk-sql-common/src/mint/mod.rs
+++ b/crates/cdk-sql-common/src/mint/mod.rs
@@ -66,7 +66,7 @@ where
     {
         let pool = Pool::new(db.into());
 
-        Self::migrate(pool.get().map_err(|e| Error::Database(Box::new(e)))?).await?;
+        Self::migrate(pool.get().await.map_err(|e| Error::Database(Box::new(e)))?).await?;
 
         Ok(Self { pool })
     }
@@ -125,7 +125,10 @@ where
     ) -> Result<Box<dyn database::MintTransaction<Error> + Send + Sync>, Error> {
         let tx = SQLTransaction {
             inner: ConnectionWithTransaction::new(
-                self.pool.get().map_err(|e| Error::Database(Box::new(e)))?,
+                self.pool
+                    .get()
+                    .await
+                    .map_err(|e| Error::Database(Box::new(e)))?,
             )
             .await?,
         };

--- a/crates/cdk-sql-common/src/mint/proofs.rs
+++ b/crates/cdk-sql-common/src/mint/proofs.rs
@@ -407,7 +407,11 @@ where
     type Err = Error;
 
     async fn get_proofs_by_ys(&self, ys: &[PublicKey]) -> Result<Vec<Option<Proof>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut proofs = query(
             r#"
             SELECT
@@ -446,7 +450,11 @@ where
         &self,
         quote_id: &QuoteId,
     ) -> Result<Vec<PublicKey>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -471,7 +479,11 @@ where
     }
 
     async fn get_proofs_states(&self, ys: &[PublicKey]) -> Result<Vec<Option<State>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut current_states = get_current_states(&*conn, ys, false).await?;
 
         Ok(ys.iter().map(|y| current_states.remove(y)).collect())
@@ -481,7 +493,11 @@ where
         &self,
         keyset_id: &Id,
     ) -> Result<(Proofs, Vec<Option<State>>), Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let (proofs, states): (Vec<Proof>, Vec<State>) = query(
             r#"
@@ -512,7 +528,11 @@ where
 
     /// Get total proofs redeemed by keyset id
     async fn get_total_redeemed(&self) -> Result<HashMap<Id, Amount>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -533,7 +553,11 @@ where
         &self,
         operation_id: &uuid::Uuid,
     ) -> Result<Vec<PublicKey>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/quotes.rs
+++ b/crates/cdk-sql-common/src/mint/quotes.rs
@@ -1117,7 +1117,11 @@ where
 
         #[cfg(feature = "prometheus")]
         let start_time = std::time::Instant::now();
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let result = get_mint_quote_inner(&*conn, quote_id, false).await;
 
@@ -1141,7 +1145,11 @@ where
         &self,
         quote_ids: &[QuoteId],
     ) -> Result<Vec<Option<MintQuote>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         get_mint_quotes_inner(&*conn, quote_ids, false).await
     }
 
@@ -1149,7 +1157,11 @@ where
         &self,
         request: &str,
     ) -> Result<Option<MintQuote>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         get_mint_quote_by_request_inner(&*conn, request, false).await
     }
 
@@ -1157,12 +1169,20 @@ where
         &self,
         request_lookup_id: &PaymentIdentifier,
     ) -> Result<Option<MintQuote>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         get_mint_quote_by_request_lookup_id_inner(&*conn, request_lookup_id, false).await
     }
 
     async fn get_mint_quotes(&self) -> Result<Vec<MintQuote>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut mint_quotes = query(
             r#"
             SELECT
@@ -1208,7 +1228,11 @@ where
 
         #[cfg(feature = "prometheus")]
         let start_time = std::time::Instant::now();
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let result = get_melt_quote_inner(&*conn, quote_id, false).await;
 
@@ -1229,7 +1253,11 @@ where
     }
 
     async fn get_melt_quotes(&self) -> Result<Vec<mint::MeltQuote>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/saga.rs
+++ b/crates/cdk-sql-common/src/mint/saga.rs
@@ -222,7 +222,11 @@ where
         &self,
         quote_id: &cdk_common::QuoteId,
     ) -> Result<Option<mint::Saga>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -252,7 +256,11 @@ where
         &self,
         operation_kind: mint::OperationKind,
     ) -> Result<Vec<mint::Saga>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -261,7 +261,11 @@ where
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut blinded_signatures = query(
             r#"SELECT
                 keyset_id,
@@ -306,7 +310,11 @@ where
         &self,
         keyset_id: &Id,
     ) -> Result<Vec<BlindSignature>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -334,7 +342,11 @@ where
         &self,
         quote_id: &QuoteId,
     ) -> Result<Vec<BlindSignature>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -359,7 +371,11 @@ where
 
     /// Get total proofs redeemed by keyset id
     async fn get_total_issued(&self) -> Result<HashMap<Id, Amount>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -380,7 +396,11 @@ where
         &self,
         operation_id: &uuid::Uuid,
     ) -> Result<Vec<PublicKey>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/pool.rs
+++ b/crates/cdk-sql-common/src/pool.rs
@@ -5,11 +5,12 @@
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 #[cfg(feature = "prometheus")]
 use cdk_prometheus::metrics::METRICS;
+use tokio::sync::Notify;
 
 use crate::database::DatabaseConnector;
 
@@ -73,11 +74,13 @@ where
     RM: DatabasePool,
 {
     config: RM::Config,
+    // std::sync::Mutex is used intentionally: only held briefly for push/pop, never across await
+    // points. This allows PooledResource::drop (which is sync) to return resources to the pool.
     queue: Mutex<Vec<(Arc<AtomicBool>, RM::Connection)>>,
     in_use: AtomicUsize,
     max_size: usize,
     default_timeout: Duration,
-    waiter: Condvar,
+    waiter: Notify,
 }
 
 /// The pooled resource
@@ -119,7 +122,7 @@ where
                 METRICS.record_db_operation(duration, "drop");
             }
 
-            // Notify a waiting thread
+            // Notify a waiting task
             self.pool.waiter.notify_one();
         }
     }
@@ -157,14 +160,14 @@ where
             config,
             queue: Default::default(),
             in_use: Default::default(),
-            waiter: Default::default(),
+            waiter: Notify::new(),
         })
     }
 
     /// Similar to get_timeout but uses the default timeout value.
     #[inline(always)]
-    pub fn get(self: &Arc<Self>) -> Result<PooledResource<RM>, Error<RM::Error>> {
-        self.get_timeout(self.default_timeout)
+    pub async fn get(self: &Arc<Self>) -> Result<PooledResource<RM>, Error<RM::Error>> {
+        self.get_timeout(self.default_timeout).await
     }
 
     /// Increments the in_use connection counter and updates the metric
@@ -179,75 +182,89 @@ where
         in_use
     }
 
-    /// Get a new resource or fail after timeout is reached.
-    ///
-    /// This function will return a free resource or create a new one if there is still room for it;
-    /// otherwise, it will wait for a resource to be released for reuse.
-    #[inline(always)]
-    pub fn get_timeout(
-        self: &Arc<Self>,
-        timeout: Duration,
-    ) -> Result<PooledResource<RM>, Error<RM::Error>> {
+    /// Try to acquire a resource without waiting. Returns `None` if no resource is available.
+    fn try_get(self: &Arc<Self>) -> Result<Option<PooledResource<RM>>, Error<RM::Error>> {
         let mut resources = self.queue.lock().map_err(|_| Error::Poison)?;
-        let time = Instant::now();
 
-        loop {
-            while let Some((stale, resource)) = resources.pop() {
-                if !stale.load(Ordering::SeqCst) {
-                    // Increment counter BEFORE releasing the mutex to prevent race condition
-                    // where another thread sees in_use < max_size and creates a duplicate connection.
-                    // For in-memory SQLite, each connection is a separate database, so this race
-                    // would cause some connections to miss migrations.
-                    self.increment_connection_counter();
+        // Try to reuse an existing non-stale connection
+        while let Some((stale, resource)) = resources.pop() {
+            if !stale.load(Ordering::SeqCst) {
+                self.increment_connection_counter();
+                return Ok(Some(PooledResource {
+                    resource: Some((stale, resource)),
+                    pool: self.clone(),
+                    #[cfg(feature = "prometheus")]
+                    start_time: Instant::now(),
+                }));
+            }
+        }
 
-                    return Ok(PooledResource {
-                        resource: Some((stale, resource)),
+        // Try to create a new connection if under max_size
+        if self.in_use.load(Ordering::Relaxed) < self.max_size {
+            // Increment counter BEFORE releasing the mutex to prevent race condition
+            // where another thread sees in_use < max_size and creates a duplicate connection.
+            // For in-memory SQLite, each connection is a separate database, so this race
+            // would cause some connections to miss migrations.
+            self.increment_connection_counter();
+            let stale: Arc<AtomicBool> = Arc::new(false.into());
+            match RM::new_resource(&self.config, stale.clone(), self.default_timeout) {
+                Ok(new_resource) => {
+                    return Ok(Some(PooledResource {
+                        resource: Some((stale, new_resource)),
                         pool: self.clone(),
                         #[cfg(feature = "prometheus")]
                         start_time: Instant::now(),
-                    });
+                    }));
+                }
+                Err(e) => {
+                    self.in_use.fetch_sub(1, Ordering::AcqRel);
+                    return Err(e);
                 }
             }
+        }
 
-            if self.in_use.load(Ordering::Relaxed) < self.max_size {
-                // Increment counter BEFORE releasing the mutex to prevent race condition.
-                // This ensures other threads see the updated count and wait instead of
-                // creating additional connections beyond max_size.
-                self.increment_connection_counter();
-                let stale: Arc<AtomicBool> = Arc::new(false.into());
-                match RM::new_resource(&self.config, stale.clone(), timeout) {
-                    Ok(new_resource) => {
-                        return Ok(PooledResource {
-                            resource: Some((stale, new_resource)),
-                            pool: self.clone(),
-                            #[cfg(feature = "prometheus")]
-                            start_time: Instant::now(),
-                        });
-                    }
-                    Err(e) => {
-                        // If resource creation fails, decrement the counter we just incremented
-                        self.in_use.fetch_sub(1, Ordering::AcqRel);
-                        return Err(e);
-                    }
-                }
+        Ok(None)
+    }
+
+    /// Get a new resource or fail after timeout is reached.
+    ///
+    /// This function will return a free resource or create a new one if there is still room for it;
+    /// otherwise, it will wait asynchronously for a resource to be released for reuse.
+    #[inline(always)]
+    pub async fn get_timeout(
+        self: &Arc<Self>,
+        timeout: Duration,
+    ) -> Result<PooledResource<RM>, Error<RM::Error>> {
+        let deadline = Instant::now() + timeout;
+
+        loop {
+            if let Some(resource) = self.try_get()? {
+                return Ok(resource);
             }
 
-            resources = self
-                .waiter
-                .wait_timeout(resources, timeout)
-                .map_err(|_| Error::Poison)
-                .and_then(|(lock, timeout_result)| {
-                    if timeout_result.timed_out() {
-                        tracing::warn!(
-                            "Timeout waiting for the resource (pool size: {}). Waited {} ms",
-                            self.max_size,
-                            time.elapsed().as_millis()
-                        );
-                        Err(Error::Timeout)
-                    } else {
-                        Ok(lock)
-                    }
-                })?;
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                tracing::warn!(
+                    "Timeout waiting for the resource (pool size: {}). Waited {} ms",
+                    self.max_size,
+                    timeout.as_millis()
+                );
+                return Err(Error::Timeout);
+            }
+
+            match tokio::time::timeout(remaining, self.waiter.notified()).await {
+                Ok(()) => {
+                    // Notification received, loop back to try_get
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        "Timeout waiting for the resource (pool size: {}). Waited {} ms",
+                        self.max_size,
+                        timeout.as_millis()
+                    );
+                    return Err(Error::Timeout);
+                }
+            }
         }
     }
 }
@@ -258,20 +275,8 @@ where
 {
     fn drop(&mut self) {
         if let Ok(mut resources) = self.queue.lock() {
-            loop {
-                while let Some(resource) = resources.pop() {
-                    RM::drop(resource.1);
-                }
-
-                if self.in_use.load(Ordering::Relaxed) == 0 {
-                    break;
-                }
-
-                resources = if let Ok(resources) = self.waiter.wait(resources) {
-                    resources
-                } else {
-                    break;
-                };
+            while let Some(resource) = resources.pop() {
+                RM::drop(resource.1);
             }
         }
     }

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -55,7 +55,7 @@ where
         X: Into<RM::Config>,
     {
         let pool = Pool::new(db.into());
-        Self::migrate(pool.get().map_err(|e| Error::Database(Box::new(e)))?).await?;
+        Self::migrate(pool.get().await.map_err(|e| Error::Database(Box::new(e)))?).await?;
 
         Ok(Self { pool })
     }
@@ -150,7 +150,11 @@ where
 {
     #[instrument(skip(self))]
     async fn get_melt_quotes(&self) -> Result<Vec<wallet::MeltQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         Ok(query(
             r#"
@@ -180,7 +184,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_mint(&self, mint_url: MintUrl) -> Result<Option<MintInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -210,7 +218,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_mints(&self) -> Result<HashMap<MintUrl, Option<MintInfo>>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
                 SELECT
@@ -250,7 +262,11 @@ where
         &self,
         mint_url: MintUrl,
     ) -> Result<Option<Vec<KeySetInfo>>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let keysets = query(
             r#"
@@ -283,7 +299,11 @@ where
         &self,
         keyset_id: &Id,
     ) -> Result<Option<KeySetInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -306,7 +326,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_mint_quote(&self, quote_id: &str) -> Result<Option<MintQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -338,7 +362,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_mint_quotes(&self) -> Result<Vec<MintQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -368,7 +396,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_unissued_mint_quotes(&self) -> Result<Vec<MintQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -405,7 +437,11 @@ where
         &self,
         quote_id: &str,
     ) -> Result<Option<wallet::MeltQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -436,7 +472,11 @@ where
 
     #[instrument(skip(self), fields(keyset_id = %keyset_id))]
     async fn get_keys(&self, keyset_id: &Id) -> Result<Option<Keys>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -463,7 +503,11 @@ where
         state: Option<Vec<State>>,
         spending_conditions: Option<Vec<SpendingConditions>>,
     ) -> Result<Vec<ProofInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -506,7 +550,11 @@ where
         &self,
         ys: Vec<PublicKey>,
     ) -> Result<Vec<ProofInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -544,7 +592,11 @@ where
         unit: Option<CurrencyUnit>,
         states: Option<Vec<State>>,
     ) -> Result<u64, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let mut query_str = "SELECT COALESCE(SUM(amount), 0) as total FROM proof".to_string();
         let mut where_clauses = Vec::new();
@@ -607,7 +659,11 @@ where
         &self,
         transaction_id: TransactionId,
     ) -> Result<Option<Transaction>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -645,7 +701,11 @@ where
         direction: Option<TransactionDirection>,
         unit: Option<CurrencyUnit>,
     ) -> Result<Vec<Transaction>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         Ok(query(
             r#"
@@ -688,7 +748,11 @@ where
         added: Vec<ProofInfo>,
         removed_ys: Vec<PublicKey>,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let tx = ConnectionWithTransaction::new(conn).await?;
 
         for proof in added {
@@ -785,7 +849,11 @@ where
         ys: Vec<PublicKey>,
         state: State,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query("UPDATE proof SET state = :state WHERE y IN (:ys)")?
             .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
@@ -798,7 +866,11 @@ where
 
     #[instrument(skip(self))]
     async fn add_transaction(&self, transaction: Transaction) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let mint_url = transaction.mint_url.to_string();
         let direction = transaction.direction.to_string();
@@ -866,7 +938,11 @@ where
         old_mint_url: MintUrl,
         new_mint_url: MintUrl,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let tx = ConnectionWithTransaction::new(conn).await?;
         let tables = ["mint_quote", "proof"];
 
@@ -895,7 +971,11 @@ where
         keyset_id: &Id,
         count: u32,
     ) -> Result<u32, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let new_counter = query(
             r#"
@@ -923,7 +1003,11 @@ where
         mint_url: MintUrl,
         mint_info: Option<MintInfo>,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let (
             name,
@@ -1024,7 +1108,11 @@ where
 
     #[instrument(skip(self))]
     async fn remove_mint(&self, mint_url: MintUrl) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM mint WHERE mint_url=:mint_url"#)?
             .bind("mint_url", mint_url.to_string())
@@ -1040,7 +1128,11 @@ where
         mint_url: MintUrl,
         keysets: Vec<KeySetInfo>,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let tx = ConnectionWithTransaction::new(conn).await?;
 
         for keyset in keysets {
@@ -1073,7 +1165,11 @@ where
 
     #[instrument(skip_all)]
     async fn add_mint_quote(&self, quote: MintQuote) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let expected_version = quote.version;
         let new_version = expected_version.wrapping_add(1);
@@ -1127,7 +1223,11 @@ where
 
     #[instrument(skip(self))]
     async fn remove_mint_quote(&self, quote_id: &str) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM mint_quote WHERE id=:id"#)?
             .bind("id", quote_id.to_string())
@@ -1139,7 +1239,11 @@ where
 
     #[instrument(skip_all)]
     async fn add_melt_quote(&self, quote: wallet::MeltQuote) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let expected_version = quote.version;
         let new_version = expected_version.wrapping_add(1);
@@ -1190,7 +1294,11 @@ where
 
     #[instrument(skip(self))]
     async fn remove_melt_quote(&self, quote_id: &str) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM melt_quote WHERE id=:id"#)?
             .bind("id", quote_id.to_owned())
@@ -1202,7 +1310,11 @@ where
 
     #[instrument(skip_all)]
     async fn add_keys(&self, keyset: KeySet) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         keyset.verify_id()?;
 
@@ -1228,7 +1340,11 @@ where
 
     #[instrument(skip(self))]
     async fn remove_keys(&self, id: &Id) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM key WHERE id = :id"#)?
             .bind("id", id.to_string())
@@ -1243,7 +1359,11 @@ where
         &self,
         transaction_id: TransactionId,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM transactions WHERE id=:id"#)?
             .bind("id", transaction_id.as_slice().to_vec())
@@ -1255,7 +1375,11 @@ where
 
     #[instrument(skip(self))]
     async fn add_saga(&self, saga: wallet::WalletSaga) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let state_json = serde_json::to_string(&saga.state).map_err(|e| {
             Error::Database(Box::new(std::io::Error::new(
@@ -1301,7 +1425,11 @@ where
         &self,
         id: &uuid::Uuid,
     ) -> Result<Option<wallet::WalletSaga>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows = query(
             r#"
@@ -1322,7 +1450,11 @@ where
 
     #[instrument(skip(self))]
     async fn update_saga(&self, saga: wallet::WalletSaga) -> Result<bool, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let state_json = serde_json::to_string(&saga.state).map_err(|e| {
             Error::Database(Box::new(std::io::Error::new(
@@ -1372,7 +1504,11 @@ where
 
     #[instrument(skip(self))]
     async fn delete_saga(&self, id: &uuid::Uuid) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM wallet_sagas WHERE id = :id"#)?
             .bind("id", id.to_string())
@@ -1384,7 +1520,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_incomplete_sagas(&self) -> Result<Vec<wallet::WalletSaga>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows = query(
             r#"
@@ -1405,7 +1545,11 @@ where
         ys: Vec<PublicKey>,
         operation_id: &uuid::Uuid,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         for y in ys {
             let rows_affected = query(
@@ -1430,7 +1574,11 @@ where
 
     #[instrument(skip(self))]
     async fn release_proofs(&self, operation_id: &uuid::Uuid) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(
             r#"
@@ -1451,7 +1599,11 @@ where
         &self,
         operation_id: &uuid::Uuid,
     ) -> Result<Vec<ProofInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows = query(
             r#"
@@ -1489,7 +1641,11 @@ where
         quote_id: &str,
         operation_id: &uuid::Uuid,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows_affected = query(
             r#"
@@ -1525,7 +1681,11 @@ where
 
     #[instrument(skip(self))]
     async fn release_melt_quote(&self, operation_id: &uuid::Uuid) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(
             r#"
@@ -1547,7 +1707,11 @@ where
         quote_id: &str,
         operation_id: &uuid::Uuid,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows_affected = query(
             r#"
@@ -1583,7 +1747,11 @@ where
 
     #[instrument(skip(self))]
     async fn release_mint_quote(&self, operation_id: &uuid::Uuid) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(
             r#"
@@ -1623,7 +1791,11 @@ where
         key: &str,
         value: &[u8],
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         crate::keyvalue::kv_write_standalone(
             &*conn,
             primary_namespace,
@@ -1641,7 +1813,11 @@ where
         secondary_namespace: &str,
         key: &str,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         crate::keyvalue::kv_remove_standalone(&*conn, primary_namespace, secondary_namespace, key)
             .await?;
         Ok(())
@@ -1656,7 +1832,11 @@ where
         derivation_path: DerivationPath,
         derivation_index: u32,
     ) -> Result<(), Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let query_str = r#"
         INSERT INTO p2pk_signing_key (pubkey, derivation_index, derivation_path, created_time)
         VALUES (:pubkey, :derivation_index, :derivation_path, :created_time)
@@ -1679,7 +1859,11 @@ where
         &self,
         pubkey: &PublicKey,
     ) -> Result<Option<wallet::P2PKSigningKey>, Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let query_str = r#"SELECT pubkey, derivation_index, derivation_path, created_time FROM p2pk_signing_key WHERE pubkey = :pubkey"#.to_string();
 
         query(&query_str)?
@@ -1692,7 +1876,11 @@ where
 
     #[instrument(skip(self))]
     async fn list_p2pk_keys(&self) -> Result<Vec<wallet::P2PKSigningKey>, Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let query_str = r#"
         SELECT pubkey, derivation_index, derivation_path, created_time FROM p2pk_signing_key ORDER BY derivation_index DESC
         "#.to_string();
@@ -1711,7 +1899,11 @@ where
 
     #[instrument(skip(self))]
     async fn latest_p2pk(&self) -> Result<Option<wallet::P2PKSigningKey>, Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let query_str = r#"
         SELECT pubkey, derivation_index, derivation_path, created_time FROM p2pk_signing_key ORDER BY derivation_index DESC LIMIT 1
         "#.to_string();


### PR DESCRIPTION

### Description

Replace `std::sync::Condvar` with `tokio::sync::Notify` in the connection pool. The blocking `Condvar::wait_timeout` was starving the tokio runtime when pool size=1 (in-memory SQLite), causing 5s cascading timeouts on concurrent ops.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
