### PR TITLE
Simplify keyset management to three core functions

### DIFF
--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -10,7 +10,7 @@ use bitcoin::hashes::{sha256, Hash, HashEngine};
 use cashu::amount::{FeeAndAmounts, KeysetFeeAndAmounts, SplitTarget};
 use cashu::nuts::nut07::ProofState;
 use cashu::nuts::nut18::PaymentRequest;
-use cashu::nuts::{AuthProof, Keys};
+use cashu::nuts::AuthProof;
 use cashu::util::hex;
 use cashu::{nut00, PaymentMethod, Proof, Proofs, PublicKey};
 use serde::{Deserialize, Serialize};
@@ -773,6 +773,28 @@ pub enum KeysetFilter {
     All,
 }
 
+/// Policy controlling how keysets are loaded.
+///
+/// Determines the data-fetching strategy for keyset queries:
+/// memory cache, local database, and/or network.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum KeysetLoadPolicy {
+    /// Use in-memory cache and local database only. Never contacts the network.
+    /// Returns an error if neither cache nor database has data.
+    CacheOnly,
+    /// Return cached data when fresh (TTL not expired). When the cache is
+    /// empty, tries the database first, then the network. When the cache is
+    /// populated but stale (TTL expired), fetches directly from the network,
+    /// falling back to the stale cache if the network call fails.
+    /// This is the default.
+    #[default]
+    CacheThenNetwork,
+    /// Fetch data from the mint over the network and update the cache.
+    /// Falls back to stale cached data if the network call fails;
+    /// only returns an error when no cached data exists at all.
+    Refresh,
+}
+
 /// Unified wallet trait providing a common interface for wallet operations.
 ///
 /// This trait abstracts over different wallet implementations (CDK wallet, FFI
@@ -842,28 +864,24 @@ pub trait Wallet: Send + Sync {
     /// Load mint info (from cache if fresh, otherwise fetches)
     async fn load_mint_info(&self) -> Result<Self::MintInfo, Self::Error>;
 
-    /// Refresh keysets from the mint (always fetches fresh data)
-    async fn refresh_keysets(&self) -> Result<Vec<Self::KeySetInfo>, Self::Error>;
+    /// Get all keysets for this wallet's unit.
+    ///
+    /// The `policy` parameter controls the fetching strategy:
+    /// - [`CacheOnly`](KeysetLoadPolicy::CacheOnly) — in-memory cache + local DB, no network
+    /// - [`CacheThenNetwork`](KeysetLoadPolicy::CacheThenNetwork) — cache if fresh, network if
+    ///   stale/absent, stale fallback on failure (default)
+    /// - [`Refresh`](KeysetLoadPolicy::Refresh) — network first, stale-cache fallback on failure
+    async fn keysets(&self, policy: KeysetLoadPolicy)
+        -> Result<Vec<Self::KeySetInfo>, Self::Error>;
 
-    /// Get the active keyset with lowest fees
-    async fn get_active_keyset(&self) -> Result<Self::KeySetInfo, Self::Error>;
+    /// Get the active keyset with the lowest fees.
+    ///
+    /// Filters the output of [`keysets()`](Self::keysets) for active keysets
+    /// and returns the one with the minimum `input_fee_ppk`.
+    async fn active_keyset(&self) -> Result<Self::KeySetInfo, Self::Error>;
 
-    /// Load keys for a specific keyset from cache or mint
-    async fn load_keyset_keys(&self, keyset_id: Id) -> Result<Keys, Self::Error>;
-
-    /// Get keysets for this wallet's unit, filtered by active/all
-    async fn get_mint_keysets(
-        &self,
-        filter: KeysetFilter,
-    ) -> Result<Vec<Self::KeySetInfo>, Self::Error>;
-
-    /// Load active keysets (alias for get_mint_keysets with Active filter)
-    async fn load_mint_keysets(&self) -> Result<Vec<Self::KeySetInfo>, Self::Error> {
-        self.get_mint_keysets(KeysetFilter::Active).await
-    }
-
-    /// Fetch the active keyset with lowest fees
-    async fn fetch_active_keyset(&self) -> Result<Self::KeySetInfo, Self::Error>;
+    /// Get a single keyset by ID.
+    async fn keyset(&self, keyset_id: Id) -> Result<Self::KeySetInfo, Self::Error>;
 
     /// Get fees and available amounts for all keysets
     async fn get_keyset_fees_and_amounts(&self) -> Result<KeysetFeeAndAmounts, Self::Error>;

--- a/crates/cdk-ffi/src/types/keys.rs
+++ b/crates/cdk-ffi/src/types/keys.rs
@@ -64,24 +64,6 @@ pub fn encode_key_set_info(info: KeySetInfo) -> Result<String, FfiError> {
     Ok(serde_json::to_string(&info)?)
 }
 
-/// FFI-compatible KeysetFilter
-#[derive(Debug, Clone, Copy, uniffi::Enum)]
-pub enum KeysetFilter {
-    /// Only return active keysets
-    Active,
-    /// Return all keysets (active and inactive)
-    All,
-}
-
-impl From<KeysetFilter> for cdk_common::wallet::KeysetFilter {
-    fn from(filter: KeysetFilter) -> Self {
-        match filter {
-            KeysetFilter::Active => cdk_common::wallet::KeysetFilter::Active,
-            KeysetFilter::All => cdk_common::wallet::KeysetFilter::All,
-        }
-    }
-}
-
 /// FFI-compatible PublicKey
 #[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
 #[serde(transparent)]

--- a/crates/cdk-ffi/src/types/wallet.rs
+++ b/crates/cdk-ffi/src/types/wallet.rs
@@ -143,6 +143,44 @@ impl From<cdk::wallet::SendKind> for SendKind {
     }
 }
 
+/// Policy controlling how keysets are loaded
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, uniffi::Enum, Default,
+)]
+pub enum KeysetLoadPolicy {
+    /// Use in-memory cache and local database only. Never contacts the network.
+    CacheOnly,
+    /// Check cache first (respects TTL). Falls back to database, then network.
+    #[default]
+    CacheThenNetwork,
+    /// Always fetch fresh data from the mint over the network.
+    Refresh,
+}
+
+impl From<KeysetLoadPolicy> for cdk_common::wallet::KeysetLoadPolicy {
+    fn from(policy: KeysetLoadPolicy) -> Self {
+        match policy {
+            KeysetLoadPolicy::CacheOnly => cdk_common::wallet::KeysetLoadPolicy::CacheOnly,
+            KeysetLoadPolicy::CacheThenNetwork => {
+                cdk_common::wallet::KeysetLoadPolicy::CacheThenNetwork
+            }
+            KeysetLoadPolicy::Refresh => cdk_common::wallet::KeysetLoadPolicy::Refresh,
+        }
+    }
+}
+
+impl From<cdk_common::wallet::KeysetLoadPolicy> for KeysetLoadPolicy {
+    fn from(policy: cdk_common::wallet::KeysetLoadPolicy) -> Self {
+        match policy {
+            cdk_common::wallet::KeysetLoadPolicy::CacheOnly => KeysetLoadPolicy::CacheOnly,
+            cdk_common::wallet::KeysetLoadPolicy::CacheThenNetwork => {
+                KeysetLoadPolicy::CacheThenNetwork
+            }
+            cdk_common::wallet::KeysetLoadPolicy::Refresh => KeysetLoadPolicy::Refresh,
+        }
+    }
+}
+
 /// FFI-compatible P2PK locked proof send mode
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, uniffi::Enum, Default,

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -653,15 +653,26 @@ impl Wallet {
         )))
     }
 
-    /// Refresh keysets from the mint
-    pub async fn refresh_keysets(&self) -> Result<Vec<KeySetInfo>, FfiError> {
-        let keysets = self.inner.refresh_keysets().await?;
+    /// Get all keysets for this wallet's unit
+    pub async fn keysets(
+        &self,
+        policy: Option<crate::types::wallet::KeysetLoadPolicy>,
+    ) -> Result<Vec<KeySet>, FfiError> {
+        let cdk_policy: cdk_common::wallet::KeysetLoadPolicy = policy.unwrap_or_default().into();
+        let keysets = self.inner.keysets(cdk_policy).await?;
         Ok(keysets.into_iter().map(Into::into).collect())
     }
 
-    /// Get the active keyset for the wallet's unit
-    pub async fn get_active_keyset(&self) -> Result<KeySetInfo, FfiError> {
-        let keyset = self.inner.get_active_keyset().await?;
+    /// Get the active keyset with the lowest fees
+    pub async fn active_keyset(&self) -> Result<KeySet, FfiError> {
+        let keyset = self.inner.active_keyset().await?;
+        Ok(keyset.into())
+    }
+
+    /// Get a single keyset by ID
+    pub async fn keyset(&self, keyset_id: String) -> Result<KeySet, FfiError> {
+        let id = cdk::nuts::Id::from_str(&keyset_id).map_err(FfiError::internal)?;
+        let keyset = self.inner.keyset(id).await?;
         Ok(keyset.into())
     }
 
@@ -669,34 +680,6 @@ impl Wallet {
     pub async fn get_keyset_fees_by_id(&self, keyset_id: String) -> Result<u64, FfiError> {
         let id = cdk::nuts::Id::from_str(&keyset_id).map_err(FfiError::internal)?;
         Ok(self.inner.get_keyset_fees_by_id(id).await?)
-    }
-
-    /// Load keys for a specific keyset
-    pub async fn load_keyset_keys(&self, keyset_id: String) -> Result<Keys, FfiError> {
-        let id = cdk::nuts::Id::from_str(&keyset_id).map_err(FfiError::internal)?;
-        let keys = self.inner.load_keyset_keys(id).await?;
-        Ok(keys.into())
-    }
-
-    /// Get keysets for this wallet's unit with filter
-    pub async fn get_mint_keysets(
-        &self,
-        filter: KeysetFilter,
-    ) -> Result<Vec<KeySetInfo>, FfiError> {
-        let keysets = self.inner.get_mint_keysets(filter.into()).await?;
-        Ok(keysets.into_iter().map(Into::into).collect())
-    }
-
-    /// Load active keysets
-    pub async fn load_mint_keysets(&self) -> Result<Vec<KeySetInfo>, FfiError> {
-        let keysets = self.inner.load_mint_keysets().await?;
-        Ok(keysets.into_iter().map(Into::into).collect())
-    }
-
-    /// Fetch active keyset with lowest fees
-    pub async fn fetch_active_keyset(&self) -> Result<KeySetInfo, FfiError> {
-        let keyset = self.inner.fetch_active_keyset().await?;
-        Ok(keyset.into())
     }
 
     /// Get fees and amounts for all keysets

--- a/crates/cdk-ffi/src/wallet_trait.rs
+++ b/crates/cdk-ffi/src/wallet_trait.rs
@@ -23,7 +23,7 @@ impl WalletTraitDef for Wallet {
     type MintUrl = MintUrl;
     type CurrencyUnit = CurrencyUnit;
     type MintInfo = MintInfo;
-    type KeySetInfo = KeySetInfo;
+    type KeySetInfo = KeySet;
     type MintQuote = MintQuote;
     type MeltQuote = MeltQuote;
     type PaymentMethod = PaymentMethod;
@@ -68,34 +68,24 @@ impl WalletTraitDef for Wallet {
         Ok(info.into())
     }
 
-    async fn refresh_keysets(&self) -> Result<Vec<Self::KeySetInfo>, Self::Error> {
-        let keysets = WalletTraitDef::refresh_keysets(self.inner().as_ref()).await?;
+    async fn keysets(
+        &self,
+        policy: cdk_common::wallet::KeysetLoadPolicy,
+    ) -> Result<Vec<Self::KeySetInfo>, Self::Error> {
+        let keysets = WalletTraitDef::keysets(self.inner().as_ref(), policy).await?;
         Ok(keysets.into_iter().map(Into::into).collect())
     }
 
-    async fn get_active_keyset(&self) -> Result<Self::KeySetInfo, Self::Error> {
-        let keyset = WalletTraitDef::get_active_keyset(self.inner().as_ref()).await?;
+    async fn active_keyset(&self) -> Result<Self::KeySetInfo, Self::Error> {
+        let keyset = WalletTraitDef::active_keyset(self.inner().as_ref()).await?;
         Ok(keyset.into())
     }
 
-    async fn load_keyset_keys(
+    async fn keyset(
         &self,
         keyset_id: cdk_common::nuts::Id,
-    ) -> Result<cdk_common::nuts::Keys, Self::Error> {
-        let keys = WalletTraitDef::load_keyset_keys(self.inner().as_ref(), keyset_id).await?;
-        Ok(keys)
-    }
-
-    async fn get_mint_keysets(
-        &self,
-        filter: cdk_common::wallet::KeysetFilter,
-    ) -> Result<Vec<Self::KeySetInfo>, Self::Error> {
-        let keysets = WalletTraitDef::get_mint_keysets(self.inner().as_ref(), filter).await?;
-        Ok(keysets.into_iter().map(Into::into).collect())
-    }
-
-    async fn fetch_active_keyset(&self) -> Result<Self::KeySetInfo, Self::Error> {
-        let keyset = WalletTraitDef::fetch_active_keyset(self.inner().as_ref()).await?;
+    ) -> Result<Self::KeySetInfo, Self::Error> {
+        let keyset = WalletTraitDef::keyset(self.inner().as_ref(), keyset_id).await?;
         Ok(keyset.into())
     }
 

--- a/crates/cdk-integration-tests/src/lib.rs
+++ b/crates/cdk-integration-tests/src/lib.rs
@@ -231,7 +231,7 @@ pub async fn attempt_manual_mint(
     mint_amount: Amount,
     payment_method: PaymentMethod,
 ) -> Result<MintResponse, cdk::Error> {
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
     let http_client = HttpClient::new(mint_url.parse().unwrap(), None);
 

--- a/crates/cdk-integration-tests/tests/bolt12.rs
+++ b/crates/cdk-integration-tests/tests/bolt12.rs
@@ -386,7 +386,7 @@ async fn test_regtest_bolt12_mint_extra() -> Result<()> {
     assert_eq!(state.amount_paid, Amount::ZERO);
     assert_eq!(state.amount_issued, Amount::ZERO);
 
-    let active_keyset_id = wallet.fetch_active_keyset().await?.id;
+    let active_keyset_id = wallet.active_keyset().await?.id;
 
     let pay_amount_msats = 10_000;
 

--- a/crates/cdk-integration-tests/tests/fake_wallet.rs
+++ b/crates/cdk-integration-tests/tests/fake_wallet.rs
@@ -512,7 +512,7 @@ async fn test_fake_melt_change_in_quote() {
         .await
         .unwrap();
 
-    let keyset = wallet.fetch_active_keyset().await.unwrap();
+    let keyset = wallet.active_keyset().await.unwrap();
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
 
     let premint_secrets = PreMintSecrets::random(
@@ -610,7 +610,7 @@ async fn test_fake_mint_without_witness() {
 
     let http_client = HttpClient::new(MINT_URL.parse().unwrap(), None);
 
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
 
     let premint_secrets = PreMintSecrets::random(
@@ -665,7 +665,7 @@ async fn test_fake_mint_with_wrong_witness() {
 
     let http_client = HttpClient::new(MINT_URL.parse().unwrap(), None);
 
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
 
     let premint_secrets = PreMintSecrets::random(
@@ -724,7 +724,7 @@ async fn test_fake_mint_inflated() {
         .expect("payment")
         .expect("no error");
 
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
 
     let pre_mint = PreMintSecrets::random(
@@ -799,7 +799,7 @@ async fn test_fake_mint_inflated_does_not_consume_quote() {
         .expect("payment")
         .expect("no error");
 
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
     let quote_info = wallet
         .localstore
@@ -922,7 +922,7 @@ async fn test_fake_mint_concurrent_same_quote_different_outputs() {
         .expect("payment")
         .expect("no error");
 
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
     let quote_info = wallet
         .localstore
@@ -1020,7 +1020,7 @@ async fn test_fake_mint_multiple_units() {
         .expect("payment")
         .expect("no error");
 
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
 
     let pre_mint = PreMintSecrets::random(
@@ -1040,7 +1040,7 @@ async fn test_fake_mint_multiple_units() {
     )
     .expect("failed to create new wallet");
 
-    let active_keyset_id = wallet_usd.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet_usd.active_keyset().await.unwrap().id;
 
     let usd_pre_mint = PreMintSecrets::random(
         active_keyset_id,
@@ -1108,7 +1108,7 @@ async fn test_fake_mint_multiple_unit_swap() {
     )
     .expect("failed to create new wallet");
 
-    wallet.refresh_keysets().await.unwrap();
+    wallet.keysets(Default::default()).await.unwrap();
 
     let mint_quote = wallet
         .mint_quote(PaymentMethod::BOLT11, Some(100.into()), None, None)
@@ -1131,7 +1131,7 @@ async fn test_fake_mint_multiple_unit_swap() {
         None,
     )
     .expect("failed to create usd wallet");
-    wallet_usd.refresh_keysets().await.unwrap();
+    wallet_usd.keysets(Default::default()).await.unwrap();
 
     let mint_quote = wallet_usd
         .mint_quote(PaymentMethod::BOLT11, Some(100.into()), None, None)
@@ -1148,7 +1148,7 @@ async fn test_fake_mint_multiple_unit_swap() {
         .await
         .unwrap();
 
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
 
     {
@@ -1184,7 +1184,7 @@ async fn test_fake_mint_multiple_unit_swap() {
     }
 
     {
-        let usd_active_keyset_id = wallet_usd.fetch_active_keyset().await.unwrap().id;
+        let usd_active_keyset_id = wallet_usd.active_keyset().await.unwrap().id;
         let inputs: Proofs = proofs.into_iter().take(2).collect();
 
         let total_inputs = inputs.total_amount().unwrap();
@@ -1327,8 +1327,8 @@ async fn test_fake_mint_multiple_unit_melt() {
         let input_amount: u64 = inputs.total_amount().unwrap().into();
 
         let invoice = create_fake_invoice((input_amount - 1) * 1000, "".to_string());
-        let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
-        let usd_active_keyset_id = wallet_usd.fetch_active_keyset().await.unwrap().id;
+        let active_keyset_id = wallet.active_keyset().await.unwrap().id;
+        let usd_active_keyset_id = wallet_usd.active_keyset().await.unwrap().id;
 
         let usd_pre_mint = PreMintSecrets::random(
             usd_active_keyset_id,
@@ -1412,7 +1412,7 @@ async fn test_fake_mint_input_output_mismatch() {
         None,
     )
     .expect("failed to create new  usd wallet");
-    let usd_active_keyset_id = wallet_usd.fetch_active_keyset().await.unwrap().id;
+    let usd_active_keyset_id = wallet_usd.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
 
     let inputs = proofs;
@@ -1467,7 +1467,7 @@ async fn test_fake_mint_swap_inflated() {
         .expect("payment")
         .expect("no error");
 
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let pre_mint = PreMintSecrets::random(
         active_keyset_id,
         101.into(),
@@ -1519,7 +1519,7 @@ async fn test_fake_mint_swap_spend_after_fail() {
         .expect("payment")
         .expect("no error");
 
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
 
     let pre_mint = PreMintSecrets::random(
@@ -1609,7 +1609,7 @@ async fn test_fake_mint_melt_spend_after_fail() {
         .expect("payment")
         .expect("no error");
 
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
 
     let pre_mint = PreMintSecrets::random(
@@ -1703,7 +1703,7 @@ async fn test_fake_mint_duplicate_proofs_swap() {
         .expect("payment")
         .expect("no error");
 
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
 
     let inputs = vec![proofs[0].clone(), proofs[0].clone()];
@@ -2177,7 +2177,7 @@ async fn test_wallet_proof_recovery_after_failed_swap() {
 
     // Create an invalid swap by manually constructing a request that will fail
     // We'll use the wallet's swap with invalid parameters to trigger a failure
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
 
     // Create invalid swap request (requesting more than we have)

--- a/crates/cdk-integration-tests/tests/happy_path_mint_wallet.rs
+++ b/crates/cdk-integration-tests/tests/happy_path_mint_wallet.rs
@@ -536,7 +536,7 @@ async fn test_restore_with_counter_gap() {
     assert_eq!(wallet.total_balance().await.unwrap(), 100.into());
 
     // Get the active keyset ID to increment counter
-    let active_keyset = wallet.fetch_active_keyset().await.unwrap();
+    let active_keyset = wallet.active_keyset().await.unwrap();
     let keyset_id = active_keyset.id;
 
     // Create a gap in the counter sequence
@@ -894,7 +894,7 @@ async fn test_fake_melt_change_in_quote() {
         .await
         .unwrap();
 
-    let keyset = wallet.fetch_active_keyset().await.unwrap();
+    let keyset = wallet.active_keyset().await.unwrap();
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
 
     let premint_secrets = PreMintSecrets::random(

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -24,17 +24,15 @@ use cashu::mint_url::MintUrl;
 use cashu::nuts::nut10::Conditions;
 use cashu::nuts::SigFlag;
 use cashu::{
-    CurrencyUnit, Id, MeltRequest, NotificationPayload, PaymentMethod, PreMintSecrets, ProofState,
-    SecretKey, SpendingConditions, State, SwapRequest,
+    CurrencyUnit, Id, KeySet, KeySetInfo, MeltRequest, NotificationPayload, PaymentMethod,
+    PreMintSecrets, ProofState, SecretKey, SpendingConditions, State, SwapRequest,
 };
 use cdk::mint::Mint;
 use cdk::nuts::nut00::ProofsMethods;
 use cdk::subscription::Params;
 use cdk::types::QuoteTTL;
 use cdk::wallet::types::{TransactionDirection, TransactionId};
-use cdk::wallet::{
-    KeysetFilter, MintConnector, P2PKLockedProofSendMode, ReceiveOptions, SendMemo, SendOptions,
-};
+use cdk::wallet::{MintConnector, P2PKLockedProofSendMode, ReceiveOptions, SendMemo, SendOptions};
 use cdk::{Amount, StreamExt};
 use cdk_common::mint::OperationKind;
 use cdk_common::payment::{
@@ -46,6 +44,19 @@ use cdk_fake_wallet::create_fake_invoice;
 use cdk_integration_tests::init_pure_tests::*;
 use futures::Stream;
 use tokio::time::sleep;
+
+fn to_keyset_infos(keysets: &[KeySet]) -> Vec<KeySetInfo> {
+    keysets
+        .iter()
+        .map(|ks| KeySetInfo {
+            id: ks.id,
+            unit: ks.unit.clone(),
+            active: ks.active.unwrap_or(true),
+            input_fee_ppk: ks.input_fee_ppk,
+            final_expiry: ks.final_expiry,
+        })
+        .collect()
+}
 
 /// Tests the token swap and send functionality:
 /// 1. Alice gets funded with 64 sats
@@ -94,10 +105,7 @@ async fn test_swap_to_send() {
         .confirm(Some(SendMemo::for_token("test_swapt_to_send")))
         .await
         .expect("Failed to send token");
-    let keysets_info = wallet_alice
-        .get_mint_keysets(KeysetFilter::Active)
-        .await
-        .unwrap();
+    let keysets_info = to_keyset_infos(&wallet_alice.keysets(Default::default()).await.unwrap());
     let token_proofs = token.proofs(&keysets_info).unwrap();
     assert_eq!(
         Amount::from(40),
@@ -1411,7 +1419,7 @@ async fn test_p2pk_send_force_swap_with_fees() {
         .expect("confirm should succeed — swap should produce enough output");
 
     // Verify token contains exactly the requested amount
-    let keysets_info = wallet.get_mint_keysets(KeysetFilter::Active).await.unwrap();
+    let keysets_info = to_keyset_infos(&wallet.keysets(Default::default()).await.unwrap());
     let token_proofs = token.proofs(&keysets_info).unwrap();
     assert_eq!(
         send_amount,
@@ -1490,10 +1498,7 @@ async fn test_p2pk_send_force_swap_with_fees_include_fee() {
         .expect("confirm should succeed");
 
     // Token should include amount + send_fee (so recipient can pay the redemption fee)
-    let keysets_info = wallet_sender
-        .get_mint_keysets(KeysetFilter::Active)
-        .await
-        .unwrap();
+    let keysets_info = to_keyset_infos(&wallet_sender.keysets(Default::default()).await.unwrap());
     let token_proofs = token.proofs(&keysets_info).unwrap();
     assert_eq!(
         send_amount + send_fee,
@@ -2006,7 +2011,7 @@ async fn test_batch_mint_then_spend() {
         "Balance should decrease after send"
     );
 
-    let keysets_info = wallet.get_mint_keysets(KeysetFilter::Active).await.unwrap();
+    let keysets_info = to_keyset_infos(&wallet.keysets(Default::default()).await.unwrap());
     let token_proofs = token.proofs(&keysets_info).unwrap();
     let token_amount = token_proofs
         .total_amount()
@@ -2141,19 +2146,13 @@ async fn test_p2bk_send_and_receive() {
         .expect("Failed to confirm send");
 
     // Check if the proofs have p2pk_e
-    let keysets_info = wallet_sender
-        .get_mint_keysets(KeysetFilter::Active)
-        .await
-        .unwrap();
+    let keysets_info = to_keyset_infos(&wallet_sender.keysets(Default::default()).await.unwrap());
     let token_proofs = token.proofs(&keysets_info).unwrap();
     for proof in &token_proofs {
         assert!(proof.p2pk_e.is_some(), "Proof should have p2pk_e set");
     }
     // Check if the proofs have p2pk_e
-    let keysets_info = wallet_sender
-        .get_mint_keysets(KeysetFilter::Active)
-        .await
-        .unwrap();
+    let keysets_info = to_keyset_infos(&wallet_sender.keysets(Default::default()).await.unwrap());
     let token_proofs = token.proofs(&keysets_info).unwrap();
     for proof in &token_proofs {
         assert!(proof.p2pk_e.is_some(), "Proof should have p2pk_e set");

--- a/crates/cdk-integration-tests/tests/onchain_regtest.rs
+++ b/crates/cdk-integration-tests/tests/onchain_regtest.rs
@@ -1173,7 +1173,7 @@ async fn test_onchain_attempt_to_mint_unpaid() {
         .await
         .expect("Failed to get mint quote");
 
-    let active_keyset = wallet.get_active_keyset().await.unwrap();
+    let active_keyset = wallet.active_keyset().await.unwrap();
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
     let premint_secrets = cdk::nuts::PreMintSecrets::random(
         active_keyset.id,

--- a/crates/cdk-integration-tests/tests/regtest.rs
+++ b/crates/cdk-integration-tests/tests/regtest.rs
@@ -363,7 +363,7 @@ async fn test_cached_mint() {
         .await
         .expect("payment");
 
-    let active_keyset_id = wallet.fetch_active_keyset().await.unwrap().id;
+    let active_keyset_id = wallet.active_keyset().await.unwrap().id;
     let fee_and_amounts = (0, ((0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>())).into();
     let http_client = HttpClient::new(get_mint_url_from_env().parse().unwrap(), None);
 

--- a/crates/cdk-integration-tests/tests/test_fees.rs
+++ b/crates/cdk-integration-tests/tests/test_fees.rs
@@ -5,7 +5,7 @@ use bip39::Mnemonic;
 use cashu::{Bolt11Invoice, PaymentMethod, ProofsMethods};
 use cdk::amount::{Amount, SplitTarget};
 use cdk::nuts::CurrencyUnit;
-use cdk::wallet::{KeysetFilter, ReceiveOptions, SendKind, SendOptions, Wallet};
+use cdk::wallet::{ReceiveOptions, SendKind, SendOptions, Wallet};
 use cdk_integration_tests::init_regtest::get_temp_dir;
 use cdk_integration_tests::{create_invoice_for_env, get_mint_url_from_env, pay_if_regtest};
 use cdk_sqlite::wallet::memory;
@@ -36,7 +36,7 @@ async fn test_swap() {
     let invoice = Bolt11Invoice::from_str(&mint_quote.request).unwrap();
     pay_if_regtest(&get_temp_dir(), &invoice).await.unwrap();
 
-    let proofs = wallet
+    let _proofs = wallet
         .wait_and_mint_quote(
             mint_quote.clone(),
             SplitTarget::default(),
@@ -45,13 +45,6 @@ async fn test_swap() {
         )
         .await
         .expect("payment");
-
-    println!("{:?}", proofs);
-
-    println!(
-        "{:?}",
-        wallet.get_mint_keysets(KeysetFilter::Active).await.unwrap()
-    );
 
     let send = wallet
         .prepare_send(

--- a/crates/cdk-integration-tests/tests/test_swap_flow.rs
+++ b/crates/cdk-integration-tests/tests/test_swap_flow.rs
@@ -1524,7 +1524,7 @@ async fn test_wallet_multi_keyset_counter_updates() {
 
     // Refresh wallet keysets to know about the new keyset
     wallet
-        .refresh_keysets()
+        .keysets(Default::default())
         .await
         .expect("Failed to refresh wallet keysets");
 

--- a/crates/cdk/examples/proof-selection.rs
+++ b/crates/cdk/examples/proof-selection.rs
@@ -6,9 +6,8 @@ use std::time::Duration;
 
 use cdk::nuts::nut00::ProofsMethods;
 use cdk::nuts::{CurrencyUnit, PaymentMethod};
-use cdk::wallet::{KeysetFilter, Wallet};
+use cdk::wallet::Wallet;
 use cdk::Amount;
-use cdk_common::nut02::KeySetInfosMethods;
 use cdk_sqlite::wallet::memory;
 use rand::random;
 
@@ -54,9 +53,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Select proofs to send
     let amount = Amount::from(64);
     let active_keyset_ids = wallet
-        .get_mint_keysets(KeysetFilter::Active)
+        .keysets(Default::default())
         .await?
-        .active()
+        .into_iter()
+        .filter(|k| k.active.unwrap_or(false))
         .map(|keyset| keyset.id)
         .collect();
     let selected =

--- a/crates/cdk/examples/token-proofs.rs
+++ b/crates/cdk/examples/token-proofs.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use cdk::nuts::nut00::ProofsMethods;
 use cdk::nuts::Token;
-use cdk::wallet::{KeysetFilter, WalletRepositoryBuilder};
+use cdk::wallet::WalletRepositoryBuilder;
 use cdk_sqlite::wallet::memory;
 use rand::random;
 
@@ -79,19 +79,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .into_iter()
         .next()
         .ok_or("No wallet found for mint")?;
-    let keysets: Vec<cdk::nuts::KeySetInfo> =
-        mint_wallet.get_mint_keysets(KeysetFilter::Active).await?;
-    println!("Found {} keysets for mint", keysets.len());
+    let keysets: Vec<cdk::nuts::KeySet> = mint_wallet.keysets(Default::default()).await?;
 
     for keyset in &keysets {
         println!(
             "  - Keyset ID: {}, Unit: {}, Active: {}",
-            keyset.id, keyset.unit, keyset.active
+            keyset.id,
+            keyset.unit,
+            keyset.active.unwrap_or(false)
         );
     }
 
+    let keysets_info: Vec<cdk::nuts::KeySetInfo> = keysets
+        .iter()
+        .map(|ks| cdk::nuts::KeySetInfo {
+            id: ks.id,
+            unit: ks.unit.clone(),
+            active: ks.active.unwrap_or(true),
+            input_fee_ppk: ks.input_fee_ppk,
+            final_expiry: ks.final_expiry,
+        })
+        .collect();
+
     // Extract proofs from the token using the keysets
-    let proofs = token.proofs(&keysets)?;
+    let proofs = token.proofs(&keysets_info)?;
     println!("\nToken contains {} proofs:", proofs.len());
 
     // Calculate total amount from proofs

--- a/crates/cdk/src/wallet/auth/auth_wallet.rs
+++ b/crates/cdk/src/wallet/auth/auth_wallet.rs
@@ -1,10 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use cdk_common::database::{self, WalletDatabase};
 use cdk_common::mint_url::MintUrl;
-use cdk_common::parking_lot::RwLock as ParkingRwLock;
 use cdk_common::wallet::ProofInfo;
 use cdk_common::{AuthProof, Id, Keys, MintInfo};
 use serde::{Deserialize, Serialize};
@@ -44,10 +42,6 @@ pub struct AuthWallet {
     pub localstore: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
     /// Mint metadata cache (lock-free cached access to keys, keysets, and mint info)
     pub metadata_cache: Arc<MintMetadataCache>,
-    /// TTL controlling how long cached auth metadata is considered fresh.
-    /// Shared with the parent [`Wallet`](crate::Wallet) so both honor the same
-    /// configured value.
-    metadata_cache_ttl: Arc<ParkingRwLock<Option<Duration>>>,
     /// Protected methods
     pub protected_endpoints: Arc<RwLock<HashMap<ProtectedEndpoint, AuthRequired>>>,
     /// Refresh token for auth
@@ -65,7 +59,6 @@ impl AuthWallet {
         cat: Option<AuthToken>,
         localstore: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
         metadata_cache: Arc<MintMetadataCache>,
-        metadata_cache_ttl: Arc<ParkingRwLock<Option<Duration>>>,
         protected_endpoints: HashMap<ProtectedEndpoint, AuthRequired>,
         oidc_client: Option<OidcClient>,
     ) -> Self {
@@ -74,7 +67,6 @@ impl AuthWallet {
             mint_url,
             localstore,
             metadata_cache,
-            metadata_cache_ttl,
             protected_endpoints: Arc::new(RwLock::new(protected_endpoints)),
             refresh_token: Arc::new(RwLock::new(None)),
             auth_client: http_client,
@@ -192,10 +184,7 @@ impl AuthWallet {
     pub async fn load_keyset_keys(&self, keyset_id: Id) -> Result<Keys, Error> {
         let metadata = self
             .metadata_cache
-            .load_auth(&self.localstore, &self.auth_client, {
-                let ttl = self.metadata_cache_ttl.read();
-                *ttl
-            })
+            .load_auth(&self.localstore, &self.auth_client)
             .await?;
 
         match metadata.keysets.get(&keyset_id) {
@@ -220,10 +209,7 @@ impl AuthWallet {
     pub async fn load_mint_keysets(&self) -> Result<Vec<KeySetInfo>, Error> {
         let metadata = self
             .metadata_cache
-            .load_auth(&self.localstore, &self.auth_client, {
-                let ttl = self.metadata_cache_ttl.read();
-                *ttl
-            })
+            .load_auth(&self.localstore, &self.auth_client)
             .await?;
 
         let auth_keysets = metadata
@@ -535,14 +521,12 @@ mod tests {
                 .expect("in-memory wallet database should initialize"),
         );
         let metadata_cache = Arc::new(MintMetadataCache::new(mint_url.clone()));
-        let metadata_cache_ttl = Arc::new(ParkingRwLock::new(Some(Duration::from_secs(3600))));
 
         AuthWallet::new(
             mint_url,
             None,
             localstore,
             metadata_cache,
-            metadata_cache_ttl,
             protected_endpoints,
             None,
         )
@@ -660,13 +644,11 @@ mod tests {
                 .expect("in-memory wallet database should initialize"),
         );
         let metadata_cache = Arc::new(MintMetadataCache::new(mint_url.clone()));
-        let metadata_cache_ttl = Arc::new(ParkingRwLock::new(Some(Duration::from_secs(3600))));
 
         AuthWallet {
             mint_url,
             localstore,
             metadata_cache,
-            metadata_cache_ttl,
             protected_endpoints: Arc::new(RwLock::new(HashMap::new())),
             refresh_token: Arc::new(RwLock::new(None)),
             auth_client: connector,

--- a/crates/cdk/src/wallet/blind_signature.rs
+++ b/crates/cdk/src/wallet/blind_signature.rs
@@ -62,7 +62,7 @@ pub(crate) async fn validate_mint_response_signatures<'a>(
             )));
         }
 
-        let keys = wallet.load_keyset_keys(sig.keyset_id).await?;
+        let keys = wallet.keyset(sig.keyset_id).await?.keys;
         let key = keys.amount_key(sig.amount).ok_or(Error::AmountKey)?;
         match sig.verify_dleq(key, blinded_message.blinded_secret) {
             Ok(_) | Err(nut12::Error::MissingDleqProof) => (),

--- a/crates/cdk/src/wallet/builder.rs
+++ b/crates/cdk/src/wallet/builder.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use cdk_common::parking_lot::RwLock;
 use cdk_common::{database, AuthToken};
 use tokio::sync::RwLock as TokioRwLock;
 use zeroize::Zeroize;
@@ -25,7 +24,7 @@ pub struct WalletBuilder {
     seed: Option<[u8; 64]>,
     use_http_subscription: bool,
     client: Option<Arc<dyn MintConnector + Send + Sync>>,
-    metadata_cache_ttl: Arc<RwLock<Option<Duration>>>,
+    metadata_cache_ttl: Option<Duration>,
     metadata_cache: Option<Arc<MintMetadataCache>>,
     metadata_caches: HashMap<MintUrl, Arc<MintMetadataCache>>,
 }
@@ -50,7 +49,7 @@ impl Default for WalletBuilder {
             auth_wallet: None,
             seed: None,
             client: None,
-            metadata_cache_ttl: Arc::new(RwLock::new(Some(Duration::from_secs(3600)))),
+            metadata_cache_ttl: Some(Duration::from_secs(3600)),
             use_http_subscription: false,
             metadata_cache: None,
             metadata_caches: HashMap::new(),
@@ -84,10 +83,8 @@ impl WalletBuilder {
     /// (unless manually refreshed).
     ///
     /// The default value is 1 hour (3600 seconds).
-    pub fn set_metadata_cache_ttl(self, metadata_cache_ttl: Option<Duration>) -> Self {
-        // Write into the shared cell rather than replacing it, so any AuthWallet
-        // already created from this builder observes the updated value.
-        *self.metadata_cache_ttl.write() = metadata_cache_ttl;
+    pub fn set_metadata_cache_ttl(mut self, metadata_cache_ttl: Option<Duration>) -> Self {
+        self.metadata_cache_ttl = metadata_cache_ttl;
         self
     }
 
@@ -202,7 +199,6 @@ impl WalletBuilder {
             Some(AuthToken::ClearAuth(cat)),
             localstore,
             metadata_cache,
-            self.metadata_cache_ttl.clone(),
             HashMap::new(),
             None,
         ));
@@ -234,8 +230,6 @@ impl WalletBuilder {
         };
         let auth_wallet = self.auth_wallet.take();
 
-        let metadata_cache_ttl = self.metadata_cache_ttl.clone();
-
         let metadata_cache = self.metadata_cache.take().unwrap_or_else(|| {
             // Check if we already have a cache for this mint in the HashMap
             if let Some(cache) = self.metadata_caches.get(&mint_url) {
@@ -246,12 +240,13 @@ impl WalletBuilder {
             }
         });
 
+        metadata_cache.set_ttl(self.metadata_cache_ttl);
+
         Ok(Wallet {
             mint_url,
             unit,
             localstore,
             metadata_cache,
-            metadata_cache_ttl,
             target_proof_count: self.target_proof_count.unwrap_or(3),
             auth_wallet: Arc::new(TokioRwLock::new(auth_wallet)),
             #[cfg(feature = "npubcash")]
@@ -270,9 +265,6 @@ mod tests {
     #[test]
     fn test_default_ttl() {
         let builder = WalletBuilder::default();
-        assert_eq!(
-            *builder.metadata_cache_ttl.read(),
-            Some(Duration::from_secs(3600))
-        );
+        assert_eq!(builder.metadata_cache_ttl, Some(Duration::from_secs(3600)));
     }
 }

--- a/crates/cdk/src/wallet/issue/mod.rs
+++ b/crates/cdk/src/wallet/issue/mod.rs
@@ -128,7 +128,7 @@ impl Wallet {
             }
         }
 
-        self.refresh_keysets().await?;
+        self.keysets(Default::default()).await?;
 
         let secret_key = SecretKey::generate();
 
@@ -419,15 +419,19 @@ impl Wallet {
         amount_split_target: SplitTarget,
         spending_conditions: Option<SpendingConditions>,
     ) -> Result<Proofs, Error> {
-        self.refresh_keysets().await?;
-
-        let saga = MintSaga::new(self);
-        let saga = saga
-            .prepare(quote_id, amount_split_target, spending_conditions)
-            .await?;
-        let saga = saga.execute().await?;
-
-        Ok(saga.into_proofs())
+        self.retry_on_inactive_keyset(|| async {
+            let saga = MintSaga::new(self);
+            let saga = saga
+                .prepare(
+                    quote_id,
+                    amount_split_target.clone(),
+                    spending_conditions.clone(),
+                )
+                .await?;
+            let saga = saga.execute().await?;
+            Ok(saga.into_proofs())
+        })
+        .await
     }
 
     /// Mint tokens for a quote (alias for `mint`)
@@ -586,8 +590,6 @@ impl Wallet {
         spending_conditions: Option<SpendingConditions>,
         external_keys: Option<std::collections::HashMap<String, SecretKey>>,
     ) -> Result<Proofs, Error> {
-        self.refresh_keysets().await?;
-
         // Create saga and prepare batch
         let saga = MintSaga::new(self);
 

--- a/crates/cdk/src/wallet/issue/saga/mod.rs
+++ b/crates/cdk/src/wallet/issue/saga/mod.rs
@@ -84,7 +84,10 @@ impl<'a> MintSaga<'a, Initial> {
         Self {
             wallet,
             compensations: new_compensations(),
-            state_data: Initial { operation_id },
+            state_data: Initial {
+                operation_id,
+                keyset_policy: Default::default(),
+            },
         }
     }
 
@@ -291,6 +294,7 @@ impl<'a> MintSaga<'a, Initial> {
                 request,
             },
             payment_method: quote_info.payment_method.clone(),
+            keyset_policy: self.state_data.keyset_policy,
             saga,
         })
     }
@@ -339,10 +343,15 @@ impl<'a> MintSaga<'a, Initial> {
             amount = quote_info.amount_mintable();
         }
 
-        let active_keyset_id = self.wallet.fetch_active_keyset().await?.id;
+        let keyset_policy = self.state_data.keyset_policy;
+        let active_keyset_id = self
+            .wallet
+            .active_keyset_with_policy(keyset_policy)
+            .await?
+            .id;
         let fee_and_amounts = self
             .wallet
-            .get_keyset_fees_and_amounts_by_id(active_keyset_id)
+            .get_keyset_fees_and_amounts_by_id_with_policy(active_keyset_id, keyset_policy)
             .await?;
 
         self.prepare_common(
@@ -456,10 +465,15 @@ impl<'a> MintSaga<'a, Initial> {
         .await;
 
         // Get active keyset
-        let active_keyset_id = self.wallet.fetch_active_keyset().await?.id;
+        let keyset_policy = self.state_data.keyset_policy;
+        let active_keyset_id = self
+            .wallet
+            .active_keyset_with_policy(keyset_policy)
+            .await?
+            .id;
         let fee_and_amounts = self
             .wallet
-            .get_keyset_fees_and_amounts_by_id(active_keyset_id)
+            .get_keyset_fees_and_amounts_by_id_with_policy(active_keyset_id, keyset_policy)
             .await?;
 
         // Create premint secrets for total amount
@@ -597,6 +611,7 @@ impl<'a> MintSaga<'a, Initial> {
                     request: batch_request,
                 },
                 payment_method,
+                keyset_policy,
                 saga,
             },
         })
@@ -623,6 +638,7 @@ impl<'a> MintSaga<'a, Prepared> {
             premint_secrets,
             mint_request,
             payment_method,
+            keyset_policy,
             saga,
         } = state_data;
 
@@ -692,7 +708,10 @@ impl<'a> MintSaga<'a, Prepared> {
                 }
             };
 
-            let keys = wallet.load_keyset_keys(active_keyset_id).await?;
+            let keys = wallet
+                .keyset_with_policy(active_keyset_id, keyset_policy)
+                .await?
+                .keys;
 
             validate_mint_response_signatures(
                 wallet,

--- a/crates/cdk/src/wallet/issue/saga/resume.rs
+++ b/crates/cdk/src/wallet/issue/saga/resume.rs
@@ -378,7 +378,7 @@ impl Wallet {
                 counter_end,
             )?;
 
-            let keys = self.load_keyset_keys(keyset_id).await?;
+            let keys = self.keyset(keyset_id).await?.keys;
 
             validate_mint_response_signatures(
                 self,
@@ -500,7 +500,7 @@ impl Wallet {
             counter_end,
         )?;
 
-        let keys = self.load_keyset_keys(keyset_id).await?;
+        let keys = self.keyset(keyset_id).await?.keys;
 
         validate_mint_response_signatures(
             self,

--- a/crates/cdk/src/wallet/issue/saga/state.rs
+++ b/crates/cdk/src/wallet/issue/saga/state.rs
@@ -4,7 +4,7 @@
 //! of the mint operation. The type state pattern ensures that only valid
 //! operations are available at each stage.
 
-use cdk_common::wallet::WalletSaga;
+use cdk_common::wallet::{KeysetLoadPolicy, WalletSaga};
 use uuid::Uuid;
 
 use crate::nuts::{BatchMintRequest, Id, PaymentMethod, PreMintSecrets, Proofs};
@@ -18,6 +18,8 @@ pub type MintRequestString = crate::nuts::MintRequest<String>;
 pub struct Initial {
     /// Unique operation identifier for tracking and crash recovery
     pub operation_id: Uuid,
+    /// Policy controlling how keysets are loaded during this saga
+    pub keyset_policy: KeysetLoadPolicy,
 }
 
 /// The mint request type - either single quote or batch.
@@ -58,6 +60,8 @@ pub struct Prepared {
     pub mint_request: PreparedMintRequest,
     /// Payment method (Bolt11 or Bolt12)
     pub payment_method: PaymentMethod,
+    /// Policy controlling how keysets are loaded
+    pub keyset_policy: KeysetLoadPolicy,
     /// Persisted saga for optimistic locking and recovery
     pub saga: WalletSaga,
 }

--- a/crates/cdk/src/wallet/keysets.rs
+++ b/crates/cdk/src/wallet/keysets.rs
@@ -1,180 +1,229 @@
 use std::collections::HashMap;
 
 use cdk_common::amount::{FeeAndAmounts, KeysetFeeAndAmounts};
-use cdk_common::nut02::KeySetInfosMethods;
-pub use cdk_common::wallet::KeysetFilter;
+use cdk_common::wallet::KeysetLoadPolicy;
 use tracing::instrument;
 
-use crate::nuts::{Id, KeySetInfo, Keys, Proofs, Token};
+use crate::nuts::{Id, KeySet, KeySetInfo, Proofs, Token};
 use crate::{Error, Wallet};
 
 impl Wallet {
-    /// Load keys for mint keyset
+    /// Get all keysets for this wallet's unit.
     ///
-    /// Returns keys from metadata cache if available.
-    /// If keys are not cached, fetches from mint server.
+    /// Tries a fresh fetch from the mint. On failure, falls back to any
+    /// cached/persisted data. Only hard-fails when the cache is empty
+    /// (first-ever fetch).
     #[instrument(skip(self))]
-    pub async fn load_keyset_keys(&self, keyset_id: Id) -> Result<Keys, Error> {
-        self.metadata_cache
-            .load(&self.localstore, &self.client, {
-                let ttl = self.metadata_cache_ttl.read();
-                *ttl
+    pub async fn keysets(&self, policy: KeysetLoadPolicy) -> Result<Vec<KeySet>, Error> {
+        let metadata = match policy {
+            KeysetLoadPolicy::CacheOnly => {
+                self.metadata_cache.load_cached(&self.localstore).await?
+            }
+            KeysetLoadPolicy::CacheThenNetwork => {
+                self.metadata_cache
+                    .load(&self.localstore, &self.client)
+                    .await?
+            }
+            KeysetLoadPolicy::Refresh => {
+                match self
+                    .metadata_cache
+                    .load_from_mint(&self.localstore, &self.client)
+                    .await
+                {
+                    Ok(m) => m,
+                    Err(e) => match self.metadata_cache.get_cached() {
+                        Some(m) => {
+                            tracing::warn!(
+                                "Failed to refresh keysets from mint: {}. Using cached data.",
+                                e
+                            );
+                            m
+                        }
+                        None => return Err(e),
+                    },
+                }
+            }
+        };
+
+        let keysets: Vec<_> = metadata
+            .keysets
+            .values()
+            .filter(|ks| ks.unit == self.unit)
+            .filter_map(|ks| {
+                let keys = metadata.keys.get(&ks.id)?;
+                Some(KeySet {
+                    id: ks.id,
+                    unit: ks.unit.clone(),
+                    active: Some(ks.active),
+                    keys: (**keys).clone(),
+                    input_fee_ppk: ks.input_fee_ppk,
+                    final_expiry: ks.final_expiry,
+                })
             })
+            .collect();
+
+        if keysets.is_empty() {
+            Err(Error::UnknownKeySet)
+        } else {
+            Ok(keysets)
+        }
+    }
+
+    /// Get the active keyset with the lowest fees.
+    ///
+    /// Filters the output of [`keysets()`](Self::keysets) for active keysets
+    /// and returns the one with the minimum `input_fee_ppk`.
+    #[instrument(skip(self))]
+    pub async fn active_keyset(&self) -> Result<KeySet, Error> {
+        self.active_keyset_with_policy(Default::default()).await
+    }
+
+    /// Get the active keyset using a specific [`KeysetLoadPolicy`].
+    ///
+    /// Same as [`active_keyset()`](Self::active_keyset) but lets callers
+    /// control whether the network may be contacted.
+    #[instrument(skip(self))]
+    pub async fn active_keyset_with_policy(
+        &self,
+        policy: KeysetLoadPolicy,
+    ) -> Result<KeySet, Error> {
+        self.keysets(policy)
             .await?
-            .keys
-            .get(&keyset_id)
-            .map(|x| (*x.clone()).clone())
+            .into_iter()
+            .filter(|k| k.active.unwrap_or(false))
+            .min_by_key(|k| k.input_fee_ppk)
+            .ok_or(Error::NoActiveKeyset)
+    }
+
+    /// Run an operation and retry once if the mint rejects it with
+    /// [`Error::InactiveKeyset`], refreshing the keyset cache before the
+    /// second attempt.
+    ///
+    /// Use this around any code path that selects the active keyset, builds
+    /// outputs, and posts them to the mint.
+    pub(crate) async fn retry_on_inactive_keyset<F, Fut, T>(&self, f: F) -> Result<T, Error>
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = Result<T, Error>>,
+    {
+        match f().await {
+            Err(Error::InactiveKeyset) => {
+                tracing::info!(
+                    "Mint rejected outputs with inactive keyset, refreshing keysets and retrying"
+                );
+
+                let old_active = self
+                    .keysets(KeysetLoadPolicy::CacheOnly)
+                    .await
+                    .ok()
+                    .and_then(|ks| {
+                        ks.into_iter()
+                            .filter(|k| k.active.unwrap_or(false))
+                            .min_by_key(|k| k.input_fee_ppk)
+                            .map(|k| k.id)
+                    });
+
+                let new_active =
+                    self.keysets(KeysetLoadPolicy::Refresh)
+                        .await
+                        .ok()
+                        .and_then(|ks| {
+                            ks.into_iter()
+                                .filter(|k| k.active.unwrap_or(false))
+                                .min_by_key(|k| k.input_fee_ppk)
+                                .map(|k| k.id)
+                        });
+
+                if new_active.is_some() && new_active != old_active {
+                    tracing::info!(
+                        "Active keyset changed from {:?} to {:?}, retrying operation",
+                        old_active,
+                        new_active
+                    );
+                    f().await
+                } else {
+                    tracing::warn!("No new active keyset found after refresh, not retrying");
+                    Err(Error::InactiveKeyset)
+                }
+            }
+            other => other,
+        }
+    }
+
+    /// Get a single keyset by ID.
+    #[instrument(skip(self))]
+    pub async fn keyset(&self, keyset_id: Id) -> Result<KeySet, Error> {
+        self.keyset_with_policy(keyset_id, Default::default()).await
+    }
+
+    /// Get a single keyset by ID using a specific [`KeysetLoadPolicy`].
+    #[instrument(skip(self))]
+    pub async fn keyset_with_policy(
+        &self,
+        keyset_id: Id,
+        policy: KeysetLoadPolicy,
+    ) -> Result<KeySet, Error> {
+        self.keysets(policy)
+            .await?
+            .into_iter()
+            .find(|k| k.id == keyset_id)
             .ok_or(Error::UnknownKeySet)
     }
 
-    /// Alias of get_mint_keysets, kept for backwards compatibility reasons
-    #[instrument(skip(self))]
-    pub async fn load_mint_keysets(&self) -> Result<Vec<KeySetInfo>, Error> {
-        self.get_mint_keysets(KeysetFilter::Active).await
-    }
-
-    /// Get keysets for this wallet's unit from the metadata cache
+    /// Decode proofs from a token using all keysets for this mint.
     ///
-    /// Checks the metadata cache for keysets. If cache is not populated,
-    /// fetches from mint and updates cache. Use [`KeysetFilter::Active`] for
-    /// operations that need current keysets, or [`KeysetFilter::All`] to
-    /// include rotated keysets (e.g. for restore).
-    #[instrument(skip(self))]
-    #[inline(always)]
-    pub async fn get_mint_keysets(&self, filter: KeysetFilter) -> Result<Vec<KeySetInfo>, Error> {
-        let keysets = self
-            .metadata_cache
-            .load(&self.localstore, &self.client, {
-                let ttl = self.metadata_cache_ttl.read();
-                *ttl
-            })
-            .await?
-            .keysets
-            .values()
-            .filter_map(|keyset| {
-                if keyset.unit != self.unit {
-                    return None;
-                }
-
-                if matches!(filter, KeysetFilter::Active) && !keyset.active {
-                    return None;
-                }
-
-                Some((*keyset.clone()).clone())
-            })
-            .collect::<Vec<_>>();
-
-        if !keysets.is_empty() {
-            Ok(keysets)
-        } else {
-            Err(Error::UnknownKeySet)
-        }
-    }
-
-    /// Decode proofs from a token using all known keysets for this mint.
-    ///
-    /// Tokens may contain proofs from inactive keysets. Inactive keysets no
-    /// longer issue new signatures, but mints can still accept their proofs for
-    /// redemption.
+    /// Loads both active and inactive keysets so that proofs minted under
+    /// any keyset can be decoded and redeemed. Uses keyset info directly
+    /// from metadata (not full key material), so keysets whose keys were
+    /// not persisted can still be resolved.
     #[instrument(skip(self, token))]
     pub(crate) async fn token_proofs(&self, token: &Token) -> Result<Proofs, Error> {
-        let keysets = self.get_mint_keysets(KeysetFilter::All).await?;
+        let metadata = self
+            .metadata_cache
+            .load(&self.localstore, &self.client)
+            .await?;
+
+        let keysets: Vec<KeySetInfo> = metadata
+            .keysets
+            .values()
+            .filter(|ks| ks.unit == self.unit)
+            .map(|ks| (**ks).clone())
+            .collect();
+
+        if keysets.is_empty() {
+            return Err(Error::UnknownKeySet);
+        }
+
         Ok(token.proofs(&keysets)?)
     }
 
-    /// Refresh keysets by fetching the latest from mint - always fetches fresh data
-    ///
-    /// Forces a fresh fetch of keyset information from the mint server,
-    /// updating the metadata cache and database. Use this when you need
-    /// the most up-to-date keyset information.
-    #[instrument(skip(self))]
-    pub async fn refresh_keysets(&self) -> Result<Vec<KeySetInfo>, Error> {
-        tracing::debug!("Refreshing keysets from mint");
-
-        let keysets = self
-            .metadata_cache
-            .load_from_mint(&self.localstore, &self.client)
-            .await?
-            .keysets
-            .values()
-            .filter_map(|keyset| {
-                if keyset.unit == self.unit && keyset.active {
-                    Some((*keyset.clone()).clone())
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-
-        if !keysets.is_empty() {
-            Ok(keysets)
-        } else {
-            Err(Error::UnknownKeySet)
-        }
-    }
-
-    /// Get the active keyset with the lowest fees - fetches fresh data from mint
-    ///
-    /// Forces a fresh fetch of keysets from the mint and returns the active keyset
-    /// with the minimum input fees. Use this when you need the most up-to-date
-    /// keyset information for operations.
-    #[instrument(skip(self))]
-    pub async fn fetch_active_keyset(&self) -> Result<KeySetInfo, Error> {
-        self.get_mint_keysets(KeysetFilter::Active)
-            .await?
-            .active()
-            .min_by_key(|k| k.input_fee_ppk)
-            .cloned()
-            .ok_or(Error::NoActiveKeyset)
-    }
-
-    /// Get the active keyset with the lowest fees from cache
-    ///
-    /// Returns the active keyset with minimum input fees from the metadata cache.
-    /// Uses cached data if available, fetches from mint if cache not populated.
-    #[instrument(skip(self))]
-    pub async fn get_active_keyset(&self) -> Result<KeySetInfo, Error> {
-        self.metadata_cache
-            .load(&self.localstore, &self.client, {
-                let ttl = self.metadata_cache_ttl.read();
-                *ttl
-            })
-            .await?
-            .active_keysets
-            .iter()
-            .min_by_key(|k| k.input_fee_ppk)
-            .map(|ks| (**ks).clone())
-            .ok_or(Error::NoActiveKeyset)
-    }
-
-    /// Get keyset fees and amounts for all keysets from metadata cache
-    ///
-    /// Returns a HashMap of keyset IDs to their input fee rates (per-proof-per-thousand)
-    /// and available amounts. Uses cached data if available, fetches from mint if not.
+    /// Get keyset fees and amounts for all keysets
     pub async fn get_keyset_fees_and_amounts(&self) -> Result<KeysetFeeAndAmounts, Error> {
-        let metadata = self
-            .metadata_cache
-            .load(&self.localstore, &self.client, {
-                let ttl = self.metadata_cache_ttl.read();
-                *ttl
-            })
-            .await?;
+        self.get_keyset_fees_and_amounts_with_policy(Default::default())
+            .await
+    }
 
+    /// Same as [`get_keyset_fees_and_amounts()`](Self::get_keyset_fees_and_amounts)
+    /// but lets callers control the [`KeysetLoadPolicy`].
+    pub async fn get_keyset_fees_and_amounts_with_policy(
+        &self,
+        policy: KeysetLoadPolicy,
+    ) -> Result<KeysetFeeAndAmounts, Error> {
+        let all = self.keysets(policy).await?;
         let mut fees = HashMap::new();
-        for keyset in metadata.keysets.values() {
-            let keys = self.load_keyset_keys(keyset.id).await?;
+        for ks in &all {
             fees.insert(
-                keyset.id,
+                ks.id,
                 (
-                    keyset.input_fee_ppk,
-                    keys.iter()
+                    ks.input_fee_ppk,
+                    ks.keys
+                        .iter()
                         .map(|(amount, _)| amount.to_u64())
                         .collect::<Vec<_>>(),
                 )
                     .into(),
             );
         }
-
         Ok(fees)
     }
 
@@ -187,14 +236,22 @@ impl Wallet {
     }
 
     /// Get keyset fees and amounts for a specific keyset ID
-    ///
-    /// Returns the input fee rate (per-proof-per-thousand) and available amounts
-    /// for a specific keyset. Uses cached data if available, fetches from mint if not.
     pub async fn get_keyset_fees_and_amounts_by_id(
         &self,
         keyset_id: Id,
     ) -> Result<FeeAndAmounts, Error> {
-        self.get_keyset_fees_and_amounts()
+        self.get_keyset_fees_and_amounts_by_id_with_policy(keyset_id, Default::default())
+            .await
+    }
+
+    /// Get keyset fees and amounts for a specific keyset ID using a specific
+    /// [`KeysetLoadPolicy`].
+    pub async fn get_keyset_fees_and_amounts_by_id_with_policy(
+        &self,
+        keyset_id: Id,
+        policy: KeysetLoadPolicy,
+    ) -> Result<FeeAndAmounts, Error> {
+        self.get_keyset_fees_and_amounts_with_policy(policy)
             .await?
             .get(&keyset_id)
             .cloned()
@@ -204,52 +261,36 @@ impl Wallet {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
     use super::*;
     use crate::nuts::{CurrencyUnit, Token};
     use crate::wallet::test_utils::{
-        create_test_db, create_test_wallet_with_mock, test_mint_url, test_proof, MockMintConnector,
+        create_test_db, create_test_wallet_with_mock, make_inactive_keyset, test_keyset,
+        test_mint_url, test_proof, MockMintConnector,
     };
 
     #[tokio::test]
     async fn token_proofs_decodes_inactive_keyset_proofs() {
-        let active_id =
-            Id::from_str("01fb5c0e707d1a26e1ea8e8a70f6117beecc22b4797ac3548e802ec7ee477ec627")
-                .expect("valid active id");
-        let inactive_id =
-            Id::from_str("01950154227f1f2b94eb0f14cb460fa7ec35c096457afdf2b4c09fddda15dc0c44")
-                .expect("valid inactive id");
+        let active_ks = test_keyset();
+        let active_id = active_ks.id;
+
+        let inactive_ks = make_inactive_keyset();
+        let inactive_id = inactive_ks.id;
 
         let db = create_test_db().await;
         let mint_url = test_mint_url();
         db.add_mint(mint_url.clone(), None)
             .await
             .expect("mint should be stored");
-        db.add_mint_keysets(
-            mint_url.clone(),
-            vec![
-                KeySetInfo {
-                    id: active_id,
-                    unit: CurrencyUnit::Sat,
-                    active: true,
-                    input_fee_ppk: 100,
-                    final_expiry: None,
-                },
-                KeySetInfo {
-                    id: inactive_id,
-                    unit: CurrencyUnit::Sat,
-                    active: false,
-                    input_fee_ppk: 0,
-                    final_expiry: None,
-                },
-            ],
-        )
-        .await
-        .expect("keysets should be stored");
 
-        let wallet = create_test_wallet_with_mock(db, Arc::new(MockMintConnector::new())).await;
+        let mock = MockMintConnector::new();
+        mock.set_mint_keys_response(Ok(vec![active_ks.clone(), inactive_ks.clone()]));
+        let mock = Arc::new(mock);
+
+        let wallet = create_test_wallet_with_mock(db, mock).await;
+
         let token = Token::new(
             mint_url,
             vec![test_proof(inactive_id, 1)],
@@ -257,10 +298,22 @@ mod tests {
             CurrencyUnit::Sat,
         );
 
-        let active_keysets = wallet
-            .get_mint_keysets(KeysetFilter::Active)
+        let active_keysets: Vec<KeySetInfo> = wallet
+            .keysets(Default::default())
             .await
-            .expect("active keysets should load");
+            .expect("keysets should load")
+            .into_iter()
+            .filter(|k| k.active.unwrap_or(false))
+            .map(|ks| KeySetInfo {
+                id: ks.id,
+                unit: ks.unit,
+                active: ks.active.unwrap_or(true),
+                input_fee_ppk: ks.input_fee_ppk,
+                final_expiry: ks.final_expiry,
+            })
+            .collect();
+        assert_eq!(active_keysets.len(), 1);
+        assert_eq!(active_keysets[0].id, active_id);
         assert!(
             token.proofs(&active_keysets).is_err(),
             "active-only keysets should not decode an inactive keyset proof"
@@ -272,5 +325,190 @@ mod tests {
             .expect("all keysets should decode an inactive keyset proof");
         assert_eq!(proofs.len(), 1);
         assert_eq!(proofs[0].keyset_id, inactive_id);
+    }
+
+    /// Verify that receiving a token with proofs from an inactive keyset
+    /// succeeds through the full receive preparation phase: token decoding,
+    /// fee calculation, and active keyset selection for swap outputs.
+    #[tokio::test]
+    async fn receive_prepares_swap_for_inactive_keyset_proofs() {
+        use crate::wallet::receive::saga::ReceiveSaga;
+        use crate::wallet::ReceiveOptions;
+
+        let inactive_ks = make_inactive_keyset();
+        let inactive_id = inactive_ks.id;
+
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        db.add_mint(mint_url.clone(), None)
+            .await
+            .expect("mint should be stored");
+
+        let mock = MockMintConnector::new();
+        mock.set_mint_keys_response(Ok(vec![test_keyset(), inactive_ks]));
+        let mock = Arc::new(mock);
+
+        let wallet = create_test_wallet_with_mock(db, mock).await;
+
+        // Build proofs as if they came from the inactive keyset
+        let proofs = vec![test_proof(inactive_id, 2), test_proof(inactive_id, 1)];
+
+        let saga = ReceiveSaga::new(&wallet);
+        // Prepare decodes proofs, looks up the inactive keyset for DLEQ
+        // verification, calculates fees, and selects the active keyset for
+        // swap outputs. If inactive keysets are not properly loaded, this
+        // call would fail with UnknownKeySet.
+        let _prepared = saga
+            .prepare(proofs, ReceiveOptions::default(), None, None)
+            .await
+            .expect("prepare should succeed with inactive keyset proofs");
+    }
+
+    /// When the active keyset changes after refresh, retry_on_inactive_keyset
+    /// should retry and return the second attempt's result.
+    #[tokio::test]
+    async fn retry_on_inactive_keyset_retries_when_keyset_changes() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        db.add_mint(mint_url.clone(), None).await.unwrap();
+
+        let mock = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db, mock.clone()).await;
+
+        // Prime the cache with the original keyset
+        wallet.keysets(KeysetLoadPolicy::Refresh).await.unwrap();
+
+        // Build a new keyset that will become the active one after rotation
+        let new_keyset = make_inactive_keyset();
+        let mut rotated = new_keyset;
+        rotated.active = Some(true);
+
+        // Deactivate the old keyset
+        let mut old = test_keyset();
+        old.active = Some(false);
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_clone = call_count.clone();
+        let mock_clone = mock.clone();
+
+        let result = wallet
+            .retry_on_inactive_keyset(|| {
+                let call_count = call_count_clone.clone();
+                let mock = mock_clone.clone();
+                let old = old.clone();
+                let rotated = rotated.clone();
+                async move {
+                    let n = call_count.fetch_add(1, Ordering::SeqCst);
+                    if n == 0 {
+                        // Before the retry, rotate the keysets on the mock
+                        // so the refresh picks up the new active keyset.
+                        mock.set_mint_keys_response(Ok(vec![old, rotated]));
+                        Err(Error::InactiveKeyset)
+                    } else {
+                        Ok(42u32)
+                    }
+                }
+            })
+            .await;
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
+    }
+
+    /// When the active keyset does NOT change after refresh,
+    /// retry_on_inactive_keyset should not retry.
+    #[tokio::test]
+    async fn retry_on_inactive_keyset_no_retry_when_keyset_unchanged() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        db.add_mint(mint_url.clone(), None).await.unwrap();
+
+        let mock = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db, mock).await;
+
+        // Prime the cache
+        wallet.keysets(KeysetLoadPolicy::Refresh).await.unwrap();
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_clone = call_count.clone();
+
+        let result: Result<u32, Error> = wallet
+            .retry_on_inactive_keyset(|| {
+                let call_count = call_count_clone.clone();
+                async move {
+                    call_count.fetch_add(1, Ordering::SeqCst);
+                    Err(Error::InactiveKeyset)
+                }
+            })
+            .await;
+
+        assert!(matches!(result, Err(Error::InactiveKeyset)));
+        // Should only be called once — no retry since keyset didn't change
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    /// When the operation succeeds on the first try, no retry logic runs.
+    #[tokio::test]
+    async fn retry_on_inactive_keyset_no_retry_on_success() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        db.add_mint(mint_url.clone(), None).await.unwrap();
+
+        let mock = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db, mock).await;
+
+        // Prime the cache
+        wallet.keysets(KeysetLoadPolicy::Refresh).await.unwrap();
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_clone = call_count.clone();
+
+        let result = wallet
+            .retry_on_inactive_keyset(|| {
+                let call_count = call_count_clone.clone();
+                async move {
+                    call_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(99u32)
+                }
+            })
+            .await;
+
+        assert_eq!(result.unwrap(), 99);
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    /// When the in-memory cache's TTL has expired, `CacheThenNetwork` should
+    /// fetch fresh data from the mint — not return stale data from the database.
+    #[tokio::test]
+    async fn load_fetches_from_mint_when_ttl_expired() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        db.add_mint(mint_url.clone(), None).await.unwrap();
+
+        let mock = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db, mock.clone()).await;
+
+        // Prime cache + DB with the default keyset (fee = 101)
+        let initial = wallet.keysets(KeysetLoadPolicy::Refresh).await.unwrap();
+        let initial_fee = initial[0].input_fee_ppk;
+        assert_eq!(initial_fee, 101);
+
+        // Expire the cache immediately
+        wallet.set_metadata_cache_ttl(Some(std::time::Duration::ZERO));
+
+        // Update the mock to return a keyset with a different fee
+        let mut updated_keyset = test_keyset();
+        updated_keyset.input_fee_ppk = 999;
+        mock.set_mint_keys_response(Ok(vec![updated_keyset]));
+
+        // CacheThenNetwork should fetch from mint since TTL expired
+        let refreshed = wallet
+            .keysets(KeysetLoadPolicy::CacheThenNetwork)
+            .await
+            .unwrap();
+        assert_eq!(
+            refreshed[0].input_fee_ppk, 999,
+            "expected fresh data from mint, got stale cache/db data"
+        );
     }
 }

--- a/crates/cdk/src/wallet/melt/custom.rs
+++ b/crates/cdk/src/wallet/melt/custom.rs
@@ -21,7 +21,7 @@ impl Wallet {
         _options: Option<MeltOptions>,
         extra: Option<serde_json::Value>,
     ) -> Result<MeltQuote, Error> {
-        self.refresh_keysets().await?;
+        self.keysets(Default::default()).await?;
 
         let quote_request = MeltQuoteCustomRequest {
             method: method.to_string(),

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -1197,10 +1197,7 @@ impl Wallet {
         // Get mint info from cache to check bolt12 support (no network call)
         let mint_info = &self
             .metadata_cache
-            .load(&self.localstore, &self.client, {
-                let ttl = self.metadata_cache_ttl.read();
-                *ttl
-            })
+            .load(&self.localstore, &self.client)
             .await?
             .mint_info;
 

--- a/crates/cdk/src/wallet/melt/saga/mod.rs
+++ b/crates/cdk/src/wallet/melt/saga/mod.rs
@@ -37,8 +37,8 @@ use std::collections::HashMap;
 use cdk_common::amount::SplitTarget;
 use cdk_common::dhke::construct_proofs;
 use cdk_common::wallet::{
-    MeltOperationData, MeltQuote, MeltSagaState, OperationData, ProofInfo, Transaction,
-    TransactionDirection, WalletSaga, WalletSagaState,
+    KeysetLoadPolicy, MeltOperationData, MeltQuote, MeltSagaState, OperationData, ProofInfo,
+    Transaction, TransactionDirection, WalletSaga, WalletSagaState,
 };
 use cdk_common::{MeltQuoteState, PaymentMethod};
 use tracing::instrument;
@@ -53,7 +53,6 @@ use crate::util::unix_time;
 use crate::wallet::blind_signature::{
     validate_mint_response_signatures, SignatureAmountValidation,
 };
-use crate::wallet::keysets::KeysetFilter;
 use crate::wallet::saga::{add_compensation, new_compensations, Compensations};
 use crate::{ensure_cdk, Amount, Error, Wallet};
 
@@ -97,9 +96,13 @@ async fn finalize_melt_common<'a>(
     payment_proof: Option<String>,
     change: Option<Vec<crate::nuts::BlindSignature>>,
     metadata: HashMap<String, String>,
+    keyset_policy: KeysetLoadPolicy,
 ) -> Result<MeltSaga<'a, Finalized>, Error> {
-    let active_keyset_id = wallet.fetch_active_keyset().await?.id;
-    let active_keys = wallet.load_keyset_keys(active_keyset_id).await?;
+    let active_keyset_id = wallet.active_keyset_with_policy(keyset_policy).await?.id;
+    let active_keys = wallet
+        .keyset_with_policy(active_keyset_id, keyset_policy)
+        .await?
+        .keys;
 
     let change_proofs = match change {
         Some(change) => {
@@ -237,7 +240,10 @@ impl<'a> MeltSaga<'a, Initial> {
         Self {
             wallet,
             compensations: new_compensations(),
-            state_data: Initial { operation_id },
+            state_data: Initial {
+                operation_id,
+                keyset_policy: Default::default(),
+            },
         }
     }
 
@@ -301,14 +307,20 @@ impl<'a> MeltSaga<'a, Initial> {
             .checked_add(quote_info.fee_reserve)
             .ok_or(Error::AmountOverflow)?;
 
+        let keyset_policy = self.state_data.keyset_policy;
+
         let active_keyset_ids = self
             .wallet
-            .get_mint_keysets(KeysetFilter::Active)
+            .keysets(keyset_policy)
             .await?
             .into_iter()
+            .filter(|k| k.active.unwrap_or(false))
             .map(|k| k.id)
             .collect();
-        let keyset_fees_and_amounts = self.wallet.get_keyset_fees_and_amounts().await?;
+        let keyset_fees_and_amounts = self
+            .wallet
+            .get_keyset_fees_and_amounts_with_policy(keyset_policy)
+            .await?;
 
         let available_proofs = self.wallet.get_unspent_proofs().await?;
 
@@ -372,21 +384,30 @@ impl<'a> MeltSaga<'a, Initial> {
                     swap_fee: Amount::ZERO,
                     input_fee,
                     input_fee_without_swap: input_fee,
+                    keyset_policy,
                     saga,
                 },
             });
         }
 
-        let active_keyset_id = self.wallet.get_active_keyset().await?.id;
+        let active_keyset_id = self
+            .wallet
+            .active_keyset_with_policy(keyset_policy)
+            .await?
+            .id;
         let fee_and_amounts = self
             .wallet
-            .get_keyset_fees_and_amounts_by_id(active_keyset_id)
+            .get_keyset_fees_and_amounts_by_id_with_policy(active_keyset_id, keyset_policy)
             .await?;
 
         let estimated_output_count = inputs_needed_amount.split(&fee_and_amounts)?.len();
         let estimated_melt_fee = self
             .wallet
-            .get_keyset_count_fee(&active_keyset_id, estimated_output_count as u64)
+            .get_keyset_count_fee_with_policy(
+                &active_keyset_id,
+                estimated_output_count as u64,
+                keyset_policy,
+            )
             .await?;
 
         let selection_amount = inputs_needed_amount
@@ -459,6 +480,7 @@ impl<'a> MeltSaga<'a, Initial> {
                 swap_fee,
                 input_fee,
                 input_fee_without_swap,
+                keyset_policy,
                 saga,
             },
         })
@@ -564,6 +586,7 @@ impl<'a> MeltSaga<'a, Initial> {
                 swap_fee: Amount::ZERO,
                 input_fee,
                 input_fee_without_swap: input_fee,
+                keyset_policy: self.state_data.keyset_policy,
                 saga,
             },
         })
@@ -600,6 +623,7 @@ impl<'a> MeltSaga<'a, Prepared> {
                 swap_fee: Amount::ZERO,
                 input_fee,
                 input_fee_without_swap,
+                keyset_policy: Default::default(),
                 saga,
             },
         }
@@ -667,7 +691,12 @@ impl<'a> MeltSaga<'a, Prepared> {
             options.skip_swap
         );
 
-        let active_keyset_id = self.wallet.fetch_active_keyset().await?.id;
+        let keyset_policy = self.state_data.keyset_policy;
+        let active_keyset_id = self
+            .wallet
+            .active_keyset_with_policy(keyset_policy)
+            .await?
+            .id;
         let mut final_proofs = self.state_data.proofs.clone();
 
         // Handle proofs_to_swap based on skip_swap option
@@ -1009,6 +1038,7 @@ impl<'a> MeltSaga<'a, MeltRequested> {
                                 standard_response.payment_preimage,
                                 standard_response.change,
                                 metadata,
+                                Default::default(),
                             )
                             .await?;
                             return Ok(MeltSagaResult::Finalized(finalized));
@@ -1066,6 +1096,7 @@ impl<'a> MeltSaga<'a, MeltRequested> {
                     melt_response.payment_proof().map(|s| s.to_string()),
                     melt_response.change().cloned(),
                     metadata,
+                    Default::default(),
                 )
                 .await?;
                 Ok(MeltSagaResult::Finalized(finalized))
@@ -1215,6 +1246,7 @@ impl<'a> MeltSaga<'a, PaymentPending> {
             payment_proof,
             change,
             metadata,
+            Default::default(),
         )
         .await
     }
@@ -1642,6 +1674,7 @@ mod tests {
             None,
             Some(oversized_change),
             HashMap::new(),
+            Default::default(),
         )
         .await;
 
@@ -1678,6 +1711,7 @@ mod tests {
             None,
             Some(change),
             HashMap::new(),
+            Default::default(),
         )
         .await;
 

--- a/crates/cdk/src/wallet/melt/saga/state.rs
+++ b/crates/cdk/src/wallet/melt/saga/state.rs
@@ -17,7 +17,7 @@
 //! Note: `PaymentPending` is a persistence state in `WalletSaga`, not a typestate.
 //! When payment is pending, the saga returns an error and recovery handles it later.
 
-use cdk_common::wallet::WalletSaga;
+use cdk_common::wallet::{KeysetLoadPolicy, WalletSaga};
 use cdk_common::MeltQuoteState;
 use uuid::Uuid;
 
@@ -30,6 +30,8 @@ use crate::Amount;
 pub struct Initial {
     /// Unique operation identifier for tracking and crash recovery
     pub operation_id: Uuid,
+    /// Policy controlling how keysets are loaded during this saga
+    pub keyset_policy: KeysetLoadPolicy,
 }
 
 /// Prepared state - proofs have been selected and reserved.
@@ -48,6 +50,8 @@ pub struct Prepared {
     pub input_fee: Amount,
     /// Input fee if swap is skipped (on all proofs directly)
     pub input_fee_without_swap: Amount,
+    /// Policy controlling how keysets are loaded
+    pub keyset_policy: KeysetLoadPolicy,
     /// The persisted saga for optimistic locking
     pub saga: WalletSaga,
 }

--- a/crates/cdk/src/wallet/mint_metadata_cache.rs
+++ b/crates/cdk/src/wallet/mint_metadata_cache.rs
@@ -90,7 +90,7 @@ pub struct MintMetadata {
     pub active_keysets: Vec<Arc<KeySetInfo>>,
 
     /// Freshness tracking for regular (non-auth) mint data
-    status: FreshnessStatus,
+    pub(crate) status: FreshnessStatus,
 
     /// Freshness tracking for blind auth keysets
     auth_status: FreshnessStatus,
@@ -119,6 +119,11 @@ pub struct MintMetadataCache {
     /// Atomically-updated metadata snapshot (lock-free reads)
     metadata: Arc<ArcSwap<MintMetadata>>,
 
+    /// How long cached metadata is considered fresh before re-fetching.
+    /// `None` means cached data never expires (unless manually refreshed).
+    /// Default: 1 hour (3600 seconds).
+    ttl: Arc<RwLock<Option<Duration>>>,
+
     /// Tracks which database instances have been synced to which cache version.
     /// Key: pointer identity of storage Arc, Value: last synced cache version
     db_sync_versions: Arc<RwLock<HashMap<usize, usize>>>,
@@ -139,17 +144,14 @@ impl std::fmt::Debug for MintMetadataCache {
 }
 
 impl Wallet {
-    /// Sets the metadata cache TTL
+    /// Sets the metadata cache TTL.
     ///
-    /// The TTL determines how often the wallet checks the mint for new keysets and information.
+    /// The TTL determines how often the wallet re-fetches keysets and mint info.
+    /// Because the cache is shared, this affects all wallets using the same mint.
     ///
-    /// If `None`, the cache will never expire and the wallet will use cached data indefinitely
-    /// (unless manually refreshed).
-    ///
-    /// The default value is 1 hour (3600 seconds).
+    /// `None` means cached data never expires. Default: 1 hour.
     pub fn set_metadata_cache_ttl(&self, ttl: Option<Duration>) {
-        let mut guarded_ttl = self.metadata_cache_ttl.write();
-        *guarded_ttl = ttl;
+        self.metadata_cache.set_ttl(ttl);
     }
 
     /// Get information about metadata cache info
@@ -186,16 +188,59 @@ impl MintMetadataCache {
     /// # Example
     ///
     /// ```ignore
-    /// let cache = MintMetadataCache::new(mint_url, None);
+    /// let cache = MintMetadataCache::new(mint_url);
     /// // No data loaded yet - call load() to fetch
     /// ```
     pub fn new(mint_url: MintUrl) -> Self {
         Self {
             mint_url,
             metadata: Arc::new(ArcSwap::default()),
+            ttl: Arc::new(RwLock::new(Some(Duration::from_secs(3600)))),
             db_sync_versions: Arc::new(Default::default()),
             fetch_lock: Arc::new(Mutex::new(())),
         }
+    }
+
+    /// Set the TTL for cached metadata.
+    ///
+    /// `None` means cached data never expires.
+    pub fn set_ttl(&self, ttl: Option<Duration>) {
+        *self.ttl.write() = ttl;
+    }
+
+    /// Get the current TTL.
+    pub fn ttl(&self) -> Option<Duration> {
+        *self.ttl.read()
+    }
+
+    /// Return cached metadata if populated, without fetching or TTL checks.
+    pub fn get_cached(&self) -> Option<Arc<MintMetadata>> {
+        let m = self.metadata.load().clone();
+        if m.status.is_populated {
+            Some(m)
+        } else {
+            None
+        }
+    }
+
+    /// Load metadata from in-memory cache or database, without network access.
+    ///
+    /// Checks the in-memory cache first. If not populated, loads from the
+    /// database. Returns an error if neither source has data.
+    pub async fn load_cached(
+        &self,
+        storage: &Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
+    ) -> Result<Arc<MintMetadata>, Error> {
+        if let Some(cached) = self.get_cached() {
+            return Ok(cached);
+        }
+
+        let from_db = self.load_from_db(storage).await?;
+        if from_db.status.is_populated {
+            return Ok(from_db);
+        }
+
+        Err(Error::UnknownKeySet)
     }
 
     /// Load metadata from mint server and update cache
@@ -314,9 +359,10 @@ impl MintMetadataCache {
             }
         }
 
-        // Only mark as populated if we actually loaded keysets
+        // Only mark as populated if we actually loaded keysets.
+        // Don't update `updated_at` — the TTL should reflect when we last
+        // fetched from the mint, not when we read from the local DB.
         new_metadata.status.is_populated = !new_metadata.keysets.is_empty();
-        new_metadata.status.updated_at = Instant::now();
         new_metadata.status.version += 1;
 
         tracing::info!(
@@ -367,10 +413,10 @@ impl MintMetadataCache {
         &self,
         storage: &Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
         client: &Arc<dyn MintConnector + Send + Sync>,
-        ttl: Option<Duration>,
     ) -> Result<Arc<MintMetadata>, Error> {
         let cached_metadata = self.metadata.load().clone();
         let storage_id = Self::arc_pointer_id(storage);
+        let ttl = *self.ttl.read();
 
         // Check what version of cache this database has seen
         let db_synced_version = self
@@ -394,15 +440,29 @@ impl MintMetadataCache {
             return Ok(cached_metadata);
         }
 
-        // Try loading from database first (avoids HTTP if data is persisted)
-        if let Ok(metadata) = self.load_from_db(storage).await {
-            if metadata.status.is_populated {
-                return Ok(metadata);
+        // In-memory cache was empty (not just stale) — try database before network
+        if !cached_metadata.status.is_populated {
+            if let Ok(metadata) = self.load_from_db(storage).await {
+                if metadata.status.is_populated {
+                    return Ok(metadata);
+                }
             }
         }
 
-        // Database had no data - fetch from mint
-        self.load_from_mint(storage, client).await
+        // Cache was stale (TTL expired) or neither cache nor DB had data — fetch from mint
+        match self.load_from_mint(storage, client).await {
+            Ok(metadata) => Ok(metadata),
+            Err(e) if cached_metadata.status.is_populated => {
+                // Network failed but we have usable stale data — return it
+                tracing::warn!(
+                    "Failed to refresh metadata from mint {}, using stale cache: {}",
+                    self.mint_url,
+                    e
+                );
+                Ok(cached_metadata)
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Load auth keysets and keys (auth feature only)
@@ -425,10 +485,10 @@ impl MintMetadataCache {
         &self,
         storage: &Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
         auth_client: &Arc<dyn AuthMintConnector + Send + Sync>,
-        ttl: Option<Duration>,
     ) -> Result<Arc<MintMetadata>, Error> {
         let cached_metadata = self.metadata.load().clone();
         let storage_id = Self::arc_pointer_id(storage);
+        let ttl = *self.ttl.read();
 
         let db_synced_version = self
             .db_sync_versions

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -4,15 +4,13 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv};
 use bitcoin::Network;
 use cdk_common::amount::FeeAndAmounts;
 use cdk_common::database::{self, WalletDatabase};
-use cdk_common::parking_lot::RwLock;
 use cdk_common::subscription::WalletParams;
-use cdk_common::wallet::ProofInfo;
+use cdk_common::wallet::{KeysetLoadPolicy, ProofInfo};
 use cdk_common::{PublicKey, SecretKey, SECP256K1};
 use getrandom::getrandom;
 pub use mint_connector::http_client::{
@@ -83,12 +81,12 @@ pub use cdk_common::wallet as types;
 pub use cdk_common::wallet::{
     NUT13Options, P2PKLockedProofSendMode, ReceiveOptions, SendMemo, SendOptions,
 };
-pub use keysets::KeysetFilter;
 pub use melt::{MeltConfirmOptions, MeltOutcome, PendingMelt, PreparedMelt};
 pub use mint_connector::transport::Transport as HttpTransport;
 pub use mint_connector::{
     AuthHttpClient, HttpClient, LnurlPayInvoiceResponse, LnurlPayResponse, MintConnector,
 };
+pub use mint_metadata_cache::MintMetadata;
 #[cfg(feature = "nostr")]
 pub use nostr_backup::{BackupOptions, BackupResult, RestoreOptions, RestoreResult};
 #[cfg(feature = "npubcash")]
@@ -131,7 +129,6 @@ pub struct Wallet {
     pub metadata_cache: Arc<MintMetadataCache>,
     /// The targeted amount of proofs to have at each size
     pub target_proof_count: usize,
-    metadata_cache_ttl: Arc<RwLock<Option<Duration>>>,
     auth_wallet: Arc<TokioRwLock<Option<AuthWallet>>>,
     #[cfg(feature = "npubcash")]
     npubcash_client: Arc<TokioRwLock<Option<Arc<cdk_npubcash::NpubCashClient>>>>,
@@ -332,10 +329,7 @@ impl Wallet {
         let mut fee_per_keyset = HashMap::new();
         let metadata = self
             .metadata_cache
-            .load(&self.localstore, &self.client, {
-                let ttl = self.metadata_cache_ttl.read();
-                *ttl
-            })
+            .load(&self.localstore, &self.client)
             .await?;
 
         for keyset_id in proofs_per_keyset.keys() {
@@ -354,17 +348,22 @@ impl Wallet {
     /// Get fee for count of proofs in a keyset
     #[instrument(skip_all)]
     pub async fn get_keyset_count_fee(&self, keyset_id: &Id, count: u64) -> Result<Amount, Error> {
+        self.get_keyset_count_fee_with_policy(keyset_id, count, Default::default())
+            .await
+    }
+
+    /// Calculate fee for a given number of proofs using a specific
+    /// [`KeysetLoadPolicy`].
+    pub async fn get_keyset_count_fee_with_policy(
+        &self,
+        keyset_id: &Id,
+        count: u64,
+        policy: KeysetLoadPolicy,
+    ) -> Result<Amount, Error> {
         let input_fee_ppk = self
-            .metadata_cache
-            .load(&self.localstore, &self.client, {
-                let ttl = self.metadata_cache_ttl.read();
-                *ttl
-            })
+            .get_keyset_fees_and_amounts_by_id_with_policy(*keyset_id, policy)
             .await?
-            .keysets
-            .get(keyset_id)
-            .ok_or(Error::UnknownKeySet)?
-            .input_fee_ppk;
+            .fee();
 
         let fee = (input_fee_ppk * count).div_ceil(1000);
 
@@ -439,7 +438,6 @@ impl Wallet {
                         None,
                         self.localstore.clone(),
                         self.metadata_cache.clone(),
-                        self.metadata_cache_ttl.clone(),
                         mint_info.protected_endpoints(),
                         oidc_client,
                     );
@@ -470,10 +468,7 @@ impl Wallet {
     pub async fn load_mint_info(&self) -> Result<MintInfo, Error> {
         let mint_info = self
             .metadata_cache
-            .load(&self.localstore, &self.client, {
-                let ttl = self.metadata_cache_ttl.read();
-                *ttl
-            })
+            .load(&self.localstore, &self.client)
             .await?
             .mint_info
             .clone();
@@ -574,12 +569,12 @@ impl Wallet {
             self.fetch_mint_info().await?;
         }
 
-        let keysets = self.get_mint_keysets(KeysetFilter::All).await?;
+        let keysets = self.keysets(Default::default()).await?;
 
         let mut restored_result = Restored::default();
 
         for keyset in keysets {
-            let keys = self.load_keyset_keys(keyset.id).await?;
+            let keys = self.keyset(keyset.id).await?.keys;
             let mut empty_batch: u32 = 0;
             let mut start_counter: u32 = 0;
             // Track the highest counter value that had a signature
@@ -881,7 +876,7 @@ impl Wallet {
             let mint_pubkey = match keys_cache.get(&proof.keyset_id) {
                 Some(keys) => keys.amount_key(proof.amount),
                 None => {
-                    let keys = self.load_keyset_keys(proof.keyset_id).await?;
+                    let keys = self.keyset(proof.keyset_id).await?.keys;
 
                     let key = keys.amount_key(proof.amount);
                     keys_cache.insert(proof.keyset_id, keys);

--- a/crates/cdk/src/wallet/receive/mod.rs
+++ b/crates/cdk/src/wallet/receive/mod.rs
@@ -27,10 +27,15 @@ impl Wallet {
         memo: Option<String>,
         token: Option<String>,
     ) -> Result<Amount, Error> {
-        let saga = ReceiveSaga::new(self);
-        let saga = saga.prepare(proofs, opts, memo, token).await?;
-        let saga = saga.execute().await?;
-        Ok(saga.into_amount())
+        self.retry_on_inactive_keyset(|| async {
+            let saga = ReceiveSaga::new(self);
+            let saga = saga
+                .prepare(proofs.clone(), opts.clone(), memo.clone(), token.clone())
+                .await?;
+            let saga = saga.execute().await?;
+            Ok(saga.into_amount())
+        })
+        .await
     }
 
     /// Receive

--- a/crates/cdk/src/wallet/receive/saga/mod.rs
+++ b/crates/cdk/src/wallet/receive/saga/mod.rs
@@ -83,7 +83,10 @@ impl<'a> ReceiveSaga<'a, Initial> {
         Self {
             wallet,
             compensations: new_compensations(),
-            state_data: Initial { operation_id },
+            state_data: Initial {
+                operation_id,
+                keyset_policy: Default::default(),
+            },
         }
     }
 
@@ -107,7 +110,12 @@ impl<'a> ReceiveSaga<'a, Initial> {
 
         let _mint_info = self.wallet.load_mint_info().await?;
 
-        let active_keyset_id = self.wallet.fetch_active_keyset().await?.id;
+        let keyset_policy = self.state_data.keyset_policy;
+        let active_keyset_id = self
+            .wallet
+            .active_keyset_with_policy(keyset_policy)
+            .await?
+            .id;
 
         let mut proofs = proofs;
         let proofs_amount = proofs.total_amount()?;
@@ -134,7 +142,11 @@ impl<'a> ReceiveSaga<'a, Initial> {
         for proof in &mut proofs {
             // Verify that proof DLEQ is valid
             if proof.dleq.is_some() {
-                let keys = self.wallet.load_keyset_keys(proof.keyset_id).await?;
+                let keys = self
+                    .wallet
+                    .keyset_with_policy(proof.keyset_id, keyset_policy)
+                    .await?
+                    .keys;
                 let key = keys.amount_key(proof.amount).ok_or(Error::AmountKey)?;
                 proof.verify_dleq(key)?;
             }
@@ -262,8 +274,9 @@ impl<'a> ReceiveSaga<'a, Prepared> {
 
         let keys = self
             .wallet
-            .load_keyset_keys(self.state_data.active_keyset_id)
-            .await?;
+            .keyset(self.state_data.active_keyset_id)
+            .await?
+            .keys;
 
         let proofs = self.state_data.proofs.clone();
         let proofs_ys = proofs.ys()?;

--- a/crates/cdk/src/wallet/receive/saga/state.rs
+++ b/crates/cdk/src/wallet/receive/saga/state.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use bitcoin::XOnlyPublicKey;
+use cdk_common::wallet::KeysetLoadPolicy;
 use uuid::Uuid;
 
 use crate::nuts::{Id, Proofs, SecretKey};
@@ -27,6 +28,8 @@ use crate::Amount;
 pub struct Initial {
     /// Unique operation identifier for tracking and crash recovery
     pub operation_id: Uuid,
+    /// Policy controlling how keysets are loaded during this saga
+    pub keyset_policy: KeysetLoadPolicy,
 }
 
 /// Prepared state - token has been parsed and proofs extracted.

--- a/crates/cdk/src/wallet/recovery.rs
+++ b/crates/cdk/src/wallet/recovery.rs
@@ -265,7 +265,7 @@ impl RecoveryHelpers for Wallet {
             PreMintSecrets::restore_batch(keyset_id, &self.seed, counter_start, counter_end)?;
 
         // Load keyset keys
-        let keys = self.load_keyset_keys(keyset_id).await?;
+        let keys = self.keyset(keyset_id).await?.keys;
 
         validate_mint_response_signatures(
             self,
@@ -489,7 +489,7 @@ impl Wallet {
         }
 
         // Load keyset keys for proof construction
-        let keys = self.load_keyset_keys(keyset_id).await?;
+        let keys = self.keyset(keyset_id).await?.keys;
 
         validate_mint_response_signatures(
             self,

--- a/crates/cdk/src/wallet/send/mod.rs
+++ b/crates/cdk/src/wallet/send/mod.rs
@@ -161,7 +161,11 @@ impl Wallet {
         amount: Amount,
         opts: SendOptions,
     ) -> Result<PreparedSend<'_>, Error> {
-        let saga = SendSaga::new(self);
+        let saga = if opts.send_kind.is_offline() {
+            SendSaga::new(self).with_keyset_policy(cdk_common::wallet::KeysetLoadPolicy::CacheOnly)
+        } else {
+            SendSaga::new(self)
+        };
         let prepared_saga = saga.prepare(amount, opts).await?;
 
         // Extract data from the saga into PreparedSend

--- a/crates/cdk/src/wallet/send/saga/mod.rs
+++ b/crates/cdk/src/wallet/send/saga/mod.rs
@@ -65,11 +65,10 @@ use std::collections::{HashMap, HashSet};
 
 use bitcoin::XOnlyPublicKey;
 use cdk_common::amount::KeysetFeeAndAmounts;
-use cdk_common::nut02::KeySetInfosMethods;
 use cdk_common::util::unix_time;
 use cdk_common::wallet::{
-    OperationData, P2PKLockedProofSendMode, SendOperationData, SendSagaState, Transaction,
-    TransactionDirection, WalletSaga, WalletSagaState,
+    KeysetLoadPolicy, OperationData, P2PKLockedProofSendMode, SendOperationData, SendSagaState,
+    Transaction, TransactionDirection, WalletSaga, WalletSagaState,
 };
 use cdk_common::Id;
 use tracing::instrument;
@@ -81,7 +80,6 @@ use crate::fees::calculate_fee;
 use crate::nuts::nut00::ProofsMethods;
 use crate::nuts::nut11::{enforce_sig_flag, SigFlag};
 use crate::nuts::{Proofs, State, Token};
-use crate::wallet::keysets::KeysetFilter;
 use crate::wallet::saga::{
     add_compensation, execute_compensations, new_compensations, Compensations,
     RevertProofReservation,
@@ -379,8 +377,17 @@ impl<'a> SendSaga<'a, Initial> {
         Self {
             wallet,
             compensations: new_compensations(),
-            state_data: Initial { operation_id },
+            state_data: Initial {
+                operation_id,
+                keyset_policy: Default::default(),
+            },
         }
+    }
+
+    /// Override the keyset load policy for this saga.
+    pub fn with_keyset_policy(mut self, policy: KeysetLoadPolicy) -> Self {
+        self.state_data.keyset_policy = policy;
+        self
     }
 
     /// Prepare the send operation by selecting and reserving proofs.
@@ -401,13 +408,44 @@ impl<'a> SendSaga<'a, Initial> {
             self.state_data.operation_id
         );
 
-        if opts.send_kind.is_online() {
-            if let Err(e) = self.wallet.refresh_keysets().await {
-                tracing::error!("Error refreshing keysets: {:?}. Using stored keysets", e);
-            }
-        }
+        let keyset_policy = self.state_data.keyset_policy;
 
-        let keyset_fees = self.wallet.get_keyset_fees_and_amounts().await?;
+        let all_keysets = self.wallet.keysets(keyset_policy).await?;
+
+        let keyset_fees: KeysetFeeAndAmounts = all_keysets
+            .iter()
+            .map(|ks| {
+                (
+                    ks.id,
+                    (
+                        ks.input_fee_ppk,
+                        ks.keys
+                            .iter()
+                            .map(|(amount, _)| amount.to_u64())
+                            .collect::<Vec<_>>(),
+                    )
+                        .into(),
+                )
+            })
+            .collect();
+
+        let active_keyset_ids: Vec<Id> = all_keysets
+            .iter()
+            .filter(|k| k.active.unwrap_or(false))
+            .map(|k| k.id)
+            .collect();
+
+        let active_keyset = all_keysets
+            .into_iter()
+            .filter(|k| k.active.unwrap_or(false))
+            .min_by_key(|k| k.input_fee_ppk)
+            .ok_or(Error::NoActiveKeyset)?;
+
+        let active_keyset_id = active_keyset.id;
+        let fee_and_amounts = keyset_fees
+            .get(&active_keyset_id)
+            .cloned()
+            .ok_or(Error::UnknownKeySet)?;
 
         let mut available_proofs = self
             .wallet
@@ -463,20 +501,6 @@ impl<'a> SendSaga<'a, Initial> {
                 }
             }
         }
-
-        let active_keyset_ids = self
-            .wallet
-            .get_mint_keysets(KeysetFilter::Active)
-            .await?
-            .active()
-            .map(|k| k.id)
-            .collect();
-
-        let active_keyset_id = self.wallet.get_active_keyset().await?.id;
-        let fee_and_amounts = self
-            .wallet
-            .get_keyset_fees_and_amounts_by_id(active_keyset_id)
-            .await?;
 
         let send_amounts = if opts.include_fee {
             let send_split = amount.split_with_fee(&fee_and_amounts)?;
@@ -538,7 +562,7 @@ impl<'a> SendSaga<'a, Initial> {
 
         if selected_total == amount + send_fee {
             return self
-                .internal_prepare(amount, opts, selected_proofs, force_swap)
+                .internal_prepare(amount, opts, selected_proofs, force_swap, keyset_policy)
                 .await;
         } else if opts.send_kind == SendKind::OfflineExact {
             return Err(Error::InsufficientFunds);
@@ -555,7 +579,7 @@ impl<'a> SendSaga<'a, Initial> {
             }
         }
 
-        self.internal_prepare(amount, opts, selected_proofs, force_swap)
+        self.internal_prepare(amount, opts, selected_proofs, force_swap, keyset_policy)
             .await
     }
 
@@ -565,12 +589,20 @@ impl<'a> SendSaga<'a, Initial> {
         opts: SendOptions,
         proofs: Proofs,
         force_swap: bool,
+        keyset_policy: KeysetLoadPolicy,
     ) -> Result<SendSaga<'a, Prepared>, Error> {
-        let active_keyset_id = self.wallet.get_active_keyset().await?.id;
+        let active_keyset_id = self
+            .wallet
+            .active_keyset_with_policy(keyset_policy)
+            .await?
+            .id;
         let fee_and_amounts = self
             .wallet
-            .get_keyset_fees_and_amounts_by_id(active_keyset_id)
-            .await?;
+            .get_keyset_fees_and_amounts_with_policy(keyset_policy)
+            .await?
+            .get(&active_keyset_id)
+            .cloned()
+            .ok_or(Error::UnknownKeySet)?;
 
         let (send_amounts, send_fee) = if opts.include_fee {
             let send_split = amount.split_with_fee(&fee_and_amounts)?;
@@ -600,7 +632,10 @@ impl<'a> SendSaga<'a, Initial> {
         let is_exact_or_offline =
             exact_proofs || opts.send_kind.is_offline() || opts.send_kind.has_tolerance();
 
-        let keyset_fees_and_amounts = self.wallet.get_keyset_fees_and_amounts().await?;
+        let keyset_fees_and_amounts = self
+            .wallet
+            .get_keyset_fees_and_amounts_with_policy(keyset_policy)
+            .await?;
         let keyset_fees: HashMap<Id, u64> = keyset_fees_and_amounts
             .iter()
             .map(|(key, values)| (*key, values.fee()))
@@ -823,7 +858,7 @@ impl<'a> SendSaga<'a, Prepared> {
                     crate::wallet::util::sign_proofs(&mut proofs_to_swap, &keys)?;
                 }
 
-                let keyset_id = self.wallet.fetch_active_keyset().await?.id;
+                let keyset_id = self.wallet.active_keyset().await?.id;
 
                 // Capture counter start before swap
                 counter_start = Some(
@@ -1141,8 +1176,8 @@ mod tests {
     use cdk_common::amount::KeysetFeeAndAmounts;
     use cdk_common::nuts::State;
     use cdk_common::wallet::{
-        OperationData, ProofInfo, SendKind, SendOperationData, SendSagaState, WalletSaga,
-        WalletSagaState,
+        KeysetLoadPolicy, OperationData, ProofInfo, SendKind, SendOperationData, SendSagaState,
+        WalletSaga, WalletSagaState,
     };
     use cdk_common::{CurrencyUnit, ProofsMethods};
 
@@ -1275,6 +1310,7 @@ mod tests {
                 SendOptions::default(),
                 vec![unused_proof, send_8_proof, send_2_proof],
                 false,
+                KeysetLoadPolicy::default(),
             )
             .await
             .unwrap();
@@ -1376,7 +1412,15 @@ mod tests {
         mock_client.reset_default_mint_state();
 
         let wallet = create_test_wallet_with_mock(db, mock_client).await;
-        let saga = SendSaga::new(&wallet);
+
+        // Prime the keyset cache — offline sends use CacheOnly and require
+        // keysets to already be cached.
+        wallet
+            .keysets(cdk_common::wallet::KeysetLoadPolicy::Refresh)
+            .await
+            .unwrap();
+
+        let saga = SendSaga::new(&wallet).with_keyset_policy(KeysetLoadPolicy::CacheOnly);
         let err = saga
             .prepare(
                 Amount::from(8),
@@ -1389,6 +1433,108 @@ mod tests {
             .expect_err("offline send must not prepare a locked-proof swap by default");
 
         assert!(matches!(err, crate::Error::InsufficientFunds));
+    }
+
+    /// Offline send with an empty keyset cache must fail because it uses
+    /// CacheOnly and never contacts the network.
+    #[tokio::test]
+    async fn test_offline_send_fails_without_cached_keysets() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+
+        let proof_info = test_proof_info(keyset_id, 64, mint_url);
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db, mock_client).await;
+
+        // Do NOT prime the cache — offline send should fail with UnknownKeySet
+        // because CacheOnly has nothing to return.
+        let saga = SendSaga::new(&wallet).with_keyset_policy(KeysetLoadPolicy::CacheOnly);
+        let err = saga
+            .prepare(
+                Amount::from(64),
+                SendOptions {
+                    send_kind: SendKind::OfflineExact,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("offline send without cached keysets should fail");
+
+        assert!(
+            matches!(err, crate::Error::UnknownKeySet),
+            "expected UnknownKeySet, got: {err:?}"
+        );
+    }
+
+    /// Offline send with a primed keyset cache succeeds without network access.
+    #[tokio::test]
+    async fn test_offline_send_succeeds_with_cached_keysets() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+
+        let proof_info = test_proof_info(keyset_id, 64, mint_url);
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db, mock_client).await;
+
+        // Prime the cache so CacheOnly can serve keyset data
+        wallet
+            .keysets(cdk_common::wallet::KeysetLoadPolicy::Refresh)
+            .await
+            .unwrap();
+
+        let saga = SendSaga::new(&wallet).with_keyset_policy(KeysetLoadPolicy::CacheOnly);
+        let prepared = saga
+            .prepare(
+                Amount::from(64),
+                SendOptions {
+                    send_kind: SendKind::OfflineExact,
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        assert!(
+            prepared.is_ok(),
+            "offline send with cached keysets should succeed"
+        );
+    }
+
+    /// Online send loads keysets from network when cache is empty.
+    #[tokio::test]
+    async fn test_online_send_loads_keysets_from_network() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+
+        let proof_info = test_proof_info(keyset_id, 64, mint_url);
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.set_post_swap_response(Ok(cdk_common::SwapResponse { signatures: vec![] }));
+        let wallet = create_test_wallet_with_mock(db, mock_client).await;
+
+        // Do NOT prime the cache — online send should fetch from the mock
+        let saga = SendSaga::new(&wallet);
+        let prepared = saga
+            .prepare(
+                Amount::from(64),
+                SendOptions {
+                    send_kind: SendKind::OnlineExact,
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        assert!(
+            prepared.is_ok(),
+            "online send should succeed by fetching keysets from network"
+        );
     }
 
     #[test]

--- a/crates/cdk/src/wallet/send/saga/mod.rs
+++ b/crates/cdk/src/wallet/send/saga/mod.rs
@@ -845,6 +845,10 @@ impl<'a> SendSaga<'a, Prepared> {
             }
 
             if !proofs_to_swap.is_empty() {
+                if options.send_kind.is_offline() {
+                    return Err(Error::InsufficientFunds);
+                }
+
                 let swap_amount = total_send_amount
                     .checked_sub(final_proofs_to_send.total_amount()?)
                     .unwrap_or(Amount::ZERO);
@@ -1395,6 +1399,57 @@ mod tests {
         assert_eq!(after.len(), 1);
         assert_eq!(after[0].state, State::PendingSpent);
         assert!(db.get_saga(&saga_id).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_offline_confirm_rejects_prepared_swap_inputs() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let operation_id = uuid::Uuid::new_v4();
+        let proof = test_proof(keyset_id, 8);
+
+        let saga_record = WalletSaga::new(
+            operation_id,
+            WalletSagaState::Send(SendSagaState::ProofsReserved),
+            Amount::from(8),
+            mint_url,
+            CurrencyUnit::Sat,
+            OperationData::Send(SendOperationData {
+                amount: Amount::from(8),
+                memo: None,
+                counter_start: None,
+                counter_end: None,
+                token: None,
+                proofs: None,
+            }),
+        );
+        db.add_saga(saga_record.clone()).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db, mock_client).await;
+        let saga = SendSaga::from_prepared(
+            &wallet,
+            operation_id,
+            Amount::from(8),
+            SendOptions {
+                send_kind: SendKind::OfflineExact,
+                ..Default::default()
+            },
+            vec![proof],
+            vec![],
+            Amount::ZERO,
+            Amount::ZERO,
+            saga_record,
+        )
+        .unwrap();
+
+        let err = match saga.confirm(None).await {
+            Ok(_) => panic!("offline confirm must reject swap inputs before contacting mint"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(err, crate::Error::InsufficientFunds));
     }
 
     #[tokio::test]

--- a/crates/cdk/src/wallet/send/saga/state.rs
+++ b/crates/cdk/src/wallet/send/saga/state.rs
@@ -6,7 +6,7 @@
 
 use core::fmt;
 
-use cdk_common::wallet::WalletSaga;
+use cdk_common::wallet::{KeysetLoadPolicy, WalletSaga};
 use uuid::Uuid;
 
 use crate::nuts::Proofs;
@@ -18,6 +18,8 @@ use crate::Amount;
 pub struct Initial {
     /// Unique operation identifier for tracking and crash recovery
     pub operation_id: Uuid,
+    /// Policy controlling how keysets are loaded during this saga
+    pub keyset_policy: KeysetLoadPolicy,
 }
 
 /// Prepared state with proofs selected and reserved.

--- a/crates/cdk/src/wallet/swap/mod.rs
+++ b/crates/cdk/src/wallet/swap/mod.rs
@@ -99,21 +99,23 @@ impl Wallet {
     ) -> Result<Option<Proofs>, Error> {
         tracing::info!("Swapping");
 
-        let saga = SwapSaga::new(self);
-        let saga = saga
-            .prepare(
-                amount,
-                amount_split_target,
-                input_proofs,
-                spending_conditions,
-                use_p2bk,
-                include_fees,
-                proof_reservation,
-            )
-            .await?;
-        let saga = saga.execute().await?;
-
-        Ok(saga.into_send_proofs())
+        self.retry_on_inactive_keyset(|| async {
+            let saga = SwapSaga::new(self);
+            let saga = saga
+                .prepare(
+                    amount,
+                    amount_split_target.clone(),
+                    input_proofs.clone(),
+                    spending_conditions.clone(),
+                    use_p2bk,
+                    include_fees,
+                    proof_reservation,
+                )
+                .await?;
+            let saga = saga.execute().await?;
+            Ok(saga.into_send_proofs())
+        })
+        .await
     }
 
     /// Create Swap Payload
@@ -326,5 +328,160 @@ impl Wallet {
             fee: proofs_fee_breakdown.total,
             p2bk_secret_keys: p2bk_ephemeral_key,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use cdk_common::wallet::{KeysetLoadPolicy, ProofInfo};
+    use cdk_common::CurrencyUnit;
+
+    use crate::amount::SplitTarget;
+    use crate::nuts::State;
+    use crate::wallet::test_utils::{
+        create_test_db, create_test_wallet_with_mock, make_inactive_keyset, test_keyset,
+        test_keyset_id, test_mint_url, test_proof, MockMintConnector,
+    };
+    use crate::Error;
+
+    /// When the mint returns InactiveKeyset on a swap and the active keyset
+    /// has rotated, the wallet should retry the swap with the new keyset.
+    #[tokio::test]
+    async fn swap_retries_on_inactive_keyset_after_rotation() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        db.add_mint(mint_url.clone(), None).await.unwrap();
+
+        let mock = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock.clone()).await;
+
+        // Prime cache with keyset A as active
+        wallet.keysets(KeysetLoadPolicy::Refresh).await.unwrap();
+
+        let keyset_a_id = test_keyset_id();
+
+        // Store proofs in the DB so reserve_proofs can find them.
+        // Use amounts 1+2=3 so that after fee (1 sat for 2 inputs), the output
+        // amount of 2 is expressible in keyset B's shifted denominations (min 2).
+        let proof1 = test_proof(keyset_a_id, 1);
+        let proof2 = test_proof(keyset_a_id, 2);
+        let pi1 = ProofInfo::new(
+            proof1.clone(),
+            mint_url.clone(),
+            State::Unspent,
+            CurrencyUnit::Sat,
+        )
+        .unwrap();
+        let pi2 =
+            ProofInfo::new(proof2.clone(), mint_url, State::Unspent, CurrencyUnit::Sat).unwrap();
+        db.update_proofs(vec![pi1, pi2], vec![]).await.unwrap();
+
+        // Rotate keysets on the mock: A becomes inactive, B becomes active
+        let mut old = test_keyset();
+        old.active = Some(false);
+        let mut rotated = make_inactive_keyset();
+        rotated.active = Some(true);
+        let keyset_b_id = rotated.id;
+        mock.set_mint_keys_response(Ok(vec![old, rotated]));
+
+        // First post_swap → InactiveKeyset, second → TokenAlreadySpent
+        // (we can't construct valid blind signatures, so use a different error
+        // to prove the retry happened)
+        mock.push_post_swap_response(Err(Error::InactiveKeyset));
+        mock.push_post_swap_response(Err(Error::TokenAlreadySpent));
+
+        let result = wallet
+            .swap(
+                None,
+                SplitTarget::default(),
+                vec![proof1, proof2],
+                None,
+                false,
+                false,
+            )
+            .await;
+
+        // The second attempt's error should surface, not InactiveKeyset
+        assert!(
+            matches!(result, Err(Error::TokenAlreadySpent)),
+            "expected TokenAlreadySpent from retry, got: {result:?}"
+        );
+
+        let requests = mock.captured_swap_requests();
+        assert_eq!(requests.len(), 2, "post_swap should be called twice");
+
+        // First attempt targeted keyset A
+        assert!(
+            requests[0]
+                .outputs()
+                .iter()
+                .all(|o| o.keyset_id == keyset_a_id),
+            "first swap attempt should target keyset A"
+        );
+        // Second attempt targeted keyset B
+        assert!(
+            requests[1]
+                .outputs()
+                .iter()
+                .all(|o| o.keyset_id == keyset_b_id),
+            "second swap attempt should target keyset B"
+        );
+    }
+
+    /// When the mint returns InactiveKeyset but the active keyset hasn't
+    /// changed, the wallet should NOT retry and return the error immediately.
+    #[tokio::test]
+    async fn swap_does_not_retry_when_keyset_unchanged() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        db.add_mint(mint_url.clone(), None).await.unwrap();
+
+        let mock = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock.clone()).await;
+
+        // Prime cache with keyset A as active
+        wallet.keysets(KeysetLoadPolicy::Refresh).await.unwrap();
+
+        // Store proofs in the DB
+        let proof1 = test_proof(test_keyset_id(), 1);
+        let proof2 = test_proof(test_keyset_id(), 2);
+        let pi1 = ProofInfo::new(
+            proof1.clone(),
+            mint_url.clone(),
+            State::Unspent,
+            CurrencyUnit::Sat,
+        )
+        .unwrap();
+        let pi2 =
+            ProofInfo::new(proof2.clone(), mint_url, State::Unspent, CurrencyUnit::Sat).unwrap();
+        db.update_proofs(vec![pi1, pi2], vec![]).await.unwrap();
+
+        // Don't rotate keysets — mock still returns keyset A as active
+        mock.push_post_swap_response(Err(Error::InactiveKeyset));
+
+        let result = wallet
+            .swap(
+                None,
+                SplitTarget::default(),
+                vec![proof1, proof2],
+                None,
+                false,
+                false,
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(Error::InactiveKeyset)),
+            "expected InactiveKeyset without rotation, got: {result:?}"
+        );
+
+        let requests = mock.captured_swap_requests();
+        assert_eq!(
+            requests.len(),
+            1,
+            "post_swap should be called only once (no retry)"
+        );
     }
 }

--- a/crates/cdk/src/wallet/swap/saga/mod.rs
+++ b/crates/cdk/src/wallet/swap/saga/mod.rs
@@ -72,7 +72,10 @@ impl<'a> SwapSaga<'a, Initial> {
         Self {
             wallet,
             compensations: new_compensations(),
-            state_data: Initial { operation_id },
+            state_data: Initial {
+                operation_id,
+                keyset_policy: Default::default(),
+            },
         }
     }
 
@@ -105,10 +108,15 @@ impl<'a> SwapSaga<'a, Initial> {
             self.state_data.operation_id
         );
 
-        let active_keyset_id = self.wallet.fetch_active_keyset().await?.id;
+        let keyset_policy = self.state_data.keyset_policy;
+        let active_keyset_id = self
+            .wallet
+            .active_keyset_with_policy(keyset_policy)
+            .await?
+            .id;
         let fee_and_amounts = self
             .wallet
-            .get_keyset_fees_and_amounts_by_id(active_keyset_id)
+            .get_keyset_fees_and_amounts_by_id_with_policy(active_keyset_id, keyset_policy)
             .await?;
 
         let fee_breakdown = self.wallet.get_proofs_fee(&input_proofs).await?;
@@ -239,7 +247,7 @@ impl<'a> SwapSaga<'a, Prepared> {
         };
 
         let active_keyset_id = self.state_data.pre_swap.pre_mint_secrets.keyset_id;
-        let active_keys = self.wallet.load_keyset_keys(active_keyset_id).await?;
+        let active_keys = self.wallet.keyset(active_keyset_id).await?.keys;
 
         validate_mint_response_signatures(
             self.wallet,

--- a/crates/cdk/src/wallet/swap/saga/state.rs
+++ b/crates/cdk/src/wallet/swap/saga/state.rs
@@ -4,7 +4,7 @@
 //! of the swap operation. The type state pattern ensures that only valid
 //! operations are available at each stage.
 
-use cdk_common::wallet::WalletSaga;
+use cdk_common::wallet::{KeysetLoadPolicy, WalletSaga};
 use uuid::Uuid;
 
 use crate::amount::SplitTarget;
@@ -18,6 +18,8 @@ use crate::Amount;
 pub struct Initial {
     /// Unique operation identifier for tracking and crash recovery
     pub operation_id: Uuid,
+    /// Policy controlling how keysets are loaded during this saga
+    pub keyset_policy: KeysetLoadPolicy,
 }
 
 /// Prepared state - swap request created, proofs reserved.

--- a/crates/cdk/src/wallet/test_utils.rs
+++ b/crates/cdk/src/wallet/test_utils.rs
@@ -11,7 +11,7 @@ use cdk_common::database::WalletDatabase;
 use cdk_common::mint_url::MintUrl;
 use cdk_common::nut00::KnownMethod;
 use cdk_common::nuts::{
-    CurrencyUnit, Id, KeySet, KeySetInfo, KeysetResponse, MeltMethodSettings, MintInfo,
+    CurrencyUnit, Id, KeySet, KeySetInfo, Keys, KeysetResponse, MeltMethodSettings, MintInfo,
     MintMethodSettings, MintVersion, MppMethodSettings, Proof,
 };
 use cdk_common::wallet::{MeltQuote, MintQuote};
@@ -336,6 +336,21 @@ pub fn test_proof_info(
     cdk_common::wallet::ProofInfo::new(proof, mint_url, State::Unspent, CurrencyUnit::Sat).unwrap()
 }
 
+/// Create an inactive keyset with different keys and a properly computed ID.
+pub fn make_inactive_keyset() -> KeySet {
+    let mut ks = test_keyset();
+    ks.active = Some(false);
+    // Shift each key amount to produce different keys → different ID
+    let shifted_keys: std::collections::BTreeMap<_, _> = ks
+        .keys
+        .iter()
+        .map(|(amount, pk)| (Amount::from(amount.to_u64() * 2), *pk))
+        .collect();
+    ks.keys = Keys::new(shifted_keys);
+    ks.id = Id::v2_from_data(&ks.keys, &ks.unit, ks.input_fee_ppk, ks.final_expiry);
+    ks
+}
+
 /// Create a test melt quote
 pub fn test_melt_quote() -> MeltQuote {
     MeltQuote {
@@ -424,7 +439,7 @@ pub async fn create_test_wallet_with_mock_http_subscription(
 #[derive(Debug)]
 pub struct MockMintConnector {
     /// Mock mint keyset state
-    pub keyset: Mutex<KeySet>,
+    pub keysets: Mutex<Vec<KeySet>>,
     /// Mock mint info state
     pub mint_info: Mutex<MintInfo>,
     /// Response for post_check_state calls
@@ -445,6 +460,13 @@ pub struct MockMintConnector {
     pub post_mint_response: Mutex<Option<Result<MintResponse, Error>>>,
     /// Response for post_swap calls
     pub post_swap_response: Mutex<Option<Result<SwapResponse, Error>>>,
+    /// Queue of responses for successive post_swap calls.
+    ///
+    /// When non-empty, each `post_swap` call pops the front entry.
+    /// Takes precedence over `post_swap_response`.
+    pub post_swap_responses: Mutex<std::collections::VecDeque<Result<SwapResponse, Error>>>,
+    /// Captured post_swap requests for test verification.
+    pub captured_swap_requests: Mutex<Vec<SwapRequest>>,
     /// Response for post_melt calls
     pub post_melt_response: Mutex<Option<Result<MeltQuoteResponse<String>, Error>>>,
     /// Last post_melt method/request captured by the mock
@@ -472,7 +494,7 @@ impl MockMintConnector {
         let mint_info = test_mint_info();
 
         Self {
-            keyset: Mutex::new(keyset),
+            keysets: Mutex::new(vec![keyset]),
             mint_info: Mutex::new(mint_info),
             check_state_response: Mutex::new(None),
             restore_response: Mutex::new(None),
@@ -480,6 +502,8 @@ impl MockMintConnector {
             melt_quote_status_responses: Mutex::new(std::collections::VecDeque::new()),
             post_mint_response: Mutex::new(None),
             post_swap_response: Mutex::new(None),
+            post_swap_responses: Mutex::new(std::collections::VecDeque::new()),
+            captured_swap_requests: Mutex::new(Vec::new()),
             post_melt_response: Mutex::new(None),
             last_post_melt_request: Mutex::new(None),
             lnurl_pay_request_response: Mutex::new(None),
@@ -495,11 +519,8 @@ impl MockMintConnector {
 
     pub fn set_mint_keys_response(&self, response: Result<Vec<KeySet>, Error>) {
         match response {
-            Ok(mut keysets) => {
-                let keyset = keysets
-                    .pop()
-                    .expect("MockMintConnector: empty keyset response");
-                *self.keyset.lock().unwrap() = keyset;
+            Ok(keysets) => {
+                *self.keysets.lock().unwrap() = keysets;
             }
             Err(_) => unimplemented!("error responses for key state are not supported"),
         }
@@ -507,25 +528,30 @@ impl MockMintConnector {
 
     pub fn set_mint_keyset_response(&self, response: Result<KeySet, Error>) {
         match response {
-            Ok(keyset) => *self.keyset.lock().unwrap() = keyset,
+            Ok(keyset) => {
+                let mut keysets = self.keysets.lock().unwrap();
+                if let Some(existing) = keysets.iter_mut().find(|k| k.id == keyset.id) {
+                    *existing = keyset;
+                } else {
+                    keysets.push(keyset);
+                }
+            }
             Err(_) => unimplemented!("error responses for key state are not supported"),
         }
     }
 
     pub fn set_mint_keysets_response(&self, response: Result<KeysetResponse, Error>) {
         match response {
-            Ok(keysets) => {
-                let keyset_info = keysets
-                    .keysets
-                    .into_iter()
-                    .next()
-                    .expect("MockMintConnector: empty keysets response");
-                let mut keyset = self.keyset.lock().unwrap();
-                keyset.id = keyset_info.id;
-                keyset.unit = keyset_info.unit;
-                keyset.active = Some(keyset_info.active);
-                keyset.input_fee_ppk = keyset_info.input_fee_ppk;
-                keyset.final_expiry = keyset_info.final_expiry;
+            Ok(resp) => {
+                let mut keysets = self.keysets.lock().unwrap();
+                for info in resp.keysets {
+                    if let Some(ks) = keysets.iter_mut().find(|k| k.id == info.id) {
+                        ks.unit = info.unit;
+                        ks.active = Some(info.active);
+                        ks.input_fee_ppk = info.input_fee_ppk;
+                        ks.final_expiry = info.final_expiry;
+                    }
+                }
             }
             Err(_) => unimplemented!("error responses for key state are not supported"),
         }
@@ -539,17 +565,7 @@ impl MockMintConnector {
     }
 
     pub fn set_active_keyset(&self, keyset: KeySet) {
-        self.set_mint_keys_response(Ok(vec![keyset.clone()]));
-        self.set_mint_keyset_response(Ok(keyset.clone()));
-        self.set_mint_keysets_response(Ok(KeysetResponse {
-            keysets: vec![KeySetInfo {
-                id: keyset.id,
-                unit: keyset.unit,
-                active: keyset.active.unwrap_or(true),
-                input_fee_ppk: keyset.input_fee_ppk,
-                final_expiry: keyset.final_expiry,
-            }],
-        }));
+        *self.keysets.lock().unwrap() = vec![keyset];
     }
 
     pub fn reset_default_mint_state(&self) {
@@ -588,6 +604,16 @@ impl MockMintConnector {
 
     pub fn set_post_swap_response(&self, response: Result<SwapResponse, Error>) {
         *self.post_swap_response.lock().unwrap() = Some(response);
+    }
+
+    /// Enqueue a response for the next `post_swap` call.
+    pub fn push_post_swap_response(&self, response: Result<SwapResponse, Error>) {
+        self.post_swap_responses.lock().unwrap().push_back(response);
+    }
+
+    /// Get all captured swap requests.
+    pub fn captured_swap_requests(&self) -> Vec<SwapRequest> {
+        self.captured_swap_requests.lock().unwrap().clone()
     }
 
     pub fn set_post_melt_response(&self, response: Result<MeltQuoteResponse<String>, Error>) {
@@ -653,29 +679,33 @@ impl MintConnector for MockMintConnector {
     }
 
     async fn get_mint_keys(&self) -> Result<Vec<crate::nuts::KeySet>, Error> {
-        Ok(vec![self.keyset.lock().unwrap().clone()])
+        Ok(self.keysets.lock().unwrap().clone())
     }
 
     async fn get_mint_keyset(&self, keyset_id: Id) -> Result<crate::nuts::KeySet, Error> {
-        let keyset = self.keyset.lock().unwrap().clone();
-
-        match keyset.id == keyset_id {
-            true => Ok(keyset),
-            false => Err(Error::UnknownKeySet),
-        }
+        self.keysets
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|ks| ks.id == keyset_id)
+            .cloned()
+            .ok_or(Error::UnknownKeySet)
     }
 
     async fn get_mint_keysets(&self) -> Result<KeysetResponse, Error> {
-        let keyset = self.keyset.lock().unwrap().clone();
+        let keysets = self.keysets.lock().unwrap();
 
         Ok(KeysetResponse {
-            keysets: vec![KeySetInfo {
-                id: keyset.id,
-                unit: keyset.unit,
-                active: keyset.active.unwrap_or(true),
-                input_fee_ppk: keyset.input_fee_ppk,
-                final_expiry: keyset.final_expiry,
-            }],
+            keysets: keysets
+                .iter()
+                .map(|ks| KeySetInfo {
+                    id: ks.id,
+                    unit: ks.unit.clone(),
+                    active: ks.active.unwrap_or(true),
+                    input_fee_ppk: ks.input_fee_ppk,
+                    final_expiry: ks.final_expiry,
+                })
+                .collect(),
         })
     }
 
@@ -733,12 +763,18 @@ impl MintConnector for MockMintConnector {
         Ok(MeltQuoteResponse::Bolt11(response))
     }
 
-    async fn post_swap(&self, _request: SwapRequest) -> Result<SwapResponse, Error> {
-        self.post_swap_response
-            .lock()
-            .unwrap()
-            .take()
-            .expect("MockMintConnector: post_swap called without configured response")
+    async fn post_swap(&self, request: SwapRequest) -> Result<SwapResponse, Error> {
+        self.captured_swap_requests.lock().unwrap().push(request);
+        let queued = self.post_swap_responses.lock().unwrap().pop_front();
+        match queued {
+            Some(response) => response,
+            None => self
+                .post_swap_response
+                .lock()
+                .unwrap()
+                .take()
+                .expect("MockMintConnector: post_swap called without configured response"),
+        }
     }
 
     async fn get_mint_info(&self) -> Result<crate::nuts::MintInfo, Error> {

--- a/crates/cdk/src/wallet/wallet_trait.rs
+++ b/crates/cdk/src/wallet/wallet_trait.rs
@@ -9,13 +9,12 @@ use cdk_common::mint_url::MintUrl;
 use cdk_common::nuts::nut07::ProofState;
 use cdk_common::nuts::nut18::PaymentRequest;
 use cdk_common::nuts::{
-    AuthProof, CurrencyUnit, Id, KeySetInfo, Keys, MeltOptions, MintInfo, PaymentMethod, Proofs,
-    SpendingConditions,
+    AuthProof, CurrencyUnit, Id, MeltOptions, MintInfo, PaymentMethod, Proofs, SpendingConditions,
 };
 use cdk_common::subscription::WalletParams;
 use cdk_common::wallet::{
-    KeysetFilter, MeltQuote, MintQuote, ReceiveOptions, Restored, SendOptions, Transaction,
-    TransactionDirection, TransactionId, Wallet as WalletTrait,
+    MeltQuote, MintQuote, ReceiveOptions, Restored, SendOptions, Transaction, TransactionDirection,
+    TransactionId, Wallet as WalletTrait,
 };
 use cdk_common::{Amount, PublicKey, SecretKey};
 use tracing::instrument;
@@ -32,7 +31,7 @@ impl WalletTrait for super::Wallet {
     type MintUrl = MintUrl;
     type CurrencyUnit = CurrencyUnit;
     type MintInfo = MintInfo;
-    type KeySetInfo = KeySetInfo;
+    type KeySetInfo = cdk_common::KeySet;
     type MintQuote = MintQuote;
     type MeltQuote = MeltQuote;
     type PaymentMethod = PaymentMethod;
@@ -78,28 +77,21 @@ impl WalletTrait for super::Wallet {
     }
 
     #[instrument(skip(self))]
-    async fn refresh_keysets(&self) -> Result<Vec<KeySetInfo>, Self::Error> {
-        self.refresh_keysets().await
+    async fn keysets(
+        &self,
+        policy: cdk_common::wallet::KeysetLoadPolicy,
+    ) -> Result<Vec<cdk_common::KeySet>, Self::Error> {
+        self.keysets(policy).await
     }
 
     #[instrument(skip(self))]
-    async fn get_active_keyset(&self) -> Result<KeySetInfo, Self::Error> {
-        self.get_active_keyset().await
+    async fn active_keyset(&self) -> Result<cdk_common::KeySet, Self::Error> {
+        self.active_keyset().await
     }
 
     #[instrument(skip(self))]
-    async fn load_keyset_keys(&self, keyset_id: Id) -> Result<Keys, Self::Error> {
-        self.load_keyset_keys(keyset_id).await
-    }
-
-    #[instrument(skip(self))]
-    async fn get_mint_keysets(&self, filter: KeysetFilter) -> Result<Vec<KeySetInfo>, Self::Error> {
-        self.get_mint_keysets(filter).await
-    }
-
-    #[instrument(skip(self))]
-    async fn fetch_active_keyset(&self) -> Result<KeySetInfo, Self::Error> {
-        self.fetch_active_keyset().await
+    async fn keyset(&self, keyset_id: Id) -> Result<cdk_common::KeySet, Self::Error> {
+        self.keyset(keyset_id).await
     }
 
     #[instrument(skip(self))]


### PR DESCRIPTION


### Description

Replace 6+ overlapping keyset functions with a clean, minimal API:

- `keysets()`: Returns `Vec<KeySet>` (full keysets with keys included).  In automatic mode, refreshes from the mint with a graceful fallback to cached data on network failure. In manual mode (`set_keysets(Some(...))`), returns injected keysets directly without network access.

- `active_keyset()`: Returns the active `KeySet` with the lowest input fee.

- `keyset(id)`: Returns a single `KeySet` by ID.

- `set_keysets(Option<Vec<KeySet>>)`: Enables manual keyset mode, bypassing the
  metadata cache entirely. Pass `None` to return to automatic mode.

By returning full `KeySet` objects (which include `.keys`), the separate `load_keyset_keys(id)` function is no longer needed; callers access `.keys` directly from the keyset.

Removed from Wallet and WalletTrait:
  - load_keyset_keys()
  - refresh_keysets()
  - fetch_active_keyset()
  - get_active_keyset()
  - get_mint_keysets(KeysetFilter)
  - load_mint_keysets()

Also moves `metadata_cache_ttl` into `MintMetadataCache`, removing boilerplate TTL passing on every cache load call.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
