### PR TITLE
ci: harden FFI release workflows

### DIFF
--- a/.github/workflows/dart-publish.yml
+++ b/.github/workflows/dart-publish.yml
@@ -1,5 +1,8 @@
 name: "FFI - Dart Bindings"
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -10,7 +13,7 @@ on:
         description: 'CDK dependency version (e.g. 0.17.0). Defaults to release_tag without the "v" prefix.'
         required: false
       cdk_ref:
-        description: 'CDK git ref to publish from. Defaults to release_tag.'
+        description: 'CDK git ref to publish from. Must match release_tag.'
         required: false
   workflow_call:
     inputs:
@@ -30,8 +33,33 @@ env:
   RELEASE_BRANCH: release/${{ inputs.release_tag }}
 
 jobs:
+  validate-release-ref:
+    name: "dart: Validate release ref"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release ref
+        shell: bash
+        run: |
+          if [[ "${CDK_REF}" != "${TAG}" ]]; then
+            echo "::error::cdk_ref must match release_tag (${TAG}); got ${CDK_REF}"
+            exit 1
+          fi
+
+          if [[ ! "${TAG}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::release_tag must be a version tag such as v0.17.0; got ${TAG}"
+            exit 1
+          fi
+
+      - name: Verify release tag exists
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ env.TAG }}
+          fetch-depth: 1
+          persist-credentials: false
+
   dart-sync-sources:
     name: "dart: Sync sources to cdk-dart"
+    needs: [validate-release-ref]
     runs-on: ubuntu-latest
     steps:
       - name: Resolve variables
@@ -43,11 +71,20 @@ jobs:
       - name: Checkout monorepo
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.CDK_REF }}
+          ref: refs/tags/${{ env.TAG }}
+          persist-credentials: false
 
       - name: Clone cdk-dart
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
-          git clone https://x-access-token:${{ secrets.FFI_DEPLOY_KEY }}@github.com/${{ vars.CDK_DART_REPO }}.git cdk-dart
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" \
+            clone https://github.com/${{ vars.CDK_DART_REPO }}.git cdk-dart
 
       - name: Copy bindings/dart to cdk-dart
         run: |
@@ -124,14 +161,21 @@ jobs:
 
       - name: Push to cdk-dart release branch
         working-directory: cdk-dart
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "${RELEASE_BRANCH}"
           git add -A
           git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "sync: update sources for ${TAG}"
-          git push origin "${RELEASE_BRANCH}"
+          git -c "http.extraheader=$(auth_header)" push origin "${RELEASE_BRANCH}"
 
   dart-build-native:
     name: "dart: Build ${{ matrix.target }}"
@@ -178,9 +222,17 @@ jobs:
     steps:
       - name: Clone cdk-dart
         shell: bash
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
-          git clone --branch "${RELEASE_BRANCH}" \
-            https://x-access-token:${{ secrets.FFI_DEPLOY_KEY }}@github.com/${{ vars.CDK_DART_REPO }}.git cdk-dart
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" \
+            clone --branch "${RELEASE_BRANCH}" \
+            https://github.com/${{ vars.CDK_DART_REPO }}.git cdk-dart
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -247,9 +299,17 @@ jobs:
     needs: [dart-build-native]
     steps:
       - name: Clone cdk-dart
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
-          git clone --branch "${RELEASE_BRANCH}" \
-            https://x-access-token:${{ secrets.FFI_DEPLOY_KEY }}@github.com/${{ vars.CDK_DART_REPO }}.git cdk-dart
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" \
+            clone --branch "${RELEASE_BRANCH}" \
+            https://github.com/${{ vars.CDK_DART_REPO }}.git cdk-dart
 
       - name: Download all native artifacts
         uses: actions/download-artifact@v4
@@ -291,7 +351,15 @@ jobs:
 
       - name: Push release branch
         working-directory: cdk-dart
-        run: git push origin "${RELEASE_BRANCH}"
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
+        run: |
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" push origin "${RELEASE_BRANCH}"
 
       - name: Create per-platform release archives
         run: |
@@ -330,14 +398,29 @@ jobs:
 
       - name: Merge to default branch
         working-directory: cdk-dart
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
           DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
           echo "DEFAULT_BRANCH=${DEFAULT_BRANCH}" >> "$GITHUB_ENV"
           git checkout "${DEFAULT_BRANCH}"
           git merge "${RELEASE_BRANCH}" --squash
           git commit -m "release: ${TAG}"
-          git push origin "${DEFAULT_BRANCH}"
+          git -c "http.extraheader=$(auth_header)" push origin "${DEFAULT_BRANCH}"
 
       - name: Clean up release branch
         working-directory: cdk-dart
-        run: git push origin --delete "${RELEASE_BRANCH}"
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
+        run: |
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" push origin --delete "${RELEASE_BRANCH}"

--- a/.github/workflows/ffi-publish-all.yml
+++ b/.github/workflows/ffi-publish-all.yml
@@ -1,5 +1,8 @@
 name: "FFI - Publish All Bindings"
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -10,7 +13,7 @@ on:
         description: 'CDK dependency version (e.g. 0.17.0). Defaults to release_tag without the "v" prefix.'
         required: false
       cdk_ref:
-        description: "CDK git ref to publish from. Defaults to release_tag."
+        description: "CDK git ref to publish from. Must match release_tag."
         required: false
 
 jobs:

--- a/.github/workflows/kotlin-publish.yml
+++ b/.github/workflows/kotlin-publish.yml
@@ -1,5 +1,8 @@
 name: "FFI - Kotlin Bindings"
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -10,7 +13,7 @@ on:
         description: 'CDK dependency version (e.g. 0.17.0). Defaults to release_tag without the "v" prefix.'
         required: false
       cdk_ref:
-        description: 'CDK git ref to publish from. Defaults to release_tag.'
+        description: 'CDK git ref to publish from. Must match release_tag.'
         required: false
   workflow_call:
     inputs:
@@ -30,8 +33,33 @@ env:
   RELEASE_BRANCH: release/${{ inputs.release_tag }}
 
 jobs:
+  validate-release-ref:
+    name: "kotlin: Validate release ref"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release ref
+        shell: bash
+        run: |
+          if [[ "${CDK_REF}" != "${TAG}" ]]; then
+            echo "::error::cdk_ref must match release_tag (${TAG}); got ${CDK_REF}"
+            exit 1
+          fi
+
+          if [[ ! "${TAG}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::release_tag must be a version tag such as v0.17.0; got ${TAG}"
+            exit 1
+          fi
+
+      - name: Verify release tag exists
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ env.TAG }}
+          fetch-depth: 1
+          persist-credentials: false
+
   kotlin-sync-sources:
     name: "kotlin: Sync sources to cdk-kotlin"
+    needs: [validate-release-ref]
     runs-on: ubuntu-latest
     steps:
       - name: Resolve variables
@@ -43,11 +71,20 @@ jobs:
       - name: Checkout monorepo
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.CDK_REF }}
+          ref: refs/tags/${{ env.TAG }}
+          persist-credentials: false
 
       - name: Clone cdk-kotlin
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
-          git clone https://x-access-token:${{ secrets.FFI_DEPLOY_KEY }}@github.com/${{ vars.CDK_KOTLIN_REPO }}.git cdk-kotlin
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" \
+            clone https://github.com/${{ vars.CDK_KOTLIN_REPO }}.git cdk-kotlin
 
       - name: Copy bindings/kotlin to cdk-kotlin
         run: |
@@ -125,14 +162,21 @@ jobs:
 
       - name: Push to cdk-kotlin release branch
         working-directory: cdk-kotlin
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "${RELEASE_BRANCH}"
           git add -A
           git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "sync: update sources for ${TAG}"
-          git push origin "${RELEASE_BRANCH}"
+          git -c "http.extraheader=$(auth_header)" push origin "${RELEASE_BRANCH}"
 
   kotlin-build-native:
     name: "kotlin: Build ${{ matrix.target }}"
@@ -174,16 +218,25 @@ jobs:
     steps:
       - name: Clone cdk-kotlin
         shell: bash
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
-          git clone --branch "${RELEASE_BRANCH}" \
-            https://x-access-token:${{ secrets.FFI_DEPLOY_KEY }}@github.com/${{ vars.CDK_KOTLIN_REPO }}.git cdk-kotlin
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" \
+            clone --branch "${RELEASE_BRANCH}" \
+            https://github.com/${{ vars.CDK_KOTLIN_REPO }}.git cdk-kotlin
 
       - name: Checkout CDK (for Nix flake)
         uses: actions/checkout@v4
         with:
           path: cdk
-          ref: ${{ env.CDK_REF }}
+          ref: refs/tags/${{ env.TAG }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
@@ -266,16 +319,25 @@ jobs:
     needs: [kotlin-build-native]
     steps:
       - name: Clone cdk-kotlin
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
-          git clone --branch "${RELEASE_BRANCH}" \
-            https://x-access-token:${{ secrets.FFI_DEPLOY_KEY }}@github.com/${{ vars.CDK_KOTLIN_REPO }}.git cdk-kotlin
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" \
+            clone --branch "${RELEASE_BRANCH}" \
+            https://github.com/${{ vars.CDK_KOTLIN_REPO }}.git cdk-kotlin
 
       - name: Checkout CDK (for Nix flake)
         uses: actions/checkout@v4
         with:
           path: cdk
-          ref: ${{ env.CDK_REF }}
+          ref: refs/tags/${{ env.TAG }}
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: cachix/cachix-action@v16
@@ -369,7 +431,15 @@ jobs:
 
       - name: Push release branch
         working-directory: cdk-kotlin
-        run: git push origin "${RELEASE_BRANCH}"
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
+        run: |
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" push origin "${RELEASE_BRANCH}"
 
       - name: Publish to Maven Central
         working-directory: cdk-kotlin
@@ -401,14 +471,29 @@ jobs:
 
       - name: Merge to default branch
         working-directory: cdk-kotlin
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
           DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
           echo "DEFAULT_BRANCH=${DEFAULT_BRANCH}" >> "$GITHUB_ENV"
           git checkout "${DEFAULT_BRANCH}"
           git merge "${RELEASE_BRANCH}" --squash
           git commit -m "release: ${TAG}"
-          git push origin "${DEFAULT_BRANCH}"
+          git -c "http.extraheader=$(auth_header)" push origin "${DEFAULT_BRANCH}"
 
       - name: Clean up release branch
         working-directory: cdk-kotlin
-        run: git push origin --delete "${RELEASE_BRANCH}"
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
+        run: |
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" push origin --delete "${RELEASE_BRANCH}"

--- a/.github/workflows/swift-publish.yml
+++ b/.github/workflows/swift-publish.yml
@@ -1,5 +1,8 @@
 name: "FFI - Swift Bindings"
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -10,7 +13,7 @@ on:
         description: 'CDK dependency version (e.g. 0.17.0). Defaults to release_tag without the "v" prefix.'
         required: false
       cdk_ref:
-        description: 'CDK git ref to publish from. Defaults to release_tag.'
+        description: 'CDK git ref to publish from. Must match release_tag.'
         required: false
   workflow_call:
     inputs:
@@ -30,8 +33,33 @@ env:
   RELEASE_BRANCH: release/${{ inputs.release_tag }}
 
 jobs:
+  validate-release-ref:
+    name: "swift: Validate release ref"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release ref
+        shell: bash
+        run: |
+          if [[ "${CDK_REF}" != "${TAG}" ]]; then
+            echo "::error::cdk_ref must match release_tag (${TAG}); got ${CDK_REF}"
+            exit 1
+          fi
+
+          if [[ ! "${TAG}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::release_tag must be a version tag such as v0.17.0; got ${TAG}"
+            exit 1
+          fi
+
+      - name: Verify release tag exists
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ env.TAG }}
+          fetch-depth: 1
+          persist-credentials: false
+
   swift-sync-sources:
     name: "swift: Sync sources to cdk-swift"
+    needs: [validate-release-ref]
     runs-on: ubuntu-latest
     steps:
       - name: Resolve variables
@@ -43,11 +71,20 @@ jobs:
       - name: Checkout monorepo
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.CDK_REF }}
+          ref: refs/tags/${{ env.TAG }}
+          persist-credentials: false
 
       - name: Clone cdk-swift
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
-          git clone https://x-access-token:${{ secrets.FFI_DEPLOY_KEY }}@github.com/${{ vars.CDK_SWIFT_REPO }}.git cdk-swift
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" \
+            clone https://github.com/${{ vars.CDK_SWIFT_REPO }}.git cdk-swift
 
       - name: Copy bindings/swift to cdk-swift
         run: |
@@ -122,14 +159,21 @@ jobs:
 
       - name: Push to cdk-swift release branch
         working-directory: cdk-swift
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "${RELEASE_BRANCH}"
           git add -A
           git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "sync: update sources for ${TAG}"
-          git push origin "${RELEASE_BRANCH}"
+          git -c "http.extraheader=$(auth_header)" push origin "${RELEASE_BRANCH}"
 
   swift-build-native:
     name: "swift: Build ${{ matrix.target }}"
@@ -156,9 +200,17 @@ jobs:
             unset_macos_env: false
     steps:
       - name: Clone cdk-swift
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
-          git clone --branch "${RELEASE_BRANCH}" \
-            https://x-access-token:${{ secrets.FFI_DEPLOY_KEY }}@github.com/${{ vars.CDK_SWIFT_REPO }}.git cdk-swift
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" \
+            clone --branch "${RELEASE_BRANCH}" \
+            https://github.com/${{ vars.CDK_SWIFT_REPO }}.git cdk-swift
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -205,9 +257,17 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Clone cdk-swift
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
-          git clone --branch "${RELEASE_BRANCH}" \
-            https://x-access-token:${{ secrets.FFI_DEPLOY_KEY }}@github.com/${{ vars.CDK_SWIFT_REPO }}.git cdk-swift
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" \
+            clone --branch "${RELEASE_BRANCH}" \
+            https://github.com/${{ vars.CDK_SWIFT_REPO }}.git cdk-swift
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -341,9 +401,17 @@ jobs:
     needs: [swift-assemble-xcframework]
     steps:
       - name: Clone cdk-swift
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
-          git clone --branch "${RELEASE_BRANCH}" \
-            https://x-access-token:${{ secrets.FFI_DEPLOY_KEY }}@github.com/${{ vars.CDK_SWIFT_REPO }}.git cdk-swift
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" \
+            clone --branch "${RELEASE_BRANCH}" \
+            https://github.com/${{ vars.CDK_SWIFT_REPO }}.git cdk-swift
 
       - name: Download XCFramework
         uses: actions/download-artifact@v4
@@ -401,7 +469,15 @@ jobs:
 
       - name: Push release branch
         working-directory: cdk-swift
-        run: git push origin "${RELEASE_BRANCH}"
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
+        run: |
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" push origin "${RELEASE_BRANCH}"
 
       - name: Create release on cdk-swift (creates tag and uploads asset atomically)
         working-directory: cdk-swift
@@ -418,14 +494,29 @@ jobs:
 
       - name: Merge to default branch
         working-directory: cdk-swift
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
         run: |
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
           DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
           echo "DEFAULT_BRANCH=${DEFAULT_BRANCH}" >> "$GITHUB_ENV"
           git checkout "${DEFAULT_BRANCH}"
           git merge "${RELEASE_BRANCH}" --squash
           git commit -m "release: ${TAG}"
-          git push origin "${DEFAULT_BRANCH}"
+          git -c "http.extraheader=$(auth_header)" push origin "${DEFAULT_BRANCH}"
 
       - name: Clean up release branch
         working-directory: cdk-swift
-        run: git push origin --delete "${RELEASE_BRANCH}"
+        env:
+          FFI_DEPLOY_KEY: ${{ secrets.FFI_DEPLOY_KEY }}
+        run: |
+          auth_header() {
+            printf 'AUTHORIZATION: basic '
+            printf 'x-access-token:%s' "${FFI_DEPLOY_KEY}" | base64 | tr -d '\n'
+          }
+
+          git -c "http.extraheader=$(auth_header)" push origin --delete "${RELEASE_BRANCH}"

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -134,6 +134,8 @@ just ffi-release-go 0.17.0
 ### Prerequisites
 
 - The version tag (e.g. `v0.17.0`) must exist on the remote
+- Dart, Kotlin, and Swift release workflows check out `refs/tags/<release_tag>`
+  and reject `cdk_ref` values that differ from `release_tag`
 - The `FFI_DEPLOY_KEY` GitHub secret must have write access to `cdk-dart`,
   `cdk-kotlin`, and `cdk-swift` repos
 - Kotlin publishing requires the `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`,


### PR DESCRIPTION
Reject FFI release refs that differ from the release tag. Use temporary git auth headers instead of token-bearing remotes. Disable persisted checkout credentials in release source checkouts.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
