### PR TITLE
fix: surface extra_json on custom mint quote responses

### DIFF
--- a/crates/cashu/src/nuts/nut04.rs
+++ b/crates/cashu/src/nuts/nut04.rs
@@ -861,6 +861,31 @@ mod tests {
     }
 
     #[test]
+    fn custom_mint_quote_response_flattens_extra_on_wire() {
+        let response = MintQuoteCustomResponse {
+            quote: "q1".to_string(),
+            request: "custom://pay".to_string(),
+            amount: Some(Amount::from(100)),
+            amount_paid: Amount::ZERO,
+            amount_issued: Amount::ZERO,
+            unit: Some(CurrencyUnit::Sat),
+            expiry: Some(9999),
+            pubkey: None,
+            extra: json!({"payment_url": "https://example.com", "ref": 42}),
+        };
+
+        let serialized = to_string(&response).expect("serializes");
+        let parsed: serde_json::Value = from_str(&serialized).expect("parses");
+
+        assert_eq!(parsed["payment_url"], json!("https://example.com"));
+        assert_eq!(parsed["ref"], json!(42));
+        assert!(
+            parsed.get("extra").is_none(),
+            "extra must be flattened, not nested under an 'extra' key"
+        );
+    }
+
+    #[test]
     fn test_onchain_settings_nested_options_round_trip() {
         // NUT-26 spec format: confirmations nested inside "options"
         let json_str = r#"{

--- a/crates/cdk-common/src/mint.rs
+++ b/crates/cdk-common/src/mint.rs
@@ -1376,7 +1376,7 @@ impl TryFrom<MintQuote> for MintQuoteResponse<QuoteId> {
                     amount_issued: quote.amount_issued().into(),
                     unit: Some(quote.unit.clone()),
                     pubkey: quote.pubkey,
-                    extra: serde_json::Value::Null,
+                    extra: quote.extra_json.clone().unwrap_or_default(),
                 },
             })
         }
@@ -2091,6 +2091,35 @@ mod tests {
 
         let returned: Vec<u32> = quote.fee_options().iter().map(|o| o.fee_index).collect();
         assert_eq!(returned, vec![0, 0]);
+    }
+
+    #[test]
+    fn test_custom_mint_quote_response_surfaces_extra_json() {
+        let extra = serde_json::json!({"payment_url": "https://example.com/pay", "ref": 42});
+        let quote = MintQuote::new(
+            Some(QuoteId::new()),
+            "custom://request".to_string(),
+            CurrencyUnit::Sat,
+            Some(Amount::new(500, CurrencyUnit::Sat)),
+            unix_time() + 3600,
+            PaymentIdentifier::Label("test".to_string()),
+            None,
+            Amount::new(0, CurrencyUnit::Sat),
+            Amount::new(0, CurrencyUnit::Sat),
+            PaymentMethod::Custom("custom".to_string()),
+            unix_time(),
+            Vec::new(),
+            Vec::new(),
+            Some(extra.clone()),
+        );
+
+        let response: MintQuoteResponse<QuoteId> = quote.try_into().expect("conversion succeeds");
+        match response {
+            MintQuoteResponse::Custom { response, .. } => {
+                assert_eq!(response.extra, extra);
+            }
+            other => panic!("expected Custom variant, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/cdk-payment-processor/src/proto/mod.rs
+++ b/crates/cdk-payment-processor/src/proto/mod.rs
@@ -187,7 +187,7 @@ impl From<CreateIncomingPaymentResponse> for CreatePaymentResponse {
             request_identifier: Some(value.request_lookup_id.into()),
             request: value.request,
             expiry: value.expiry,
-            extra_json: None,
+            extra_json: value.extra_json.map(|v| v.to_string()),
         }
     }
 }


### PR DESCRIPTION
### Description

The unified TryFrom<MintQuote> for MintQuoteResponse<QuoteId> was hardcoding extra: serde_json::Value::Null for the Custom variant, silently discarding the payment processor's extra_json on both POST mint-quote-create and GET mint-quote-status.

Replace with quote.extra_json.clone().unwrap_or_default(), consistent with the sibling TryFrom<MintQuote> for MintQuoteCustomResponse<QuoteId>.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

- Custom payment-method mint quotes now surface extra_json on both create and status responses instead of silently dropping it
- CreateIncomingPaymentResponse to proto CreatePaymentResponse conversion now forwards extra_json instead of hardcoding None


----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
