### PR TITLE
fix(mint): preserve change promises order in paid melt quotes

### DIFF
--- a/crates/cdk-common/src/database/mint/test/signatures.rs
+++ b/crates/cdk-common/src/database/mint/test/signatures.rs
@@ -119,8 +119,8 @@ where
     let quote_id1 = QuoteId::new_uuid();
     let quote_id2 = QuoteId::new_uuid();
 
-    // Create signatures for quote 1
     let blinded_message1 = SecretKey::generate().public_key();
+    let blinded_message2 = SecretKey::generate().public_key();
     let sig1 = BlindSignature {
         amount: Amount::from(100u64),
         keyset_id,
@@ -128,10 +128,17 @@ where
         dleq: None,
     };
 
-    // Create signatures for quote 2
-    let blinded_message2 = SecretKey::generate().public_key();
     let sig2 = BlindSignature {
         amount: Amount::from(200u64),
+        keyset_id,
+        c: SecretKey::generate().public_key(),
+        dleq: None,
+    };
+
+    // Create signature for quote 2
+    let blinded_message3 = SecretKey::generate().public_key();
+    let sig3 = BlindSignature {
+        amount: Amount::from(300u64),
         keyset_id,
         c: SecretKey::generate().public_key(),
         dleq: None,
@@ -140,15 +147,15 @@ where
     // Add signatures with different quote ids
     let mut tx = Database::begin_transaction(&db).await.unwrap();
     tx.add_blind_signatures(
-        &[blinded_message1],
-        std::slice::from_ref(&sig1),
+        &[blinded_message1, blinded_message2],
+        &[sig1.clone(), sig2.clone()],
         Some(quote_id1.clone()),
     )
     .await
     .unwrap();
     tx.add_blind_signatures(
-        &[blinded_message2],
-        std::slice::from_ref(&sig2),
+        &[blinded_message3],
+        std::slice::from_ref(&sig3),
         Some(quote_id2.clone()),
     )
     .await
@@ -157,15 +164,17 @@ where
 
     // Get signatures for quote 1
     let sigs1 = db.get_blind_signatures_for_quote(&quote_id1).await.unwrap();
-    assert_eq!(sigs1.len(), 1);
+    assert_eq!(sigs1.len(), 2);
     assert_eq!(sigs1[0].c, sig1.c);
     assert_eq!(sigs1[0].amount, sig1.amount);
+    assert_eq!(sigs1[1].c, sig2.c);
+    assert_eq!(sigs1[1].amount, sig2.amount);
 
     // Get signatures for quote 2
     let sigs2 = db.get_blind_signatures_for_quote(&quote_id2).await.unwrap();
     assert_eq!(sigs2.len(), 1);
-    assert_eq!(sigs2[0].c, sig2.c);
-    assert_eq!(sigs2[0].amount, sig2.amount);
+    assert_eq!(sigs2[0].c, sig3.c);
+    assert_eq!(sigs2[0].amount, sig3.amount);
 }
 
 /// Test getting total issued by keyset

--- a/crates/cdk-integration-tests/tests/test_blind_signature_order.rs
+++ b/crates/cdk-integration-tests/tests/test_blind_signature_order.rs
@@ -1,0 +1,84 @@
+use std::str::FromStr;
+
+use anyhow::Result;
+use cdk_common::mint::{MeltPaymentRequest, MeltQuote, Operation, OperationKind};
+use cdk_common::quote_id::QuoteId;
+use cdk_common::{Amount, BlindedMessage, CurrencyUnit, Id, PaymentMethod, SecretKey};
+use cdk_integration_tests::init_pure_tests::*;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn test_blind_signature_order_in_db() -> Result<()> {
+    setup_tracing();
+    let mint = create_and_start_test_mint().await?;
+    let db = mint.localstore();
+
+    let quote_id = QuoteId::from_str("00000000-0000-0000-0000-000000000000").unwrap();
+
+    let msg1 = BlindedMessage {
+        blinded_secret: SecretKey::generate().public_key(),
+        keyset_id: Id::from_str("001711afb1de20cb").unwrap(),
+        amount: Amount::from(10),
+        witness: None,
+    };
+    let msg2 = BlindedMessage {
+        blinded_secret: SecretKey::generate().public_key(),
+        keyset_id: Id::from_str("001711afb1de20cb").unwrap(),
+        amount: Amount::from(20),
+        witness: None,
+    };
+
+    let messages = vec![msg1.clone(), msg2.clone()];
+
+    let operation = Operation::new(
+        Uuid::new_v4(),
+        OperationKind::Melt,
+        Amount::ZERO,
+        Amount::ZERO,
+        Amount::ZERO,
+        None,
+        None,
+    );
+
+    let mut tx = db.begin_transaction().await?;
+
+    let quote = MeltQuote::new(
+        Some(quote_id.clone()),
+        MeltPaymentRequest::Custom {
+            method: "test".to_string(),
+            request: "test".to_string(),
+        },
+        CurrencyUnit::Sat,
+        Amount::from(30).with_unit(CurrencyUnit::Sat),
+        Amount::ZERO.with_unit(CurrencyUnit::Sat),
+        0,
+        None,
+        None,
+        PaymentMethod::Custom("test".to_string()),
+        None,
+    );
+    tx.add_melt_quote(quote).await?;
+    tx.add_blinded_messages(Some(&quote_id), &messages, &operation)
+        .await?;
+
+    tx.add_melt_request(
+        &quote_id,
+        Amount::from(30).with_unit(CurrencyUnit::Sat),
+        Amount::from(0).with_unit(CurrencyUnit::Sat),
+    )
+    .await?;
+
+    tx.commit().await?;
+
+    let mut tx2 = db.begin_transaction().await?;
+    let info = tx2
+        .get_melt_request_and_blinded_messages(&quote_id)
+        .await?
+        .expect("Should find melt request");
+
+    assert_eq!(info.change_outputs.len(), 2);
+    assert_eq!(info.change_outputs[0].blinded_secret, msg1.blinded_secret);
+    assert_eq!(info.change_outputs[1].blinded_secret, msg2.blinded_secret);
+
+    Ok(())
+}

--- a/crates/cdk-sql-common/src/mint/migrations/postgres/20260512120000_add_order_index_to_blind_signatures.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/postgres/20260512120000_add_order_index_to_blind_signatures.sql
@@ -1,0 +1,1 @@
+ALTER TABLE blind_signature ADD COLUMN order_index INTEGER DEFAULT 0;

--- a/crates/cdk-sql-common/src/mint/migrations/sqlite/20260512120000_add_order_index_to_blind_signatures.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/sqlite/20260512120000_add_order_index_to_blind_signatures.sql
@@ -1,0 +1,1 @@
+ALTER TABLE blind_signature ADD COLUMN order_index INTEGER DEFAULT 0;

--- a/crates/cdk-sql-common/src/mint/quotes.rs
+++ b/crates/cdk-sql-common/src/mint/quotes.rs
@@ -665,13 +665,13 @@ where
 
         // Insert blinded_messages directly into blind_signature with c = NULL
         // Let the database constraint handle duplicate detection
-        for message in blinded_messages {
+        for (i, message) in blinded_messages.iter().enumerate() {
             match query(
                 r#"
                 INSERT INTO blind_signature
-                (blinded_message, amount, keyset_id, c, quote_id, created_time, operation_kind, operation_id)
+                (blinded_message, amount, keyset_id, c, quote_id, created_time, operation_kind, operation_id, order_index)
                 VALUES
-                (:blinded_message, :amount, :keyset_id, NULL, :quote_id, :created_time, :operation_kind, :operation_id)
+                (:blinded_message, :amount, :keyset_id, NULL, :quote_id, :created_time, :operation_kind, :operation_id, :order_index)
                 "#,
             )?
             .bind(
@@ -684,6 +684,7 @@ where
             .bind("created_time", current_time as i64)
             .bind("operation_kind", operation.kind().to_string())
             .bind("operation_id", operation.id().to_string())
+            .bind("order_index", i as i64)
             .execute(&self.inner)
             .await
             {
@@ -755,6 +756,7 @@ where
                 SELECT blinded_message, keyset_id, amount
                 FROM blind_signature
                 WHERE quote_id = :quote_id AND c IS NULL
+                ORDER BY order_index ASC
                 FOR UPDATE
                 "#,
             )?

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -92,16 +92,16 @@ where
         .collect::<Result<HashMap<_, _>, Error>>()?;
 
         // Iterate over the provided blinded messages and signatures
-        for (message, signature) in blinded_messages.iter().zip(blind_signatures) {
+        for (i, (message, signature)) in blinded_messages.iter().zip(blind_signatures).enumerate() {
             match existing_rows.remove(message) {
                 None => {
                     // Unknown blind message: Insert new row with all columns
                     query(
                         r#"
                         INSERT INTO blind_signature
-                        (blinded_message, amount, keyset_id, c, quote_id, dleq_e, dleq_s, created_time, signed_time)
+                        (blinded_message, amount, keyset_id, c, quote_id, dleq_e, dleq_s, created_time, signed_time, order_index)
                         VALUES
-                        (:blinded_message, :amount, :keyset_id, :c, :quote_id, :dleq_e, :dleq_s, :created_time, :signed_time)
+                        (:blinded_message, :amount, :keyset_id, :c, :quote_id, :dleq_e, :dleq_s, :created_time, :signed_time, :order_index)
                         "#,
                     )?
                     .bind("blinded_message", message.to_bytes().to_vec())
@@ -119,6 +119,7 @@ where
                     )
                     .bind("created_time", current_time as i64)
                     .bind("signed_time", current_time as i64)
+                    .bind("order_index", i as i64)
                     .execute(&self.inner)
                     .await?;
 

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -359,6 +359,7 @@ where
                 blind_signature
             WHERE
                 quote_id=:quote_id AND c IS NOT NULL
+            ORDER BY order_index ASC
             "#,
         )?
         .bind("quote_id", quote_id.to_string())


### PR DESCRIPTION
## Summary
- Added `order_index` to `blind_signature` table to preserve the insertion order of change outputs.
- Updated database queries to use `ORDER BY order_index` when retrieving blinded messages/signatures for melt quotes.
- Ensures deterministic order for change signatures in paid melt quotes, fixing non-deterministic behavior found in nutshell (https://github.com/cashubtc/nutshell/pull/991).