### PR TITLE
fix: spent proofs only show witness

### DIFF
--- a/crates/cdk/src/mint/check_spendable.rs
+++ b/crates/cdk/src/mint/check_spendable.rs
@@ -33,12 +33,15 @@ impl Mint {
             return Err(Error::UnknownPaymentState);
         }
 
-        // Collect ys that need witness fetching (where state.is_some())
+        // Collect ys that need witness fetching (only spent proofs expose witnesses)
         let ys_needing_witness: Vec<_> = check_state
             .ys
             .iter()
             .zip(states.iter())
-            .filter_map(|(y, state)| state.as_ref().map(|_| *y))
+            .filter_map(|(y, state)| match state {
+                Some(State::Spent) => Some(*y),
+                _ => None,
+            })
             .collect();
 
         // Build a lookup map for witnesses (only query if there are ys to fetch)
@@ -69,5 +72,92 @@ impl Mint {
         Ok(CheckStateResponse {
             states: proof_states,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cdk_common::mint::Operation;
+    use cdk_common::nuts::{CheckStateRequest, ProofsMethods};
+    use cdk_common::{Amount, State};
+
+    use crate::test_helpers::mint::{create_test_mint, mint_test_proofs};
+    use crate::Mint;
+
+    async fn check_state_witness_for_proof_state(state: State) -> bool {
+        let mint = create_test_mint().await.unwrap();
+        let mut proofs = mint_test_proofs(&mint, Amount::from(100)).await.unwrap();
+
+        for proof in proofs.iter_mut() {
+            proof.add_preimage("deadbeefdeadbeefdeadbeefdeadbeef".to_string());
+        }
+
+        let ys = proofs.ys().unwrap();
+        let db = mint.localstore();
+
+        {
+            let mut tx = db.begin_transaction().await.unwrap();
+            tx.add_proofs(
+                proofs,
+                None,
+                &Operation::new_swap(Amount::ZERO, Amount::ZERO, Amount::ZERO),
+            )
+            .await
+            .unwrap();
+            tx.commit().await.unwrap();
+        }
+
+        match state {
+            State::Unspent => {}
+            State::Pending => {
+                let mut tx = db.begin_transaction().await.unwrap();
+                let mut acquired = tx.get_proofs(&ys).await.unwrap();
+                Mint::update_proofs_state(&mut tx, &mut acquired, State::Pending)
+                    .await
+                    .unwrap();
+                tx.commit().await.unwrap();
+            }
+            State::Spent => {
+                let mut tx = db.begin_transaction().await.unwrap();
+                let mut acquired = tx.get_proofs(&ys).await.unwrap();
+                Mint::update_proofs_state(&mut tx, &mut acquired, State::Pending)
+                    .await
+                    .unwrap();
+                Mint::update_proofs_state(&mut tx, &mut acquired, State::Spent)
+                    .await
+                    .unwrap();
+                tx.commit().await.unwrap();
+            }
+            State::Reserved | State::PendingSpent => {
+                panic!("mint proof state is not valid for check_state witness tests");
+            }
+        }
+
+        let response = mint.check_state(&CheckStateRequest { ys }).await.unwrap();
+
+        assert!(response
+            .states
+            .iter()
+            .all(|proof_state| proof_state.state == state));
+
+        response
+            .states
+            .iter()
+            .any(|proof_state| proof_state.witness.is_some())
+    }
+
+    #[tokio::test]
+    async fn test_check_state_does_not_return_witness_for_unspent_proofs() {
+        assert!(!check_state_witness_for_proof_state(State::Unspent).await);
+    }
+
+    #[tokio::test]
+    async fn test_check_state_does_not_return_witness_for_pending_proofs() {
+        assert!(!check_state_witness_for_proof_state(State::Pending).await);
+    }
+
+    #[tokio::test]
+    async fn test_check_state_returns_witness_for_spent_proofs() {
+        assert!(check_state_witness_for_proof_state(State::Spent).await);
     }
 }


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe).

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
