### PR TITLE
fix: propagate FFI mint info conversion errors

### DIFF
--- a/crates/cdk-ffi/src/database.rs
+++ b/crates/cdk-ffi/src/database.rs
@@ -324,7 +324,10 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .get_mint(ffi_mint_url)
             .await
             .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
-        Ok(result.map(Into::into))
+        result
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))
     }
 
     async fn get_mints(
@@ -344,7 +347,11 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             let cdk_url = ffi_mint_url
                 .try_into()
                 .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))?;
-            cdk_result.insert(cdk_url, mint_info_opt.map(Into::into));
+            let cdk_mint_info = mint_info_opt
+                .map(TryInto::try_into)
+                .transpose()
+                .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            cdk_result.insert(cdk_url, cdk_mint_info);
         }
         Ok(cdk_result)
     }
@@ -1570,7 +1577,7 @@ where
         mint_info: Option<MintInfo>,
     ) -> Result<(), FfiError> {
         let cdk_mint_url = mint_url.try_into()?;
-        let cdk_mint_info = mint_info.map(Into::into);
+        let cdk_mint_info = mint_info.map(TryInto::try_into).transpose()?;
         self.inner
             .add_mint(cdk_mint_url, cdk_mint_info)
             .await

--- a/crates/cdk-ffi/src/types/mint.rs
+++ b/crates/cdk-ffi/src/types/mint.rs
@@ -646,11 +646,11 @@ impl From<cdk::nuts::MintInfo> for MintInfo {
     }
 }
 
-impl From<MintInfo> for cdk::nuts::MintInfo {
-    fn from(info: MintInfo) -> Self {
-        // Convert FFI Nuts back to cdk::nuts::Nuts (best-effort)
-        let nuts_cdk: cdk::nuts::Nuts = info.nuts.clone().try_into().unwrap_or_default();
-        Self {
+impl TryFrom<MintInfo> for cdk::nuts::MintInfo {
+    type Error = FfiError;
+
+    fn try_from(info: MintInfo) -> Result<Self, Self::Error> {
+        Ok(Self {
             name: info.name,
             pubkey: info.pubkey.and_then(|p| p.parse().ok()),
             version: info.version.map(Into::into),
@@ -659,13 +659,13 @@ impl From<MintInfo> for cdk::nuts::MintInfo {
             contact: info
                 .contact
                 .map(|contacts| contacts.into_iter().map(Into::into).collect()),
-            nuts: nuts_cdk,
+            nuts: info.nuts.try_into()?,
             icon_url: info.icon_url,
             urls: info.urls,
             motd: info.motd,
             time: info.time,
             tos_url: info.tos_url,
-        }
+        })
     }
 }
 
@@ -1027,6 +1027,71 @@ mod tests {
         };
 
         let result: Result<cdk::nuts::ProtectedEndpoint, _> = invalid_endpoint.try_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_protected_endpoint_custom_payment_method_path() {
+        let endpoint = ProtectedEndpoint {
+            method: "POST".to_string(),
+            path: "/v1/mint/custom-method".to_string(),
+        };
+
+        let converted: cdk::nuts::ProtectedEndpoint = endpoint
+            .try_into()
+            .expect("custom payment method routes should be accepted");
+        assert_eq!(
+            converted.path,
+            cdk::nuts::RoutePath::Mint("custom-method".to_string())
+        );
+    }
+
+    #[test]
+    fn test_mint_info_unknown_endpoint_returns_error() {
+        let ffi_mint_info = MintInfo {
+            name: None,
+            pubkey: None,
+            version: None,
+            description: None,
+            description_long: None,
+            contact: None,
+            nuts: Nuts {
+                nut04: Nut04Settings {
+                    methods: vec![],
+                    disabled: false,
+                },
+                nut05: Nut05Settings {
+                    methods: vec![],
+                    disabled: false,
+                },
+                nut07_supported: true,
+                nut08_supported: false,
+                nut09_supported: false,
+                nut10_supported: false,
+                nut11_supported: false,
+                nut12_supported: true,
+                nut14_supported: false,
+                nut20_supported: false,
+                nut21: None,
+                nut22: Some(BlindAuthSettings {
+                    bat_max_mint: 10,
+                    protected_endpoints: vec![ProtectedEndpoint {
+                        method: "POST".to_string(),
+                        path: "/v1/unknown-custom-endpoint".to_string(),
+                    }],
+                }),
+                nut29: Nut29Settings::default(),
+                mint_units: vec![],
+                melt_units: vec![],
+            },
+            icon_url: None,
+            urls: None,
+            motd: None,
+            time: None,
+            tos_url: None,
+        };
+
+        let result = cdk::nuts::MintInfo::try_from(ffi_mint_info);
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
