### PR TITLE
fix: spending conditions transformation should error

### DIFF
--- a/crates/cdk-ffi/src/lib.rs
+++ b/crates/cdk-ffi/src/lib.rs
@@ -282,6 +282,21 @@ mod tests {
     }
 
     #[test]
+    fn test_send_options_invalid_conditions_returns_error() {
+        let options = SendOptions {
+            conditions: Some(SpendingConditions::P2PK {
+                pubkey: "not_a_valid_pubkey".to_string(),
+                conditions: None,
+            }),
+            ..Default::default()
+        };
+
+        let result: Result<cdk::wallet::SendOptions, _> = options.try_into();
+
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_send_options_json_defaults_new_p2pk_fields() {
         let json = r#"{
             "memo": null,

--- a/crates/cdk-ffi/src/types/proof.rs
+++ b/crates/cdk-ffi/src/types/proof.rs
@@ -527,7 +527,7 @@ pub fn encode_proof_info(info: ProofInfo) -> Result<String, FfiError> {
         y: info.y.try_into()?,
         mint_url: info.mint_url.try_into()?,
         state: info.state.into(),
-        spending_condition: info.spending_condition.and_then(|c| c.try_into().ok()),
+        spending_condition: info.spending_condition.map(TryInto::try_into).transpose()?,
         unit: info.unit.into(),
         used_by_operation: info
             .used_by_operation

--- a/crates/cdk-ffi/src/types/wallet.rs
+++ b/crates/cdk-ffi/src/types/wallet.rs
@@ -231,7 +231,7 @@ impl TryFrom<SendOptions> for cdk::wallet::SendOptions {
 
         Ok(cdk::wallet::SendOptions {
             memo: opts.memo.map(Into::into),
-            conditions: opts.conditions.and_then(|c| c.try_into().ok()),
+            conditions: opts.conditions.map(TryInto::try_into).transpose()?,
             amount_split_target: opts.amount_split_target.into(),
             send_kind: opts.send_kind.into(),
             include_fee: opts.include_fee,


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----
This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe).

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
