### PR TITLE
fix: prevent logging p2pk key

### DIFF
--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -329,7 +329,7 @@ pub struct Restored {
 }
 
 /// Send options
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct SendOptions {
     /// Memo
     pub memo: Option<SendMemo>,
@@ -351,6 +351,26 @@ pub struct SendOptions {
     pub p2pk_signing_keys: Vec<SecretKey>,
     /// How P2PK-locked input proofs should be handled during send
     pub p2pk_locked_proof_send_mode: P2PKLockedProofSendMode,
+}
+
+impl fmt::Debug for SendOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SendOptions")
+            .field("memo", &self.memo)
+            .field("conditions", &self.conditions)
+            .field("amount_split_target", &self.amount_split_target)
+            .field("send_kind", &self.send_kind)
+            .field("include_fee", &self.include_fee)
+            .field("max_proofs", &self.max_proofs)
+            .field("metadata", &self.metadata)
+            .field("use_p2bk", &self.use_p2bk)
+            .field("p2pk_signing_keys", &"[redacted]")
+            .field(
+                "p2pk_locked_proof_send_mode",
+                &self.p2pk_locked_proof_send_mode,
+            )
+            .finish()
+    }
 }
 
 /// Send behavior for selected P2PK-locked input proofs
@@ -383,7 +403,7 @@ impl SendMemo {
 }
 
 /// Receive options
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct ReceiveOptions {
     /// Amount split target
     pub amount_split_target: SplitTarget,
@@ -393,6 +413,17 @@ pub struct ReceiveOptions {
     pub preimages: Vec<String>,
     /// Metadata
     pub metadata: HashMap<String, String>,
+}
+
+impl fmt::Debug for ReceiveOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceiveOptions")
+            .field("amount_split_target", &self.amount_split_target)
+            .field("p2pk_signing_keys", &"[redacted]")
+            .field("preimages", &self.preimages)
+            .field("metadata", &self.metadata)
+            .finish()
+    }
 }
 
 /// Send Kind
@@ -1192,5 +1223,28 @@ mod tests {
             conditions: None,
         };
         assert!(!proof_info.matches_conditions(&None, &None, &None, &Some(vec![dummy_condition])));
+    }
+
+    #[test]
+    fn test_wallet_options_debug_redacts_p2pk_signing_keys() {
+        let secret_key = SecretKey::generate();
+        let secret_hex = secret_key.to_secret_hex();
+
+        let send_options = SendOptions {
+            p2pk_signing_keys: vec![secret_key.clone()],
+            ..Default::default()
+        };
+        let receive_options = ReceiveOptions {
+            p2pk_signing_keys: vec![secret_key],
+            ..Default::default()
+        };
+
+        let send_debug = format!("{:?}", send_options);
+        let receive_debug = format!("{:?}", receive_options);
+
+        assert!(!send_debug.contains(&secret_hex));
+        assert!(send_debug.contains("[redacted]"));
+        assert!(!receive_debug.contains(&secret_hex));
+        assert!(receive_debug.contains("[redacted]"));
     }
 }

--- a/crates/cdk-ffi/src/lib.rs
+++ b/crates/cdk-ffi/src/lib.rs
@@ -297,6 +297,91 @@ mod tests {
     }
 
     #[test]
+    fn test_send_options_json_preserves_p2pk_signing_keys() {
+        let secret_hex =
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".to_string();
+        let options = SendOptions {
+            p2pk_signing_keys: vec![SecretKey {
+                hex: secret_hex.clone(),
+            }],
+            ..Default::default()
+        };
+
+        let to_json = options.to_json().unwrap();
+        let encoded = crate::types::wallet::encode_send_options(options.clone()).unwrap();
+        let debug = format!("{:?}", options);
+
+        assert!(to_json.contains(&secret_hex));
+        assert!(to_json.contains("p2pk_signing_keys"));
+        assert!(encoded.contains(&secret_hex));
+        assert!(encoded.contains("p2pk_signing_keys"));
+        assert!(!debug.contains(&secret_hex));
+        assert!(debug.contains("[redacted]"));
+
+        let decoded = crate::types::wallet::decode_send_options(encoded).unwrap();
+
+        assert_eq!(decoded.p2pk_signing_keys.len(), 1);
+        assert_eq!(decoded.p2pk_signing_keys[0].hex, secret_hex);
+    }
+
+    #[test]
+    fn test_send_options_json_still_decodes_p2pk_signing_keys() {
+        let secret_hex = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+        let json = format!(
+            r#"{{
+                "memo": null,
+                "conditions": null,
+                "amount_split_target": "None",
+                "send_kind": "OnlineExact",
+                "include_fee": false,
+                "use_p2bk": false,
+                "max_proofs": null,
+                "metadata": {{}},
+                "p2pk_signing_keys": ["{}"],
+                "p2pk_locked_proof_send_mode": "SignAndSend"
+            }}"#,
+            secret_hex
+        );
+
+        let options = crate::types::wallet::decode_send_options(json).unwrap();
+
+        assert_eq!(options.p2pk_signing_keys.len(), 1);
+        assert_eq!(options.p2pk_signing_keys[0].hex, secret_hex);
+        assert_eq!(
+            options.p2pk_locked_proof_send_mode,
+            P2PKLockedProofSendMode::SignAndSend
+        );
+    }
+
+    #[test]
+    fn test_receive_options_json_preserves_p2pk_signing_keys() {
+        let secret_hex =
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".to_string();
+        let options = ReceiveOptions {
+            p2pk_signing_keys: vec![SecretKey {
+                hex: secret_hex.clone(),
+            }],
+            ..Default::default()
+        };
+
+        let to_json = options.to_json().unwrap();
+        let encoded = crate::types::wallet::encode_receive_options(options.clone()).unwrap();
+        let debug = format!("{:?}", options);
+
+        assert!(to_json.contains(&secret_hex));
+        assert!(to_json.contains("p2pk_signing_keys"));
+        assert!(encoded.contains(&secret_hex));
+        assert!(encoded.contains("p2pk_signing_keys"));
+        assert!(!debug.contains(&secret_hex));
+        assert!(debug.contains("[redacted]"));
+
+        let decoded = crate::types::wallet::decode_receive_options(encoded).unwrap();
+
+        assert_eq!(decoded.p2pk_signing_keys.len(), 1);
+        assert_eq!(decoded.p2pk_signing_keys[0].hex, secret_hex);
+    }
+
+    #[test]
     fn test_send_options_json_defaults_new_p2pk_fields() {
         let json = r#"{
             "memo": null,

--- a/crates/cdk-ffi/src/types/wallet.rs
+++ b/crates/cdk-ffi/src/types/wallet.rs
@@ -1,6 +1,7 @@
 //! Wallet-related FFI types
 
 use std::collections::HashMap;
+use std::fmt;
 
 use cdk_common::bitcoin;
 use serde::{Deserialize, Serialize};
@@ -281,11 +282,19 @@ pub fn encode_send_options(options: SendOptions) -> Result<String, FfiError> {
 }
 
 /// FFI-compatible SecretKey
-#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+#[derive(Clone, Serialize, Deserialize, uniffi::Record)]
 #[serde(transparent)]
 pub struct SecretKey {
     /// Hex-encoded secret key (64 characters)
     pub hex: String,
+}
+
+impl fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecretKey")
+            .field("hex", &"[redacted]")
+            .finish()
+    }
 }
 
 impl SecretKey {
@@ -341,6 +350,7 @@ pub struct ReceiveOptions {
     /// Amount split target
     pub amount_split_target: SplitTarget,
     /// P2PK signing keys
+    #[serde(default)]
     pub p2pk_signing_keys: Vec<SecretKey>,
     /// Preimages for HTLC conditions
     pub preimages: Vec<String>,


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
