### PR TITLE
fix(wallet): honor TTL in auth metadata cache

### DIFF
--- a/crates/cdk/src/wallet/auth/auth_wallet.rs
+++ b/crates/cdk/src/wallet/auth/auth_wallet.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use cdk_common::database::{self, WalletDatabase};
 use cdk_common::mint_url::MintUrl;
+use cdk_common::parking_lot::RwLock as ParkingRwLock;
 use cdk_common::wallet::ProofInfo;
 use cdk_common::{AuthProof, Id, Keys, MintInfo};
 use serde::{Deserialize, Serialize};
@@ -42,6 +44,10 @@ pub struct AuthWallet {
     pub localstore: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
     /// Mint metadata cache (lock-free cached access to keys, keysets, and mint info)
     pub metadata_cache: Arc<MintMetadataCache>,
+    /// TTL controlling how long cached auth metadata is considered fresh.
+    /// Shared with the parent [`Wallet`](crate::Wallet) so both honor the same
+    /// configured value.
+    metadata_cache_ttl: Arc<ParkingRwLock<Option<Duration>>>,
     /// Protected methods
     pub protected_endpoints: Arc<RwLock<HashMap<ProtectedEndpoint, AuthRequired>>>,
     /// Refresh token for auth
@@ -53,11 +59,13 @@ pub struct AuthWallet {
 
 impl AuthWallet {
     /// Create a new [`AuthWallet`] instance
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         mint_url: MintUrl,
         cat: Option<AuthToken>,
         localstore: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
         metadata_cache: Arc<MintMetadataCache>,
+        metadata_cache_ttl: Arc<ParkingRwLock<Option<Duration>>>,
         protected_endpoints: HashMap<ProtectedEndpoint, AuthRequired>,
         oidc_client: Option<OidcClient>,
     ) -> Self {
@@ -66,6 +74,7 @@ impl AuthWallet {
             mint_url,
             localstore,
             metadata_cache,
+            metadata_cache_ttl,
             protected_endpoints: Arc::new(RwLock::new(protected_endpoints)),
             refresh_token: Arc::new(RwLock::new(None)),
             auth_client: http_client,
@@ -183,7 +192,10 @@ impl AuthWallet {
     pub async fn load_keyset_keys(&self, keyset_id: Id) -> Result<Keys, Error> {
         let metadata = self
             .metadata_cache
-            .load_auth(&self.localstore, &self.auth_client)
+            .load_auth(&self.localstore, &self.auth_client, {
+                let ttl = self.metadata_cache_ttl.read();
+                *ttl
+            })
             .await?;
 
         match metadata.keysets.get(&keyset_id) {
@@ -208,7 +220,10 @@ impl AuthWallet {
     pub async fn load_mint_keysets(&self) -> Result<Vec<KeySetInfo>, Error> {
         let metadata = self
             .metadata_cache
-            .load_auth(&self.localstore, &self.auth_client)
+            .load_auth(&self.localstore, &self.auth_client, {
+                let ttl = self.metadata_cache_ttl.read();
+                *ttl
+            })
             .await?;
 
         let auth_keysets = metadata
@@ -520,12 +535,14 @@ mod tests {
                 .expect("in-memory wallet database should initialize"),
         );
         let metadata_cache = Arc::new(MintMetadataCache::new(mint_url.clone()));
+        let metadata_cache_ttl = Arc::new(ParkingRwLock::new(Some(Duration::from_secs(3600))));
 
         AuthWallet::new(
             mint_url,
             None,
             localstore,
             metadata_cache,
+            metadata_cache_ttl,
             protected_endpoints,
             None,
         )

--- a/crates/cdk/src/wallet/builder.rs
+++ b/crates/cdk/src/wallet/builder.rs
@@ -25,7 +25,7 @@ pub struct WalletBuilder {
     seed: Option<[u8; 64]>,
     use_http_subscription: bool,
     client: Option<Arc<dyn MintConnector + Send + Sync>>,
-    metadata_cache_ttl: Option<Duration>,
+    metadata_cache_ttl: Arc<RwLock<Option<Duration>>>,
     metadata_cache: Option<Arc<MintMetadataCache>>,
     metadata_caches: HashMap<MintUrl, Arc<MintMetadataCache>>,
 }
@@ -50,7 +50,7 @@ impl Default for WalletBuilder {
             auth_wallet: None,
             seed: None,
             client: None,
-            metadata_cache_ttl: Some(Duration::from_secs(3600)),
+            metadata_cache_ttl: Arc::new(RwLock::new(Some(Duration::from_secs(3600)))),
             use_http_subscription: false,
             metadata_cache: None,
             metadata_caches: HashMap::new(),
@@ -84,8 +84,10 @@ impl WalletBuilder {
     /// (unless manually refreshed).
     ///
     /// The default value is 1 hour (3600 seconds).
-    pub fn set_metadata_cache_ttl(mut self, metadata_cache_ttl: Option<Duration>) -> Self {
-        self.metadata_cache_ttl = metadata_cache_ttl;
+    pub fn set_metadata_cache_ttl(self, metadata_cache_ttl: Option<Duration>) -> Self {
+        // Write into the shared cell rather than replacing it, so any AuthWallet
+        // already created from this builder observes the updated value.
+        *self.metadata_cache_ttl.write() = metadata_cache_ttl;
         self
     }
 
@@ -200,6 +202,7 @@ impl WalletBuilder {
             Some(AuthToken::ClearAuth(cat)),
             localstore,
             metadata_cache,
+            self.metadata_cache_ttl.clone(),
             HashMap::new(),
             None,
         ));
@@ -248,7 +251,7 @@ impl WalletBuilder {
             unit,
             localstore,
             metadata_cache,
-            metadata_cache_ttl: Arc::new(RwLock::new(metadata_cache_ttl)),
+            metadata_cache_ttl,
             target_proof_count: self.target_proof_count.unwrap_or(3),
             auth_wallet: Arc::new(TokioRwLock::new(auth_wallet)),
             #[cfg(feature = "npubcash")]
@@ -267,6 +270,9 @@ mod tests {
     #[test]
     fn test_default_ttl() {
         let builder = WalletBuilder::default();
-        assert_eq!(builder.metadata_cache_ttl, Some(Duration::from_secs(3600)));
+        assert_eq!(
+            *builder.metadata_cache_ttl.read(),
+            Some(Duration::from_secs(3600))
+        );
     }
 }

--- a/crates/cdk/src/wallet/mint_metadata_cache.rs
+++ b/crates/cdk/src/wallet/mint_metadata_cache.rs
@@ -407,13 +407,16 @@ impl MintMetadataCache {
 
     /// Load auth keysets and keys (auth feature only)
     ///
-    /// Fetches blind authentication keysets from the mint. Always performs
-    /// an HTTP fetch to get current auth keysets.
+    /// Returns cached blind authentication keysets if they are populated and
+    /// still fresh according to `ttl`; otherwise fetches them from the mint over
+    /// HTTP and updates the cache.
     ///
     /// # Arguments
     ///
     /// * `storage` - Database to persist metadata to
     /// * `auth_client` - Auth-capable HTTP client for fetching blind auth keysets
+    /// * `ttl` - Optional TTL; if not provided, any populated cached data is
+    ///   considered fresh and no HTTP fetch is performed
     ///
     /// # Returns
     ///
@@ -422,6 +425,7 @@ impl MintMetadataCache {
         &self,
         storage: &Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
         auth_client: &Arc<dyn AuthMintConnector + Send + Sync>,
+        ttl: Option<Duration>,
     ) -> Result<Arc<MintMetadata>, Error> {
         let cached_metadata = self.metadata.load().clone();
         let storage_id = Self::arc_pointer_id(storage);
@@ -433,9 +437,11 @@ impl MintMetadataCache {
             .cloned()
             .unwrap_or_default();
 
-        // Check if auth data is populated in cache
+        // Check if auth data is populated in cache and still fresh
         if cached_metadata.auth_status.is_populated
-            && cached_metadata.auth_status.updated_at > Instant::now()
+            && ttl
+                .map(|ttl| cached_metadata.auth_status.updated_at + ttl > Instant::now())
+                .unwrap_or(true)
         {
             if db_synced_version != cached_metadata.status.version {
                 // Database needs updating - sync before returning
@@ -451,7 +457,9 @@ impl MintMetadataCache {
         // Re-check if auth data was updated while waiting for lock
         let current_metadata = self.metadata.load().clone();
         if current_metadata.auth_status.is_populated
-            && current_metadata.auth_status.updated_at > Instant::now()
+            && ttl
+                .map(|ttl| current_metadata.auth_status.updated_at + ttl > Instant::now())
+                .unwrap_or(true)
         {
             tracing::debug!(
                 "Auth cache was updated while waiting for fetch lock, returning cached data"

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -437,6 +437,7 @@ impl Wallet {
                         None,
                         self.localstore.clone(),
                         self.metadata_cache.clone(),
+                        self.metadata_cache_ttl.clone(),
                         mint_info.protected_endpoints(),
                         oidc_client,
                     );


### PR DESCRIPTION
load_auth compared auth_status.updated_at > Instant::now(), but updated_at is stamped at write time and is therefore always in the past. The comparison was always false, so the cache-hit branch was dead and every load_auth re-fetched auth keysets from the mint over HTTP, ignoring the configured cache TTL.

Mirror the non-auth load() path: pass an Option<Duration> TTL into load_auth and treat cached data as fresh while updated_at + ttl is in the future. Thread the wallet's metadata_cache_ttl into AuthWallet so both paths share one configurable TTL via set_metadata_cache_ttl.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
