### PR TITLE
fix: soft-error the mint time-tolerance check

### DIFF
--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -400,13 +400,14 @@ impl Wallet {
         // If mint provides time make sure it is accurate
         if let Some(mint_unix_time) = mint_info.time {
             let current_unix_time = crate::util::unix_time();
-            if current_unix_time.abs_diff(mint_unix_time) > 30 {
+            let mint_time_delta = current_unix_time.abs_diff(mint_unix_time);
+            if mint_time_delta > 30 {
                 tracing::warn!(
-                    "Mint time does match wallet time. Mint: {}, Wallet: {}",
+                    "Mint time does not match wallet time. Mint: {}, Wallet: {}, Delta: {} seconds",
                     mint_unix_time,
-                    current_unix_time
+                    current_unix_time,
+                    mint_time_delta
                 );
-                return Err(Error::MintTimeExceedsTolerance);
             }
         }
 


### PR DESCRIPTION
### Description

Soft-errors the mint time-tolerance check in the wallet so a mint whose timestamp is slightly outside the tolerance window no longer hard-fails the operation; it logs and continues instead, per the maintainer's prescribed approach in #1194. Fixes #1194.

-----

### Notes to the reviewers

The change is scoped to the non-consensus time-tolerance check at `crates/cdk/src/wallet/mod.rs`; token/proof validation logic is untouched.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

None.

#### ADDED

None.

#### REMOVED

None.

#### FIXED

- Mint time-tolerance check is now a soft error (log and continue) instead of a hard failure.

----

### Checklist

* [x] I followed the code style guidelines
* [x] The change compiles for the cdk wallet feature set
* [x] The Wallet API signature was not modified, so no FFI binding changes are needed
