### PR TITLE
fix: disable checkout credential persistence in nightly rustfmt

### DIFF
--- a/.github/workflows/nightly-rustfmt.yml
+++ b/.github/workflows/nightly-rustfmt.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           ref: main
           token: ${{ secrets.BACKPORT_TOKEN }}
+          persist-credentials: false
       - uses: cachix/cachix-action@v17
         with:
           name: cashudevkit


### PR DESCRIPTION
### Motivation
- Prevent `BACKPORT_TOKEN` from being persisted into the local Git config during the nightly rustfmt job so repository-controlled `nix`/`cargo` commands cannot access a write-capable token.

### Description
- Add `persist-credentials: false` to the `actions/checkout@v4` step in `.github/workflows/nightly-rustfmt.yml` so credentials are not written to the workspace while keeping the token available for the final PR creation step.

### Testing
- Confirmed the workflow file was updated and contains the new `persist-credentials: false` line using `nl -ba .github/workflows/nightly-rustfmt.yml | sed -n '10,30p'` and committed the change; no unit tests apply to this workflow-only fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f4ceb8ee8832c8668f267242b3e9d)