### PR TITLE
include inactive keysets in wallet token operations

### DIFF
--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -766,9 +766,13 @@ pub trait Wallet: Send + Sync {
         filter: KeysetFilter,
     ) -> Result<Vec<Self::KeySetInfo>, Self::Error>;
 
-    /// Load active keysets (alias for get_mint_keysets with Active filter)
+    /// Load all keysets (active and inactive) for token operations.
+    ///
+    /// Token operations need to resolve short keyset ids in proofs to their
+    /// full ids, and proofs from inactive/rotated keysets are still valid, so
+    /// callers handling tokens must see all keysets.
     async fn load_mint_keysets(&self) -> Result<Vec<Self::KeySetInfo>, Self::Error> {
-        self.get_mint_keysets(KeysetFilter::Active).await
+        self.get_mint_keysets(KeysetFilter::All).await
     }
 
     /// Fetch the active keyset with lowest fees

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -2250,6 +2250,113 @@ async fn test_restore_after_keyset_rotation() {
     );
 }
 
+/// Regression test for #1994: token operations must accept proofs from inactive (rotated) keysets.
+///
+/// Before the fix, `Wallet::load_mint_keysets()` returned only active keysets. Token operations
+/// such as `receive` and `prepare_melt_token` use that list to resolve the short keyset id
+/// embedded in V2 proofs to the full id. If the token's keyset had been rotated out (inactive),
+/// the lookup failed and the wallet could neither swap nor melt the token.
+///
+/// Scenario covered:
+/// 1. Mint starts on a V2 keyset (rotation #1).
+/// 2. Sender mints sats under that keyset and produces a token while it is still active.
+/// 3. Mint rotates again to a new V2 keyset; the previous V2 keyset becomes inactive.
+/// 4. A fresh receiver wallet must still be able to `receive` the token.
+/// 5. Independently, a wallet must still be able to `prepare_melt_token` against a token from
+///    the now-inactive keyset.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_token_ops_accept_inactive_keyset_proofs() {
+    setup_tracing();
+    let mint = create_and_start_test_mint()
+        .await
+        .expect("Failed to create test mint");
+
+    // Rotation #1 -> active keyset is V2 ("A").
+    mint.rotate_keyset(
+        CurrencyUnit::Sat,
+        cdk_integration_tests::standard_keyset_amounts(32),
+        0,
+        true,
+        None,
+    )
+    .await
+    .expect("first rotation");
+
+    let sender = create_test_wallet_for_mint(mint.clone())
+        .await
+        .expect("Failed to create sender wallet");
+
+    // Sender funds enough to produce two independent tokens later.
+    fund_wallet(sender.clone(), 100, None)
+        .await
+        .expect("Failed to fund sender");
+
+    // Build the receive-test token while keyset A is still active.
+    let token_for_receive = sender
+        .prepare_send(Amount::from(20), SendOptions::default())
+        .await
+        .expect("prepare send (receive)")
+        .confirm(None)
+        .await
+        .expect("confirm send (receive)");
+
+    // Build the melt-test token while keyset A is still active.
+    let token_for_melt = sender
+        .prepare_send(Amount::from(40), SendOptions::default())
+        .await
+        .expect("prepare send (melt)")
+        .confirm(None)
+        .await
+        .expect("confirm send (melt)");
+
+    // Rotation #2 -> keyset A is now inactive; both tokens reference an inactive V2 keyset.
+    mint.rotate_keyset(
+        CurrencyUnit::Sat,
+        cdk_integration_tests::standard_keyset_amounts(32),
+        0,
+        true,
+        None,
+    )
+    .await
+    .expect("second rotation");
+
+    // --- receive path ---
+    let receiver = create_test_wallet_for_mint(mint.clone())
+        .await
+        .expect("Failed to create receiver wallet");
+
+    let received = receiver
+        .receive(&token_for_receive.to_string(), ReceiveOptions::default())
+        .await
+        .expect("receive must succeed for token from inactive keyset");
+    assert_eq!(received, Amount::from(20));
+
+    // --- melt path (prepare_melt_token) ---
+    // We need a melt quote on the same wallet that will consume the token.
+    let melter = create_test_wallet_for_mint(mint.clone())
+        .await
+        .expect("Failed to create melter wallet");
+
+    let fake_invoice = create_fake_invoice(30_000, "inactive keyset melt".to_string());
+    let melt_quote = melter
+        .melt_quote(PaymentMethod::BOLT11, fake_invoice.to_string(), None, None)
+        .await
+        .expect("create melt quote");
+
+    let prepared = melter
+        .prepare_melt_token(
+            &melt_quote.id,
+            &token_for_melt.to_string(),
+            std::collections::HashMap::new(),
+        )
+        .await
+        .expect("prepare_melt_token must succeed for token from inactive keyset");
+
+    // Cancel rather than execute the melt; this test asserts the keyset-resolution path,
+    // not the LN settlement, and leaves the fake LN backend untouched.
+    prepared.cancel().await.expect("cancel prepared melt");
+}
+
 #[derive(Debug, Default)]
 struct CustomPaymentProcessor {
     /// Captures the quote_id seen by `get_payment_quote` so tests can assert

--- a/crates/cdk/src/wallet/auth/auth_wallet.rs
+++ b/crates/cdk/src/wallet/auth/auth_wallet.rs
@@ -243,11 +243,12 @@ impl AuthWallet {
         self.load_mint_keysets().await
     }
 
-    /// Get the first active blind auth keyset - always goes online
+    /// Get the first blind auth keyset returned by the mint - always goes online
     ///
-    /// This method always goes online to refresh keysets from the mint and then returns
-    /// the first active keyset found. Use this when you need the most up-to-date
-    /// keyset information for blind auth operations.
+    /// Refreshes keysets from the mint and returns the first one. Note that the
+    /// underlying `refresh_keysets` does not filter by `active`, so this returns
+    /// whichever auth keyset the mint lists first (typically the only one in
+    /// practice for `CurrencyUnit::Auth`).
     #[instrument(skip(self))]
     pub async fn fetch_active_keyset(&self) -> Result<KeySetInfo, Error> {
         let auth_keysets = self.refresh_keysets().await?;

--- a/crates/cdk/src/wallet/keysets.rs
+++ b/crates/cdk/src/wallet/keysets.rs
@@ -27,10 +27,16 @@ impl Wallet {
             .ok_or(Error::UnknownKeySet)
     }
 
-    /// Alias of get_mint_keysets, kept for backwards compatibility reasons
+    /// Load all mint keysets (active and inactive) for token operations.
+    ///
+    /// Token operations such as receive, melt, P2PK/DLEQ verification, and
+    /// payment-request decoding must resolve the short keyset id embedded in a
+    /// token to its full id. Proofs from rotated (inactive) keysets are still
+    /// valid and the wallet must be able to swap or melt them, so all keysets
+    /// are returned here regardless of `active` status.
     #[instrument(skip(self))]
     pub async fn load_mint_keysets(&self) -> Result<Vec<KeySetInfo>, Error> {
-        self.get_mint_keysets(KeysetFilter::Active).await
+        self.get_mint_keysets(KeysetFilter::All).await
     }
 
     /// Get keysets for this wallet's unit from the metadata cache
@@ -74,8 +80,10 @@ impl Wallet {
     /// Refresh keysets by fetching the latest from mint - always fetches fresh data
     ///
     /// Forces a fresh fetch of keyset information from the mint server,
-    /// updating the metadata cache and database. Use this when you need
-    /// the most up-to-date keyset information.
+    /// updating the metadata cache and database. Returns all keysets for this
+    /// wallet's unit (active and inactive) so callers handling tokens can
+    /// resolve short keyset ids from rotated keysets; pair with
+    /// `KeySetInfosMethods::active` if only active keysets are needed.
     #[instrument(skip(self))]
     pub async fn refresh_keysets(&self) -> Result<Vec<KeySetInfo>, Error> {
         tracing::debug!("Refreshing keysets from mint");
@@ -87,7 +95,7 @@ impl Wallet {
             .keysets
             .values()
             .filter_map(|keyset| {
-                if keyset.unit == self.unit && keyset.active {
+                if keyset.unit == self.unit {
                     Some((*keyset.clone()).clone())
                 } else {
                     None

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -740,7 +740,6 @@ impl Wallet {
         ensure_cdk!(self.mint_url == token.mint_url()?, Error::IncorrectMint);
 
         let keysets_info = self.load_mint_keysets().await?;
-        println!("{:?}", keysets_info);
         let proofs = token.proofs(&keysets_info)?;
 
         self.prepare_melt_proofs(quote_id, proofs, metadata).await

--- a/crates/cdk/src/wallet/wallet_repository.rs
+++ b/crates/cdk/src/wallet/wallet_repository.rs
@@ -738,8 +738,9 @@ impl WalletRepository {
 
         // Get the keysets for this mint using the token's unit
         let wallet = self.get_wallet(&mint_url, &unit).await?;
-        let keysets = wallet.get_mint_keysets(KeysetFilter::Active).await?;
-        // Extract proofs using the keysets
+        // Use `All` so tokens containing proofs from inactive/rotated keysets
+        // can still be decoded; their short ids must resolve to a full id.
+        let keysets = wallet.get_mint_keysets(KeysetFilter::All).await?;
         let proofs = token.proofs(&keysets)?;
 
         // Get the memo


### PR DESCRIPTION
### Description

Fixes #1994. `Wallet::load_mint_keysets` and `Wallet::refresh_keysets` were filtering out inactive keysets. Token operations (`receive`, `prepare_melt_token`, P2PK and DLEQ verification, payment-request decoding, `WalletRepository::get_token_data`) feed that list into `Id::from_short_keyset_id`, which resolves the short keyset id embedded in V2 proofs to its full id. Proofs from rotated/inactive keysets are still valid, so dropping them broke swap/melt of any token whose keyset had since rotated (failing with `NUT00(NUT02(UnknownShortKeysetId))`).                                                                                

Both methods now return all keysets for the wallet's unit, and  `get_token_data` was updated to use `KeysetFilter::All` directly.

-----

### Notes to the reviewers

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

-`Wallet::load_mint_keysets` and `Wallet::refresh_keysets` now return both active and inactive keysets so token operations can resolve short keyset ids from rotated keysets.
-removed a stray debug `println!` in `Wallet::prepare_melt_token`.


----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
