### PR TITLE
fix: bind docker ldk dashboard to localhost

### DIFF
--- a/docker-compose.ldk-node.yaml
+++ b/docker-compose.ldk-node.yaml
@@ -46,7 +46,7 @@ services:
     container_name: mint-ldk-node
     ports:
       - "8085:8085"
-      - "8091:8091" # LDK admin dashboard (WARNING!!! Do not expose to network! Doing so will leave LDK node funds accessible by whole network)
+      - "127.0.0.1:8091:8091" # LDK admin dashboard; host-local only because it has no authentication
     environment:
       - CDK_MINTD_URL=https://example.com
       - CDK_MINTD_LN_BACKEND=ldk-node


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
