### PR TITLE
fix(wallet): stop persisting wallet seed bytes in npubcash quotes

### DIFF
--- a/crates/cdk/src/wallet/issue/mod.rs
+++ b/crates/cdk/src/wallet/issue/mod.rs
@@ -68,6 +68,26 @@ fn mint_quote_response_amount(response: &MintQuoteResponse<String>) -> Option<Am
 }
 
 impl Wallet {
+    /// Resolve the NUT-20 signing key for a mint quote
+    ///
+    /// Returns the quote's stored key if present. NpubCash quotes do not
+    /// persist a key; for those the key is re-derived from the wallet seed.
+    pub(crate) async fn mint_quote_signing_key(
+        &self,
+        quote: &MintQuote,
+    ) -> Result<Option<SecretKey>, Error> {
+        if let Some(secret_key) = &quote.secret_key {
+            return Ok(Some(secret_key.clone()));
+        }
+
+        #[cfg(feature = "npubcash")]
+        if self.is_npubcash_quote(&quote.id).await? {
+            return Ok(Some(self.derive_npubcash_secret_key()?));
+        }
+
+        Ok(None)
+    }
+
     /// Create a mint quote for the given payment method and amount
     #[instrument(skip(self, method))]
     pub async fn mint_quote(

--- a/crates/cdk/src/wallet/issue/saga/mod.rs
+++ b/crates/cdk/src/wallet/issue/saga/mod.rs
@@ -234,8 +234,8 @@ impl<'a> MintSaga<'a, Initial> {
             signature: None,
         };
 
-        if let Some(secret_key) = &quote_info.secret_key {
-            request.sign(secret_key.clone())?;
+        if let Some(secret_key) = self.wallet.mint_quote_signing_key(quote_info).await? {
+            request.sign(secret_key)?;
         } else if quote_info.payment_method.is_bolt12() {
             // Bolt12 requires signature
             tracing::error!("Signature is required for bolt12.");
@@ -523,17 +523,17 @@ impl<'a> MintSaga<'a, Initial> {
         let mut signatures: Vec<Option<String>> = Vec::new();
 
         for quote in &quote_infos {
-            let requires_signature = quote.secret_key.is_some() || quote.payment_method.is_bolt12();
+            let secret_key = match self.wallet.mint_quote_signing_key(quote).await? {
+                Some(secret_key) => Some(secret_key),
+                None => external_keys.and_then(|keys| keys.get(&quote.id)).cloned(),
+            };
+
+            let requires_signature = secret_key.is_some() || quote.payment_method.is_bolt12();
 
             if requires_signature {
-                let secret_key = quote
-                    .secret_key
-                    .as_ref()
-                    .or_else(|| external_keys.and_then(|keys| keys.get(&quote.id)));
-
                 let sk = secret_key.ok_or(Error::SignatureMissingOrInvalid)?;
                 let sig = batch_request
-                    .sign_quote(&quote.id, sk)
+                    .sign_quote(&quote.id, &sk)
                     .map_err(|e| Error::Custom(format!("NUT-20 signing failed: {}", e)))?;
                 signatures.push(Some(sig));
             } else {
@@ -543,9 +543,7 @@ impl<'a> MintSaga<'a, Initial> {
         }
 
         // Check if any quote requires a signature.
-        let has_locked = quote_infos
-            .iter()
-            .any(|q| q.secret_key.is_some() || q.payment_method.is_bolt12());
+        let has_locked = signatures.iter().any(Option::is_some);
         let signatures_to_send = if has_locked { Some(signatures) } else { None };
         batch_request.signatures = signatures_to_send;
 

--- a/crates/cdk/src/wallet/issue/saga/resume.rs
+++ b/crates/cdk/src/wallet/issue/saga/resume.rs
@@ -298,9 +298,9 @@ impl Wallet {
             // Build signatures for locked quotes (NUT-20)
             let mut signatures: Vec<Option<String>> = Vec::new();
             for quote in &quote_infos {
-                if let Some(secret_key) = &quote.secret_key {
+                if let Some(secret_key) = self.mint_quote_signing_key(quote).await? {
                     let sig = batch_request
-                        .sign_quote(&quote.id, secret_key)
+                        .sign_quote(&quote.id, &secret_key)
                         .map_err(|e| Error::Custom(format!("NUT-20 signing failed: {}", e)))?;
                     signatures.push(Some(sig));
                 } else {
@@ -308,7 +308,7 @@ impl Wallet {
                 }
             }
 
-            let has_locked = quote_infos.iter().any(|q| q.secret_key.is_some());
+            let has_locked = signatures.iter().any(Option::is_some);
             let signatures_to_send = if has_locked { Some(signatures) } else { None };
             batch_request.signatures = signatures_to_send;
 
@@ -406,9 +406,9 @@ impl Wallet {
             signature: None,
         };
 
-        // Sign the request if the quote has a secret key (required for bolt12)
-        if let Some(ref secret_key) = quote.secret_key {
-            if let Err(e) = mint_request.sign(secret_key.clone()) {
+        // Sign the request if the quote has a signing key (required for bolt12)
+        if let Some(secret_key) = self.mint_quote_signing_key(&quote).await? {
+            if let Err(e) = mint_request.sign(secret_key) {
                 tracing::warn!(
                     "Issue saga {} - failed to sign mint request: {}, cannot replay",
                     saga_id,

--- a/crates/cdk/src/wallet/npubcash.rs
+++ b/crates/cdk/src/wallet/npubcash.rs
@@ -5,6 +5,9 @@
 
 use std::sync::Arc;
 
+use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv};
+use bitcoin::Network;
+use cdk_common::SECP256K1;
 use cdk_npubcash::{JwtAuthProvider, NpubCashClient, Quote};
 use tracing::instrument;
 
@@ -15,6 +18,8 @@ use crate::wallet::Wallet;
 
 /// KV store namespace for npubcash-related data
 pub const NPUBCASH_KV_NAMESPACE: &str = "npubcash";
+/// KV store secondary namespace marking quotes that came from NpubCash
+const QUOTES_KV_SECONDARY_NAMESPACE: &str = "quotes";
 /// KV store key for the last fetch timestamp (stored as u64 Unix timestamp)
 const LAST_FETCH_TIMESTAMP_KEY: &str = "last_fetch_timestamp";
 /// KV store key for the active mint URL
@@ -63,20 +68,44 @@ impl Wallet {
         Ok(())
     }
 
+    /// Derive the NpubCash secret key from the wallet seed
+    ///
+    /// Uses NIP-06 BIP-32 derivation (`m/44'/1237'/0'/0/0`) so the key never
+    /// equals raw seed material and cannot be used to recover the seed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the key derivation fails
+    pub(crate) fn derive_npubcash_secret_key(&self) -> Result<SecretKey, Error> {
+        let path = DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(44)?,
+            ChildNumber::from_hardened_idx(1237)?,
+            ChildNumber::from_hardened_idx(0)?,
+            ChildNumber::from_normal_idx(0)?,
+            ChildNumber::from_normal_idx(0)?,
+        ]);
+
+        let xpriv = Xpriv::new_master(Network::Bitcoin, &self.seed)?;
+
+        Ok(SecretKey::from(
+            xpriv.derive_priv(&SECP256K1, &path)?.private_key,
+        ))
+    }
+
     /// Derive Nostr keys from wallet seed for NpubCash authentication
     ///
-    /// This uses the first 32 bytes of the wallet seed to derive a Nostr keypair.
+    /// Uses NIP-06 derivation (`m/44'/1237'/0'/0/0`) from the wallet seed.
     ///
     /// # Errors
     ///
     /// Returns an error if the key derivation fails
     fn derive_npubcash_keys(&self) -> Result<nostr_sdk::Keys, Error> {
-        use nostr_sdk::SecretKey;
+        let secret_key = self.derive_npubcash_secret_key()?;
 
-        let secret_key = SecretKey::from_slice(&self.seed[..32])
+        let nostr_secret = nostr_sdk::SecretKey::from_slice(&secret_key.to_secret_bytes())
             .map_err(|e| Error::Custom(format!("Failed to derive Nostr keys: {}", e)))?;
 
-        Ok(nostr_sdk::Keys::new(secret_key))
+        Ok(nostr_sdk::Keys::new(nostr_secret))
     }
 
     /// Get the Nostr keys used for NpubCash authentication
@@ -211,8 +240,10 @@ impl Wallet {
 
     /// Add an NpubCash quote to the wallet's mint quote database
     ///
-    /// Converts an NpubCash quote to a wallet MintQuote and stores it using the
-    /// NpubCash-derived secret key for signing.
+    /// Converts an NpubCash quote to a wallet MintQuote and stores it. The
+    /// NUT-20 signing key is not persisted; the quote is marked in the KV
+    /// store so the NpubCash key can be re-derived from the seed at claim
+    /// time.
     ///
     /// # Arguments
     ///
@@ -226,12 +257,7 @@ impl Wallet {
         &self,
         npubcash_quote: cdk_npubcash::Quote,
     ) -> Result<Option<MintQuote>, Error> {
-        let npubcash_keys = self.derive_npubcash_keys()?;
-        let secret_key = SecretKey::from_slice(&npubcash_keys.secret_key().to_secret_bytes())
-            .map_err(|e| Error::Custom(format!("Failed to convert secret key: {}", e)))?;
-
-        let mut mint_quote: MintQuote = npubcash_quote.into();
-        mint_quote.secret_key = Some(secret_key);
+        let mint_quote: MintQuote = npubcash_quote.into();
 
         let exists = self
             .list_transactions(Some(TransactionDirection::Incoming))
@@ -243,10 +269,35 @@ impl Wallet {
             return Ok(None);
         }
 
+        self.localstore
+            .kv_write(
+                NPUBCASH_KV_NAMESPACE,
+                QUOTES_KV_SECONDARY_NAMESPACE,
+                &mint_quote.id,
+                &[],
+            )
+            .await?;
+
         self.localstore.add_mint_quote(mint_quote.clone()).await?;
 
         tracing::info!("Added NpubCash quote {} to wallet database", mint_quote.id);
         Ok(Some(mint_quote))
+    }
+
+    /// Check whether a mint quote was added from NpubCash
+    ///
+    /// NpubCash quotes do not persist their NUT-20 signing key; callers use
+    /// this marker to re-derive it from the seed instead.
+    pub(crate) async fn is_npubcash_quote(&self, quote_id: &str) -> Result<bool, Error> {
+        Ok(self
+            .localstore
+            .kv_read(
+                NPUBCASH_KV_NAMESPACE,
+                QUOTES_KV_SECONDARY_NAMESPACE,
+                quote_id,
+            )
+            .await?
+            .is_some())
     }
 
     /// Get reference to the NpubCash client if enabled
@@ -296,5 +347,120 @@ impl Wallet {
             )
             .await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    use cdk_common::database::{self, WalletDatabase};
+
+    use super::*;
+    use crate::mint_url::MintUrl;
+    use crate::nuts::CurrencyUnit;
+    use crate::wallet::WalletBuilder;
+
+    async fn build_test_wallet(seed: [u8; 64]) -> Wallet {
+        let localstore: Arc<dyn WalletDatabase<database::Error> + Send + Sync> = Arc::new(
+            cdk_sqlite::wallet::memory::empty()
+                .await
+                .expect("memory db"),
+        );
+
+        WalletBuilder::new()
+            .mint_url(MintUrl::from_str("https://mint.example.com").expect("valid mint url"))
+            .unit(CurrencyUnit::Sat)
+            .localstore(localstore)
+            .seed(seed)
+            .build()
+            .expect("wallet builds")
+    }
+
+    fn test_quote() -> Quote {
+        Quote {
+            id: "npubcash-quote-1".to_string(),
+            amount: 1000,
+            unit: "sat".to_string(),
+            created_at: 0,
+            paid_at: None,
+            expires_at: None,
+            mint_url: Some("https://mint.example.com".to_string()),
+            request: Some("lnbc100n1pjz".to_string()),
+            state: Some("PAID".to_string()),
+            locked: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn npubcash_key_is_nip06_derived_not_raw_seed() {
+        let seed = [0x42u8; 64];
+        let wallet = build_test_wallet(seed).await;
+
+        let secret_key = wallet.derive_npubcash_secret_key().expect("key derives");
+
+        assert_ne!(
+            &secret_key.to_secret_bytes()[..],
+            &seed[..32],
+            "npubcash key must not equal raw wallet seed bytes"
+        );
+
+        let xpriv = Xpriv::new_master(Network::Bitcoin, &seed).expect("master key");
+        let path = DerivationPath::from_str("m/44'/1237'/0'/0/0").expect("valid path");
+        let expected = xpriv
+            .derive_priv(&SECP256K1, &path)
+            .expect("derivation")
+            .private_key;
+
+        assert_eq!(secret_key.to_secret_bytes(), expected.secret_bytes());
+    }
+
+    #[tokio::test]
+    async fn add_npubcash_mint_quote_does_not_persist_secret_key() {
+        let seed = [0x42u8; 64];
+        let wallet = build_test_wallet(seed).await;
+
+        let stored = wallet
+            .add_npubcash_mint_quote(test_quote())
+            .await
+            .expect("add_npubcash_mint_quote succeeds")
+            .expect("quote was inserted");
+
+        assert!(
+            stored.secret_key.is_none(),
+            "npubcash quotes must not carry a persisted secret key"
+        );
+
+        let persisted = wallet
+            .localstore
+            .get_mint_quote(&stored.id)
+            .await
+            .expect("quote lookup")
+            .expect("quote in store");
+        assert!(
+            persisted.secret_key.is_none(),
+            "no secret key may be written to the localstore"
+        );
+
+        assert!(wallet
+            .is_npubcash_quote(&stored.id)
+            .await
+            .expect("kv lookup"));
+
+        let signing_key = wallet
+            .mint_quote_signing_key(&persisted)
+            .await
+            .expect("signing key lookup")
+            .expect("npubcash quote signing key is re-derivable");
+
+        assert_eq!(
+            signing_key.to_secret_bytes(),
+            wallet
+                .derive_npubcash_secret_key()
+                .expect("key derives")
+                .to_secret_bytes()
+        );
+        assert_ne!(&signing_key.to_secret_bytes()[..], &seed[..32]);
     }
 }


### PR DESCRIPTION
add_npubcash_mint_quote attached seed[..32] as the quote secret key, writing raw master seed material to the mint_quote table in cleartext for every synced npubcash quote.

Derive the npubcash identity via NIP-06 (m/44'/1237'/0'/0/0) instead of using raw seed bytes, and stop persisting the key entirely: npubcash quotes are marked in the KV store and the NUT-20 signing key is re-derived from the seed at claim time, including saga resume paths.

This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe).

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
