### PR TITLE
fix: ensure split amount is non-zero

### DIFF
--- a/crates/cashu/src/amount.rs
+++ b/crates/cashu/src/amount.rs
@@ -233,6 +233,12 @@ impl Amount<()> {
         let mut parts = match target {
             SplitTarget::None => self.split(fee_and_amounts)?,
             SplitTarget::Value(amount) => {
+                if amount.eq(&Amount::ZERO) {
+                    return Err(Error::InvalidAmount(
+                        "SplitTarget::Value amount must be greater than zero".to_owned(),
+                    ));
+                }
+
                 if self.le(amount) {
                     return self.split(fee_and_amounts);
                 }
@@ -2447,6 +2453,18 @@ mod tests {
             result,
             vec![Amount::from(5), Amount::from(5), Amount::from(5)]
         );
+    }
+
+    /// Tests split_targeted() with SplitTarget::Value(0).
+    /// A zero target value is invalid and must not enter the targeted split loop.
+    #[test]
+    fn test_split_targeted_value_zero_errors() {
+        let fee_and_amounts: FeeAndAmounts = (0, vec![1, 2, 4, 8, 16, 32]).into();
+
+        let result =
+            Amount::from(10).split_targeted(&SplitTarget::Value(Amount::ZERO), &fee_and_amounts);
+
+        assert!(matches!(result, Err(Error::InvalidAmount(_))));
     }
 
     // =========================================================================


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----
This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe).

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
