### PR TITLE
fix: remove placeholders from ffi keys

### DIFF
--- a/crates/cdk-ffi/src/types/keys.rs
+++ b/crates/cdk-ffi/src/types/keys.rs
@@ -108,24 +108,16 @@ impl TryFrom<PublicKey> for cdk::nuts::PublicKey {
     }
 }
 
-/// FFI-compatible Keys (simplified - contains only essential info)
+/// FFI-compatible Keys
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
 pub struct Keys {
-    /// Keyset ID
-    pub id: String,
-    /// Currency unit
-    pub unit: CurrencyUnit,
-    /// Map of amount to public key hex (simplified from BTreeMap)
+    /// Map of amount to public key hex
     pub keys: HashMap<u64, String>,
 }
 
 impl From<cdk::nuts::Keys> for Keys {
     fn from(keys: cdk::nuts::Keys) -> Self {
-        // Keys doesn't have id and unit - we'll need to get these from context
-        // For now, use placeholder values
         Self {
-            id: "unknown".to_string(), // This should come from KeySet
-            unit: CurrencyUnit::Sat,   // This should come from KeySet
             keys: keys
                 .keys()
                 .iter()


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
