### PR TITLE
fix(cdk-sqlite): use pragma_update for PRAGMA key to enable safe string handling

### DIFF
--- a/crates/cdk-sqlite/src/common.rs
+++ b/crates/cdk-sqlite/src/common.rs
@@ -62,7 +62,7 @@ impl DatabasePool for SqliteConnectionManager {
         };
 
         if let Some(password) = config.password.as_ref() {
-            conn.execute_batch(&format!("pragma key = '{password}';"))?;
+            conn.pragma_update(None, "key", password)?;
         }
 
         conn.execute_batch(


### PR DESCRIPTION
## Problem

`format!("pragma key = '{password}';")` interpolates the password into a SQL string literal. Passphrases containing `'` crash with confusing SQL errors, and SQL metacharacters in the password are unescaped.

## Fix

Use rusqlite's parameter binding:

```rust
conn.pragma_update(None, "key", password)?;
```

## Severity

Not a CVE — SQLCipher's PRAGMA ordering blocks `cipher_compatibility` / `cipher_kdf_algorithm` injection vectors. Practical impact is correctness (passphrases with `'` crash) and consistency with rusqlite's recommended pattern.

## History

This pattern dates back to PR #640 which introduced the `sqlcipher` feature using sqlx's `db_options.pragma("key", password)` — sqlx's `pragma_string()` builds SQL via `write!("PRAGMA {} = {};", key, value)` with no quoting or escaping ([source](https://github.com/launchbadge/sqlx/blob/v0.6.3/sqlx-core/src/sqlite/options/mod.rs)). The subsequent rusqlite rewrite kept the same shape, just with explicit quotes around the value. Both versions produce SQL whose correctness depends on the password being well-formed.

## Test

`cargo test -p cdk-sqlite --features sqlcipher` passes.