### PR TITLE
fix(mint-rpc): gate plaintext management RPC behind explicit opt-in

### DIFF
--- a/crates/cdk-mint-rpc/README.md
+++ b/crates/cdk-mint-rpc/README.md
@@ -30,6 +30,18 @@ cdk-mint-rpc = "*"
 
 ## Usage
 
+### Server TLS
+
+Management RPC requires mTLS by default. The server TLS directory must contain:
+
+- `server.pem`
+- `server.key`
+- `ca.pem`
+
+When running through `cdk-mintd`, configure it with `CDK_MINTD_MANAGEMENT_TLS_DIR_PATH`.
+To allow insecure plaintext gRPC, omit the TLS directory and set
+`CDK_MINTD_MANAGEMENT_ALLOW_INSECURE=true`.
+
 ### CLI
 
 ```bash

--- a/crates/cdk-mint-rpc/README.md
+++ b/crates/cdk-mint-rpc/README.md
@@ -38,7 +38,7 @@ Management RPC requires mTLS by default. The server TLS directory must contain:
 - `server.key`
 - `ca.pem`
 
-When running through `cdk-mintd`, configure it with `CDK_MINTD_MANAGEMENT_TLS_DIR_PATH`.
+When running through `cdk-mintd`, configure it with `CDK_MINTD_MANAGEMENT_TLS_DIR`.
 To allow insecure plaintext gRPC, omit the TLS directory and set
 `CDK_MINTD_MANAGEMENT_ALLOW_INSECURE=true`.
 

--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -27,6 +28,8 @@ use crate::{
     UpdateResponse, UpdateTosUrlRequest, UpdateUrlRequest,
 };
 
+const ENV_MINT_MANAGEMENT_ALLOW_INSECURE: &str = "CDK_MINTD_MANAGEMENT_ALLOW_INSECURE";
+
 /// Error
 #[derive(Debug, Error)]
 pub enum Error {
@@ -39,6 +42,11 @@ pub enum Error {
     /// Io error
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    /// Insecure plaintext gRPC is disabled
+    #[error(
+        "management RPC requires mTLS; provide a TLS directory or set {ENV_MINT_MANAGEMENT_ALLOW_INSECURE}=true to allow insecure plaintext gRPC"
+    )]
+    InsecureRpcDisabled,
 }
 
 /// CDK Mint RPC Server
@@ -76,6 +84,8 @@ impl MintRPCServer {
     /// - server.pem: Server certificate
     /// - server.key: Server private key
     /// - ca.pem: CA certificate for client authentication
+    ///
+    /// Plaintext gRPC requires `CDK_MINTD_MANAGEMENT_ALLOW_INSECURE=true`.
     pub async fn start(&mut self, tls_dir: Option<PathBuf>) -> Result<(), Error> {
         tracing::info!("Starting RPC server {}", self.socket_addr);
 
@@ -147,7 +157,11 @@ impl MintRPCServer {
                 )
             }
             None => {
-                tracing::warn!("No valid TLS configuration found, starting insecure server");
+                if !allow_insecure_management_rpc()? {
+                    return Err(Error::InsecureRpcDisabled);
+                }
+
+                tracing::warn!("Starting management RPC without TLS");
                 Server::builder().add_service(CdkMintServer::with_interceptor(
                     self.clone(),
                     create_version_check_interceptor(
@@ -185,6 +199,19 @@ impl MintRPCServer {
 
         tracing::info!("Mint rpc server stopped");
         Ok(())
+    }
+}
+
+fn allow_insecure_management_rpc() -> std::io::Result<bool> {
+    match env::var(ENV_MINT_MANAGEMENT_ALLOW_INSECURE) {
+        Ok(value) => value.parse::<bool>().map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("{ENV_MINT_MANAGEMENT_ALLOW_INSECURE} must be true or false: {err}"),
+            )
+        }),
+        Err(env::VarError::NotPresent) => Ok(false),
+        Err(err) => Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, err)),
     }
 }
 

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -31,6 +31,9 @@ melt_ttl = 120
 enabled = false
 # address = "127.0.0.1"
 # port = 8086
+# tls_dir_path = "/path/to/tls"
+# To allow plaintext management RPC, omit tls_dir_path and set:
+# CDK_MINTD_MANAGEMENT_ALLOW_INSECURE=true
 
 #[prometheus]
 #enabled = true

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -31,8 +31,8 @@ melt_ttl = 120
 enabled = false
 # address = "127.0.0.1"
 # port = 8086
-# tls_dir_path = "/path/to/tls"
-# To allow plaintext management RPC, omit tls_dir_path and set:
+# tls_dir = "/path/to/tls"
+# To allow plaintext management RPC, omit tls_dir and set:
 # CDK_MINTD_MANAGEMENT_ALLOW_INSECURE=true
 
 #[prometheus]

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -1097,7 +1097,8 @@ pub struct MintManagementRpc {
     pub enabled: bool,
     pub address: Option<String>,
     pub port: Option<u16>,
-    pub tls_dir_path: Option<PathBuf>,
+    #[serde(alias = "tls_dir_path")]
+    pub tls_dir: Option<PathBuf>,
 }
 
 impl Settings {
@@ -1807,6 +1808,36 @@ max_melt = 500000
         assert_eq!(settings.ln.len(), 1);
         assert_eq!(settings.ln[0].ln_backend, LnBackend::FakeWallet);
         assert_eq!(settings.ln[0].unit, CurrencyUnit::Sat);
+
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[cfg(feature = "management-rpc")]
+    #[test]
+    fn test_management_rpc_legacy_tls_dir_path_alias_parses() {
+        use std::{env, fs};
+
+        let temp_dir = env::temp_dir().join("cdk_test_management_rpc_tls_alias");
+        fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
+        let config_path = temp_dir.join("config.toml");
+
+        let config_content = r#"
+[mint_management_rpc]
+enabled = true
+tls_dir_path = "/var/lib/cdk/tls"
+"#;
+        fs::write(&config_path, config_content).expect("Failed to write config file");
+
+        let settings = Settings::try_new(Some(&config_path)).expect("config should parse");
+
+        let management_rpc = settings
+            .mint_management_rpc
+            .expect("management RPC section should parse");
+        assert!(management_rpc.enabled);
+        assert_eq!(
+            management_rpc.tls_dir,
+            Some(PathBuf::from("/var/lib/cdk/tls"))
+        );
 
         let _ = fs::remove_dir_all(&temp_dir);
     }

--- a/crates/cdk-mintd/src/env_vars/management_rpc.rs
+++ b/crates/cdk-mintd/src/env_vars/management_rpc.rs
@@ -9,7 +9,8 @@ pub const ENV_MINT_MANAGEMENT_ENABLED: &str = "CDK_MINTD_MANAGEMENT_ENABLED";
 pub const ENV_MINT_MANAGEMENT_ENABLED_LEGACY: &str = "CDK_MINTD_MINT_MANAGEMENT_ENABLED";
 pub const ENV_MINT_MANAGEMENT_ADDRESS: &str = "CDK_MINTD_MANAGEMENT_ADDRESS";
 pub const ENV_MINT_MANAGEMENT_PORT: &str = "CDK_MINTD_MANAGEMENT_PORT";
-pub const ENV_MINT_MANAGEMENT_TLS_DIR_PATH: &str = "CDK_MINTD_MANAGEMENT_TLS_DIR_PATH";
+pub const ENV_MINT_MANAGEMENT_TLS_DIR: &str = "CDK_MINTD_MANAGEMENT_TLS_DIR";
+pub const ENV_MINT_MANAGEMENT_TLS_DIR_LEGACY: &str = "CDK_MINTD_MANAGEMENT_TLS_DIR_PATH";
 
 impl MintManagementRpc {
     pub fn from_env(mut self) -> Self {
@@ -31,8 +32,10 @@ impl MintManagementRpc {
             }
         }
 
-        if let Ok(tls_path) = env::var(ENV_MINT_MANAGEMENT_TLS_DIR_PATH) {
-            self.tls_dir_path = Some(tls_path.into());
+        if let Ok(tls_dir) = env::var(ENV_MINT_MANAGEMENT_TLS_DIR)
+            .or_else(|_| env::var(ENV_MINT_MANAGEMENT_TLS_DIR_LEGACY))
+        {
+            self.tls_dir = Some(tls_dir.into());
         }
 
         self
@@ -59,7 +62,8 @@ mod tests {
         env::remove_var(ENV_MINT_MANAGEMENT_ENABLED_LEGACY);
         env::remove_var(ENV_MINT_MANAGEMENT_ADDRESS);
         env::remove_var(ENV_MINT_MANAGEMENT_PORT);
-        env::remove_var(ENV_MINT_MANAGEMENT_TLS_DIR_PATH);
+        env::remove_var(ENV_MINT_MANAGEMENT_TLS_DIR);
+        env::remove_var(ENV_MINT_MANAGEMENT_TLS_DIR_LEGACY);
     }
 
     #[test]
@@ -68,7 +72,8 @@ mod tests {
             ENV_MINT_MANAGEMENT_ENABLED,
             ENV_MINT_MANAGEMENT_ADDRESS,
             ENV_MINT_MANAGEMENT_PORT,
-            ENV_MINT_MANAGEMENT_TLS_DIR_PATH,
+            ENV_MINT_MANAGEMENT_TLS_DIR,
+            ENV_MINT_MANAGEMENT_TLS_DIR_LEGACY,
         ];
 
         let prefixes: BTreeSet<&str> = names
@@ -96,7 +101,7 @@ mod tests {
         env::set_var(ENV_MINT_MANAGEMENT_ENABLED, "true");
         env::set_var(ENV_MINT_MANAGEMENT_ADDRESS, "0.0.0.0");
         env::set_var(ENV_MINT_MANAGEMENT_PORT, "10000");
-        env::set_var(ENV_MINT_MANAGEMENT_TLS_DIR_PATH, "/var/lib/cdk/tls");
+        env::set_var(ENV_MINT_MANAGEMENT_TLS_DIR, "/var/lib/cdk/tls");
 
         let management_rpc = MintManagementRpc::default().from_env();
 
@@ -104,7 +109,7 @@ mod tests {
         assert_eq!(management_rpc.address.as_deref(), Some("0.0.0.0"));
         assert_eq!(management_rpc.port, Some(10000));
         assert_eq!(
-            management_rpc.tls_dir_path,
+            management_rpc.tls_dir,
             Some(PathBuf::from("/var/lib/cdk/tls"))
         );
 
@@ -126,6 +131,47 @@ mod tests {
     }
 
     #[test]
+    fn management_rpc_from_env_still_reads_legacy_tls_dir_path_env_var() {
+        let _guard = env_lock();
+        clear_env_vars();
+
+        env::set_var(
+            ENV_MINT_MANAGEMENT_TLS_DIR_LEGACY,
+            "/var/lib/cdk/legacy-tls",
+        );
+
+        let management_rpc = MintManagementRpc::default().from_env();
+
+        assert_eq!(
+            management_rpc.tls_dir,
+            Some(PathBuf::from("/var/lib/cdk/legacy-tls"))
+        );
+
+        clear_env_vars();
+    }
+
+    #[test]
+    fn management_rpc_from_env_prefers_canonical_tls_dir_env_var() {
+        let _guard = env_lock();
+        clear_env_vars();
+
+        env::set_var(ENV_MINT_MANAGEMENT_TLS_DIR, "/var/lib/cdk/tls");
+        env::set_var(
+            ENV_MINT_MANAGEMENT_TLS_DIR_LEGACY,
+            "/var/lib/cdk/legacy-tls",
+        );
+
+        let management_rpc = MintManagementRpc::default().from_env();
+
+        assert_eq!(
+            management_rpc.tls_dir,
+            Some(PathBuf::from("/var/lib/cdk/tls"))
+        );
+
+        clear_env_vars();
+    }
+
+    #[test]
     fn management_rpc_from_env_allows_no_tls_configuration() {
         let _guard = env_lock();
         clear_env_vars();
@@ -135,7 +181,7 @@ mod tests {
         let management_rpc = MintManagementRpc::default().from_env();
 
         assert!(management_rpc.enabled);
-        assert_eq!(management_rpc.tls_dir_path, None);
+        assert_eq!(management_rpc.tls_dir, None);
 
         clear_env_vars();
     }

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -1268,7 +1268,7 @@ async fn start_services_with_shutdown(
                 let port = rpc_settings.port.unwrap_or(8086);
                 let mut mint_rpc = cdk_mint_rpc::MintRPCServer::new(&addr, port, mint.clone())?;
 
-                let tls_dir = rpc_settings.tls_dir_path.unwrap_or(_work_dir.join("tls"));
+                let tls_dir = rpc_settings.tls_dir.unwrap_or(_work_dir.join("tls"));
 
                 let tls_dir = if tls_dir.exists() {
                     Some(tls_dir)

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -1274,7 +1274,7 @@ async fn start_services_with_shutdown(
                     Some(tls_dir)
                 } else {
                     tracing::warn!(
-                        "TLS directory does not exist: {}. Starting RPC server in INSECURE mode without TLS encryption",
+                        "TLS directory does not exist: {}. Management RPC startup without TLS requires CDK_MINTD_MANAGEMENT_ALLOW_INSECURE=true",
                         tls_dir.display()
                     );
                     None


### PR DESCRIPTION
Require CDK_MINTD_MANAGEMENT_ALLOW_INSECURE=true before starting the management RPC server without TLS. Keep mTLS as the default posture, surface invalid opt-in values as startup errors, and document the plaintext development override.
