### PR TITLE
feat: flag pre-releases in FFI binding publish workflows

### DIFF
--- a/.github/workflows/dart-publish.yml
+++ b/.github/workflows/dart-publish.yml
@@ -15,6 +15,10 @@ on:
       cdk_ref:
         description: 'CDK git ref to publish from. Must match release_tag.'
         required: false
+      prerelease:
+        description: 'Mark the GitHub release as a pre-release'
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       release_tag:
@@ -26,6 +30,10 @@ on:
       cdk_ref:
         type: string
         required: false
+      prerelease:
+        type: boolean
+        required: false
+        default: false
 env:
   CARGO_TERM_COLOR: ${{ vars.CARGO_TERM_COLOR }}
   TAG: ${{ inputs.release_tag }}
@@ -394,6 +402,7 @@ jobs:
             --target "${COMMIT_SHA}" \
             --title "Release ${TAG}" \
             --generate-notes \
+            ${{ inputs.prerelease && '--prerelease' || '' }} \
             release-archives/*
 
       - name: Merge to default branch

--- a/.github/workflows/ffi-publish-all.yml
+++ b/.github/workflows/ffi-publish-all.yml
@@ -17,38 +17,63 @@ on:
         required: false
 
 jobs:
+  detect-prerelease:
+    name: "Detect pre-release"
+    runs-on: ubuntu-latest
+    outputs:
+      prerelease: ${{ steps.check.outputs.prerelease }}
+    steps:
+      - name: Check semver pre-release
+        id: check
+        run: |
+          TAG="${{ inputs.release_tag }}"
+          if [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Pre-release detected: ${TAG}"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
   dart:
     name: "Trigger Dart bindings"
+    needs: detect-prerelease
     uses: ./.github/workflows/dart-publish.yml
     with:
       release_tag: ${{ inputs.release_tag }}
       cdk_version: ${{ inputs.cdk_version }}
       cdk_ref: ${{ inputs.cdk_ref }}
+      prerelease: ${{ needs.detect-prerelease.outputs.prerelease == 'true' }}
     secrets: inherit
 
   kotlin:
     name: "Trigger Kotlin bindings"
+    needs: detect-prerelease
     uses: ./.github/workflows/kotlin-publish.yml
     with:
       release_tag: ${{ inputs.release_tag }}
       cdk_version: ${{ inputs.cdk_version }}
       cdk_ref: ${{ inputs.cdk_ref }}
+      prerelease: ${{ needs.detect-prerelease.outputs.prerelease == 'true' }}
     secrets: inherit
 
   swift:
     name: "Trigger Swift bindings"
+    needs: detect-prerelease
     uses: ./.github/workflows/swift-publish.yml
     with:
       release_tag: ${{ inputs.release_tag }}
       cdk_version: ${{ inputs.cdk_version }}
       cdk_ref: ${{ inputs.cdk_ref }}
+      prerelease: ${{ needs.detect-prerelease.outputs.prerelease == 'true' }}
     secrets: inherit
 
   go:
     name: "Trigger Go bindings"
+    needs: detect-prerelease
     uses: ./.github/workflows/go-publish.yml
     with:
       release_tag: ${{ inputs.release_tag }}
       cdk_version: ${{ inputs.cdk_version }}
       cdk_ref: ${{ inputs.cdk_ref }}
+      prerelease: ${{ needs.detect-prerelease.outputs.prerelease == 'true' }}
     secrets: inherit

--- a/.github/workflows/go-publish.yml
+++ b/.github/workflows/go-publish.yml
@@ -12,6 +12,10 @@ on:
       cdk_ref:
         description: "CDK git ref to publish from. Defaults to release_tag."
         required: false
+      prerelease:
+        description: 'Mark the GitHub release as a pre-release'
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       release_tag:
@@ -23,6 +27,10 @@ on:
       cdk_ref:
         type: string
         required: false
+      prerelease:
+        type: boolean
+        required: false
+        default: false
 env:
   CARGO_TERM_COLOR: ${{ vars.CARGO_TERM_COLOR }}
   TAG: ${{ inputs.release_tag }}
@@ -399,6 +407,7 @@ jobs:
             --target "${COMMIT_SHA}" \
             --title "Release ${TAG}" \
             --generate-notes \
+            ${{ inputs.prerelease && '--prerelease' || '' }} \
             "../cdk-go-bindings-${TAG}.tar.gz"
 
       - name: Merge to default branch

--- a/.github/workflows/kotlin-publish.yml
+++ b/.github/workflows/kotlin-publish.yml
@@ -15,6 +15,10 @@ on:
       cdk_ref:
         description: 'CDK git ref to publish from. Must match release_tag.'
         required: false
+      prerelease:
+        description: 'Mark the GitHub release as a pre-release'
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       release_tag:
@@ -26,6 +30,10 @@ on:
       cdk_ref:
         type: string
         required: false
+      prerelease:
+        type: boolean
+        required: false
+        default: false
 env:
   CARGO_TERM_COLOR: ${{ vars.CARGO_TERM_COLOR }}
   TAG: ${{ inputs.release_tag }}
@@ -468,7 +476,8 @@ jobs:
             --repo ${{ vars.CDK_KOTLIN_REPO }} \
             --target "${COMMIT_SHA}" \
             --title "Release ${TAG}" \
-            --generate-notes
+            --generate-notes \
+            ${{ inputs.prerelease && '--prerelease' || '' }}
 
       - name: Merge to default branch
         working-directory: cdk-kotlin

--- a/.github/workflows/swift-publish.yml
+++ b/.github/workflows/swift-publish.yml
@@ -15,6 +15,10 @@ on:
       cdk_ref:
         description: 'CDK git ref to publish from. Must match release_tag.'
         required: false
+      prerelease:
+        description: 'Mark the GitHub release as a pre-release'
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       release_tag:
@@ -26,6 +30,10 @@ on:
       cdk_ref:
         type: string
         required: false
+      prerelease:
+        type: boolean
+        required: false
+        default: false
 env:
   CARGO_TERM_COLOR: ${{ vars.CARGO_TERM_COLOR }}
   TAG: ${{ inputs.release_tag }}
@@ -490,6 +498,7 @@ jobs:
             --target "${COMMIT_SHA}" \
             --title "Release ${TAG}" \
             --generate-notes \
+            ${{ inputs.prerelease && '--prerelease' || '' }} \
             ../artifacts/CashuDevKitFFI.xcframework.zip
 
       - name: Merge to default branch


### PR DESCRIPTION
### Description

Auto-detect semver pre-release tags (e.g. v0.17.0-rc.3) in ffi-publish-all and pass --prerelease to gh release create.  Individual workflows also accept a manual prerelease toggle.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
