### PR TITLE
Add tos_url to gRPC GetInfoResponse and UpdateTosUrl RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,8 +1623,11 @@ name = "cdk-mint-rpc"
 version = "0.17.0-rc.3"
 dependencies = [
  "anyhow",
+ "bip39",
  "cdk",
  "cdk-common",
+ "cdk-fake-wallet",
+ "cdk-sqlite",
  "clap",
  "home",
  "prost 0.14.3",

--- a/crates/cdk-mint-rpc/Cargo.toml
+++ b/crates/cdk-mint-rpc/Cargo.toml
@@ -38,6 +38,11 @@ home.workspace = true
 rustls.workspace = true
 
 
+[dev-dependencies]
+cdk-sqlite = { workspace = true }
+cdk-fake-wallet = { workspace = true }
+bip39.workspace = true
+
 [build-dependencies]
 tonic-prost-build.workspace = true
 

--- a/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
+++ b/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
@@ -82,6 +82,8 @@ enum Commands {
     UpdateName(subcommands::UpdateNameCommand),
     /// Update icon url
     UpdateIconUrl(subcommands::UpdateIconUrlCommand),
+    /// Update terms of service URL
+    UpdateTosUrl(subcommands::UpdateTosUrlCommand),
     /// Add Url
     AddUrl(subcommands::AddUrlCommand),
     /// Remove Url
@@ -178,6 +180,7 @@ async fn main() -> Result<()> {
             );
             println!("motd: {}", info.motd.unwrap_or("None".to_string()));
             println!("icon_url: {}", info.icon_url.unwrap_or("None".to_string()));
+            println!("tos_url: {}", info.tos_url.unwrap_or("None".to_string()));
 
             for url in info.urls {
                 println!("mint_url: {url}");
@@ -203,6 +206,9 @@ async fn main() -> Result<()> {
         }
         Commands::UpdateIconUrl(sub_command_args) => {
             subcommands::update_icon_url(&mut client, &sub_command_args).await?;
+        }
+        Commands::UpdateTosUrl(sub_command_args) => {
+            subcommands::update_tos_url(&mut client, &sub_command_args).await?;
         }
         Commands::AddUrl(sub_command_args) => {
             subcommands::add_url(&mut client, &sub_command_args).await?;

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
@@ -20,6 +20,8 @@ mod update_nut04_quote;
 mod update_nut05;
 /// Module for updating the mint's short description
 mod update_short_description;
+/// Module for updating the mint's terms of service URL
+mod update_tos_url;
 /// Module for updating quote time-to-live settings
 mod update_ttl;
 /// Module for managing mint URLs
@@ -35,5 +37,6 @@ pub use update_nut04::{update_nut04, UpdateNut04Command};
 pub use update_nut04_quote::{update_nut04_quote_state, UpdateNut04QuoteCommand};
 pub use update_nut05::{update_nut05, UpdateNut05Command};
 pub use update_short_description::{update_short_description, UpdateShortDescriptionCommand};
+pub use update_tos_url::{update_tos_url, UpdateTosUrlCommand};
 pub use update_ttl::{get_quote_ttl, update_quote_ttl, UpdateQuoteTtlCommand};
 pub use update_urls::{add_url, remove_url, AddUrlCommand, RemoveUrlCommand};

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_tos_url.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_tos_url.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::Request;
+
+use crate::{InterceptedCdkMintClient, UpdateTosUrlRequest};
+
+/// Command to update the mint's terms of service URL
+#[derive(Args, Debug)]
+pub struct UpdateTosUrlCommand {
+    /// The URL to the mint's terms of service
+    url: String,
+}
+
+/// Executes the update_tos_url command against the mint server
+pub async fn update_tos_url(
+    client: &mut InterceptedCdkMintClient,
+    sub_command_args: &UpdateTosUrlCommand,
+) -> Result<()> {
+    let _response = client
+        .update_tos_url(Request::new(UpdateTosUrlRequest {
+            tos_url: sub_command_args.url.clone(),
+        }))
+        .await?;
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/proto/cdk-mint-rpc.proto
+++ b/crates/cdk-mint-rpc/src/proto/cdk-mint-rpc.proto
@@ -8,6 +8,7 @@ service CdkMint {
     rpc UpdateShortDescription(UpdateDescriptionRequest) returns (UpdateResponse) {}
     rpc UpdateLongDescription(UpdateDescriptionRequest) returns (UpdateResponse) {}
     rpc UpdateIconUrl(UpdateIconUrlRequest) returns (UpdateResponse) {}
+    rpc UpdateTosUrl(UpdateTosUrlRequest) returns (UpdateResponse) {}
     rpc UpdateName(UpdateNameRequest) returns (UpdateResponse) {}
     rpc AddUrl(UpdateUrlRequest) returns (UpdateResponse) {}
     rpc RemoveUrl(UpdateUrlRequest) returns (UpdateResponse) {}
@@ -40,6 +41,7 @@ message GetInfoResponse {
     repeated string urls = 8;
     uint64 total_issued = 9;
     uint64 total_redeemed = 10;
+    optional string tos_url = 11;
 }
 
 message UpdateResponse{
@@ -56,6 +58,10 @@ message UpdateDescriptionRequest {
 
 message UpdateIconUrlRequest {
     string icon_url = 1;
+}
+
+message UpdateTosUrlRequest {
+    string tos_url = 1;
 }
 
 message UpdateNameRequest {

--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -24,7 +24,7 @@ use crate::{
     RotateNextKeysetRequest, RotateNextKeysetResponse, UpdateContactRequest,
     UpdateDescriptionRequest, UpdateIconUrlRequest, UpdateMotdRequest, UpdateNameRequest,
     UpdateNut04QuoteRequest, UpdateNut04Request, UpdateNut05Request, UpdateQuoteTtlRequest,
-    UpdateResponse, UpdateUrlRequest,
+    UpdateResponse, UpdateTosUrlRequest, UpdateUrlRequest,
 };
 
 /// Error
@@ -244,6 +244,7 @@ impl CdkMint for MintRPCServer {
             contact,
             motd: info.motd,
             icon_url: info.icon_url,
+            tos_url: info.tos_url,
             urls: info.urls.unwrap_or_default(),
             total_issued: total_issued.into(),
             total_redeemed: total_redeemed.into(),
@@ -350,6 +351,28 @@ impl CdkMint for MintRPCServer {
             .map_err(|err| Status::internal(err.to_string()))?;
 
         info.icon_url = Some(icon_url);
+
+        self.mint
+            .set_mint_info(info)
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
+        Ok(Response::new(UpdateResponse {}))
+    }
+
+    /// Updates the mint's terms of service URL
+    async fn update_tos_url(
+        &self,
+        request: Request<UpdateTosUrlRequest>,
+    ) -> Result<Response<UpdateResponse>, Status> {
+        let tos_url = request.into_inner().tos_url;
+
+        let mut info = self
+            .mint
+            .mint_info()
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
+
+        info.tos_url = Some(tos_url);
 
         self.mint
             .set_mint_info(info)
@@ -788,5 +811,125 @@ impl CdkMint for MintRPCServer {
             amounts: keyset_info.amounts,
             input_fee_ppk: keyset_info.input_fee_ppk,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::sync::Arc;
+
+    use bip39::Mnemonic;
+    use cdk::mint::{MintBuilder, MintMeltLimits};
+    use cdk::nuts::{CurrencyUnit, PaymentMethod};
+    use cdk::types::QuoteTTL;
+    use cdk_common::nut00::KnownMethod;
+    use cdk_fake_wallet::FakeWallet;
+    use tonic::Request;
+
+    use super::*;
+    use crate::cdk_mint_server::CdkMint;
+    use crate::{GetInfoRequest, UpdateTosUrlRequest};
+
+    async fn create_test_rpc_server() -> MintRPCServer {
+        let db = Arc::new(cdk_sqlite::mint::memory::empty().await.unwrap());
+
+        let mut mint_builder = MintBuilder::new(db.clone());
+
+        let fee_reserve = cdk::types::FeeReserve {
+            min_fee_reserve: 1.into(),
+            percent_fee_reserve: 1.0,
+        };
+
+        let ln_fake = FakeWallet::new(
+            fee_reserve,
+            HashMap::default(),
+            HashSet::default(),
+            2,
+            CurrencyUnit::Sat,
+        );
+
+        mint_builder
+            .add_payment_processor(
+                CurrencyUnit::Sat,
+                PaymentMethod::Known(KnownMethod::Bolt11),
+                MintMeltLimits::new(1, 10_000),
+                Arc::new(ln_fake),
+            )
+            .await
+            .unwrap();
+
+        let mnemonic = Mnemonic::generate(12).unwrap();
+
+        mint_builder = mint_builder
+            .with_name("test mint".to_string())
+            .with_description("test mint".to_string());
+
+        let mint = mint_builder
+            .build_with_seed(db.clone(), &mnemonic.to_seed_normalized(""))
+            .await
+            .unwrap();
+
+        mint.set_quote_ttl(QuoteTTL::new(10000, 10000))
+            .await
+            .unwrap();
+
+        mint.start().await.unwrap();
+
+        MintRPCServer {
+            socket_addr: "127.0.0.1:0".parse().unwrap(),
+            mint: Arc::new(mint),
+            shutdown: Arc::new(Notify::new()),
+            handle: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_info_tos_url_none_when_not_set() {
+        let server = create_test_rpc_server().await;
+
+        let response = server
+            .get_info(Request::new(GetInfoRequest {}))
+            .await
+            .unwrap();
+
+        assert!(response.into_inner().tos_url.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_info_includes_tos_url() {
+        let server = create_test_rpc_server().await;
+        let tos = "https://example.com/tos";
+
+        let mut info = server.mint.mint_info().await.unwrap();
+        info.tos_url = Some(tos.to_string());
+        server.mint.set_mint_info(info).await.unwrap();
+
+        let response = server
+            .get_info(Request::new(GetInfoRequest {}))
+            .await
+            .unwrap();
+
+        assert_eq!(response.into_inner().tos_url.unwrap(), tos);
+    }
+
+    #[tokio::test]
+    async fn test_update_tos_url() {
+        let server = create_test_rpc_server().await;
+        let tos = "https://example.com/terms";
+
+        server
+            .update_tos_url(Request::new(UpdateTosUrlRequest {
+                tos_url: tos.to_string(),
+            }))
+            .await
+            .unwrap();
+
+        let response = server
+            .get_info(Request::new(GetInfoRequest {}))
+            .await
+            .unwrap();
+
+        assert_eq!(response.into_inner().tos_url.unwrap(), tos);
     }
 }


### PR DESCRIPTION
### Description

Fixes https://github.com/cashubtc/cdk/issues/1093

Add tos_url to gRPC GetInfoResponse and UpdateTosUrl RPC


-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
