### PR TITLE
fix ffi send options condition errors

### DIFF
--- a/crates/cdk-ffi/src/lib.rs
+++ b/crates/cdk-ffi/src/lib.rs
@@ -219,6 +219,72 @@ mod tests {
     }
 
     #[test]
+    fn test_send_options_invalid_p2pk_conditions_returns_error() {
+        let options = SendOptions {
+            conditions: Some(SpendingConditions::P2PK {
+                pubkey: "not-a-pubkey".to_string(),
+                conditions: None,
+            }),
+            ..Default::default()
+        };
+
+        let result: Result<cdk::wallet::SendOptions, _> = options.try_into();
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_send_options_invalid_htlc_conditions_returns_error() {
+        let options = SendOptions {
+            conditions: Some(SpendingConditions::HTLC {
+                hash: "not-a-hash".to_string(),
+                conditions: None,
+            }),
+            ..Default::default()
+        };
+
+        let result: Result<cdk::wallet::SendOptions, _> = options.try_into();
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wallet_prepare_send_invalid_conditions_returns_error() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let wallet = Wallet::new(
+                "https://mint.example.com".to_string(),
+                CurrencyUnit::Sat,
+                generate_mnemonic().unwrap(),
+                WalletStore::Sqlite {
+                    path: ":memory:".to_string(),
+                },
+                WalletConfig {
+                    target_proof_count: None,
+                },
+            )
+            .unwrap();
+
+            let options = SendOptions {
+                conditions: Some(SpendingConditions::P2PK {
+                    pubkey: "not-a-pubkey".to_string(),
+                    conditions: None,
+                }),
+                ..Default::default()
+            };
+
+            let result = wallet.prepare_send(Amount::new(1), options).await;
+
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
     fn test_receive_options_with_all_fields() {
         use std::collections::HashMap;
 

--- a/crates/cdk-ffi/src/types/wallet.rs
+++ b/crates/cdk-ffi/src/types/wallet.rs
@@ -177,18 +177,22 @@ impl Default for SendOptions {
     }
 }
 
-impl From<SendOptions> for cdk::wallet::SendOptions {
-    fn from(opts: SendOptions) -> Self {
-        cdk::wallet::SendOptions {
+impl TryFrom<SendOptions> for cdk::wallet::SendOptions {
+    type Error = FfiError;
+
+    fn try_from(opts: SendOptions) -> Result<Self, Self::Error> {
+        let conditions = opts.conditions.map(TryInto::try_into).transpose()?;
+
+        Ok(cdk::wallet::SendOptions {
             memo: opts.memo.map(Into::into),
-            conditions: opts.conditions.and_then(|c| c.try_into().ok()),
+            conditions,
             amount_split_target: opts.amount_split_target.into(),
             send_kind: opts.send_kind.into(),
             include_fee: opts.include_fee,
             max_proofs: opts.max_proofs.map(|p| p as usize),
             metadata: opts.metadata,
             use_p2bk: opts.use_p2bk,
-        }
+        })
     }
 }
 

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -208,10 +208,8 @@ impl Wallet {
         amount: Amount,
         options: SendOptions,
     ) -> Result<std::sync::Arc<PreparedSend>, FfiError> {
-        let prepared = self
-            .inner
-            .prepare_send(amount.into(), options.into())
-            .await?;
+        let options = options.try_into()?;
+        let prepared = self.inner.prepare_send(amount.into(), options).await?;
         Ok(std::sync::Arc::new(PreparedSend::new(
             self.inner.clone(),
             &prepared,


### PR DESCRIPTION
### Description

FFI `SendOptions.conditions` previously used `.try_into().ok()`, which silently converted malformed spending conditions into `None`. That could cause an FFI caller intending to create a locked send to accidentally create an unlocked send instead.

This now matches the existing fallible conversion pattern used by `ReceiveOptions`.

-----

### Notes to the reviewers

This removes the infallible `From<cdk_ffi::SendOptions> for cdk::wallet::SendOptions` impl and replaces it with `TryFrom`. That is intentional: invalid FFI send conditions must be observable as errors rather than being dropped. FFI method signatures are unchanged.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED
- make FFI `SendOptions` conversion to `cdk::wallet::SendOptions` fallible
- propagate invalid send condition errors from `Wallet::prepare_send`

#### ADDED
- add regression coverage for invalid P2PK/HTLC send conditions and the FFI wallet prepare-send path

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
