### PR TITLE
fix(mint): avoid under-recording LND melt spends

### DIFF
--- a/crates/cdk-lnd/src/lib.rs
+++ b/crates/cdk-lnd/src/lib.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
-use cdk_common::amount::Amount;
+use cdk_common::amount::{Amount, MSAT_IN_SAT};
 use cdk_common::bitcoin::hashes::Hash;
 use cdk_common::common::FeeReserve;
 use cdk_common::database::DynKVStore;
@@ -185,6 +185,32 @@ impl Lnd {
             settle_index
         );
         Ok((add_index, settle_index))
+    }
+}
+
+fn lnrpc_payment_total_spent(payment: &lnrpc::Payment) -> Result<Amount<CurrencyUnit>, Error> {
+    let total_msat = payment
+        .value_msat
+        .checked_add(payment.fee_msat)
+        .ok_or(Error::AmountOverflow)?;
+    let total_msat = u64::try_from(total_msat).map_err(|_| Error::AmountOverflow)?;
+
+    Ok(Amount::new(total_msat, CurrencyUnit::Msat))
+}
+
+fn msat_total_spent_for_unit(
+    total_msat: u64,
+    unit: &CurrencyUnit,
+) -> Result<Amount<CurrencyUnit>, Error> {
+    match unit {
+        CurrencyUnit::Msat => Ok(Amount::new(total_msat, CurrencyUnit::Msat)),
+        CurrencyUnit::Sat => Ok(Amount::new(
+            total_msat.div_ceil(MSAT_IN_SAT),
+            CurrencyUnit::Sat,
+        )),
+        _ => Amount::new(total_msat, CurrencyUnit::Msat)
+            .convert_to(unit)
+            .map_err(Error::from),
     }
 }
 
@@ -541,8 +567,7 @@ impl MintPayment for Lnd {
                                     ),
                                     payment_proof: payment_preimage,
                                     status,
-                                    total_spent: Amount::new(total_amt_msat, CurrencyUnit::Msat)
-                                        .convert_to(unit)?,
+                                    total_spent: msat_total_spent_for_unit(total_amt_msat, unit)?,
                                 });
                             }
 
@@ -629,8 +654,7 @@ impl MintPayment for Lnd {
                                 payment_lookup_id: payment_identifier,
                                 payment_proof: payment_preimage,
                                 status: response_status,
-                                total_spent: Amount::new(total_msat as u64, CurrencyUnit::Msat)
-                                    .convert_to(unit)?,
+                                total_spent: msat_total_spent_for_unit(total_msat as u64, unit)?,
                             });
                         }
 
@@ -785,19 +809,16 @@ impl MintPayment for Lnd {
                             // Continue waiting for the next update
                             continue;
                         }
-                        PaymentStatus::Succeeded => MakePaymentResponse {
-                            payment_lookup_id: payment_identifier.clone(),
-                            payment_proof: Some(update.payment_preimage),
-                            status: MeltQuoteState::Paid,
-                            total_spent: Amount::new(
-                                (update
-                                    .value_sat
-                                    .checked_add(update.fee_sat)
-                                    .ok_or(Error::AmountOverflow)?)
-                                    as u64,
-                                CurrencyUnit::Sat,
-                            ),
-                        },
+                        PaymentStatus::Succeeded => {
+                            let total_spent = lnrpc_payment_total_spent(&update)?;
+
+                            MakePaymentResponse {
+                                payment_lookup_id: payment_identifier.clone(),
+                                payment_proof: Some(update.payment_preimage),
+                                status: MeltQuoteState::Paid,
+                                total_spent,
+                            }
+                        }
                         PaymentStatus::Failed => MakePaymentResponse {
                             payment_lookup_id: payment_identifier.clone(),
                             payment_proof: Some(update.payment_preimage),
@@ -817,5 +838,54 @@ impl MintPayment for Lnd {
 
         // If the stream is exhausted without a final status
         Err(Error::UnknownPaymentStatus.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lnrpc_payment_total_spent_uses_msat_fields() {
+        let payment = lnrpc::Payment {
+            value_msat: 1500,
+            fee_msat: 500,
+            value_sat: 1,
+            fee_sat: 0,
+            ..Default::default()
+        };
+
+        let total_spent = lnrpc_payment_total_spent(&payment)
+            .expect("sub-sat payment total should be calculated");
+
+        assert_eq!(
+            total_spent
+                .convert_to(&CurrencyUnit::Msat)
+                .expect("msat amount should convert to msat")
+                .value(),
+            2000
+        );
+    }
+
+    #[test]
+    fn lnrpc_payment_total_spent_rejects_overflow() {
+        let payment = lnrpc::Payment {
+            value_msat: i64::MAX,
+            fee_msat: 1,
+            ..Default::default()
+        };
+
+        let err = lnrpc_payment_total_spent(&payment)
+            .expect_err("overflowing payment total should be rejected");
+
+        assert!(matches!(err, Error::AmountOverflow));
+    }
+
+    #[test]
+    fn msat_total_spent_for_unit_rounds_up_sats() {
+        let total_spent = msat_total_spent_for_unit(1501, &CurrencyUnit::Sat)
+            .expect("msat total should convert to sat");
+
+        assert_eq!(total_spent, Amount::new(2, CurrencyUnit::Sat));
     }
 }

--- a/crates/cdk/src/mint/melt/melt_saga/mod.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/mod.rs
@@ -896,15 +896,14 @@ impl MeltSaga<PaymentConfirmed> {
     pub async fn finalize(mut self) -> Result<MeltQuoteResponse<QuoteId>, Error> {
         tracing::info!("TX2: Finalizing melt (mark spent + change)");
 
-        let total_spent: Amount<CurrencyUnit> = self
-            .state_data
-            .payment_result
-            .total_spent
-            .convert_to(&self.state_data.quote.unit)
-            .map_err(|e| {
-                tracing::error!("Failed to convert total_spent to quote unit: {:?}", e);
-                Error::UnitMismatch
-            })?;
+        let total_spent: Amount<CurrencyUnit> = self.state_data.payment_result.total_spent;
+        let total_spent =
+            shared::total_spent_for_quote_unit(&total_spent, &self.state_data.quote.unit).map_err(
+                |e| {
+                    tracing::error!("Failed to convert total_spent to quote unit: {:?}", e);
+                    Error::UnitMismatch
+                },
+            )?;
 
         let payment_proof = self.state_data.payment_result.payment_proof.clone();
         let payment_lookup_id = &self.state_data.payment_result.payment_lookup_id;

--- a/crates/cdk/src/mint/melt/melt_saga/tests.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/tests.rs
@@ -17,10 +17,12 @@ use cdk_common::mint::{
 };
 use cdk_common::nut00::KnownMethod;
 use cdk_common::nuts::nut30::MeltQuoteOnchainFeeOption;
-use cdk_common::nuts::{MeltQuoteBolt11Request, MeltQuoteState, MintQuoteState};
+use cdk_common::nuts::{MeltQuoteBolt11Request, MeltQuoteState, MeltRequest, MintQuoteState};
 use cdk_common::payment::PaymentIdentifier;
 use cdk_common::util::unix_time;
-use cdk_common::{Amount, MintQuoteBolt11Request, PaymentMethod, ProofsMethods, State};
+use cdk_common::{
+    Amount, CurrencyUnit, MintQuoteBolt11Request, PaymentMethod, ProofsMethods, State,
+};
 
 use crate::mint::melt::melt_saga::{MeltSaga, PaymentOutcome};
 use crate::mint::melt::shared::{finalize_melt_quote, rollback_melt_quote};
@@ -494,6 +496,55 @@ async fn test_completed_operation_recorded_on_finalize() {
     assert_eq!(completed_operation.total_redeemed(), Amount::from(10_000));
     assert_eq!(completed_operation.total_issued(), Amount::ZERO);
     assert_eq!(response.state(), MeltQuoteState::Paid);
+}
+
+#[tokio::test]
+async fn test_msat_total_spent_rounds_up_when_recording_sat_melt() {
+    use crate::test_helpers::mint::create_test_blinded_messages;
+
+    let mint = create_test_mint().await.unwrap();
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let quote = create_test_melt_quote(&mint, Amount::from(9_000)).await;
+    let (change_outputs, _premint) = create_test_blinded_messages(&mint, Amount::from(1_023))
+        .await
+        .unwrap();
+    let melt_request = MeltRequest::new(quote.id.clone(), proofs.clone(), Some(change_outputs));
+
+    let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+    let saga = MeltSaga::new(
+        std::sync::Arc::new(mint.clone()),
+        mint.localstore(),
+        mint.pubsub_manager(),
+    );
+
+    let setup_saga = saga
+        .setup_melt(
+            &melt_request,
+            verification,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+        )
+        .await
+        .unwrap();
+    let operation_id = setup_saga.operation_id;
+    let payment_lookup_id = PaymentIdentifier::CustomId("rounded_msat_lookup".to_string());
+
+    let change = finalize_melt_quote(
+        &mint,
+        &mint.localstore(),
+        &mint.pubsub_manager(),
+        &quote,
+        Amount::new(9_000_001, CurrencyUnit::Msat),
+        Some("rounded_msat_preimage".to_string()),
+        &payment_lookup_id,
+        Some(operation_id),
+    )
+    .await
+    .unwrap()
+    .expect("rounded spent amount should leave change");
+    let change_amount =
+        Amount::try_sum(change.iter().map(|sig| sig.amount)).expect("change cannot overflow");
+
+    assert_eq!(change_amount, Amount::from(999));
 }
 
 #[tokio::test]

--- a/crates/cdk/src/mint/melt/shared.rs
+++ b/crates/cdk/src/mint/melt/shared.rs
@@ -6,6 +6,7 @@
 //!
 //! The functions here ensure consistency between these two code paths.
 
+use cdk_common::amount::MSAT_IN_SAT;
 use cdk_common::database::mint::Acquired;
 use cdk_common::database::{self, DynMintDatabase};
 use cdk_common::mint::{self as mint_types};
@@ -72,6 +73,20 @@ fn record_confirmed_payment_metrics(quote: &MeltQuote, total_spent: &Amount<Curr
                 METRICS.record_payment_fee(payment_method, payment_fee_sats);
             }
         }
+    }
+}
+
+pub(crate) fn total_spent_for_quote_unit(
+    total_spent: &Amount<CurrencyUnit>,
+    quote_unit: &CurrencyUnit,
+) -> Result<Amount<CurrencyUnit>, Error> {
+    match (total_spent.unit(), quote_unit) {
+        (spent_unit, quote_unit) if spent_unit == quote_unit => Ok(total_spent.clone()),
+        (CurrencyUnit::Msat, CurrencyUnit::Sat) => {
+            let rounded_sats = total_spent.value().div_ceil(MSAT_IN_SAT);
+            Ok(Amount::new(rounded_sats, CurrencyUnit::Sat))
+        }
+        _ => total_spent.convert_to(quote_unit).map_err(Error::from),
     }
 }
 
@@ -619,6 +634,8 @@ pub async fn finalize_melt_quote(
     operation_id: Option<uuid::Uuid>,
 ) -> Result<Option<Vec<BlindSignature>>, Error> {
     tracing::info!("Finalizing melt quote {}", quote.id);
+
+    let total_spent = total_spent_for_quote_unit(&total_spent, &quote.unit)?;
 
     let settlement_matches = |stored_quote: &MeltQuote| {
         stored_quote.request_lookup_id.as_ref() == Some(payment_lookup_id)

--- a/crates/cdk/src/mint/saga_recovery.rs
+++ b/crates/cdk/src/mint/saga_recovery.rs
@@ -48,19 +48,20 @@ pub(crate) async fn process_melt_saga_outcome(
                 saga.operation_id
             );
 
-            // Persist the exact payment result before finalizing so recovery uses
+            // Persist the quote-unit payment result before finalizing so recovery uses
             // the same durable Finalizing handoff as the in-process finalize path.
-            let total_spent = payment_response
-                .total_spent
-                .convert_to(&quote.unit)
-                .map_err(|e| {
-                    tracing::error!(
-                        "Failed to convert recovered total_spent for quote {}: {:?}",
-                        quote.id,
-                        e
-                    );
-                    Error::UnitMismatch
-                })?;
+            let total_spent = super::melt::shared::total_spent_for_quote_unit(
+                &payment_response.total_spent,
+                &quote.unit,
+            )
+            .map_err(|e| {
+                tracing::error!(
+                    "Failed to convert recovered total_spent for quote {}: {:?}",
+                    quote.id,
+                    e
+                );
+                Error::UnitMismatch
+            })?;
 
             let mut tx = db.begin_transaction().await?;
             let finalization_data = MeltFinalizationData {


### PR DESCRIPTION
Use LND msat fields for checked outgoing payments and preserve sub-sat precision until mint finalization. When a sat-denominated mint records a backend msat spend, round up so change and payment fees do not understate what the mint paid.


This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe).
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
