### PR TITLE
fix: support generic NUT-17 quote kinds

### DIFF
--- a/crates/cashu/src/nuts/nut17/mod.rs
+++ b/crates/cashu/src/nuts/nut17/mod.rs
@@ -60,8 +60,8 @@ impl SupportedMethods {
     /// Create [`SupportedMethods`] for Bolt11 with all supported commands
     pub fn default_bolt11(unit: CurrencyUnit) -> Self {
         let commands = vec![
-            WsCommand::Bolt11MintQuote,
-            WsCommand::Bolt11MeltQuote,
+            WsCommand::MintQuote,
+            WsCommand::MeltQuote,
             WsCommand::ProofState,
         ];
 
@@ -75,8 +75,8 @@ impl SupportedMethods {
     /// Create [`SupportedMethods`] for Bolt12 with all supported commands
     pub fn default_bolt12(unit: CurrencyUnit) -> Self {
         let commands = vec![
-            WsCommand::Bolt12MintQuote,
-            WsCommand::Bolt12MeltQuote,
+            WsCommand::MintQuote,
+            WsCommand::MeltQuote,
             WsCommand::ProofState,
         ];
 
@@ -89,10 +89,9 @@ impl SupportedMethods {
 
     /// Create [`SupportedMethods`] for custom payment method with all supported commands
     pub fn default_custom(method: PaymentMethod, unit: CurrencyUnit) -> Self {
-        let method_name = method.to_string();
         let commands = vec![
-            WsCommand::Custom(format!("{}_mint_quote", method_name)),
-            WsCommand::Custom(format!("{}_melt_quote", method_name)),
+            WsCommand::MintQuote,
+            WsCommand::MeltQuote,
             WsCommand::ProofState,
         ];
 
@@ -105,14 +104,14 @@ impl SupportedMethods {
 }
 
 impl WsCommand {
-    /// Create a custom mint quote command for a payment method
-    pub fn custom_mint_quote(method: &str) -> Self {
-        WsCommand::Custom(format!("{}_mint_quote", method))
+    /// Create the generic mint quote command for any payment method
+    pub fn custom_mint_quote(_method: &str) -> Self {
+        Self::MintQuote
     }
 
-    /// Create a custom melt quote command for a payment method
-    pub fn custom_melt_quote(method: &str) -> Self {
-        WsCommand::Custom(format!("{}_melt_quote", method))
+    /// Create the generic melt quote command for any payment method
+    pub fn custom_melt_quote(_method: &str) -> Self {
+        Self::MeltQuote
     }
 }
 
@@ -120,12 +119,28 @@ impl WsCommand {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 pub enum WsCommand {
+    /// Command to subscribe to mint quote updates
+    MintQuote,
+    /// Command to subscribe to melt quote updates
+    MeltQuote,
+    #[deprecated(
+        note = "Temporary backwards compatibility for legacy NUT-17 websocket commands. TODO: remove once old quote command strings are dropped."
+    )]
     /// Command to request a Lightning invoice for minting tokens
     Bolt11MintQuote,
+    #[deprecated(
+        note = "Temporary backwards compatibility for legacy NUT-17 websocket commands. TODO: remove once old quote command strings are dropped."
+    )]
     /// Command to request a Lightning payment for melting tokens
     Bolt11MeltQuote,
+    #[deprecated(
+        note = "Temporary backwards compatibility for legacy NUT-17 websocket commands. TODO: remove once old quote command strings are dropped."
+    )]
     /// Websocket support for Bolt12 Mint Quote
     Bolt12MintQuote,
+    #[deprecated(
+        note = "Temporary backwards compatibility for legacy NUT-17 websocket commands. TODO: remove once old quote command strings are dropped."
+    )]
     /// Websocket support for Bolt12 Melt Quote
     Bolt12MeltQuote,
     /// Command to check the state of a proof
@@ -135,11 +150,14 @@ pub enum WsCommand {
 }
 
 impl Serialize for WsCommand {
+    #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         let s = match self {
+            WsCommand::MintQuote => "mint_quote",
+            WsCommand::MeltQuote => "melt_quote",
             WsCommand::Bolt11MintQuote => "bolt11_mint_quote",
             WsCommand::Bolt11MeltQuote => "bolt11_melt_quote",
             WsCommand::Bolt12MintQuote => "bolt12_mint_quote",
@@ -152,12 +170,15 @@ impl Serialize for WsCommand {
 }
 
 impl<'de> Deserialize<'de> for WsCommand {
+    #[allow(deprecated)]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
         Ok(match s.as_str() {
+            "mint_quote" => WsCommand::MintQuote,
+            "melt_quote" => WsCommand::MeltQuote,
             "bolt11_mint_quote" => WsCommand::Bolt11MintQuote,
             "bolt11_melt_quote" => WsCommand::Bolt11MeltQuote,
             "bolt12_mint_quote" => WsCommand::Bolt12MintQuote,
@@ -219,6 +240,10 @@ where
 {
     /// ProofState id is a Pubkey
     ProofState(PublicKey),
+    /// MintQuote id is a QuoteId, regardless of payment method
+    MintQuote(T),
+    /// MeltQuote id is a QuoteId, regardless of payment method
+    MeltQuote(T),
     /// MeltQuote id is an QuoteId
     MeltQuoteBolt11(T),
     /// MintQuote id is an QuoteId
@@ -236,14 +261,30 @@ where
 /// Kind
 #[derive(Debug, Clone, Eq, Ord, PartialOrd, PartialEq, Hash)]
 pub enum Kind {
+    /// Generic mint quote subscription kind
+    MintQuote,
+    /// Generic melt quote subscription kind
+    MeltQuote,
+    #[deprecated(
+        note = "Temporary backwards compatibility for legacy NUT-17 websocket kinds. TODO: remove once old quote kind strings are dropped."
+    )]
     /// Bolt 11 Melt Quote
     Bolt11MeltQuote,
+    #[deprecated(
+        note = "Temporary backwards compatibility for legacy NUT-17 websocket kinds. TODO: remove once old quote kind strings are dropped."
+    )]
     /// Bolt 11 Mint Quote
     Bolt11MintQuote,
     /// Proof State
     ProofState,
+    #[deprecated(
+        note = "Temporary backwards compatibility for legacy NUT-17 websocket kinds. TODO: remove once old quote kind strings are dropped."
+    )]
     /// Bolt 12 Mint Quote
     Bolt12MintQuote,
+    #[deprecated(
+        note = "Temporary backwards compatibility for legacy NUT-17 websocket kinds. TODO: remove once old quote kind strings are dropped."
+    )]
     /// Bolt 12 Melt Quote
     Bolt12MeltQuote,
     /// Custom
@@ -251,11 +292,14 @@ pub enum Kind {
 }
 
 impl Serialize for Kind {
+    #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         let s = match self {
+            Kind::MintQuote => "mint_quote",
+            Kind::MeltQuote => "melt_quote",
             Kind::Bolt11MintQuote => "bolt11_mint_quote",
             Kind::Bolt11MeltQuote => "bolt11_melt_quote",
             Kind::Bolt12MintQuote => "bolt12_mint_quote",
@@ -268,12 +312,15 @@ impl Serialize for Kind {
 }
 
 impl<'de> Deserialize<'de> for Kind {
+    #[allow(deprecated)]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
         Ok(match s.as_str() {
+            "mint_quote" => Kind::MintQuote,
+            "melt_quote" => Kind::MeltQuote,
             "bolt11_mint_quote" => Kind::Bolt11MintQuote,
             "bolt11_melt_quote" => Kind::Bolt11MeltQuote,
             "bolt12_mint_quote" => Kind::Bolt12MintQuote,
@@ -281,6 +328,52 @@ impl<'de> Deserialize<'de> for Kind {
             "proof_state" => Kind::ProofState,
             custom => Kind::Custom(custom.to_string()),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_generic_ws_commands() {
+        assert_eq!(
+            serde_json::to_string(&WsCommand::MintQuote).unwrap(),
+            "\"mint_quote\""
+        );
+        assert_eq!(
+            serde_json::to_string(&WsCommand::MeltQuote).unwrap(),
+            "\"melt_quote\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Kind::MintQuote).unwrap(),
+            "\"mint_quote\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Kind::MeltQuote).unwrap(),
+            "\"melt_quote\""
+        );
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deserialize_legacy_quote_kinds_for_compatibility() {
+        assert_eq!(
+            serde_json::from_str::<WsCommand>("\"bolt11_mint_quote\"").unwrap(),
+            WsCommand::Bolt11MintQuote
+        );
+        assert_eq!(
+            serde_json::from_str::<WsCommand>("\"bolt12_melt_quote\"").unwrap(),
+            WsCommand::Bolt12MeltQuote
+        );
+        assert_eq!(
+            serde_json::from_str::<Kind>("\"bolt11_mint_quote\"").unwrap(),
+            Kind::Bolt11MintQuote
+        );
+        assert_eq!(
+            serde_json::from_str::<Kind>("\"bolt12_melt_quote\"").unwrap(),
+            Kind::Bolt12MeltQuote
+        );
     }
 }
 

--- a/crates/cdk-axum/src/ws/mod.rs
+++ b/crates/cdk-axum/src/ws/mod.rs
@@ -229,7 +229,7 @@ mod tests {
         // the channel closes immediately and the ActiveSubscription is dropped
         // before the test can observe the active_subscribers count.
         Params {
-            kind: cdk::nuts::nut17::Kind::Bolt11MintQuote,
+            kind: cdk::nuts::nut17::Kind::MintQuote,
             filters: vec![QuoteId::new_uuid().to_string()],
             id: Arc::new(SubId::from(sub_id)),
         }

--- a/crates/cdk-common/src/subscription.rs
+++ b/crates/cdk-common/src/subscription.rs
@@ -24,10 +24,17 @@ impl SubscriptionRequest for Params {
         self.id.clone()
     }
 
+    #[allow(deprecated)]
     fn try_get_topics(&self) -> Result<Vec<Self::Topic>, Error> {
         self.filters
             .iter()
             .map(|filter| match self.kind {
+                Kind::MintQuote => QuoteId::from_str(filter)
+                    .map(NotificationId::MintQuote)
+                    .map_err(|_| Error::ParsingError(filter.to_owned())),
+                Kind::MeltQuote => QuoteId::from_str(filter)
+                    .map(NotificationId::MeltQuote)
+                    .map_err(|_| Error::ParsingError(filter.to_owned())),
                 Kind::Bolt11MeltQuote => QuoteId::from_str(filter)
                     .map(NotificationId::MeltQuoteBolt11)
                     .map_err(|_| Error::ParsingError(filter.to_owned())),
@@ -45,6 +52,8 @@ impl SubscriptionRequest for Params {
                     .map(NotificationId::MeltQuoteBolt12)
                     .map_err(|_| Error::ParsingError(filter.to_owned())),
                 Kind::Custom(ref s) => {
+                    // TODO: Remove this legacy custom-kind compatibility once old
+                    // websocket quote kind strings are no longer accepted by mints.
                     if let Some(method) = s.strip_suffix("_mint_quote") {
                         QuoteId::from_str(filter)
                             .map(|id| NotificationId::MintQuoteCustom(method.to_string(), id))
@@ -77,11 +86,14 @@ impl SubscriptionRequest for WalletParams {
         self.id.clone()
     }
 
+    #[allow(deprecated)]
     fn try_get_topics(&self) -> Result<Vec<Self::Topic>, Error> {
         self.filters
             .iter()
             .map(|filter| {
                 Ok(match self.kind {
+                    Kind::MintQuote => NotificationId::MintQuote(filter.to_owned()),
+                    Kind::MeltQuote => NotificationId::MeltQuote(filter.to_owned()),
                     Kind::Bolt11MeltQuote => NotificationId::MeltQuoteBolt11(filter.to_owned()),
                     Kind::Bolt11MintQuote => NotificationId::MintQuoteBolt11(filter.to_owned()),
                     Kind::ProofState => PublicKey::from_str(filter)
@@ -91,6 +103,8 @@ impl SubscriptionRequest for WalletParams {
                     Kind::Bolt12MintQuote => NotificationId::MintQuoteBolt12(filter.to_owned()),
                     Kind::Bolt12MeltQuote => NotificationId::MeltQuoteBolt12(filter.to_owned()),
                     Kind::Custom(ref s) => {
+                        // TODO: Remove this legacy custom-kind compatibility once old
+                        // websocket quote kind strings are no longer accepted by wallets.
                         if let Some(method) = s.strip_suffix("_mint_quote") {
                             NotificationId::MintQuoteCustom(method.to_string(), filter.to_owned())
                         } else if let Some(method) = s.strip_suffix("_melt_quote") {

--- a/crates/cdk-ffi/src/types/subscription.rs
+++ b/crates/cdk-ffi/src/types/subscription.rs
@@ -11,12 +11,28 @@ use crate::error::FfiError;
 /// FFI-compatible SubscriptionKind
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, uniffi::Enum)]
 pub enum SubscriptionKind {
+    /// Generic mint quote subscription
+    MintQuote,
+    /// Generic melt quote subscription
+    MeltQuote,
+    #[deprecated(
+        note = "Temporary backwards compatibility for legacy NUT-17 FFI subscription kinds. TODO: remove once downstream clients migrate to generic kinds."
+    )]
     /// Bolt 11 Melt Quote
     Bolt11MeltQuote,
+    #[deprecated(
+        note = "Temporary backwards compatibility for legacy NUT-17 FFI subscription kinds. TODO: remove once downstream clients migrate to generic kinds."
+    )]
     /// Bolt 11 Mint Quote
     Bolt11MintQuote,
+    #[deprecated(
+        note = "Temporary backwards compatibility for legacy NUT-17 FFI subscription kinds. TODO: remove once downstream clients migrate to generic kinds."
+    )]
     /// Bolt 12 Mint Quote
     Bolt12MintQuote,
+    #[deprecated(
+        note = "Temporary backwards compatibility for legacy NUT-17 FFI subscription kinds. TODO: remove once downstream clients migrate to generic kinds."
+    )]
     /// Bolt 12 Melt Quote
     Bolt12MeltQuote,
     /// Proof State
@@ -24,20 +40,26 @@ pub enum SubscriptionKind {
 }
 
 impl From<SubscriptionKind> for cdk::nuts::nut17::Kind {
+    #[allow(deprecated)]
     fn from(kind: SubscriptionKind) -> Self {
         match kind {
-            SubscriptionKind::Bolt11MeltQuote => cdk::nuts::nut17::Kind::Bolt11MeltQuote,
-            SubscriptionKind::Bolt11MintQuote => cdk::nuts::nut17::Kind::Bolt11MintQuote,
-            SubscriptionKind::Bolt12MintQuote => cdk::nuts::nut17::Kind::Bolt12MintQuote,
-            SubscriptionKind::Bolt12MeltQuote => cdk::nuts::nut17::Kind::Bolt12MeltQuote,
+            SubscriptionKind::MintQuote => cdk::nuts::nut17::Kind::MintQuote,
+            SubscriptionKind::MeltQuote => cdk::nuts::nut17::Kind::MeltQuote,
+            SubscriptionKind::Bolt11MeltQuote => cdk::nuts::nut17::Kind::MeltQuote,
+            SubscriptionKind::Bolt11MintQuote => cdk::nuts::nut17::Kind::MintQuote,
+            SubscriptionKind::Bolt12MintQuote => cdk::nuts::nut17::Kind::MintQuote,
+            SubscriptionKind::Bolt12MeltQuote => cdk::nuts::nut17::Kind::MeltQuote,
             SubscriptionKind::ProofState => cdk::nuts::nut17::Kind::ProofState,
         }
     }
 }
 
 impl From<cdk::nuts::nut17::Kind> for SubscriptionKind {
+    #[allow(deprecated)]
     fn from(kind: cdk::nuts::nut17::Kind) -> Self {
         match kind {
+            cdk::nuts::nut17::Kind::MintQuote => SubscriptionKind::MintQuote,
+            cdk::nuts::nut17::Kind::MeltQuote => SubscriptionKind::MeltQuote,
             cdk::nuts::nut17::Kind::Bolt11MeltQuote => SubscriptionKind::Bolt11MeltQuote,
             cdk::nuts::nut17::Kind::Bolt11MintQuote => SubscriptionKind::Bolt11MintQuote,
             cdk::nuts::nut17::Kind::Bolt12MintQuote => SubscriptionKind::Bolt12MintQuote,

--- a/crates/cdk/src/event.rs
+++ b/crates/cdk/src/event.rs
@@ -113,36 +113,48 @@ where
     fn get_topics(&self) -> Vec<Self::Topic> {
         match &self.0 {
             NotificationPayload::MeltQuoteBolt11Response(r) => {
+                // TODO: Remove the legacy per-method topic fan-out once old
+                // websocket quote kinds are no longer supported by the mint.
                 // TODO: MeltQuoteBolt12Response is a type alias for MeltQuoteBolt11Response.
                 // Since NotificationPayload uses untagged serde, all melt responses are
                 // deserialized as Bolt11. We broadcast to both topics to ensure Bolt12
                 // subscribers receive the event. This workaround should be addressed by
                 // properly distinguishing the response types in the protocol.
                 vec![
+                    NotificationId::MeltQuote(r.quote.to_owned()),
                     NotificationId::MeltQuoteBolt11(r.quote.to_owned()),
                     NotificationId::MeltQuoteBolt12(r.quote.to_owned()),
                 ]
             }
             NotificationPayload::MintQuoteBolt11Response(r) => {
-                vec![NotificationId::MintQuoteBolt11(r.quote.to_owned())]
+                vec![
+                    NotificationId::MintQuote(r.quote.to_owned()),
+                    NotificationId::MintQuoteBolt11(r.quote.to_owned()),
+                ]
             }
             NotificationPayload::MintQuoteBolt12Response(r) => {
-                vec![NotificationId::MintQuoteBolt12(r.quote.to_owned())]
+                vec![
+                    NotificationId::MintQuote(r.quote.to_owned()),
+                    NotificationId::MintQuoteBolt12(r.quote.to_owned()),
+                ]
             }
             NotificationPayload::MeltQuoteBolt12Response(r) => {
-                vec![NotificationId::MeltQuoteBolt12(r.quote.to_owned())]
+                vec![
+                    NotificationId::MeltQuote(r.quote.to_owned()),
+                    NotificationId::MeltQuoteBolt12(r.quote.to_owned()),
+                ]
             }
             NotificationPayload::CustomMintQuoteResponse(method, r) => {
-                vec![NotificationId::MintQuoteCustom(
-                    method.clone(),
-                    r.quote.to_owned(),
-                )]
+                vec![
+                    NotificationId::MintQuote(r.quote.to_owned()),
+                    NotificationId::MintQuoteCustom(method.clone(), r.quote.to_owned()),
+                ]
             }
             NotificationPayload::CustomMeltQuoteResponse(method, r) => {
-                vec![NotificationId::MeltQuoteCustom(
-                    method.clone(),
-                    r.quote.to_owned(),
-                )]
+                vec![
+                    NotificationId::MeltQuote(r.quote.to_owned()),
+                    NotificationId::MeltQuoteCustom(method.clone(), r.quote.to_owned()),
+                ]
             }
             NotificationPayload::ProofState(p) => vec![NotificationId::ProofState(p.y.to_owned())],
         }

--- a/crates/cdk/src/mint/melt/mod.rs
+++ b/crates/cdk/src/mint/melt/mod.rs
@@ -838,8 +838,8 @@ impl Mint {
                         Ok(PaymentOutcome::Pending) => {
                             // Wait for the background task to complete the payment
                             let kind = match quote_for_spawn.payment_method {
-                                PaymentMethod::Known(KnownMethod::Bolt11) => Kind::Bolt11MeltQuote,
-                                PaymentMethod::Known(KnownMethod::Bolt12) => Kind::Bolt12MeltQuote,
+                                PaymentMethod::Known(KnownMethod::Bolt11)
+                                | PaymentMethod::Known(KnownMethod::Bolt12) => Kind::MeltQuote,
                                 PaymentMethod::Custom(ref method) => {
                                     Kind::Custom(format!("{}_melt_quote", method))
                                 }

--- a/crates/cdk/src/mint/subscription.rs
+++ b/crates/cdk/src/mint/subscription.rs
@@ -33,18 +33,19 @@ impl MintPubSubSpec {
         request: &NotificationId<QuoteId>,
         melt_quote: MeltQuote,
     ) -> Option<MintEvent<QuoteId>> {
+        let payment_method = melt_quote.payment_method.clone();
+
         match request {
-            NotificationId::MeltQuote(_) => match &melt_quote.payment_method {
+            NotificationId::MeltQuote(_) => match payment_method {
                 cdk_common::PaymentMethod::Known(cdk_common::nut00::KnownMethod::Bolt11) => {
                     Some(MeltQuoteBolt11Response::from(melt_quote).into())
                 }
                 cdk_common::PaymentMethod::Known(cdk_common::nut00::KnownMethod::Bolt12) => {
                     Some(MeltQuoteBolt12Response::from(melt_quote).into())
                 }
-                cdk_common::PaymentMethod::Custom(method) => Some(
-                    NotificationPayload::CustomMeltQuoteResponse(method.clone(), melt_quote.into())
-                        .into(),
-                ),
+                cdk_common::PaymentMethod::Custom(method) => {
+                    Some(NotificationPayload::CustomMeltQuoteResponse(method, melt_quote.into()).into())
+                }
             },
             NotificationId::MeltQuoteBolt11(_) => {
                 Some(MeltQuoteBolt11Response::from(melt_quote).into())
@@ -64,8 +65,10 @@ impl MintPubSubSpec {
         request: &NotificationId<QuoteId>,
         mint_quote: MintQuote,
     ) -> Option<MintEvent<QuoteId>> {
+        let payment_method = mint_quote.payment_method.clone();
+
         match request {
-            NotificationId::MintQuote(_) => match &mint_quote.payment_method {
+            NotificationId::MintQuote(_) => match payment_method {
                 cdk_common::PaymentMethod::Known(cdk_common::nut00::KnownMethod::Bolt11) => {
                     Some(MintQuoteBolt11Response::from(mint_quote).into())
                 }
@@ -78,8 +81,7 @@ impl MintPubSubSpec {
                     MintQuoteCustomResponse::try_from(mint_quote)
                         .ok()
                         .map(|response| {
-                            NotificationPayload::CustomMintQuoteResponse(method.clone(), response)
-                                .into()
+                            NotificationPayload::CustomMintQuoteResponse(method, response).into()
                         })
                 }
             },

--- a/crates/cdk/src/mint/subscription.rs
+++ b/crates/cdk/src/mint/subscription.rs
@@ -29,6 +29,78 @@ pub struct MintPubSubSpec {
 }
 
 impl MintPubSubSpec {
+    fn melt_quote_event_for_request(
+        request: &NotificationId<QuoteId>,
+        melt_quote: MeltQuote,
+    ) -> Option<MintEvent<QuoteId>> {
+        match request {
+            NotificationId::MeltQuote(_) => match &melt_quote.payment_method {
+                cdk_common::PaymentMethod::Known(cdk_common::nut00::KnownMethod::Bolt11) => {
+                    Some(MeltQuoteBolt11Response::from(melt_quote).into())
+                }
+                cdk_common::PaymentMethod::Known(cdk_common::nut00::KnownMethod::Bolt12) => {
+                    Some(MeltQuoteBolt12Response::from(melt_quote).into())
+                }
+                cdk_common::PaymentMethod::Custom(method) => Some(
+                    NotificationPayload::CustomMeltQuoteResponse(method.clone(), melt_quote.into())
+                        .into(),
+                ),
+            },
+            NotificationId::MeltQuoteBolt11(_) => {
+                Some(MeltQuoteBolt11Response::from(melt_quote).into())
+            }
+            NotificationId::MeltQuoteBolt12(_) => {
+                Some(MeltQuoteBolt12Response::from(melt_quote).into())
+            }
+            NotificationId::MeltQuoteCustom(method, _) => Some(
+                NotificationPayload::CustomMeltQuoteResponse(method.clone(), melt_quote.into())
+                    .into(),
+            ),
+            _ => None,
+        }
+    }
+
+    fn mint_quote_event_for_request(
+        request: &NotificationId<QuoteId>,
+        mint_quote: MintQuote,
+    ) -> Option<MintEvent<QuoteId>> {
+        match request {
+            NotificationId::MintQuote(_) => match &mint_quote.payment_method {
+                cdk_common::PaymentMethod::Known(cdk_common::nut00::KnownMethod::Bolt11) => {
+                    Some(MintQuoteBolt11Response::from(mint_quote).into())
+                }
+                cdk_common::PaymentMethod::Known(cdk_common::nut00::KnownMethod::Bolt12) => {
+                    MintQuoteBolt12Response::try_from(mint_quote)
+                        .ok()
+                        .map(Into::into)
+                }
+                cdk_common::PaymentMethod::Custom(method) => {
+                    MintQuoteCustomResponse::try_from(mint_quote)
+                        .ok()
+                        .map(|response| {
+                            NotificationPayload::CustomMintQuoteResponse(method.clone(), response)
+                                .into()
+                        })
+                }
+            },
+            NotificationId::MintQuoteBolt11(_) => {
+                Some(MintQuoteBolt11Response::from(mint_quote).into())
+            }
+            NotificationId::MintQuoteBolt12(_) => MintQuoteBolt12Response::try_from(mint_quote)
+                .ok()
+                .map(Into::into),
+            NotificationId::MintQuoteCustom(method, _) => {
+                MintQuoteCustomResponse::try_from(mint_quote)
+                    .ok()
+                    .map(|response| {
+                        NotificationPayload::CustomMintQuoteResponse(method.clone(), response)
+                            .into()
+                    })
+            }
+            _ => None,
+        }
+    }
+
     /// Call Mint::check_mint_quote_payments to update quotes by pinging the payment backend
     async fn get_mint_quotes(
         &self,
@@ -70,9 +142,10 @@ impl MintPubSubSpec {
         let mint_quote_ids = request
             .iter()
             .filter_map(|idx| match idx {
-                NotificationId::MintQuoteBolt11(uuid) | NotificationId::MintQuoteBolt12(uuid) => {
-                    Some(uuid.clone())
-                }
+                NotificationId::MintQuote(uuid)
+                | NotificationId::MintQuoteBolt11(uuid)
+                | NotificationId::MintQuoteBolt12(uuid)
+                | NotificationId::MintQuoteCustom(_, uuid) => Some(uuid.clone()),
                 _ => None,
             })
             .collect::<Vec<_>>();
@@ -84,7 +157,10 @@ impl MintPubSubSpec {
         for idx in request.iter() {
             match idx {
                 NotificationId::ProofState(pk) => public_keys.push(*pk),
-                NotificationId::MeltQuoteBolt11(uuid) => {
+                NotificationId::MeltQuote(uuid)
+                | NotificationId::MeltQuoteBolt11(uuid)
+                | NotificationId::MeltQuoteBolt12(uuid)
+                | NotificationId::MeltQuoteCustom(_, uuid) => {
                     // TODO: In the HTTP handler, we check with the LN backend if a payment is in a pending quote state to resolve stuck payments.
                     // Implement similar logic here for WebSocket-only wallets.
                     if let Some(melt_quote) = self
@@ -93,43 +169,20 @@ impl MintPubSubSpec {
                         .await
                         .map_err(|e| e.to_string())?
                     {
-                        let melt_quote: MeltQuoteBolt11Response<_> = melt_quote.into();
-                        to_return.push(melt_quote.into());
+                        if let Some(event) = Self::melt_quote_event_for_request(idx, melt_quote) {
+                            to_return.push(event);
+                        }
                     }
                 }
-                NotificationId::MeltQuoteBolt12(uuid) => {
-                    if let Some(melt_quote) = self
-                        .db
-                        .get_melt_quote(uuid)
-                        .await
-                        .map_err(|e| e.to_string())?
-                    {
-                        let melt_quote: MeltQuoteBolt12Response<_> = melt_quote.into();
-                        to_return.push(melt_quote.into());
-                    }
-                }
-                NotificationId::MintQuoteBolt11(uuid) | NotificationId::MintQuoteBolt12(uuid) => {
+                NotificationId::MintQuote(uuid)
+                | NotificationId::MintQuoteBolt11(uuid)
+                | NotificationId::MintQuoteBolt12(uuid)
+                | NotificationId::MintQuoteCustom(_, uuid) => {
                     if let Some(mint_quote) = mint_quotes.get(uuid).cloned() {
-                        let mint_quote = match idx {
-                            NotificationId::MintQuoteBolt11(_) => {
-                                let response: MintQuoteBolt11Response<QuoteId> = mint_quote.into();
-                                response.into()
-                            }
-                            NotificationId::MintQuoteBolt12(_) => match mint_quote.try_into() {
-                                Ok(response) => {
-                                    let response: MintQuoteBolt12Response<QuoteId> = response;
-                                    response.into()
-                                }
-                                Err(_) => continue,
-                            },
-                            _ => continue,
-                        };
-
-                        to_return.push(mint_quote);
+                        if let Some(event) = Self::mint_quote_event_for_request(idx, mint_quote) {
+                            to_return.push(event);
+                        }
                     }
-                }
-                NotificationId::MintQuoteCustom(_, _) | NotificationId::MeltQuoteCustom(_, _) => {
-                    continue;
                 }
             }
         }
@@ -387,8 +440,8 @@ mod tests {
         };
         let events = spec
             .get_events_from_db(&[
-                NotificationId::MintQuoteBolt11(first_quote_id.clone()),
-                NotificationId::MintQuoteBolt11(second_quote_id.clone()),
+                NotificationId::MintQuote(first_quote_id.clone()),
+                NotificationId::MintQuote(second_quote_id.clone()),
             ])
             .await
             .expect("get events");

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -178,25 +178,28 @@ impl From<WalletSubscription> for WalletParams {
             },
             WalletSubscription::Bolt11MintQuoteState(filters) => WalletParams {
                 filters,
-                kind: Kind::Bolt11MintQuote,
+                kind: Kind::MintQuote,
                 id,
             },
             WalletSubscription::Bolt11MeltQuoteState(filters) => WalletParams {
                 filters,
-                kind: Kind::Bolt11MeltQuote,
+                kind: Kind::MeltQuote,
                 id,
             },
             WalletSubscription::Bolt12MintQuoteState(filters) => WalletParams {
                 filters,
-                kind: Kind::Bolt12MintQuote,
+                kind: Kind::MintQuote,
                 id,
             },
             WalletSubscription::Bolt12MeltQuoteState(filters) => WalletParams {
                 filters,
-                kind: Kind::Bolt12MeltQuote,
+                kind: Kind::MeltQuote,
                 id,
             },
             WalletSubscription::MeltQuoteCustom(method, filters) => WalletParams {
+                // TODO: Switch custom wallet subscriptions to the generic melt
+                // quote kind once the local subscription topic carries the
+                // payment method separately from the websocket kind.
                 filters,
                 kind: Kind::Custom(format!("{}_melt_quote", method)),
                 id,

--- a/crates/cdk/src/wallet/subscription.rs
+++ b/crates/cdk/src/wallet/subscription.rs
@@ -169,17 +169,108 @@ impl SubscriptionClient {
     fn subscription_kind(params: &NotificationId<String>) -> Kind {
         match params {
             NotificationId::ProofState(_) => Kind::ProofState,
-            NotificationId::MeltQuoteBolt11(_) => Kind::Bolt11MeltQuote,
-            NotificationId::MeltQuoteBolt12(_) => Kind::Bolt12MeltQuote,
-            NotificationId::MintQuoteBolt11(_) => Kind::Bolt11MintQuote,
-            NotificationId::MintQuoteBolt12(_) => Kind::Bolt12MintQuote,
-            NotificationId::MintQuoteCustom(method, _) => {
-                Kind::Custom(format!("{}_mint_quote", method))
+            NotificationId::MintQuote(_)
+            | NotificationId::MintQuoteBolt11(_)
+            | NotificationId::MintQuoteBolt12(_)
+            | NotificationId::MintQuoteCustom(_, _) => Kind::MintQuote,
+            NotificationId::MeltQuote(_)
+            | NotificationId::MeltQuoteBolt11(_)
+            | NotificationId::MeltQuoteBolt12(_)
+            | NotificationId::MeltQuoteCustom(_, _) => Kind::MeltQuote,
+        }
+    }
+
+    async fn supported_subscription_methods(&self) -> Vec<PaymentMethod> {
+        let mint_info = match self.http_client.get_mint_info().await {
+            Ok(mint_info) => mint_info,
+            Err(err) => {
+                tracing::warn!(
+                    "Could not load mint info for generic quote polling: {:?}",
+                    err
+                );
+                return vec![PaymentMethod::BOLT11, PaymentMethod::BOLT12];
             }
-            NotificationId::MeltQuoteCustom(method, _) => {
-                Kind::Custom(format!("{}_melt_quote", method))
+        };
+
+        let mut methods = vec![];
+
+        for supported in mint_info.nuts.nut17.supported {
+            if !methods.contains(&supported.method) {
+                methods.push(supported.method);
             }
         }
+
+        if methods.is_empty() {
+            return vec![PaymentMethod::BOLT11, PaymentMethod::BOLT12];
+        }
+
+        methods
+    }
+
+    async fn get_mint_quote_status_any_method(&self, id: &str) -> Option<NotificationPayload> {
+        for method in self.supported_subscription_methods().await {
+            match self
+                .http_client
+                .get_mint_quote_status(method.clone(), id)
+                .await
+            {
+                Ok(cdk_common::MintQuoteResponse::Bolt11(response)) => {
+                    return Some(NotificationPayload::MintQuoteBolt11Response(response));
+                }
+                Ok(cdk_common::MintQuoteResponse::Bolt12(response)) => {
+                    return Some(NotificationPayload::MintQuoteBolt12Response(response));
+                }
+                Ok(cdk_common::MintQuoteResponse::Custom { method, response }) => {
+                    return Some(NotificationPayload::CustomMintQuoteResponse(
+                        method.to_string(),
+                        response,
+                    ));
+                }
+                Err(err) => {
+                    tracing::debug!(
+                        "Mint quote {} did not resolve with payment method {}: {:?}",
+                        id,
+                        method,
+                        err
+                    );
+                }
+            }
+        }
+
+        None
+    }
+
+    async fn get_melt_quote_status_any_method(&self, id: &str) -> Option<NotificationPayload> {
+        for method in self.supported_subscription_methods().await {
+            match self
+                .http_client
+                .get_melt_quote_status(method.clone(), id)
+                .await
+            {
+                Ok(cdk_common::MeltQuoteResponse::Bolt11(response)) => {
+                    return Some(NotificationPayload::MeltQuoteBolt11Response(response));
+                }
+                Ok(cdk_common::MeltQuoteResponse::Bolt12(response)) => {
+                    return Some(NotificationPayload::MeltQuoteBolt12Response(response));
+                }
+                Ok(cdk_common::MeltQuoteResponse::Custom((method, response))) => {
+                    return Some(NotificationPayload::CustomMeltQuoteResponse(
+                        method.to_string(),
+                        response,
+                    ));
+                }
+                Err(err) => {
+                    tracing::debug!(
+                        "Melt quote {} did not resolve with payment method {}: {:?}",
+                        id,
+                        method,
+                        err
+                    );
+                }
+            }
+        }
+
+        None
     }
 
     fn get_sub_request(
@@ -190,7 +281,9 @@ impl SubscriptionClient {
         let kind = Self::subscription_kind(&params);
         let filter = match params {
             NotificationId::ProofState(x) => x.to_string(),
-            NotificationId::MeltQuoteBolt11(q)
+            NotificationId::MintQuote(q)
+            | NotificationId::MeltQuote(q)
+            | NotificationId::MeltQuoteBolt11(q)
             | NotificationId::MeltQuoteBolt12(q)
             | NotificationId::MintQuoteBolt11(q)
             | NotificationId::MintQuoteBolt12(q)
@@ -236,38 +329,61 @@ impl SubscriptionClient {
 }
 
 fn decode_notification_payload(
-    kind: &Kind,
+    subscription: &NotificationId<String>,
     payload: serde_json::Value,
 ) -> Result<NotificationPayload, PubsubError> {
-    match kind {
-        Kind::ProofState => serde_json::from_value::<ProofState>(payload)
+    match subscription {
+        NotificationId::ProofState(_) => serde_json::from_value::<ProofState>(payload)
             .map(NotificationPayload::ProofState)
             .map_err(|err| PubsubError::ParsingError(err.to_string())),
-        Kind::Bolt11MintQuote => serde_json::from_value::<MintQuoteBolt11Response<String>>(payload)
-            .map(NotificationPayload::MintQuoteBolt11Response)
-            .map_err(|err| PubsubError::ParsingError(err.to_string())),
-        Kind::Bolt11MeltQuote => serde_json::from_value::<MeltQuoteBolt11Response<String>>(payload)
-            .map(NotificationPayload::MeltQuoteBolt11Response)
-            .map_err(|err| PubsubError::ParsingError(err.to_string())),
-        Kind::Bolt12MintQuote => serde_json::from_value::<MintQuoteBolt12Response<String>>(payload)
-            .map(NotificationPayload::MintQuoteBolt12Response)
-            .map_err(|err| PubsubError::ParsingError(err.to_string())),
-        Kind::Bolt12MeltQuote => serde_json::from_value::<MeltQuoteBolt12Response<String>>(payload)
-            .map(NotificationPayload::MeltQuoteBolt12Response)
-            .map_err(|err| PubsubError::ParsingError(err.to_string())),
-        Kind::Custom(method) if method.ends_with("_mint_quote") => serde_json::from_value::<
+        NotificationId::MintQuote(_) => {
+            serde_json::from_value::<MintQuoteBolt12Response<String>>(payload.clone())
+                .map(NotificationPayload::MintQuoteBolt12Response)
+                .or_else(|_| {
+                    serde_json::from_value::<MintQuoteBolt11Response<String>>(payload)
+                        .map(NotificationPayload::MintQuoteBolt11Response)
+                })
+                .map_err(|err| PubsubError::ParsingError(err.to_string()))
+        }
+        NotificationId::MintQuoteBolt11(_) => {
+            serde_json::from_value::<MintQuoteBolt11Response<String>>(payload)
+                .map(NotificationPayload::MintQuoteBolt11Response)
+                .map_err(|err| PubsubError::ParsingError(err.to_string()))
+        }
+        NotificationId::MeltQuote(_) => {
+            serde_json::from_value::<MeltQuoteBolt11Response<String>>(payload.clone())
+                .map(NotificationPayload::MeltQuoteBolt11Response)
+                .or_else(|_| {
+                    serde_json::from_value::<MeltQuoteBolt12Response<String>>(payload)
+                        .map(NotificationPayload::MeltQuoteBolt12Response)
+                })
+                .map_err(|err| PubsubError::ParsingError(err.to_string()))
+        }
+        NotificationId::MeltQuoteBolt11(_) => {
+            serde_json::from_value::<MeltQuoteBolt11Response<String>>(payload)
+                .map(NotificationPayload::MeltQuoteBolt11Response)
+                .map_err(|err| PubsubError::ParsingError(err.to_string()))
+        }
+        NotificationId::MintQuoteBolt12(_) => {
+            serde_json::from_value::<MintQuoteBolt12Response<String>>(payload)
+                .map(NotificationPayload::MintQuoteBolt12Response)
+                .map_err(|err| PubsubError::ParsingError(err.to_string()))
+        }
+        NotificationId::MeltQuoteBolt12(_) => {
+            serde_json::from_value::<MeltQuoteBolt12Response<String>>(payload)
+                .map(NotificationPayload::MeltQuoteBolt12Response)
+                .map_err(|err| PubsubError::ParsingError(err.to_string()))
+        }
+        NotificationId::MintQuoteCustom(method, _) => serde_json::from_value::<
             MintQuoteCustomResponse<String>,
         >(payload)
         .map(|response| NotificationPayload::CustomMintQuoteResponse(method.clone(), response))
         .map_err(|err| PubsubError::ParsingError(err.to_string())),
-        Kind::Custom(method) if method.ends_with("_melt_quote") => serde_json::from_value::<
+        NotificationId::MeltQuoteCustom(method, _) => serde_json::from_value::<
             MeltQuoteCustomResponse<String>,
         >(payload)
         .map(|response| NotificationPayload::CustomMeltQuoteResponse(method.clone(), response))
         .map_err(|err| PubsubError::ParsingError(err.to_string())),
-        Kind::Custom(method) => Err(PubsubError::ParsingError(format!(
-            "Unsupported custom websocket notification kind: {method}"
-        ))),
     }
 }
 
@@ -321,6 +437,22 @@ impl Transport for SubscriptionClient {
             .filter(|x| !matches!(x, NotificationId::ProofState(_)))
         {
             match topic {
+                NotificationId::MintQuote(id) => {
+                    let Some(response) = self.get_mint_quote_status_any_method(&id).await else {
+                        tracing::error!("Error resolving generic mint quote {}", id);
+                        continue;
+                    };
+
+                    reply_to.send(MintEvent::new(response));
+                }
+                NotificationId::MeltQuote(id) => {
+                    let Some(response) = self.get_melt_quote_status_any_method(&id).await else {
+                        tracing::error!("Error resolving generic melt quote {}", id);
+                        continue;
+                    };
+
+                    reply_to.send(MintEvent::new(response));
+                }
                 NotificationId::MintQuoteBolt11(id) => {
                     let response = match self
                         .http_client
@@ -479,7 +611,7 @@ async fn stream_client(
     topics: Vec<SubscribeMessage<MintSubTopics>>,
     reply_to: InternalRelay<MintSubTopics>,
 ) -> Result<(), PubsubError> {
-    let mut sub_id_to_kind = HashMap::new();
+    let mut sub_id_to_topic = HashMap::new();
 
     let mut url = client
         .mint_url
@@ -533,14 +665,14 @@ async fn stream_client(
     tracing::debug!("Connected to {}", url);
 
     for (name, index) in topics {
-        let kind = SubscriptionClient::subscription_kind(&index);
+        let topic = index.clone();
         let (_, req) = if let Some(req) = client.get_sub_request(name.clone(), index) {
             req
         } else {
             continue;
         };
 
-        sub_id_to_kind.insert(name, kind);
+        sub_id_to_topic.insert(name, topic);
         let _ = sender.send(req).await;
     }
 
@@ -549,17 +681,17 @@ async fn stream_client(
             Some(msg) = ctrl.recv() => {
                 match msg {
                     StreamCtrl::Subscribe(msg) => {
-                        let kind = SubscriptionClient::subscription_kind(&msg.1);
+                        let topic = msg.1.clone();
                         let (_, req) = if let Some(req) = client.get_sub_request(msg.0.clone(), msg.1) {
                             req
                         } else {
                             continue;
                         };
-                        sub_id_to_kind.insert(msg.0, kind);
+                        sub_id_to_topic.insert(msg.0, topic);
                         let _ = sender.send(req).await;
                     }
                     StreamCtrl::Unsubscribe(msg) => {
-                        sub_id_to_kind.remove(&msg);
+                        sub_id_to_topic.remove(&msg);
                         let req = if let Some(req) = client.get_unsub_request(msg) {
                             req
                         } else {
@@ -582,11 +714,11 @@ async fn stream_client(
                         if let Err(err) = sender.close().await {
                             tracing::error!("Closing error {err:?}");
                         }
-                        sub_id_to_kind.clear();
+                        sub_id_to_topic.clear();
                         break;
                     }
                     None => {
-                        sub_id_to_kind.clear();
+                        sub_id_to_topic.clear();
                         break;
                     }
                 };
@@ -597,7 +729,7 @@ async fn stream_client(
 
                 match msg {
                     RawWsMessageOrResponse::Notification(ref payload) => {
-                        let Some(kind) = sub_id_to_kind.get(&payload.params.sub_id) else {
+                        let Some(subscription) = sub_id_to_topic.get(&payload.params.sub_id) else {
                             tracing::warn!(
                                 "Received websocket notification for unknown subId {}",
                                 payload.params.sub_id
@@ -605,10 +737,8 @@ async fn stream_client(
                             continue;
                         };
 
-                        let payload = decode_notification_payload(
-                            kind,
-                            payload.params.payload.clone(),
-                        )?;
+                        let payload =
+                            decode_notification_payload(subscription, payload.params.payload.clone())?;
                         reply_to.send(payload);
                     }
                     RawWsMessageOrResponse::Response(response) => {
@@ -647,7 +777,15 @@ mod tests {
             "witness": null
         });
 
-        let decoded = decode_notification_payload(&Kind::ProofState, payload).unwrap();
+        let decoded = decode_notification_payload(
+            &NotificationId::ProofState(
+                "02194603ffa062682c4f10e2dfe8f53e17d5d0329db51c8d3935cc74a4c0e0d4cb"
+                    .parse()
+                    .unwrap(),
+            ),
+            payload,
+        )
+        .unwrap();
 
         assert!(matches!(decoded, NotificationPayload::ProofState(_)));
     }
@@ -670,10 +808,16 @@ mod tests {
             "payment_proof": "abc"
         });
 
-        let mint_decoded =
-            decode_notification_payload(&Kind::Bolt11MintQuote, mint_payload).unwrap();
-        let melt_decoded =
-            decode_notification_payload(&Kind::Bolt11MeltQuote, melt_payload).unwrap();
+        let mint_decoded = decode_notification_payload(
+            &NotificationId::MintQuote("mint-quote".to_string()),
+            mint_payload,
+        )
+        .unwrap();
+        let melt_decoded = decode_notification_payload(
+            &NotificationId::MeltQuote("melt-quote".to_string()),
+            melt_payload,
+        )
+        .unwrap();
 
         assert!(matches!(
             mint_decoded,
@@ -699,7 +843,11 @@ mod tests {
             "amount_issued": 0
         });
 
-        let decoded = decode_notification_payload(&Kind::Bolt12MintQuote, payload).unwrap();
+        let decoded = decode_notification_payload(
+            &NotificationId::MintQuote("quote-id".to_string()),
+            payload,
+        )
+        .unwrap();
 
         assert!(matches!(
             decoded,
@@ -709,8 +857,7 @@ mod tests {
 
     #[test]
     fn decode_custom_notifications() {
-        let mint_method = "foo_mint_quote".to_string();
-        let melt_method = "foo_melt_quote".to_string();
+        let method = "foo".to_string();
         let mint_payload = json!({
             "quote": "mint-custom",
             "request": "custom-request",
@@ -734,25 +881,32 @@ mod tests {
             "extra_field": "value"
         });
 
-        let mint_decoded =
-            decode_notification_payload(&Kind::Custom(mint_method.clone()), mint_payload).unwrap();
-        let melt_decoded =
-            decode_notification_payload(&Kind::Custom(melt_method.clone()), melt_payload).unwrap();
+        let mint_decoded = decode_notification_payload(
+            &NotificationId::MintQuoteCustom(method.clone(), "mint-custom".to_string()),
+            mint_payload,
+        )
+        .unwrap();
+        let melt_decoded = decode_notification_payload(
+            &NotificationId::MeltQuoteCustom(method.clone(), "melt-custom".to_string()),
+            melt_payload,
+        )
+        .unwrap();
 
         assert!(matches!(
             mint_decoded,
-            NotificationPayload::CustomMintQuoteResponse(method, _) if method == mint_method
+            NotificationPayload::CustomMintQuoteResponse(decoded_method, _) if decoded_method == method
         ));
         assert!(matches!(
             melt_decoded,
-            NotificationPayload::CustomMeltQuoteResponse(method, _) if method == melt_method
+            NotificationPayload::CustomMeltQuoteResponse(decoded_method, _) if decoded_method == method
         ));
     }
 
     #[test]
     fn decode_unknown_custom_kind_errors() {
-        let err = decode_notification_payload(&Kind::Custom("foo_status".to_string()), json!({}))
-            .unwrap_err();
+        let err =
+            decode_notification_payload(&NotificationId::MintQuote("foo".to_string()), json!({}))
+                .unwrap_err();
 
         assert!(matches!(err, PubsubError::ParsingError(_)));
     }
@@ -765,7 +919,11 @@ mod tests {
             "witness": null
         });
 
-        let err = decode_notification_payload(&Kind::Bolt12MintQuote, payload).unwrap_err();
+        let err = decode_notification_payload(
+            &NotificationId::MintQuote("quote-id".to_string()),
+            payload,
+        )
+        .unwrap_err();
 
         assert!(matches!(err, PubsubError::ParsingError(_)));
     }

--- a/crates/cdk/src/wallet/test_utils.rs
+++ b/crates/cdk/src/wallet/test_utils.rs
@@ -271,8 +271,8 @@ pub fn test_mint_info() -> MintInfo {
                         PaymentMethod::Known(KnownMethod::Bolt11),
                         CurrencyUnit::Sat,
                         vec![
-                            nut17::WsCommand::Bolt11MintQuote,
-                            nut17::WsCommand::Bolt11MeltQuote,
+                            nut17::WsCommand::MintQuote,
+                            nut17::WsCommand::MeltQuote,
                             nut17::WsCommand::ProofState,
                         ],
                     ),
@@ -280,8 +280,8 @@ pub fn test_mint_info() -> MintInfo {
                         PaymentMethod::Known(KnownMethod::Bolt12),
                         CurrencyUnit::Sat,
                         vec![
-                            nut17::WsCommand::Bolt12MintQuote,
-                            nut17::WsCommand::Bolt12MeltQuote,
+                            nut17::WsCommand::MintQuote,
+                            nut17::WsCommand::MeltQuote,
                             nut17::WsCommand::ProofState,
                         ],
                     ),


### PR DESCRIPTION
## Summary
- switch advertised and wallet-used NUT-17 quote commands to the new generic `mint_quote` and `melt_quote` strings from cashubtc/nuts#372
- keep mint-side backwards compatibility for the legacy method-specific quote kind strings and mark the temporary compatibility paths as deprecated/TODO cleanup points
- fan out mint events to both generic and legacy quote topics so old websocket clients keep working while new wallets subscribe with the generic kinds

## Testing
- `cargo test -p cashu nut17::tests --lib`
- `cargo check -p cdk-common -p cdk --lib --no-default-features --features wallet`
- `cargo check -p cdk-ffi --no-default-features --features bip353`
- `cargo test -p cdk --lib --no-default-features --features wallet subscription::tests`

## Notes
- `cargo check -p cdk-axum` / mint-feature verification is blocked in this environment because `cdk-signatory` requires a local `protoc` binary during build.