### PR TITLE
fix: set root project group for nexus-publish staging profile lookup

### DIFF
--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
+group = property("GROUP") as String
+
 nexusPublishing {
     repositories {
         sonatype {

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 group = property("GROUP") as String
+version = property("VERSION_NAME") as String
 
 nexusPublishing {
     repositories {


### PR DESCRIPTION

### Description

The nexus-publish-plugin derives the Sonatype staging profile from project.group on the root project. Without it, the package group was empty and initializeSonatypeStagingRepository failed.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
