### PR TITLE
feat: add check to wallet that signature is for correct amount

### DIFF
--- a/crates/cdk/src/wallet/blind_signature.rs
+++ b/crates/cdk/src/wallet/blind_signature.rs
@@ -1,0 +1,74 @@
+use crate::nuts::{nut12, BlindSignature, BlindedMessage};
+use crate::wallet::Wallet;
+use crate::{Amount, Error};
+
+/// How strictly returned signature amounts must match requested output amounts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SignatureAmountValidation {
+    /// Returned signature amounts must exactly match the requested output amounts.
+    Exact,
+    /// A zero-amount requested output is a placeholder and may receive any amount.
+    AllowZeroAmountPlaceholder,
+}
+
+/// Validate mint-returned blind signatures against the wallet's requested outputs.
+///
+/// The mint controls the `amount` and `keyset_id` fields in each returned
+/// [`BlindSignature`], so callers must verify those fields against the
+/// corresponding premint blinded message before constructing wallet proofs.
+///
+/// Use [`SignatureAmountValidation::Exact`] for mint/swap responses where the
+/// wallet requested a specific denomination. Use
+/// [`SignatureAmountValidation::AllowZeroAmountPlaceholder`] for NUT-08/NUT-09
+/// style outputs where the wallet sends amount `0` and the mint fills in the
+/// actual change or restored amount. DLEQ proofs are optional for compatibility,
+/// but when present they are verified after the signature metadata has been
+/// cross-checked.
+pub(crate) async fn validate_mint_response_signatures<'a>(
+    wallet: &Wallet,
+    signatures: &[BlindSignature],
+    blinded_messages: impl IntoIterator<Item = &'a BlindedMessage>,
+    amount_validation: SignatureAmountValidation,
+) -> Result<(), Error> {
+    let blinded_messages = blinded_messages.into_iter().collect::<Vec<_>>();
+
+    if signatures.len() != blinded_messages.len() {
+        return Err(Error::InvalidMintResponse(format!(
+            "mint signatures ({}) does not match secrets sent ({})",
+            signatures.len(),
+            blinded_messages.len()
+        )));
+    }
+
+    for (sig, blinded_message) in signatures.iter().zip(blinded_messages) {
+        let amount_matches = match amount_validation {
+            SignatureAmountValidation::Exact => sig.amount == blinded_message.amount,
+            SignatureAmountValidation::AllowZeroAmountPlaceholder => {
+                blinded_message.amount == Amount::ZERO || sig.amount == blinded_message.amount
+            }
+        };
+
+        if !amount_matches {
+            return Err(Error::InvalidMintResponse(format!(
+                "mint signature amount ({}) does not match requested amount ({})",
+                sig.amount, blinded_message.amount
+            )));
+        }
+
+        if sig.keyset_id != blinded_message.keyset_id {
+            return Err(Error::InvalidMintResponse(format!(
+                "mint signature keyset ({}) does not match requested keyset ({})",
+                sig.keyset_id, blinded_message.keyset_id
+            )));
+        }
+
+        let keys = wallet.load_keyset_keys(sig.keyset_id).await?;
+        let key = keys.amount_key(sig.amount).ok_or(Error::AmountKey)?;
+        match sig.verify_dleq(key, blinded_message.blinded_secret) {
+            Ok(_) | Err(nut12::Error::MissingDleqProof) => (),
+            Err(_) => return Err(Error::CouldNotVerifyDleq),
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cdk/src/wallet/issue/saga/mod.rs
+++ b/crates/cdk/src/wallet/issue/saga/mod.rs
@@ -47,8 +47,11 @@ use self::state::{Finalized, Initial, Prepared, PreparedMintRequest};
 use crate::amount::SplitTarget;
 use crate::dhke::construct_proofs;
 use crate::nuts::nut00::ProofsMethods;
-use crate::nuts::{nut12, MintRequest, PreMintSecrets, Proofs, SpendingConditions, State};
+use crate::nuts::{MintRequest, PreMintSecrets, Proofs, SpendingConditions, State};
 use crate::util::unix_time;
+use crate::wallet::blind_signature::{
+    validate_mint_response_signatures, SignatureAmountValidation,
+};
 use crate::wallet::saga::{
     add_compensation, clear_compensations, execute_compensations, new_compensations, Compensations,
 };
@@ -693,14 +696,13 @@ impl<'a> MintSaga<'a, Prepared> {
 
             let keys = wallet.load_keyset_keys(active_keyset_id).await?;
 
-            for (sig, premint) in mint_res.signatures.iter().zip(&premint_secrets.secrets) {
-                let keys = wallet.load_keyset_keys(sig.keyset_id).await?;
-                let key = keys.amount_key(sig.amount).ok_or(Error::AmountKey)?;
-                match sig.verify_dleq(key, premint.blinded_message.blinded_secret) {
-                    Ok(_) | Err(nut12::Error::MissingDleqProof) => (),
-                    Err(_) => return Err(Error::CouldNotVerifyDleq),
-                }
-            }
+            validate_mint_response_signatures(
+                wallet,
+                &mint_res.signatures,
+                premint_secrets.secrets.iter().map(|p| &p.blinded_message),
+                SignatureAmountValidation::Exact,
+            )
+            .await?;
 
             let proofs = construct_proofs(
                 mint_res.signatures,
@@ -834,5 +836,64 @@ impl<S: std::fmt::Debug> std::fmt::Debug for MintSaga<'_, S> {
         f.debug_struct("MintSaga")
             .field("state_data", &self.state_data)
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use cdk_common::nuts::MintQuoteState;
+
+    use super::*;
+    use crate::nuts::{BlindSignature, MintResponse};
+    use crate::wallet::test_utils::{
+        create_test_db, create_test_wallet_with_mock, test_mint_quote, test_mint_url,
+        MockMintConnector,
+    };
+
+    #[tokio::test]
+    async fn test_execute_rejects_signature_with_mismatched_amount() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.reset_default_mint_state();
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client.clone()).await;
+
+        let mut mint_quote = test_mint_quote(mint_url);
+        mint_quote.state = MintQuoteState::Paid;
+        mint_quote.amount = Some(Amount::from(64));
+        mint_quote.amount_paid = Amount::from(64);
+        let quote_id = mint_quote.id.clone();
+        db.add_mint_quote(mint_quote).await.expect("add mint quote");
+
+        let prepared = MintSaga::new(&wallet)
+            .prepare(&quote_id, SplitTarget::Values(vec![Amount::from(64)]), None)
+            .await
+            .expect("prepare mint saga");
+
+        let outputs = match &prepared.state_data.mint_request {
+            PreparedMintRequest::Single { request, .. } => request.outputs.clone(),
+            PreparedMintRequest::Batch { .. } => panic!("expected single mint request"),
+        };
+
+        let bad_signatures = outputs
+            .iter()
+            .map(|blinded_message| BlindSignature {
+                amount: Amount::from(1),
+                keyset_id: blinded_message.keyset_id,
+                c: blinded_message.blinded_secret,
+                dleq: None,
+            })
+            .collect();
+
+        mock_client.set_post_mint_response(Ok(MintResponse {
+            signatures: bad_signatures,
+        }));
+
+        let result = prepared.execute().await;
+
+        assert!(matches!(result, Err(Error::InvalidMintResponse(_))));
     }
 }

--- a/crates/cdk/src/wallet/issue/saga/resume.rs
+++ b/crates/cdk/src/wallet/issue/saga/resume.rs
@@ -22,6 +22,9 @@ use tracing::instrument;
 use crate::dhke::construct_proofs;
 use crate::nuts::{MintRequest, State};
 use crate::util::unix_time;
+use crate::wallet::blind_signature::{
+    validate_mint_response_signatures, SignatureAmountValidation,
+};
 use crate::wallet::issue::saga::compensation::ReleaseMintQuote;
 use crate::wallet::recovery::{RecoveryAction, RecoveryHelpers};
 use crate::wallet::saga::CompensatingAction;
@@ -354,6 +357,14 @@ impl Wallet {
 
             let keys = self.load_keyset_keys(keyset_id).await?;
 
+            validate_mint_response_signatures(
+                self,
+                &mint_response.signatures,
+                blinded_messages.iter(),
+                SignatureAmountValidation::Exact,
+            )
+            .await?;
+
             let proofs = construct_proofs(
                 mint_response.signatures,
                 premint_secrets.rs(),
@@ -458,6 +469,14 @@ impl Wallet {
         )?;
 
         let keys = self.load_keyset_keys(keyset_id).await?;
+
+        validate_mint_response_signatures(
+            self,
+            &mint_response.signatures,
+            blinded_messages.iter(),
+            SignatureAmountValidation::Exact,
+        )
+        .await?;
 
         let proofs = construct_proofs(
             mint_response.signatures,

--- a/crates/cdk/src/wallet/melt/saga/mod.rs
+++ b/crates/cdk/src/wallet/melt/saga/mod.rs
@@ -50,6 +50,9 @@ use super::MeltConfirmOptions;
 use crate::nuts::nut00::{KnownMethod, ProofsMethods};
 use crate::nuts::{MeltRequest, PreMintSecrets, Proofs, State};
 use crate::util::unix_time;
+use crate::wallet::blind_signature::{
+    validate_mint_response_signatures, SignatureAmountValidation,
+};
 use crate::wallet::keysets::KeysetFilter;
 use crate::wallet::saga::{add_compensation, new_compensations, Compensations};
 use crate::{ensure_cdk, Amount, Error, Wallet};
@@ -112,6 +115,16 @@ async fn finalize_melt_common<'a>(
                 }
                 _ => num_change_proof,
             };
+
+            validate_mint_response_signatures(
+                wallet,
+                &change,
+                premint_secrets.secrets[..num_change_proof]
+                    .iter()
+                    .map(|p| &p.blinded_message),
+                SignatureAmountValidation::AllowZeroAmountPlaceholder,
+            )
+            .await?;
 
             Some(construct_proofs(
                 change,
@@ -1583,5 +1596,45 @@ mod tests {
         .await;
 
         assert!(matches!(result, Err(Error::AmountOverflow)));
+    }
+
+    #[tokio::test]
+    async fn test_finalize_melt_accepts_change_amount_for_zero_amount_output() {
+        let db = create_test_db().await;
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.reset_default_mint_state();
+        let wallet = create_test_wallet_with_mock(db, mock_client).await;
+
+        let keyset_id = test_keyset_id();
+        let quote = test_melt_quote();
+        let final_proofs = vec![test_proof_info(keyset_id, 1008, test_mint_url()).proof];
+        let premint_secrets =
+            PreMintSecrets::blank(keyset_id, Amount::from(8)).expect("blank premint secrets");
+        let change = vec![BlindSignature {
+            amount: Amount::from(8),
+            keyset_id,
+            c: premint_secrets.blinded_messages()[0].blinded_secret,
+            dleq: None,
+        }];
+
+        let result = finalize_melt_common(
+            &wallet,
+            new_compensations(),
+            Uuid::new_v4(),
+            &quote,
+            &final_proofs,
+            &premint_secrets,
+            MeltQuoteState::Paid,
+            None,
+            Some(change),
+            HashMap::new(),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap().into_change().expect("change proofs")[0].amount,
+            Amount::from(8)
+        );
     }
 }

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -40,6 +40,7 @@ use crate::Amount;
 
 mod auth;
 pub mod bip321;
+mod blind_signature;
 #[cfg(feature = "nostr")]
 mod nostr_backup;
 #[cfg(all(feature = "tor", not(target_arch = "wasm32")))]

--- a/crates/cdk/src/wallet/recovery.rs
+++ b/crates/cdk/src/wallet/recovery.rs
@@ -14,6 +14,8 @@
 //!   - If successful: The wallet completes the local state update (e.g. marking proofs spent).
 //!   - If failed/unknown: The wallet may rollback or retry depending on the specific state.
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use cdk_common::wallet::{ProofInfo, WalletSagaState};
 use cdk_common::BlindedMessage;
@@ -21,6 +23,9 @@ use tracing::instrument;
 
 use crate::dhke::construct_proofs;
 use crate::nuts::{CheckStateRequest, PreMintSecrets, Proofs, RestoreRequest, State, SwapRequest};
+use crate::wallet::blind_signature::{
+    validate_mint_response_signatures, SignatureAmountValidation,
+};
 use crate::{Error, Wallet};
 
 /// Parameters for recovering outputs using stored blinded messages.
@@ -262,6 +267,14 @@ impl RecoveryHelpers for Wallet {
         // Load keyset keys
         let keys = self.load_keyset_keys(keyset_id).await?;
 
+        validate_mint_response_signatures(
+            self,
+            &swap_response.signatures,
+            blinded_messages.iter(),
+            SignatureAmountValidation::Exact,
+        )
+        .await?;
+
         // Construct proofs
         let proofs = construct_proofs(
             swap_response.signatures,
@@ -441,19 +454,36 @@ impl Wallet {
             params.counter_end,
         )?;
 
-        // Match the returned outputs to our premint secrets by B_ value
-        let matched_secrets: Vec<_> = premint_secrets
+        let premints_by_blinded_secret = premint_secrets
             .secrets
             .iter()
-            .filter(|p| restore_response.outputs.contains(&p.blinded_message))
+            .map(|premint| (premint.blinded_message.blinded_secret, premint))
+            .collect::<HashMap<_, _>>();
+        let requested_outputs_by_blinded_secret = params
+            .blinded_messages
+            .iter()
+            .map(|output| (output.blinded_secret, output))
+            .collect::<HashMap<_, _>>();
+
+        // Match the returned outputs to our premint secrets by B_ value, preserving
+        // the mint response order used by the returned signatures.
+        let matched: Vec<_> = restore_response
+            .outputs
+            .iter()
+            .filter_map(|output| {
+                let premint = premints_by_blinded_secret.get(&output.blinded_secret)?;
+                let requested_output =
+                    requested_outputs_by_blinded_secret.get(&output.blinded_secret)?;
+                Some((*premint, *requested_output))
+            })
             .collect();
 
-        if matched_secrets.len() != restore_response.signatures.len() {
+        if matched.len() != restore_response.signatures.len() {
             tracing::warn!(
                 "{} saga {} - signature count mismatch: {} secrets, {} signatures",
                 saga_type,
                 saga_id,
-                matched_secrets.len(),
+                matched.len(),
                 restore_response.signatures.len()
             );
         }
@@ -461,11 +491,21 @@ impl Wallet {
         // Load keyset keys for proof construction
         let keys = self.load_keyset_keys(keyset_id).await?;
 
+        validate_mint_response_signatures(
+            self,
+            &restore_response.signatures,
+            matched
+                .iter()
+                .map(|(_, requested_output)| *requested_output),
+            SignatureAmountValidation::AllowZeroAmountPlaceholder,
+        )
+        .await?;
+
         // Construct proofs from signatures
         let proofs = construct_proofs(
             restore_response.signatures,
-            matched_secrets.iter().map(|p| p.r.clone()).collect(),
-            matched_secrets.iter().map(|p| p.secret.clone()).collect(),
+            matched.iter().map(|(p, _)| p.r.clone()).collect(),
+            matched.iter().map(|(p, _)| p.secret.clone()).collect(),
             &keys,
         )?;
 

--- a/crates/cdk/src/wallet/swap/saga/mod.rs
+++ b/crates/cdk/src/wallet/swap/saga/mod.rs
@@ -41,6 +41,9 @@ use crate::amount::SplitTarget;
 use crate::dhke::construct_proofs;
 use crate::nuts::nut00::ProofsMethods;
 use crate::nuts::{nut10, Proofs, SpendingConditions, State};
+use crate::wallet::blind_signature::{
+    validate_mint_response_signatures, SignatureAmountValidation,
+};
 use crate::wallet::saga::{
     add_compensation, clear_compensations, execute_compensations, new_compensations, Compensations,
     RevertProofReservation as RevertSwapProofReservation,
@@ -238,6 +241,14 @@ impl<'a> SwapSaga<'a, Prepared> {
         let active_keyset_id = self.state_data.pre_swap.pre_mint_secrets.keyset_id;
         let active_keys = self.wallet.load_keyset_keys(active_keyset_id).await?;
 
+        validate_mint_response_signatures(
+            self.wallet,
+            &swap_response.signatures,
+            self.state_data.pre_swap.swap_request.outputs().iter(),
+            SignatureAmountValidation::Exact,
+        )
+        .await?;
+
         let post_swap_proofs = construct_proofs(
             swap_response.signatures,
             self.state_data.pre_swap.pre_mint_secrets.rs(),
@@ -377,11 +388,13 @@ mod tests {
 
     use super::SwapSaga;
     use crate::amount::SplitTarget;
+    use crate::nuts::{BlindSignature, SecretKey as Nut01SecretKey, SwapResponse};
     use crate::wallet::swap::ProofReservation;
     use crate::wallet::test_utils::{
         create_test_db, create_test_wallet_with_mock, test_keyset_id, test_mint_url,
         test_proof_info, MockMintConnector,
     };
+    use crate::{Amount, Error};
 
     #[tokio::test]
     async fn test_prepare_swap_reserves_proofs_for_operation() {
@@ -545,5 +558,52 @@ mod tests {
             prepared.compensations.is_empty(),
             "No compensation should be registered when skipping reservation"
         );
+    }
+
+    #[tokio::test]
+    async fn test_execute_rejects_signature_with_mismatched_amount() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+
+        let proof_info = test_proof_info(keyset_id, 3, mint_url);
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.reset_default_mint_state();
+        let wallet = create_test_wallet_with_mock(db, mock_client.clone()).await;
+
+        let input_proofs = wallet.get_unspent_proofs().await.unwrap();
+        let prepared = SwapSaga::new(&wallet)
+            .prepare(
+                None,
+                SplitTarget::Values(vec![Amount::from(2)]),
+                input_proofs,
+                None,
+                false,
+                false,
+                ProofReservation::Reserve,
+            )
+            .await
+            .expect("prepare swap saga");
+
+        let outputs = prepared.state_data.pre_swap.swap_request.outputs().clone();
+        let bad_signatures = outputs
+            .iter()
+            .map(|blinded_message| BlindSignature {
+                amount: Amount::from(1),
+                keyset_id: blinded_message.keyset_id,
+                c: Nut01SecretKey::generate().public_key(),
+                dleq: None,
+            })
+            .collect();
+
+        mock_client.set_post_swap_response(Ok(SwapResponse {
+            signatures: bad_signatures,
+        }));
+
+        let result = prepared.execute().await;
+
+        assert!(matches!(result, Err(Error::InvalidMintResponse(_))));
     }
 }


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe).

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
