### PR TITLE
fix: in memory sqlite start from state

### DIFF
--- a/crates/cdk-sqlite/src/mint/memory.rs
+++ b/crates/cdk-sqlite/src/mint/memory.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use cdk_common::database::{self, MintDatabase, MintKeysDatabase};
 use cdk_common::mint::{self, MintKeySetInfo, MintQuote, Operation};
-use cdk_common::nuts::{CurrencyUnit, Id, Proofs};
+use cdk_common::nuts::{CurrencyUnit, Id, Proofs, State};
 use cdk_common::MintInfo;
 
 use super::MintSqliteDatabase;
@@ -56,19 +56,16 @@ pub async fn new_with_state(
         tx.add_melt_quote(quote).await?;
     }
 
+    let operation = Operation::new_swap(Default::default(), Default::default(), Default::default());
+
+    if !pending_proofs.is_empty() {
+        let mut proofs = tx.add_proofs(pending_proofs, None, &operation).await?;
+        tx.update_proofs_state(&mut proofs, State::Pending).await?;
+    }
+
     if !spent_proofs.is_empty() {
-        tx.add_proofs(
-            pending_proofs,
-            None,
-            &Operation::new_swap(Default::default(), Default::default(), Default::default()),
-        )
-        .await?;
-        tx.add_proofs(
-            spent_proofs,
-            None,
-            &Operation::new_swap(Default::default(), Default::default(), Default::default()),
-        )
-        .await?;
+        let mut proofs = tx.add_proofs(spent_proofs, None, &operation).await?;
+        tx.update_proofs_state(&mut proofs, State::Spent).await?;
     }
     let mint_info_bytes = serde_json::to_vec(&mint_info)?;
     tx.kv_write(
@@ -81,4 +78,85 @@ pub async fn new_with_state(
     tx.commit().await?;
 
     Ok(db)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::str::FromStr;
+
+    use cdk_common::database::MintProofsDatabase;
+    use cdk_common::nuts::{Id, Proof, State};
+    use cdk_common::secret::Secret;
+    use cdk_common::{Amount, MintInfo, SecretKey};
+
+    use super::new_with_state;
+
+    fn make_proof(keyset_id: Id, amount: u64) -> Proof {
+        Proof {
+            amount: Amount::from(amount),
+            keyset_id,
+            secret: Secret::generate(),
+            c: SecretKey::generate().public_key(),
+            witness: None,
+            dleq: None,
+            p2pk_e: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn new_with_state_restores_spent_proofs_as_spent() {
+        let keyset_id = Id::from_str("00916bbf7ef91a36").expect("valid keyset id");
+        let pending_proofs = vec![make_proof(keyset_id, 1)];
+        let spent_proofs = vec![make_proof(keyset_id, 2), make_proof(keyset_id, 4)];
+        let spent_ys = spent_proofs
+            .iter()
+            .map(|proof| proof.y().expect("valid proof y"))
+            .collect::<Vec<_>>();
+
+        let db = new_with_state(
+            HashMap::new(),
+            vec![],
+            vec![],
+            vec![],
+            pending_proofs,
+            spent_proofs,
+            MintInfo::default(),
+        )
+        .await
+        .expect("valid db");
+
+        let states = db.get_proofs_states(&spent_ys).await.expect("proof states");
+
+        assert_eq!(states, vec![Some(State::Spent), Some(State::Spent)]);
+    }
+
+    #[tokio::test]
+    async fn new_with_state_restores_pending_proofs_without_spent_proofs() {
+        let keyset_id = Id::from_str("00916bbf7ef91a36").expect("valid keyset id");
+        let pending_proofs = vec![make_proof(keyset_id, 1), make_proof(keyset_id, 2)];
+        let pending_ys = pending_proofs
+            .iter()
+            .map(|proof| proof.y().expect("valid proof y"))
+            .collect::<Vec<_>>();
+
+        let db = new_with_state(
+            HashMap::new(),
+            vec![],
+            vec![],
+            vec![],
+            pending_proofs,
+            vec![],
+            MintInfo::default(),
+        )
+        .await
+        .expect("valid db");
+
+        let states = db
+            .get_proofs_states(&pending_ys)
+            .await
+            .expect("proof states");
+
+        assert_eq!(states, vec![Some(State::Pending), Some(State::Pending)]);
+    }
 }


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe).

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
