### PR TITLE
fix: stabilize onchain regtest helpers

### DIFF
--- a/misc/itest_helpers.sh
+++ b/misc/itest_helpers.sh
@@ -43,7 +43,7 @@ run_mintd_bg() {
 }
 
 # Helper: run cargo nextest with archive if available, or fall back to cargo test.
-# For nextest: translates '-- --nocapture' to '--no-capture' and strips '--' separators.
+# For nextest: translates cargo test conventions and strips '--' separators.
 #
 # Usage: run_test <test_name> [extra cargo-test args...]
 run_test() {
@@ -52,18 +52,30 @@ run_test() {
     if [ -n "${CDK_ITEST_ARCHIVE:-}" ] && [ -f "${CDK_ITEST_ARCHIVE:-}" ]; then
         # Build nextest args, translating cargo test conventions
         local nextest_args=()
-        for arg in "$@"; do
+        local args=("$@")
+        local i=0
+        while [ "$i" -lt "${#args[@]}" ]; do
+            local arg="${args[$i]}"
             if [ "$arg" = "--" ]; then
+                i=$((i + 1))
                 continue
             fi
             if [ "$arg" = "--nocapture" ]; then
                 nextest_args+=("--no-capture")
+            elif [ "$arg" = "--test-threads" ]; then
+                i=$((i + 1))
+                if [ "$i" -lt "${#args[@]}" ]; then
+                    nextest_args+=("-j" "${args[$i]}")
+                fi
+            elif [[ "$arg" == --test-threads=* ]]; then
+                nextest_args+=("-j" "${arg#--test-threads=}")
             else
                 nextest_args+=("$arg")
             fi
+            i=$((i + 1))
         done
         echo "Running test '$test_name' from nextest archive"
-        cargo nextest run --archive-file "$CDK_ITEST_ARCHIVE" --workspace-remap . -E "binary(~$test_name)" "${nextest_args[@]}"
+        cargo nextest run --archive-file "$CDK_ITEST_ARCHIVE" --workspace-remap . -E "binary(/^${test_name}$/)" "${nextest_args[@]}"
     else
         echo "Running test '$test_name' via cargo test"
         cargo test -p cdk-integration-tests --test "$test_name" "$@"

--- a/misc/regtest_helper.sh
+++ b/misc/regtest_helper.sh
@@ -288,6 +288,20 @@ restart_mints() {
     echo "==============================="
     echo "Restarting CDK Mints"
     echo "==============================="
+
+    export_regtest_bdk_env() {
+        local mnemonic="$1"
+
+        export CDK_MINTD_BDK_MNEMONIC="$mnemonic"
+        export CDK_MINTD_ONCHAIN_BACKEND="bdk"
+        export CDK_MINTD_BDK_BITCOIND_RPC_HOST="127.0.0.1"
+        export CDK_MINTD_BDK_BITCOIND_RPC_PORT=18443
+        export CDK_MINTD_BDK_BITCOIND_RPC_USER="testuser"
+        export CDK_MINTD_BDK_BITCOIND_RPC_PASSWORD="testpass"
+        export CDK_MINTD_BDK_NETWORK="regtest"
+        export CDK_MINTD_BDK_CHAIN_SOURCE_TYPE="bitcoinrpc"
+        export CDK_MINTD_BDK_NUM_CONFS=1
+    }
     
     # Stop existing mints
     echo "Stopping existing mints..."
@@ -321,6 +335,7 @@ restart_mints() {
     export CDK_MINTD_LN_BACKEND="cln"
     export CDK_MINTD_MNEMONIC="eye survey guilt napkin crystal cup whisper salt luggage manage unveil loyal"
     export RUST_BACKTRACE=1
+    export_regtest_bdk_env "$CDK_MINTD_MNEMONIC"
     
     cargo run --bin cdk-mintd > "$CDK_MINTD_WORK_DIR/mintd.log" 2>&1 &
     NEW_CLN_PID=$!
@@ -355,6 +370,7 @@ restart_mints() {
     export CDK_MINTD_LISTEN_PORT=8087
     export CDK_MINTD_LN_BACKEND="lnd"
     export CDK_MINTD_MNEMONIC="cattle gold bind busy sound reduce tone addict baby spend february strategy"
+    export_regtest_bdk_env "$CDK_MINTD_MNEMONIC"
     
     cargo run --bin cdk-mintd > "$CDK_MINTD_WORK_DIR/mintd.log" 2>&1 &
     NEW_LND_PID=$!


### PR DESCRIPTION
Configure BDK env vars when restarting regtest mints so onchain flows keep working after restart.

Translate cargo test thread flags to nextest job flags for archived integration tests.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
