### PR TITLE
fix: payment request without unit should be treated as sat

### DIFF
--- a/crates/cdk-cli/src/sub_commands/pay_request.rs
+++ b/crates/cdk-cli/src/sub_commands/pay_request.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use cdk::nuts::PaymentRequest;
+use cdk::nuts::{CurrencyUnit, PaymentRequest};
 use cdk::wallet::WalletRepository;
 use cdk::Amount;
 use clap::Args;
@@ -20,7 +20,7 @@ pub async fn pay_request(
 ) -> Result<()> {
     let payment_request = &sub_command_args.payment_request;
 
-    let unit = &payment_request.unit;
+    let unit = payment_request.unit.clone().unwrap_or(CurrencyUnit::Sat);
 
     let amount: Amount = match payment_request.amount {
         Some(amount) => amount,
@@ -47,10 +47,8 @@ pub async fn pay_request(
             continue;
         }
 
-        if let Some(unit) = unit {
-            if &wallet.unit != unit {
-                continue;
-            }
+        if wallet.unit != unit {
+            continue;
         }
 
         if balance >= amount {
@@ -66,4 +64,64 @@ pub async fn pay_request(
         .pay_request(payment_request.clone(), Some(amount))
         .await
         .map_err(|e| anyhow!(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use cdk::mint_url::MintUrl;
+    use cdk::wallet::WalletRepositoryBuilder;
+    use cdk_sqlite::wallet::memory;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn unitless_fixed_amount_request_defaults_to_sat_wallet_selection() {
+        let seed = [0u8; 64];
+        let localstore = Arc::new(memory::empty().await.expect("memory store"));
+        let wallet_repository = WalletRepositoryBuilder::new()
+            .localstore(localstore)
+            .seed(seed)
+            .build()
+            .await
+            .expect("wallet repository");
+
+        let mint_url =
+            MintUrl::from_str("https://nonexistent.example.invalid").expect("valid mint url");
+        wallet_repository
+            .create_wallet(mint_url, CurrencyUnit::Usd, None)
+            .await
+            .expect("wallet");
+
+        let payment_request = PaymentRequest {
+            payment_id: None,
+            amount: Some(Amount::from(0_u64)),
+            unit: None,
+            single_use: None,
+            mints: vec![],
+            description: None,
+            transports: vec![],
+            nut10: None,
+        };
+        let sub_command_args = PayRequestSubCommand {
+            payment_request,
+            amount: None,
+        };
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            pay_request(&wallet_repository, &sub_command_args),
+        )
+        .await
+        .expect("pay_request should not hang")
+        .expect_err("usd wallet must not match unitless fixed-amount request");
+
+        assert!(
+            result.to_string().contains("No wallet found"),
+            "unexpected error: {result}"
+        );
+    }
 }


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe).

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
