### PR TITLE
fix: token can handle proofs from inactive keysets

### DIFF
--- a/crates/cdk-ffi/src/wallet_repository.rs
+++ b/crates/cdk-ffi/src/wallet_repository.rs
@@ -217,6 +217,14 @@ impl WalletRepository {
             wallet,
         ))))
     }
+
+    /// Get token data, including the expected redemption fee, without redeeming it.
+    pub async fn get_token_data(
+        &self,
+        token: Arc<crate::token::Token>,
+    ) -> Result<TokenData, FfiError> {
+        Ok(self.inner.get_token_data(&token.inner).await?.into())
+    }
 }
 
 /// Token data FFI type

--- a/crates/cdk/src/wallet/keysets.rs
+++ b/crates/cdk/src/wallet/keysets.rs
@@ -5,7 +5,7 @@ use cdk_common::nut02::KeySetInfosMethods;
 pub use cdk_common::wallet::KeysetFilter;
 use tracing::instrument;
 
-use crate::nuts::{Id, KeySetInfo, Keys};
+use crate::nuts::{Id, KeySetInfo, Keys, Proofs, Token};
 use crate::{Error, Wallet};
 
 impl Wallet {
@@ -69,6 +69,17 @@ impl Wallet {
         } else {
             Err(Error::UnknownKeySet)
         }
+    }
+
+    /// Decode proofs from a token using all known keysets for this mint.
+    ///
+    /// Tokens may contain proofs from inactive keysets. Inactive keysets no
+    /// longer issue new signatures, but mints can still accept their proofs for
+    /// redemption.
+    #[instrument(skip(self, token))]
+    pub(crate) async fn token_proofs(&self, token: &Token) -> Result<Proofs, Error> {
+        let keysets = self.get_mint_keysets(KeysetFilter::All).await?;
+        Ok(token.proofs(&keysets)?)
     }
 
     /// Refresh keysets by fetching the latest from mint - always fetches fresh data
@@ -188,5 +199,78 @@ impl Wallet {
             .get(&keyset_id)
             .cloned()
             .ok_or(Error::UnknownKeySet)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::nuts::{CurrencyUnit, Token};
+    use crate::wallet::test_utils::{
+        create_test_db, create_test_wallet_with_mock, test_mint_url, test_proof, MockMintConnector,
+    };
+
+    #[tokio::test]
+    async fn token_proofs_decodes_inactive_keyset_proofs() {
+        let active_id =
+            Id::from_str("01fb5c0e707d1a26e1ea8e8a70f6117beecc22b4797ac3548e802ec7ee477ec627")
+                .expect("valid active id");
+        let inactive_id =
+            Id::from_str("01950154227f1f2b94eb0f14cb460fa7ec35c096457afdf2b4c09fddda15dc0c44")
+                .expect("valid inactive id");
+
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        db.add_mint(mint_url.clone(), None)
+            .await
+            .expect("mint should be stored");
+        db.add_mint_keysets(
+            mint_url.clone(),
+            vec![
+                KeySetInfo {
+                    id: active_id,
+                    unit: CurrencyUnit::Sat,
+                    active: true,
+                    input_fee_ppk: 100,
+                    final_expiry: None,
+                },
+                KeySetInfo {
+                    id: inactive_id,
+                    unit: CurrencyUnit::Sat,
+                    active: false,
+                    input_fee_ppk: 0,
+                    final_expiry: None,
+                },
+            ],
+        )
+        .await
+        .expect("keysets should be stored");
+
+        let wallet = create_test_wallet_with_mock(db, Arc::new(MockMintConnector::new())).await;
+        let token = Token::new(
+            mint_url,
+            vec![test_proof(inactive_id, 1)],
+            None,
+            CurrencyUnit::Sat,
+        );
+
+        let active_keysets = wallet
+            .get_mint_keysets(KeysetFilter::Active)
+            .await
+            .expect("active keysets should load");
+        assert!(
+            token.proofs(&active_keysets).is_err(),
+            "active-only keysets should not decode an inactive keyset proof"
+        );
+
+        let proofs = wallet
+            .token_proofs(&token)
+            .await
+            .expect("all keysets should decode an inactive keyset proof");
+        assert_eq!(proofs.len(), 1);
+        assert_eq!(proofs[0].keyset_id, inactive_id);
     }
 }

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -739,9 +739,7 @@ impl Wallet {
         ensure_cdk!(unit == self.unit, Error::UnsupportedUnit);
         ensure_cdk!(self.mint_url == token.mint_url()?, Error::IncorrectMint);
 
-        let keysets_info = self.load_mint_keysets().await?;
-        println!("{:?}", keysets_info);
-        let proofs = token.proofs(&keysets_info)?;
+        let proofs = self.token_proofs(&token).await?;
 
         self.prepare_melt_proofs(quote_id, proofs, metadata).await
     }

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -782,8 +782,7 @@ impl Wallet {
             )));
         }
         // We need the keysets information to properly convert from token proof to proof
-        let keysets_info = self.load_mint_keysets().await?;
-        let proofs = token.proofs(&keysets_info)?;
+        let proofs = self.token_proofs(token).await?;
 
         for proof in proofs {
             let secret: nut10::Secret = (&proof.secret).try_into()?;
@@ -876,8 +875,7 @@ impl Wallet {
         }
 
         // We need the keysets information to properly convert from token proof to proof
-        let keysets_info = self.load_mint_keysets().await?;
-        let proofs = token.proofs(&keysets_info)?;
+        let proofs = self.token_proofs(token).await?;
         let mut keys_cache: HashMap<Id, Keys> = HashMap::new();
         for proof in proofs {
             let mint_pubkey = match keys_cache.get(&proof.keyset_id) {

--- a/crates/cdk/src/wallet/payment_request.rs
+++ b/crates/cdk/src/wallet/payment_request.rs
@@ -87,11 +87,7 @@ impl Wallet {
         let token = prepared_send.confirm(None).await?;
 
         // We need the keysets information to properly convert from token proof to proof
-        let keysets_info = match self.localstore.get_mint_keysets(token.mint_url()?).await? {
-            Some(keysets_info) => keysets_info,
-            None => self.load_mint_keysets().await?,
-        };
-        let proofs = token.proofs(&keysets_info)?;
+        let proofs = self.token_proofs(&token).await?;
 
         if let Some(transport) = transport {
             let payload = PaymentRequestPayload {

--- a/crates/cdk/src/wallet/receive/mod.rs
+++ b/crates/cdk/src/wallet/receive/mod.rs
@@ -69,8 +69,7 @@ impl Wallet {
 
         ensure_cdk!(unit == self.unit, Error::UnsupportedUnit);
 
-        let keysets_info = self.load_mint_keysets().await?;
-        let proofs = token.proofs(&keysets_info)?;
+        let proofs = self.token_proofs(&token).await?;
 
         if let Token::TokenV3(token) = &token {
             ensure_cdk!(!token.is_multi_mint(), Error::MultiMintTokenNotSupported);

--- a/crates/cdk/src/wallet/wallet_repository.rs
+++ b/crates/cdk/src/wallet/wallet_repository.rs
@@ -18,7 +18,6 @@ use super::builder::WalletBuilder;
 use super::{Error, MintConnector};
 use crate::mint_url::MintUrl;
 use crate::nuts::CurrencyUnit;
-use crate::wallet::keysets::KeysetFilter;
 #[cfg(all(feature = "tor", not(target_arch = "wasm32")))]
 use crate::wallet::mint_connector::transport::tor_transport::TorAsync;
 use crate::Wallet;
@@ -768,9 +767,7 @@ impl WalletRepository {
 
         // Get the keysets for this mint using the token's unit
         let wallet = self.get_wallet(&mint_url, &unit).await?;
-        let keysets = wallet.get_mint_keysets(KeysetFilter::Active).await?;
-        // Extract proofs using the keysets
-        let proofs = token.proofs(&keysets)?;
+        let proofs = wallet.token_proofs(token).await?;
 
         // Get the memo
         let memo = token.memo().clone();


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
