### PR TITLE
fix(signatory): gate plaintext gRPC behind explicit opt-in

### DIFF
--- a/crates/cdk-signatory/src/proto/client.rs
+++ b/crates/cdk-signatory/src/proto/client.rs
@@ -6,6 +6,7 @@ use cdk_common::{BlindSignature, BlindedMessage, Proof};
 use tonic::codegen::InterceptedService;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
 
+use super::{allow_insecure_signatory_rpc, ENV_SIGNATORY_ALLOW_INSECURE};
 use crate::proto;
 use crate::proto::signatory_client::SignatoryClient;
 use crate::signatory::{RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets};
@@ -35,6 +36,12 @@ pub enum ClientError {
     /// Invalid URL
     #[error("Invalid URL")]
     InvalidUrl,
+
+    /// Insecure plaintext gRPC is disabled
+    #[error(
+        "signatory gRPC client requires mTLS; provide signatory certs or set {ENV_SIGNATORY_ALLOW_INSECURE}=true to allow insecure plaintext gRPC"
+    )]
+    InsecureRpcDisabled,
 }
 
 impl SignatoryRpcClient {
@@ -65,6 +72,11 @@ impl SignatoryRpcClient {
                 .connect()
                 .await?
         } else {
+            if !allow_insecure_signatory_rpc()? {
+                return Err(ClientError::InsecureRpcDisabled);
+            }
+
+            tracing::warn!("Connecting to signatory gRPC without TLS");
             Channel::from_shared(url.clone())
                 .map_err(|_| ClientError::InvalidUrl)?
                 .connect()

--- a/crates/cdk-signatory/src/proto/mod.rs
+++ b/crates/cdk-signatory/src/proto/mod.rs
@@ -2,5 +2,20 @@ mod convert;
 
 tonic::include_proto!("signatory");
 
+pub(crate) const ENV_SIGNATORY_ALLOW_INSECURE: &str = "CDK_SIGNATORY_ALLOW_INSECURE";
+
+pub(crate) fn allow_insecure_signatory_rpc() -> std::io::Result<bool> {
+    match std::env::var(ENV_SIGNATORY_ALLOW_INSECURE) {
+        Ok(value) => value.parse::<bool>().map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("{ENV_SIGNATORY_ALLOW_INSECURE} must be true or false: {err}"),
+            )
+        }),
+        Err(std::env::VarError::NotPresent) => Ok(false),
+        Err(err) => Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, err)),
+    }
+}
+
 pub mod client;
 pub mod server;

--- a/crates/cdk-signatory/src/proto/server.rs
+++ b/crates/cdk-signatory/src/proto/server.rs
@@ -11,6 +11,7 @@ use tonic::transport::server::Connected;
 use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
 use tonic::{Request, Response, Status};
 
+use super::{allow_insecure_signatory_rpc, ENV_SIGNATORY_ALLOW_INSECURE};
 use crate::proto::{self, signatory_server};
 use crate::signatory::Signatory;
 
@@ -187,6 +188,11 @@ pub enum Error {
     /// Io error
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    /// Insecure plaintext gRPC is disabled
+    #[error(
+        "signatory gRPC requires mTLS; provide a TLS directory or set {ENV_SIGNATORY_ALLOW_INSECURE}=true to allow insecure plaintext gRPC"
+    )]
+    InsecureRpcDisabled,
 }
 
 /// Runs the signatory server
@@ -262,7 +268,11 @@ where
             Server::builder().tls_config(tls_config)?
         }
         None => {
-            tracing::warn!("No valid TLS configuration found, starting insecure server");
+            if !allow_insecure_signatory_rpc()? {
+                return Err(Error::InsecureRpcDisabled);
+            }
+
+            tracing::warn!("Starting signatory gRPC without TLS");
             Server::builder()
         }
     };
@@ -291,6 +301,12 @@ where
     IO: AsyncRead + AsyncWrite + Connected + Unpin + Send + 'static,
     IE: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
+    if !allow_insecure_signatory_rpc()? {
+        return Err(Error::InsecureRpcDisabled);
+    }
+
+    tracing::warn!("Starting signatory gRPC without TLS on an incoming stream");
+
     let version_str = (proto::Constants::SchemaVersion as u8).to_string();
     let version: &'static str = Box::leak(version_str.into_boxed_str());
     Server::builder()


### PR DESCRIPTION
Require CDK_SIGNATORY_ALLOW_INSECURE=true before using signatory gRPC without TLS. This prevents the signatory server and remote client from silently falling back to unauthenticated plaintext transport when TLS configuration is absent.

Apply the same opt-in to the incoming-stream server helper so all plaintext signatory RPC entry points are explicitly acknowledged by the operator.
