### PR TITLE
fix: prevent onchain fee estimation overflow panics

### DIFF
--- a/crates/cdk-bdk/src/error.rs
+++ b/crates/cdk-bdk/src/error.rs
@@ -9,6 +9,9 @@ pub enum Error {
     /// Fee estimation failed
     #[error("Fee estimation failed: {0}")]
     FeeEstimationFailed(String),
+    /// Arithmetic overflow during fee estimation
+    #[error("Fee estimation overflow")]
+    FeeEstimationOverflow,
     /// Fee estimation unavailable
     #[error("Fee estimation unavailable")]
     FeeEstimationUnavailable,

--- a/crates/cdk-bdk/src/fee.rs
+++ b/crates/cdk-bdk/src/fee.rs
@@ -91,19 +91,37 @@ impl CoinSelectionAlgorithm for PessimisticFallback {
                 .checked_sub(input_fee)
                 .unwrap_or(BitcoinAmount::ZERO);
 
-            if selected_amount < target_amount + fee_amount || effective_value > BitcoinAmount::ZERO
-            {
+            let needed_amount = target_amount
+                .checked_add(fee_amount)
+                .ok_or(InsufficientFunds {
+                    needed: BitcoinAmount::MAX_MONEY,
+                    available: selected_amount,
+                })?;
+
+            if selected_amount < needed_amount || effective_value > BitcoinAmount::ZERO {
                 fee_amount += input_fee;
                 selected_amount += weighted_utxo.utxo.txout().value;
                 selected.push(weighted_utxo.utxo);
             }
 
-            if selected_amount >= target_amount + fee_amount {
+            let needed_amount = target_amount
+                .checked_add(fee_amount)
+                .ok_or(InsufficientFunds {
+                    needed: BitcoinAmount::MAX_MONEY,
+                    available: selected_amount,
+                })?;
+            if selected_amount >= needed_amount {
                 break;
             }
         }
 
-        let amount_needed_with_fees = target_amount + fee_amount;
+        let amount_needed_with_fees =
+            target_amount
+                .checked_add(fee_amount)
+                .ok_or(InsufficientFunds {
+                    needed: BitcoinAmount::MAX_MONEY,
+                    available: selected_amount,
+                })?;
         if selected_amount < amount_needed_with_fees {
             return Err(InsufficientFunds {
                 needed: amount_needed_with_fees,
@@ -176,7 +194,10 @@ fn base_transaction_fee(
     fee_rate * tx.weight()
 }
 
-fn raw_fee_from_selection(base_fee: BitcoinAmount, result: &CoinSelectionResult) -> BitcoinAmount {
+fn raw_fee_from_selection(
+    base_fee: BitcoinAmount,
+    result: &CoinSelectionResult,
+) -> Result<BitcoinAmount, Error> {
     let excess_fee = match result.excess {
         Excess::Change { fee, .. } => fee,
         Excess::NoChange {
@@ -184,7 +205,13 @@ fn raw_fee_from_selection(base_fee: BitcoinAmount, result: &CoinSelectionResult)
         } => remaining_amount,
     };
 
-    base_fee + result.fee_amount + excess_fee
+    let with_input_fees = base_fee
+        .checked_add(result.fee_amount)
+        .ok_or(Error::FeeEstimationOverflow)?;
+
+    with_input_fees
+        .checked_add(excess_fee)
+        .ok_or(Error::FeeEstimationOverflow)
 }
 
 /// Apply quote-time safety padding to a raw fee estimate.
@@ -269,7 +296,9 @@ impl CdkBdk {
         let sampled_utxo_count = weighted_utxos.len();
 
         let base_fee = base_transaction_fee(fee_rate, recipient_script.as_script(), amount_sat);
-        let target_amount = BitcoinAmount::from_sat(amount_sat) + base_fee;
+        let target_amount = BitcoinAmount::from_sat(amount_sat)
+            .checked_add(base_fee)
+            .ok_or(Error::FeeEstimationOverflow)?;
         let fallback_used = Cell::new(false);
         let fallback = TrackingFallback {
             fallback: PessimisticFallback,
@@ -288,7 +317,7 @@ impl CdkBdk {
             )
             .map_err(|e| Error::FeeEstimationFailed(e.to_string()))?;
 
-        let raw_fee_sat = raw_fee_from_selection(base_fee, &result).to_sat();
+        let raw_fee_sat = raw_fee_from_selection(base_fee, &result)?.to_sat();
         let padded_fee_sat = apply_quote_fee_safety(raw_fee_sat, &self.batch_config.fee_estimation);
         let fee_reserve_sat = self.fee_reserve_for_estimate(padded_fee_sat);
         let path = if fallback_used.get() {


### PR DESCRIPTION
### Motivation
- Public on-chain melt quote requests carry an attacker-controlled `Amount` (u64) which could be near `u64::MAX`, and unchecked additions in the BDK-backed fee estimator could panic instead of returning an error.\
- A panic in the estimator can abort the daemon (panic-abort builds) or crash request tasks, causing availability impact.\
- The change aims to convert overflow panic paths into recoverable errors while preserving existing fee-estimation behavior for normal inputs.

### Description
- Add a new error variant `FeeEstimationOverflow` in `crates/cdk-bdk/src/error.rs` to represent arithmetic overflow during fee estimation.\
- Replace unchecked `BitcoinAmount` arithmetic with checked additions in `crates/cdk-bdk/src/fee.rs`, mapping overflow to `Error::FeeEstimationOverflow` for the main estimator.\
- Harden the pessimistic fallback coin selector by using `checked_add` for `target_amount + fee_amount` checks and returning `InsufficientFunds` on overflow instead of panicking.\
- Make `raw_fee_from_selection` return `Result<BitcoinAmount, Error>` and propagate checked-arithmetic errors through the estimator with `?` so callers receive normal errors rather than panics.

### Testing
- Ran formatting with `cargo fmt --all` (succeeded).\
- Performed a compile check with `cargo check -p cdk-bdk --all-targets` (succeeded).\
- No behavioral unit tests were added; changes are defensive arithmetic checks that convert panic paths into error returns.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1058100970832cb030eeaeec876df7)