### PR TITLE
Copy Cargo.lock to binding target repos for reproducible builds

### DIFF
--- a/.github/scripts/seed-binding-lockfile.sh
+++ b/.github/scripts/seed-binding-lockfile.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Seeds a downstream binding crate's Cargo.lock from the workspace lockfile, so
+# every release leg builds against the dependency versions pinned at the tagged
+# commit instead of re-resolving. Fails if any dependency the binding resolves
+# to was not pinned by the workspace lock.
+#
+# The reference is the tree that published the cdk-ffi the binding pins, which
+# is an earlier tag whenever a release pins an older cdk-ffi than its own tag.
+# Pass that checkout's manifest as the second argument.
+#
+# Usage: seed-binding-lockfile.sh <downstream-rust-dir> [root-manifest]
+#   run from the monorepo checkout root.
+
+set -euo pipefail
+
+BINDING_DIR="${1:?usage: seed-binding-lockfile.sh <downstream-rust-dir> [root-manifest]}"
+ROOT_MANIFEST="${2:-Cargo.toml}"
+ROOT_LOCK="$(dirname "${ROOT_MANIFEST}")/Cargo.lock"
+
+if [[ ! -f "${ROOT_LOCK}" ]]; then
+  echo "::error::${ROOT_LOCK} not found; the workspace lockfile must be committed"
+  exit 1
+fi
+
+cp "${ROOT_LOCK}" "${BINDING_DIR}/Cargo.lock"
+
+# `cargo fetch` resolves minimally against the lock it is handed, changing only
+# the entries the rewritten manifest forces (cdk-ffi moves from a path dep to a
+# registry or git source). `cargo update` and `cargo generate-lockfile` both
+# re-resolve to latest and would silently undo the seeding.
+( cd "${BINDING_DIR}" && cargo fetch )
+
+# The wrapper crate and cdk-ffi itself are excluded: their source and version
+# legitimately differ downstream, especially for nightlies.
+resolved_versions() {
+  cargo metadata --format-version 1 --locked --manifest-path "$1" \
+    | jq -r '.packages[] | select(.name | startswith("cdk-ffi") | not)
+             | "\(.name) \(.version)"' \
+    | sort -u
+}
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+resolved_versions "${ROOT_MANIFEST}" > "${workdir}/workspace.txt"
+resolved_versions "${BINDING_DIR}/Cargo.toml" > "${workdir}/binding.txt"
+
+# Anything the binding resolves that the workspace did not pin is drift. The
+# reverse is expected: the workspace has members the binding never pulls in.
+drift="$(comm -13 "${workdir}/workspace.txt" "${workdir}/binding.txt")"
+
+if [[ -n "${drift}" ]]; then
+  echo "::error::binding dependencies drifted from ${ROOT_LOCK}"
+  echo "${drift}" | sed 's/^/  /'
+  echo
+  echo "Re-run with the workspace lock updated, or pin the offending crate."
+  echo "A binding whose dependencies moved ahead of the pinned cdk-ffi needs a"
+  echo "matching cdk-ffi released first."
+  exit 1
+fi
+
+echo "Dependency graph matches the workspace lockfile ($(wc -l < "${workdir}/binding.txt") packages)."

--- a/.github/scripts/verify-binding-lockfile.sh
+++ b/.github/scripts/verify-binding-lockfile.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Checks, after the fact, that a published binding release resolved only
+# dependency versions that the monorepo's Cargo.lock pinned at the commit the
+# release claims to come from.
+#
+# Usage: verify-binding-lockfile.sh <language> <release-tag>
+#   run from the monorepo checkout root. Needs `gh` and a checkout at the
+#   source commit recorded in the release's build-manifest.json.
+
+set -euo pipefail
+
+LANGUAGE="${1:?usage: verify-binding-lockfile.sh <language> <release-tag>}"
+TAG="${2:?missing release tag}"
+
+case "${LANGUAGE}" in
+  dart|swift|kotlin|go) ;;
+  *) echo "unknown language: ${LANGUAGE}" >&2; exit 2 ;;
+esac
+
+REPO="cashubtc/cdk-${LANGUAGE}"
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+git clone --quiet --depth 1 --branch "${TAG}" \
+  "https://github.com/${REPO}.git" "${workdir}/downstream"
+
+MANIFEST="${workdir}/downstream/build-manifest.json"
+if [[ ! -f "${MANIFEST}" ]]; then
+  echo "::error::${REPO}@${TAG} has no build-manifest.json; it predates provenance recording"
+  exit 1
+fi
+
+CLAIMED_COMMIT="$(jq -r '.source.commit' "${MANIFEST}")"
+HEAD_COMMIT="$(git rev-parse HEAD)"
+if [[ "${CLAIMED_COMMIT}" != "${HEAD_COMMIT}" ]]; then
+  echo "::error::checkout mismatch: release was built from ${CLAIMED_COMMIT}, this tree is ${HEAD_COMMIT}"
+  echo "Run: git checkout ${CLAIMED_COMMIT}"
+  exit 1
+fi
+
+CLAIMED_WS_LOCK="$(jq -r '.lockfiles.workspace_cargo_lock_sha256' "${MANIFEST}")"
+ACTUAL_WS_LOCK="$(shasum -a 256 Cargo.lock 2>/dev/null | cut -d' ' -f1)"
+if [[ "${CLAIMED_WS_LOCK}" != "${ACTUAL_WS_LOCK}" ]]; then
+  echo "::error::workspace Cargo.lock hash mismatch"
+  echo "  manifest: ${CLAIMED_WS_LOCK}"
+  echo "  checkout: ${ACTUAL_WS_LOCK}"
+  exit 1
+fi
+
+BINDING_LOCK="${workdir}/downstream/rust/Cargo.lock"
+if [[ ! -f "${BINDING_LOCK}" ]]; then
+  # Releases cut before a language started seeding its lockfile have none, and
+  # the workspace lock hash checked above is then the whole guarantee.
+  echo "${LANGUAGE}: no downstream lockfile; verified against the workspace lock."
+  exit 0
+fi
+
+lock_versions() {
+  awk -F'"' '/^name = /{n=$2} /^version = /{print n" "$2}' "$1" \
+    | grep -v '^cdk-ffi' \
+    | sort -u
+}
+
+# Releases that pin an older cdk-ffi than their own tag were seeded from that
+# cdk-ffi's tag, so that is what the binding lock has to be compared against.
+LOCK_REF="$(jq -r '.lockfiles.binding_cargo_lock_source_ref // empty' "${MANIFEST}")"
+REFERENCE_LOCK="${workdir}/reference.lock"
+if [[ -n "${LOCK_REF}" && "${LOCK_REF}" != "${HEAD_COMMIT}" ]]; then
+  if ! git fetch --quiet --depth 1 origin "${LOCK_REF}"; then
+    echo "::error::cannot fetch ${LOCK_REF}, the ref the binding lockfile was seeded from"
+    exit 1
+  fi
+  git show FETCH_HEAD:Cargo.lock > "${REFERENCE_LOCK}"
+else
+  LOCK_REF="${CLAIMED_COMMIT}"
+  cp Cargo.lock "${REFERENCE_LOCK}"
+fi
+
+lock_versions "${REFERENCE_LOCK}" > "${workdir}/workspace.txt"
+lock_versions "${BINDING_LOCK}" > "${workdir}/binding.txt"
+
+drift="$(comm -13 "${workdir}/workspace.txt" "${workdir}/binding.txt")"
+if [[ -n "${drift}" ]]; then
+  echo "::error::${REPO}@${TAG} used dependencies the lockfile at ${LOCK_REF} did not pin"
+  echo "${drift}" | sed 's/^/  /'
+  exit 1
+fi
+
+echo "${LANGUAGE} ${TAG}: all $(wc -l < "${workdir}/binding.txt" | tr -d ' ') dependencies match the lockfile at ${LOCK_REF}."

--- a/.github/scripts/write-build-manifest.sh
+++ b/.github/scripts/write-build-manifest.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Records what a binding release was built from, so the dependency graph and
+# toolchain can be checked after the fact without re-running the release.
+#
+# Usage: write-build-manifest.sh <language> <downstream-dir> <output-path>
+#   run from the monorepo checkout root. Reads TAG, CDK_REF, CDK_VER, NIGHTLY
+#   and GITHUB_REPOSITORY from the environment.
+
+set -euo pipefail
+
+LANGUAGE="${1:?usage: write-build-manifest.sh <language> <downstream-dir> <output-path>}"
+DOWNSTREAM_DIR="${2:?missing downstream dir}"
+OUTPUT="${3:?missing output path}"
+
+sha256() {
+  if [[ ! -f "$1" ]]; then
+    echo "null"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+CDK_VER="${CDK_VER:-${TAG:-}}"
+CDK_VER="${CDK_VER#v}"
+
+# The binding lockfile is seeded from the tree that published the pinned
+# cdk-ffi: its tag for a release, the exact commit for a nightly.
+if [[ "${NIGHTLY:-false}" == "true" ]]; then
+  BINDING_LOCK_REF="${CDK_REF:-}"
+else
+  BINDING_LOCK_REF="refs/tags/v${CDK_VER}"
+fi
+
+RUST_CHANNEL="$(grep '^channel' rust-toolchain.toml | cut -d'"' -f2)"
+WORKSPACE_LOCK="$(sha256 Cargo.lock)"
+BINDING_LOCK="$(sha256 "${DOWNSTREAM_DIR}/rust/Cargo.lock")"
+FLAKE_LOCK="$(sha256 flake.lock)"
+
+# binding_cargo_lock_sha256 stays null for a binding with no downstream Rust
+# crate to seed. Every language currently released has one.
+jq -n \
+  --arg language "${LANGUAGE}" \
+  --arg tag "${TAG:-}" \
+  --arg repo "${GITHUB_REPOSITORY:-cashubtc/cdk}" \
+  --arg commit "${CDK_REF:-}" \
+  --arg cdk_version "${CDK_VER}" \
+  --arg binding_lock_ref "${BINDING_LOCK_REF}" \
+  --arg rust_channel "${RUST_CHANNEL}" \
+  --arg workspace_lock "${WORKSPACE_LOCK}" \
+  --arg binding_lock "${BINDING_LOCK}" \
+  --arg flake_lock "${FLAKE_LOCK}" \
+  '{
+     schema_version: 2,
+     language: $language,
+     release_tag: $tag,
+     source: { repo: $repo, commit: $commit, cdk_version: $cdk_version },
+     toolchain: { rust_channel: $rust_channel },
+     lockfiles: {
+       workspace_cargo_lock_sha256: $workspace_lock,
+       binding_cargo_lock_sha256: (if $binding_lock == "null" then null else $binding_lock end),
+       binding_cargo_lock_source_ref: $binding_lock_ref,
+       flake_lock_sha256: $flake_lock
+     }
+   }' > "${OUTPUT}"
+
+cat "${OUTPUT}"

--- a/.github/workflows/dart-publish.yml
+++ b/.github/workflows/dart-publish.yml
@@ -102,7 +102,6 @@ jobs:
             --exclude='.git' \
             bindings/dart/ cdk-dart/
           cp rust-toolchain.toml cdk-dart/
-          cp Cargo.lock cdk-dart/rust/
 
       - name: Update versions and resolve workspace references
         run: |
@@ -162,11 +161,18 @@ jobs:
           sed -i '/^\[lints\]/,/^$/s/^workspace = true//' cdk-dart/rust/Cargo.toml
 
           # Add release profile
-          printf '\n[profile.release]\nlto = true\nstrip = true\ncodegen-units = 1\n' >> cdk-dart/rust/Cargo.toml
+          printf '\n[workspace]\n\n[profile.release]\nlto = true\nstrip = true\ncodegen-units = 1\n' >> cdk-dart/rust/Cargo.toml
 
           cat cdk-dart/pubspec.yaml
           echo "---"
           cat cdk-dart/rust/Cargo.toml
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Generate Cargo.lock for standalone crate
+        working-directory: cdk-dart/rust
+        run: cargo generate-lockfile
 
       - name: Push to cdk-dart release branch
         working-directory: cdk-dart

--- a/.github/workflows/dart-publish.yml
+++ b/.github/workflows/dart-publish.yml
@@ -102,6 +102,7 @@ jobs:
             --exclude='.git' \
             bindings/dart/ cdk-dart/
           cp rust-toolchain.toml cdk-dart/
+          cp Cargo.lock cdk-dart/rust/
 
       - name: Update versions and resolve workspace references
         run: |
@@ -254,12 +255,12 @@ jobs:
       - name: Build (native)
         if: "!contains(matrix.target, 'android')"
         working-directory: cdk-dart/rust
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Build (cross / Android)
         if: contains(matrix.target, 'android')
         working-directory: cdk-dart/rust
-        run: cross build --release --target ${{ matrix.target }}
+        run: cross build --release --locked --target ${{ matrix.target }}
 
       - name: Strip debug symbols
         shell: bash
@@ -277,7 +278,7 @@ jobs:
         working-directory: cdk-dart/rust
         run: |
           mkdir -p ../generated-bindings
-          cargo run --release --bin uniffi-bindgen -- \
+          cargo run --release --locked --bin uniffi-bindgen -- \
             target/${{ matrix.target }}/release/${{ matrix.artifact }} \
             --out-dir ../generated-bindings
 

--- a/.github/workflows/dart-publish.yml
+++ b/.github/workflows/dart-publish.yml
@@ -47,6 +47,8 @@ env:
   TAG: ${{ inputs.release_tag }}
   CDK_REF: ${{ inputs.cdk_ref || inputs.release_tag }}
   CDK_CHECKOUT_REF: ${{ inputs.nightly && inputs.cdk_ref || format('refs/tags/{0}', inputs.release_tag) }}
+  CDK_SOURCE_TAG: ${{ inputs.cdk_version && format('refs/tags/v{0}', inputs.cdk_version) || format('refs/tags/{0}', inputs.release_tag) }}
+  CDK_SOURCE_MANIFEST: ${{ inputs.nightly && 'Cargo.toml' || 'cdk-src/Cargo.toml' }}
   RELEASE_BRANCH: release/${{ inputs.release_tag }}
 
 jobs:
@@ -82,6 +84,13 @@ jobs:
             exit 1
           fi
 
+      - name: Verify the cdk-ffi source tag exists
+        if: ${{ !inputs.nightly }}
+        run: |
+          git ls-remote --exit-code --tags \
+            "https://github.com/${GITHUB_REPOSITORY}.git" "${CDK_SOURCE_TAG}" >/dev/null \
+            || { echo "::error::${CDK_SOURCE_TAG} does not exist; cdk_version must name a released CDK tag"; exit 1; }
+
       - name: Verify release source exists
         uses: actions/checkout@v5
         with:
@@ -105,6 +114,29 @@ jobs:
         with:
           ref: ${{ env.CDK_CHECKOUT_REF }}
           persist-credentials: false
+
+      # cdk-ffi is pinned to a published version, whose dependency requirements
+      # were frozen when it was released. Its own tag, not the release tag, is
+      # what the binding lockfile has to be seeded from.
+      - name: Checkout the cdk-ffi source tag
+        if: ${{ !inputs.nightly }}
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.CDK_SOURCE_TAG }}
+          path: cdk-src
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify the cdk-ffi source tag
+        if: ${{ !inputs.nightly }}
+        run: |
+          REF_VER=$(sed -n '/^\[workspace\.package\]/,/^\[/p' cdk-src/Cargo.toml \
+            | grep '^version ' | head -1 | cut -d'"' -f2)
+          if [[ "${REF_VER}" != "${CDK_VER}" ]]; then
+            echo "::error::${CDK_SOURCE_TAG} declares workspace version ${REF_VER}, not ${CDK_VER}"
+            exit 1
+          fi
+          echo "Seeding the binding lockfile from ${CDK_SOURCE_TAG}"
 
       - name: Clone cdk-dart
         env:
@@ -194,12 +226,20 @@ jobs:
           # Remove workspace lints reference
           sed -i '/^\[lints\]/,/^$/s/^workspace = true//' cdk-dart/rust/Cargo.toml
 
+          # Detach from the monorepo workspace: the release job clones
+          # cdk-dart inside the checkout, so cargo would otherwise walk up
+          # to the root Cargo.toml and reject a non-member package.
+          printf '\n[workspace]\n' >> cdk-dart/rust/Cargo.toml
+
           # Add release profile
           printf '\n[profile.release]\nlto = true\nstrip = true\ncodegen-units = 1\n' >> cdk-dart/rust/Cargo.toml
 
           cat cdk-dart/pubspec.yaml
           echo "---"
           cat cdk-dart/rust/Cargo.toml
+
+      - name: Seed Cargo.lock from the cdk-ffi source lockfile
+        run: ./.github/scripts/seed-binding-lockfile.sh cdk-dart/rust "${CDK_SOURCE_MANIFEST}"
 
       - name: Push to cdk-dart release branch
         working-directory: cdk-dart
@@ -246,7 +286,7 @@ jobs:
 
           # Windows
           - target: x86_64-pc-windows-msvc
-            runner: windows-latest
+            runner: windows-2022
             artifact: cdk_ffi_dart.dll
 
           # Android
@@ -280,24 +320,43 @@ jobs:
             clone --branch "${RELEASE_BRANCH}" \
             https://github.com/${{ vars.CDK_DART_REPO }}.git cdk-dart
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+      - name: Install pinned Rust toolchain
+        working-directory: cdk-dart
+        shell: bash
+        run: |
+          # rust-toolchain.toml is the single source of truth here; rustup
+          # installs it on demand. Never resolve to floating stable.
+          rustup show active-toolchain
+          rustup target add ${{ matrix.target }}
+          CHANNEL=$(grep '^channel' rust-toolchain.toml | cut -d'"' -f2)
+          # Captured rather than piped into grep -q: a short-circuiting grep
+          # kills rustc with SIGPIPE, which pipefail reports as a failure even
+          # when the version matched.
+          RUSTC_VV=$(rustc -vV)
+          echo "${RUSTC_VV}"
+          RUSTC_RELEASE=$(awk '/^release:/ { print $2 }' <<< "${RUSTC_VV}")
+          if [[ "${RUSTC_RELEASE}" != "${CHANNEL}" ]]; then
+            echo "::error::expected rustc ${CHANNEL} per rust-toolchain.toml; got ${RUSTC_RELEASE}"
+            exit 1
+          fi
 
       - name: Install cross (Android)
         if: contains(matrix.target, 'android')
+        # Deliberately not --locked: cross only drives the pinned
+        # ghcr.io/cross-rs/<target>:0.2.5 container, so its own dependency graph
+        # never reaches the released library, and its 2022-era lockfile does not
+        # reliably build on current rustc.
         run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
 
       - name: Build (native)
         if: "!contains(matrix.target, 'android')"
         working-directory: cdk-dart/rust
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --locked --release --target ${{ matrix.target }}
 
       - name: Build (cross / Android)
         if: contains(matrix.target, 'android')
         working-directory: cdk-dart/rust
-        run: cross build --release --target ${{ matrix.target }}
+        run: cross build --locked --release --target ${{ matrix.target }}
 
       - name: Strip debug symbols
         shell: bash
@@ -315,7 +374,7 @@ jobs:
         working-directory: cdk-dart/rust
         run: |
           mkdir -p ../generated-bindings
-          cargo run --release --bin uniffi-bindgen-dart -- \
+          cargo run --locked --release --bin uniffi-bindgen-dart -- \
             target/${{ matrix.target }}/release/${{ matrix.artifact }} \
             --out-dir ../generated-bindings
 
@@ -342,6 +401,10 @@ jobs:
   dart-publish:
     name: "dart: Publish to cdk-dart"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     needs: [dart-build-native]
     steps:
       - name: Clone cdk-dart
@@ -356,6 +419,14 @@ jobs:
           git -c "http.extraheader=$(auth_header)" \
             clone --branch "${RELEASE_BRANCH}" \
             https://github.com/${{ vars.CDK_DART_REPO }}.git cdk-dart
+
+      - name: Checkout monorepo (for the build manifest)
+        uses: actions/checkout@v5
+        with:
+          path: cdk
+          ref: ${{ env.CDK_CHECKOUT_REF }}
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Download all native artifacts
         uses: actions/download-artifact@v8
@@ -385,6 +456,15 @@ jobs:
         with:
           name: dart-bindings-generated
           path: cdk-dart/lib/src/generated
+
+      - name: Write build manifest
+        working-directory: cdk
+        env:
+          CDK_VER: ${{ inputs.cdk_version }}
+          NIGHTLY: ${{ inputs.nightly }}
+        run: |
+          ./.github/scripts/write-build-manifest.sh dart \
+            ../cdk-dart ../cdk-dart/build-manifest.json
 
       - name: Commit to release branch
         working-directory: cdk-dart
@@ -428,7 +508,16 @@ jobs:
             # Clean up for next platform
             rm -rf staging/prebuilt
           done
+          ( cd release-archives && sha256sum -- * > SHA256SUMS )
+          cp cdk-dart/build-manifest.json release-archives/
           ls -lh release-archives/
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            release-archives/*.tar.gz
+            release-archives/*.zip
 
       - name: Create release on cdk-dart
         env:

--- a/.github/workflows/ffi-nightly.yml
+++ b/.github/workflows/ffi-nightly.yml
@@ -102,6 +102,10 @@ jobs:
     name: "Publish Dart nightly"
     needs: prepare
     if: needs.prepare.outputs.dart == 'true'
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/dart-publish.yml
     with:
       release_tag: ${{ needs.prepare.outputs.release_tag }}
@@ -115,6 +119,10 @@ jobs:
     name: "Publish Go nightly"
     needs: prepare
     if: needs.prepare.outputs.go == 'true'
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/go-publish.yml
     with:
       release_tag: ${{ needs.prepare.outputs.release_tag }}
@@ -128,6 +136,10 @@ jobs:
     name: "Publish Kotlin nightly"
     needs: prepare
     if: needs.prepare.outputs.kotlin == 'true'
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/kotlin-publish.yml
     with:
       release_tag: ${{ needs.prepare.outputs.release_tag }}
@@ -141,6 +153,10 @@ jobs:
     name: "Publish Swift nightly"
     needs: prepare
     if: needs.prepare.outputs.swift == 'true'
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/swift-publish.yml
     with:
       release_tag: ${{ needs.prepare.outputs.release_tag }}

--- a/.github/workflows/ffi-publish-all.yml
+++ b/.github/workflows/ffi-publish-all.yml
@@ -37,6 +37,10 @@ jobs:
   dart:
     name: "Trigger Dart bindings"
     needs: detect-prerelease
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/dart-publish.yml
     with:
       release_tag: ${{ inputs.release_tag }}
@@ -48,6 +52,10 @@ jobs:
   kotlin:
     name: "Trigger Kotlin bindings"
     needs: detect-prerelease
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/kotlin-publish.yml
     with:
       release_tag: ${{ inputs.release_tag }}
@@ -59,6 +67,10 @@ jobs:
   swift:
     name: "Trigger Swift bindings"
     needs: detect-prerelease
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/swift-publish.yml
     with:
       release_tag: ${{ inputs.release_tag }}
@@ -70,6 +82,10 @@ jobs:
   go:
     name: "Trigger Go bindings"
     needs: detect-prerelease
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/go-publish.yml
     with:
       release_tag: ${{ inputs.release_tag }}

--- a/.github/workflows/ffi-verify.yml
+++ b/.github/workflows/ffi-verify.yml
@@ -1,0 +1,83 @@
+name: "FFI - Verify Published Bindings"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Binding release tag to verify (e.g. v0.18.0)"
+        required: true
+        type: string
+      language:
+        description: "Binding to verify, or 'all'"
+        required: false
+        default: all
+        type: choice
+        options: [all, dart, swift, kotlin, go]
+  schedule:
+    # Re-check the most recent releases weekly so drift surfaces without a
+    # release having to happen first.
+    - cron: "23 5 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-lockfiles:
+    name: "verify: ${{ matrix.language }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [dart, swift, kotlin, go]
+    steps:
+      - name: Skip unselected languages
+        id: gate
+        run: |
+          SELECTED="${{ inputs.language || 'all' }}"
+          if [[ "${SELECTED}" == "all" || "${SELECTED}" == "${{ matrix.language }}" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout monorepo
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve the release and its source commit
+        if: steps.gate.outputs.run == 'true'
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.FFI_DEPLOY_KEY }}
+        run: |
+          REPO="cashubtc/cdk-${{ matrix.language }}"
+          TAG="${{ inputs.release_tag }}"
+          if [[ -z "${TAG}" ]]; then
+            TAG=$(gh release view --repo "${REPO}" --json tagName -q .tagName)
+            echo "No tag given; using latest release ${TAG} of ${REPO}"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+          MANIFEST=$(gh release download "${TAG}" --repo "${REPO}" \
+            --pattern build-manifest.json --output - 2>/dev/null || true)
+          if [[ -z "${MANIFEST}" ]]; then
+            echo "::warning::${REPO}@${TAG} has no build-manifest.json; it predates provenance recording"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "${MANIFEST}" | jq .
+          echo "commit=$(echo "${MANIFEST}" | jq -r .source.commit)" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Check out the source commit the release claims
+        if: steps.gate.outputs.run == 'true' && steps.resolve.outputs.skip == 'false'
+        run: git checkout --detach "${{ steps.resolve.outputs.commit }}"
+
+      - name: Verify the dependency graph
+        if: steps.gate.outputs.run == 'true' && steps.resolve.outputs.skip == 'false'
+        run: |
+          ./.github/scripts/verify-binding-lockfile.sh \
+            "${{ matrix.language }}" "${{ steps.resolve.outputs.tag }}"

--- a/.github/workflows/go-publish.yml
+++ b/.github/workflows/go-publish.yml
@@ -66,7 +66,6 @@ jobs:
             --exclude='.git' \
             bindings/go/ cdk-go/
           cp rust-toolchain.toml cdk-go/
-          cp Cargo.lock cdk-go/rust/
 
       - name: Update versions and resolve workspace references
         run: |
@@ -124,7 +123,7 @@ jobs:
           sed -i '/^\[lints\]/,/^$/s/^workspace = true//' cdk-go/rust/Cargo.toml
 
           # Add release profile
-          printf '\n[profile.release]\nlto = true\nstrip = true\ncodegen-units = 1\n' >> cdk-go/rust/Cargo.toml
+          printf '\n[workspace]\n\n[profile.release]\nlto = true\nstrip = true\ncodegen-units = 1\n' >> cdk-go/rust/Cargo.toml
 
           echo "--- rust/Cargo.toml ---"
           cat cdk-go/rust/Cargo.toml

--- a/.github/workflows/go-publish.yml
+++ b/.github/workflows/go-publish.yml
@@ -66,6 +66,7 @@ jobs:
             --exclude='.git' \
             bindings/go/ cdk-go/
           cp rust-toolchain.toml cdk-go/
+          cp Cargo.lock cdk-go/rust/
 
       - name: Update versions and resolve workspace references
         run: |
@@ -182,7 +183,7 @@ jobs:
       - name: Build cdk-ffi
         shell: bash
         run: |
-          cargo build --release --package cdk-ffi \
+          cargo build --release --locked --package cdk-ffi \
             --target ${{ matrix.target }}
 
       - name: Fix dylib install name

--- a/.github/workflows/go-publish.yml
+++ b/.github/workflows/go-publish.yml
@@ -47,8 +47,12 @@ env:
   TAG: ${{ inputs.release_tag }}
   CDK_REF: ${{ inputs.cdk_ref || inputs.release_tag }}
   CDK_CHECKOUT_REF: ${{ inputs.nightly && inputs.cdk_ref || format('refs/tags/{0}', inputs.release_tag) }}
+  CDK_SOURCE_TAG: ${{ inputs.cdk_version && format('refs/tags/v{0}', inputs.cdk_version) || format('refs/tags/{0}', inputs.release_tag) }}
+  CDK_SOURCE_MANIFEST: ${{ inputs.nightly && 'Cargo.toml' || 'cdk-src/Cargo.toml' }}
   RELEASE_BRANCH: release/${{ inputs.release_tag }}
-  UNIFFI_BINDGEN_GO_TAG: v0.6.0+v0.30.0
+  # Tag v0.6.0+v0.30.0. Pinned by commit because a tag can be repointed
+  # upstream, and --locked only pins the tool's own dependencies.
+  UNIFFI_BINDGEN_GO_REV: 5ad642822ad3c52219bd7081c0e58c2ac22bd9f8
 
 jobs:
   validate-release-ref:
@@ -83,6 +87,13 @@ jobs:
             exit 1
           fi
 
+      - name: Verify the cdk-ffi source tag exists
+        if: ${{ !inputs.nightly }}
+        run: |
+          git ls-remote --exit-code --tags \
+            "https://github.com/${GITHUB_REPOSITORY}.git" "${CDK_SOURCE_TAG}" >/dev/null \
+            || { echo "::error::${CDK_SOURCE_TAG} does not exist; cdk_version must name a released CDK tag"; exit 1; }
+
       - name: Verify release source exists
         uses: actions/checkout@v5
         with:
@@ -105,6 +116,29 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ env.CDK_CHECKOUT_REF }}
+
+      # cdk-ffi is pinned to a published version, whose dependency requirements
+      # were frozen when it was released. Its own tag, not the release tag, is
+      # what the binding lockfile has to be seeded from.
+      - name: Checkout the cdk-ffi source tag
+        if: ${{ !inputs.nightly }}
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.CDK_SOURCE_TAG }}
+          path: cdk-src
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify the cdk-ffi source tag
+        if: ${{ !inputs.nightly }}
+        run: |
+          REF_VER=$(sed -n '/^\[workspace\.package\]/,/^\[/p' cdk-src/Cargo.toml \
+            | grep '^version ' | head -1 | cut -d'"' -f2)
+          if [[ "${REF_VER}" != "${CDK_VER}" ]]; then
+            echo "::error::${CDK_SOURCE_TAG} declares workspace version ${REF_VER}, not ${CDK_VER}"
+            exit 1
+          fi
+          echo "Seeding the binding lockfile from ${CDK_SOURCE_TAG}"
 
       - name: Clone cdk-go
         run: |
@@ -180,11 +214,19 @@ jobs:
           # Remove workspace lints reference
           sed -i '/^\[lints\]/,/^$/s/^workspace = true//' cdk-go/rust/Cargo.toml
 
+          # Detach from the monorepo workspace: the release job clones
+          # cdk-go inside the checkout, so cargo would otherwise walk up
+          # to the root Cargo.toml and reject a non-member package.
+          printf '\n[workspace]\n' >> cdk-go/rust/Cargo.toml
+
           # Add release profile
           printf '\n[profile.release]\nlto = true\nstrip = true\ncodegen-units = 1\n' >> cdk-go/rust/Cargo.toml
 
           echo "--- rust/Cargo.toml ---"
           cat cdk-go/rust/Cargo.toml
+
+      - name: Seed Cargo.lock from the cdk-ffi source lockfile
+        run: ./.github/scripts/seed-binding-lockfile.sh cdk-go/rust "${CDK_SOURCE_MANIFEST}"
 
       - name: Push to cdk-go release branch
         working-directory: cdk-go
@@ -212,64 +254,82 @@ jobs:
           # Linux
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-22.04
-            artifact: libcdk_ffi.so
+            artifact: libcdk_ffi_go.so
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
-            artifact: libcdk_ffi.so
+            artifact: libcdk_ffi_go.so
 
           # macOS
           - target: aarch64-apple-darwin
             runner: macos-14
-            artifact: libcdk_ffi.dylib
+            artifact: libcdk_ffi_go.dylib
           - target: x86_64-apple-darwin
             runner: macos-14
-            artifact: libcdk_ffi.dylib
+            artifact: libcdk_ffi_go.dylib
 
           # Windows
           - target: x86_64-pc-windows-msvc
-            runner: windows-latest
-            artifact: cdk_ffi.dll
+            runner: windows-2022
+            artifact: cdk_ffi_go.dll
 
     steps:
-      - name: Checkout monorepo
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ env.CDK_CHECKOUT_REF }}
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Build cdk-ffi
+      - name: Clone cdk-go
         shell: bash
         run: |
-          cargo build --release --package cdk-ffi \
-            --target ${{ matrix.target }}
+          git clone --branch "${RELEASE_BRANCH}" \
+            https://x-access-token:${{ secrets.FFI_DEPLOY_KEY }}@github.com/${{ vars.CDK_GO_REPO }}.git cdk-go
+
+      - name: Install pinned Rust toolchain
+        working-directory: cdk-go
+        shell: bash
+        run: |
+          # rust-toolchain.toml is the single source of truth here; rustup
+          # installs it on demand. Never resolve to floating stable.
+          rustup show active-toolchain
+          rustup target add ${{ matrix.target }}
+          CHANNEL=$(grep '^channel' rust-toolchain.toml | cut -d'"' -f2)
+          # Captured rather than piped into grep -q: a short-circuiting grep
+          # kills rustc with SIGPIPE, which pipefail reports as a failure even
+          # when the version matched.
+          RUSTC_VV=$(rustc -vV)
+          echo "${RUSTC_VV}"
+          RUSTC_RELEASE=$(awk '/^release:/ { print $2 }' <<< "${RUSTC_VV}")
+          if [[ "${RUSTC_RELEASE}" != "${CHANNEL}" ]]; then
+            echo "::error::expected rustc ${CHANNEL} per rust-toolchain.toml; got ${RUSTC_RELEASE}"
+            exit 1
+          fi
+
+      - name: Build cdk-ffi-go
+        working-directory: cdk-go/rust
+        shell: bash
+        run: cargo build --locked --release --target ${{ matrix.target }}
 
       - name: Fix dylib install name
         if: endsWith(matrix.artifact, '.dylib')
+        working-directory: cdk-go/rust
         run: |
-          install_name_tool -id @rpath/libcdk_ffi.dylib \
+          install_name_tool -id @rpath/libcdk_ffi_go.dylib \
             target/${{ matrix.target }}/release/${{ matrix.artifact }}
 
       - name: Install uniffi-bindgen-go
         if: matrix.target == 'x86_64-unknown-linux-gnu'
+        working-directory: cdk-go
         run: |
           cargo install uniffi-bindgen-go \
             --git https://github.com/NordSecurity/uniffi-bindgen-go \
-            --tag ${{ env.UNIFFI_BINDGEN_GO_TAG }} \
+            --rev ${{ env.UNIFFI_BINDGEN_GO_REV }} \
             --locked --force
 
       - name: Generate Go bindings
         if: matrix.target == 'x86_64-unknown-linux-gnu'
+        working-directory: cdk-go/rust
         run: |
-          mkdir -p generated-bindings
+          mkdir -p ../../generated-bindings
           uniffi-bindgen-go \
             "target/${{ matrix.target }}/release/${{ matrix.artifact }}" \
             --library \
-            --config bindings/go/uniffi.toml \
-            --out-dir generated-bindings
+            --config ../uniffi.toml \
+            --out-dir ../../generated-bindings
 
       - name: Upload generated bindings
         if: matrix.target == 'x86_64-unknown-linux-gnu'
@@ -279,6 +339,7 @@ jobs:
           path: generated-bindings/
 
       - name: Strip debug symbols
+        working-directory: cdk-go/rust
         shell: bash
         run: |
           FILE="target/${{ matrix.target }}/release/${{ matrix.artifact }}"
@@ -292,7 +353,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          cp "target/${{ matrix.target }}/release/${{ matrix.artifact }}" \
+          cp "cdk-go/rust/target/${{ matrix.target }}/release/${{ matrix.artifact }}" \
              "dist/${{ matrix.target }}-${{ matrix.artifact }}"
 
       - name: Upload artifact
@@ -304,12 +365,24 @@ jobs:
   go-publish:
     name: "go: Publish to cdk-go"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     needs: [go-build-native]
     steps:
       - name: Clone cdk-go
         run: |
           git clone --branch "${RELEASE_BRANCH}" \
             https://x-access-token:${{ secrets.FFI_DEPLOY_KEY }}@github.com/${{ vars.CDK_GO_REPO }}.git cdk-go
+
+      - name: Checkout monorepo (for the build manifest)
+        uses: actions/checkout@v5
+        with:
+          path: cdk
+          ref: ${{ env.CDK_CHECKOUT_REF }}
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Download all native artifacts
         uses: actions/download-artifact@v8
@@ -328,6 +401,11 @@ jobs:
         run: |
           NATIVE_DIR="cdk-go/bindings/cdkffi/native"
 
+          # Regenerated wholesale: the sync rsync does not --delete, so a
+          # library renamed between releases would otherwise linger here and
+          # land in checksums.sha256.
+          rm -rf "${NATIVE_DIR}"
+
           declare -A TARGET_MAP
           TARGET_MAP[x86_64-unknown-linux-gnu]="linux_amd64"
           TARGET_MAP[aarch64-unknown-linux-gnu]="linux_arm64"
@@ -336,11 +414,11 @@ jobs:
           TARGET_MAP[x86_64-pc-windows-msvc]="windows_amd64"
 
           declare -A ARTIFACT_MAP
-          ARTIFACT_MAP[x86_64-unknown-linux-gnu]="libcdk_ffi.so"
-          ARTIFACT_MAP[aarch64-unknown-linux-gnu]="libcdk_ffi.so"
-          ARTIFACT_MAP[aarch64-apple-darwin]="libcdk_ffi.dylib"
-          ARTIFACT_MAP[x86_64-apple-darwin]="libcdk_ffi.dylib"
-          ARTIFACT_MAP[x86_64-pc-windows-msvc]="cdk_ffi.dll"
+          ARTIFACT_MAP[x86_64-unknown-linux-gnu]="libcdk_ffi_go.so"
+          ARTIFACT_MAP[aarch64-unknown-linux-gnu]="libcdk_ffi_go.so"
+          ARTIFACT_MAP[aarch64-apple-darwin]="libcdk_ffi_go.dylib"
+          ARTIFACT_MAP[x86_64-apple-darwin]="libcdk_ffi_go.dylib"
+          ARTIFACT_MAP[x86_64-pc-windows-msvc]="cdk_ffi_go.dll"
 
           for target in "${!TARGET_MAP[@]}"; do
             go_dir="${TARGET_MAP[$target]}"
@@ -383,7 +461,7 @@ jobs:
 
           package cdk_ffi
 
-          // #cgo LDFLAGS: -L${SRCDIR}/native/linux_amd64 -lcdk_ffi -Wl,-rpath,${SRCDIR}/native/linux_amd64 -lm -ldl
+          // #cgo LDFLAGS: -L${SRCDIR}/native/linux_amd64 -lcdk_ffi_go -Wl,-rpath,${SRCDIR}/native/linux_amd64 -lm -ldl
           import "C"
           EOF
 
@@ -392,7 +470,7 @@ jobs:
 
           package cdk_ffi
 
-          // #cgo LDFLAGS: -L${SRCDIR}/native/linux_arm64 -lcdk_ffi -Wl,-rpath,${SRCDIR}/native/linux_arm64 -lm -ldl
+          // #cgo LDFLAGS: -L${SRCDIR}/native/linux_arm64 -lcdk_ffi_go -Wl,-rpath,${SRCDIR}/native/linux_arm64 -lm -ldl
           import "C"
           EOF
 
@@ -401,7 +479,7 @@ jobs:
 
           package cdk_ffi
 
-          // #cgo LDFLAGS: -L${SRCDIR}/native/darwin_amd64 -lcdk_ffi -Wl,-rpath,${SRCDIR}/native/darwin_amd64 -lm
+          // #cgo LDFLAGS: -L${SRCDIR}/native/darwin_amd64 -lcdk_ffi_go -Wl,-rpath,${SRCDIR}/native/darwin_amd64 -lm
           import "C"
           EOF
 
@@ -410,7 +488,7 @@ jobs:
 
           package cdk_ffi
 
-          // #cgo LDFLAGS: -L${SRCDIR}/native/darwin_arm64 -lcdk_ffi -Wl,-rpath,${SRCDIR}/native/darwin_arm64 -lm
+          // #cgo LDFLAGS: -L${SRCDIR}/native/darwin_arm64 -lcdk_ffi_go -Wl,-rpath,${SRCDIR}/native/darwin_arm64 -lm
           import "C"
           EOF
 
@@ -419,7 +497,7 @@ jobs:
 
           package cdk_ffi
 
-          // #cgo LDFLAGS: -L${SRCDIR}/native/windows_amd64 -lcdk_ffi
+          // #cgo LDFLAGS: -L${SRCDIR}/native/windows_amd64 -lcdk_ffi_go
           import "C"
           EOF
 
@@ -430,7 +508,7 @@ jobs:
           LIBS=()
           while IFS= read -r -d '' f; do
             LIBS+=("${f}")
-          done < <(find "${NATIVE_DIR}" -type f \( -name "*.so" -o -name "*.dylib" \) -print0 | sort -z)
+          done < <(find "${NATIVE_DIR}" -type f \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" \) -print0 | sort -z)
           {
             for abs_path in "${LIBS[@]}"; do
               rel_path="${abs_path#"${NATIVE_DIR}/"}"
@@ -440,6 +518,15 @@ jobs:
           } > "${CHECKSUM_FILE}"
           echo "Updated ${CHECKSUM_FILE}:"
           cat "${CHECKSUM_FILE}"
+
+      - name: Write build manifest
+        working-directory: cdk
+        env:
+          CDK_VER: ${{ inputs.cdk_version }}
+          NIGHTLY: ${{ inputs.nightly }}
+        run: |
+          ./.github/scripts/write-build-manifest.sh go \
+            ../cdk-go ../cdk-go/build-manifest.json
 
       - name: Commit to release branch
         working-directory: cdk-go
@@ -457,6 +544,12 @@ jobs:
       - name: Build release archive
         run: |
           tar -czf "cdk-go-bindings-${TAG}.tar.gz" -C cdk-go bindings/cdkffi
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            cdk-go-bindings-${{ inputs.release_tag }}.tar.gz
 
       - name: Create release on cdk-go (creates tag and uploads asset atomically)
         working-directory: cdk-go
@@ -480,7 +573,8 @@ jobs:
             --target "${COMMIT_SHA}" \
             --title "Release ${TAG}" \
             "${RELEASE_OPTIONS[@]}" \
-            "../cdk-go-bindings-${TAG}.tar.gz"
+            "../cdk-go-bindings-${TAG}.tar.gz" \
+            build-manifest.json
 
       - name: Merge to default branch
         if: ${{ !inputs.nightly }}

--- a/.github/workflows/kotlin-publish.yml
+++ b/.github/workflows/kotlin-publish.yml
@@ -102,6 +102,7 @@ jobs:
             --exclude='.git' \
             bindings/kotlin/ cdk-kotlin/
           cp rust-toolchain.toml cdk-kotlin/
+          cp Cargo.lock cdk-kotlin/rust/
 
       - name: Update versions and resolve workspace references
         run: |
@@ -271,10 +272,10 @@ jobs:
                 DEVELOPER_DIR="$XCODE_DEV_DIR" \
                 CC_aarch64_apple_ios=/usr/bin/clang \
                 CARGO_TARGET_AARCH64_APPLE_IOS_LINKER=/usr/bin/clang \
-                cargo build --release --target ${{ matrix.target }}
+                cargo build --release --locked --target ${{ matrix.target }}
           else
             nix develop -L ../../cdk#kotlin-build --command \
-              cargo build --release --target ${{ matrix.target }}
+              cargo build --release --locked --target ${{ matrix.target }}
           fi
 
       - name: Strip debug symbols
@@ -295,7 +296,7 @@ jobs:
         run: |
           mkdir -p ../generated-bindings
           nix develop -L ../../cdk#kotlin-build --command \
-            cargo run --release --bin uniffi-bindgen -- generate \
+            cargo run --release --locked --bin uniffi-bindgen -- generate \
               --library "target/${{ matrix.target }}/release/${{ matrix.artifact }}" \
               --language kotlin \
               --out-dir ../generated-bindings \

--- a/.github/workflows/kotlin-publish.yml
+++ b/.github/workflows/kotlin-publish.yml
@@ -102,7 +102,6 @@ jobs:
             --exclude='.git' \
             bindings/kotlin/ cdk-kotlin/
           cp rust-toolchain.toml cdk-kotlin/
-          cp Cargo.lock cdk-kotlin/rust/
 
       - name: Update versions and resolve workspace references
         run: |
@@ -163,11 +162,18 @@ jobs:
           sed -i '/^\[lints\]/,/^$/s/^workspace = true//' cdk-kotlin/rust/Cargo.toml
 
           # Add release profile
-          printf '\n[profile.release]\nlto = true\nstrip = true\ncodegen-units = 1\n' >> cdk-kotlin/rust/Cargo.toml
+          printf '\n[workspace]\n\n[profile.release]\nlto = true\nstrip = true\ncodegen-units = 1\n' >> cdk-kotlin/rust/Cargo.toml
 
           cat cdk-kotlin/gradle.properties
           echo "---"
           cat cdk-kotlin/rust/Cargo.toml
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Generate Cargo.lock for standalone crate
+        working-directory: cdk-kotlin/rust
+        run: cargo generate-lockfile
 
       - name: Push to cdk-kotlin release branch
         working-directory: cdk-kotlin

--- a/.github/workflows/kotlin-publish.yml
+++ b/.github/workflows/kotlin-publish.yml
@@ -47,6 +47,8 @@ env:
   TAG: ${{ inputs.release_tag }}
   CDK_REF: ${{ inputs.cdk_ref || inputs.release_tag }}
   CDK_CHECKOUT_REF: ${{ inputs.nightly && inputs.cdk_ref || format('refs/tags/{0}', inputs.release_tag) }}
+  CDK_SOURCE_TAG: ${{ inputs.cdk_version && format('refs/tags/v{0}', inputs.cdk_version) || format('refs/tags/{0}', inputs.release_tag) }}
+  CDK_SOURCE_MANIFEST: ${{ inputs.nightly && 'Cargo.toml' || 'cdk-src/Cargo.toml' }}
   RELEASE_BRANCH: release/${{ inputs.release_tag }}
 
 jobs:
@@ -82,6 +84,13 @@ jobs:
             exit 1
           fi
 
+      - name: Verify the cdk-ffi source tag exists
+        if: ${{ !inputs.nightly }}
+        run: |
+          git ls-remote --exit-code --tags \
+            "https://github.com/${GITHUB_REPOSITORY}.git" "${CDK_SOURCE_TAG}" >/dev/null \
+            || { echo "::error::${CDK_SOURCE_TAG} does not exist; cdk_version must name a released CDK tag"; exit 1; }
+
       - name: Verify release source exists
         uses: actions/checkout@v5
         with:
@@ -105,6 +114,29 @@ jobs:
         with:
           ref: ${{ env.CDK_CHECKOUT_REF }}
           persist-credentials: false
+
+      # cdk-ffi is pinned to a published version, whose dependency requirements
+      # were frozen when it was released. Its own tag, not the release tag, is
+      # what the binding lockfile has to be seeded from.
+      - name: Checkout the cdk-ffi source tag
+        if: ${{ !inputs.nightly }}
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.CDK_SOURCE_TAG }}
+          path: cdk-src
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify the cdk-ffi source tag
+        if: ${{ !inputs.nightly }}
+        run: |
+          REF_VER=$(sed -n '/^\[workspace\.package\]/,/^\[/p' cdk-src/Cargo.toml \
+            | grep '^version ' | head -1 | cut -d'"' -f2)
+          if [[ "${REF_VER}" != "${CDK_VER}" ]]; then
+            echo "::error::${CDK_SOURCE_TAG} declares workspace version ${REF_VER}, not ${CDK_VER}"
+            exit 1
+          fi
+          echo "Seeding the binding lockfile from ${CDK_SOURCE_TAG}"
 
       - name: Clone cdk-kotlin
         env:
@@ -191,6 +223,11 @@ jobs:
           # Remove workspace lints reference
           sed -i '/^\[lints\]/,/^$/s/^workspace = true//' cdk-kotlin/rust/Cargo.toml
 
+          # Detach from the monorepo workspace: the release job clones
+          # cdk-kotlin inside the checkout, so cargo would otherwise walk up
+          # to the root Cargo.toml and reject a non-member package.
+          printf '\n[workspace]\n' >> cdk-kotlin/rust/Cargo.toml
+
           # Keep the symbol table until UniFFI has generated the Kotlin bindings.
           # The build job strips the native library explicitly after generation.
           printf '\n[profile.release]\nlto = true\nstrip = "debuginfo"\ncodegen-units = 1\n' >> cdk-kotlin/rust/Cargo.toml
@@ -198,6 +235,9 @@ jobs:
           cat cdk-kotlin/gradle.properties
           echo "---"
           cat cdk-kotlin/rust/Cargo.toml
+
+      - name: Seed Cargo.lock from the cdk-ffi source lockfile
+        run: ./.github/scripts/seed-binding-lockfile.sh cdk-kotlin/rust "${CDK_SOURCE_MANIFEST}"
 
       - name: Push to cdk-kotlin release branch
         working-directory: cdk-kotlin
@@ -278,11 +318,29 @@ jobs:
           useDaemon: false
         continue-on-error: true
 
+      - name: Verify pinned Rust toolchain
+        working-directory: cdk-kotlin/rust
+        shell: bash
+        run: |
+          # flake.nix and rust-toolchain.toml pin rustc independently; a drift
+          # between them would silently change what gets released.
+          CHANNEL=$(grep '^channel' ../rust-toolchain.toml | cut -d'"' -f2)
+          # Captured rather than piped into grep -q: a short-circuiting grep
+          # kills rustc with SIGPIPE, which pipefail reports as a failure even
+          # when the version matched.
+          RUSTC_VV=$(nix develop --fallback -L ../../cdk#kotlin-build --command rustc -vV)
+          echo "${RUSTC_VV}"
+          RUSTC_RELEASE=$(awk '/^release:/ { print $2 }' <<< "${RUSTC_VV}")
+          if [[ "${RUSTC_RELEASE}" != "${CHANNEL}" ]]; then
+            echo "::error::nix rustc does not match rust-toolchain.toml (${CHANNEL}); got ${RUSTC_RELEASE}"
+            exit 1
+          fi
+
       - name: Build (Nix)
         working-directory: cdk-kotlin/rust
         run: |
           nix develop --fallback -L ../../cdk#kotlin-build --command \
-            cargo build --release --target ${{ matrix.target }}
+            cargo build --locked --release --target ${{ matrix.target }}
 
       # uniffi 0.30 reads the component interface statically from the library
       # (it does not load it), so the arm64 Android .so works as the source on
@@ -295,7 +353,7 @@ jobs:
         run: |
           mkdir -p ../generated-bindings
           nix develop --fallback -L ../../cdk#kotlin-build --command \
-            cargo run --release --bin uniffi-bindgen-kotlin -- generate \
+            cargo run --locked --release --bin uniffi-bindgen-kotlin -- generate \
               --library "target/${{ matrix.target }}/release/${{ matrix.artifact }}" \
               --language kotlin \
               --config uniffi.toml \
@@ -345,6 +403,10 @@ jobs:
   kotlin-publish:
     name: "kotlin: Publish to cdk-kotlin"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     needs: [kotlin-build-native]
     concurrency:
       # Prevent duplicate publishes of the same immutable version without
@@ -419,6 +481,15 @@ jobs:
           name: kotlin-bindings-generated
           path: cdk-kotlin/cdk-jvm/src/main/kotlin
 
+      - name: Write build manifest
+        working-directory: cdk
+        env:
+          CDK_VER: ${{ inputs.cdk_version }}
+          NIGHTLY: ${{ inputs.nightly }}
+        run: |
+          ./.github/scripts/write-build-manifest.sh kotlin \
+            ../cdk-kotlin ../cdk-kotlin/build-manifest.json
+
       - name: Commit to release branch
         working-directory: cdk-kotlin
         run: |
@@ -453,6 +524,12 @@ jobs:
             env -u ANDROID_SDK_ROOT \
             ./gradlew --no-parallel publishAndReleaseToMavenCentral
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            cdk-kotlin/cdk-android/src/main/jniLibs/*/libcdk_ffi_kotlin.so
+
       - name: Create release on cdk-kotlin
         working-directory: cdk-kotlin
         env:
@@ -474,7 +551,8 @@ jobs:
             --repo ${{ vars.CDK_KOTLIN_REPO }} \
             --target "${COMMIT_SHA}" \
             --title "Release ${TAG}" \
-            "${RELEASE_OPTIONS[@]}"
+            "${RELEASE_OPTIONS[@]}" \
+            build-manifest.json
 
       - name: Merge to default branch
         if: ${{ !inputs.nightly }}

--- a/.github/workflows/swift-publish.yml
+++ b/.github/workflows/swift-publish.yml
@@ -103,6 +103,7 @@ jobs:
             --exclude='build' \
             bindings/swift/ cdk-swift/
           cp rust-toolchain.toml cdk-swift/
+          cp Cargo.lock cdk-swift/rust/
 
       - name: Update versions and resolve workspace references
         run: |
@@ -231,9 +232,9 @@ jobs:
           export DEVELOPER_DIR=$(/usr/bin/xcrun xcode-select -p)
           if [[ "${{ matrix.unset_macos_env }}" == "true" ]]; then
             env -u MACOSX_DEPLOYMENT_TARGET -u SDKROOT \
-              cargo build --release --target ${{ matrix.target }}
+              cargo build --release --locked --target ${{ matrix.target }}
           else
-            cargo build --release --target ${{ matrix.target }}
+            cargo build --release --locked --target ${{ matrix.target }}
           fi
 
       - name: Fix dylib install name
@@ -334,7 +335,7 @@ jobs:
         working-directory: cdk-swift/rust
         run: |
           # Build uniffi-bindgen-swift binary
-          cargo build --release --bin uniffi-bindgen-swift
+          cargo build --release --locked --bin uniffi-bindgen-swift
 
           BINDGEN="./target/release/uniffi-bindgen-swift"
 

--- a/.github/workflows/swift-publish.yml
+++ b/.github/workflows/swift-publish.yml
@@ -103,7 +103,6 @@ jobs:
             --exclude='build' \
             bindings/swift/ cdk-swift/
           cp rust-toolchain.toml cdk-swift/
-          cp Cargo.lock cdk-swift/rust/
 
       - name: Update versions and resolve workspace references
         run: |
@@ -161,10 +160,17 @@ jobs:
           sed -i '/^\[lints\]/,/^$/s/^workspace = true//' cdk-swift/rust/Cargo.toml
 
           # Add release profile
-          printf '\n[profile.release]\nlto = true\nstrip = true\ncodegen-units = 1\n' >> cdk-swift/rust/Cargo.toml
+          printf '\n[workspace]\n\n[profile.release]\nlto = true\nstrip = true\ncodegen-units = 1\n' >> cdk-swift/rust/Cargo.toml
 
           echo "--- rust/Cargo.toml ---"
           cat cdk-swift/rust/Cargo.toml
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Generate Cargo.lock for standalone crate
+        working-directory: cdk-swift/rust
+        run: cargo generate-lockfile
 
       - name: Push to cdk-swift release branch
         working-directory: cdk-swift

--- a/.github/workflows/swift-publish.yml
+++ b/.github/workflows/swift-publish.yml
@@ -47,6 +47,8 @@ env:
   TAG: ${{ inputs.release_tag }}
   CDK_REF: ${{ inputs.cdk_ref || inputs.release_tag }}
   CDK_CHECKOUT_REF: ${{ inputs.nightly && inputs.cdk_ref || format('refs/tags/{0}', inputs.release_tag) }}
+  CDK_SOURCE_TAG: ${{ inputs.cdk_version && format('refs/tags/v{0}', inputs.cdk_version) || format('refs/tags/{0}', inputs.release_tag) }}
+  CDK_SOURCE_MANIFEST: ${{ inputs.nightly && 'Cargo.toml' || 'cdk-src/Cargo.toml' }}
   RELEASE_BRANCH: release/${{ inputs.release_tag }}
 
 jobs:
@@ -82,6 +84,13 @@ jobs:
             exit 1
           fi
 
+      - name: Verify the cdk-ffi source tag exists
+        if: ${{ !inputs.nightly }}
+        run: |
+          git ls-remote --exit-code --tags \
+            "https://github.com/${GITHUB_REPOSITORY}.git" "${CDK_SOURCE_TAG}" >/dev/null \
+            || { echo "::error::${CDK_SOURCE_TAG} does not exist; cdk_version must name a released CDK tag"; exit 1; }
+
       - name: Verify release source exists
         uses: actions/checkout@v5
         with:
@@ -114,6 +123,29 @@ jobs:
         with:
           ref: ${{ env.CDK_CHECKOUT_REF }}
           persist-credentials: false
+
+      # cdk-ffi is pinned to a published version, whose dependency requirements
+      # were frozen when it was released. Its own tag, not the release tag, is
+      # what the binding lockfile has to be seeded from.
+      - name: Checkout the cdk-ffi source tag
+        if: ${{ !inputs.nightly }}
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.CDK_SOURCE_TAG }}
+          path: cdk-src
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify the cdk-ffi source tag
+        if: ${{ !inputs.nightly }}
+        run: |
+          REF_VER=$(sed -n '/^\[workspace\.package\]/,/^\[/p' cdk-src/Cargo.toml \
+            | grep '^version ' | head -1 | cut -d'"' -f2)
+          if [[ "${REF_VER}" != "${CDK_VER}" ]]; then
+            echo "::error::${CDK_SOURCE_TAG} declares workspace version ${REF_VER}, not ${CDK_VER}"
+            exit 1
+          fi
+          echo "Seeding the binding lockfile from ${CDK_SOURCE_TAG}"
 
       - name: Clone cdk-swift
         env:
@@ -198,6 +230,11 @@ jobs:
           # Remove workspace lints reference
           sed -i '/^\[lints\]/,/^$/s/^workspace = true//' cdk-swift/rust/Cargo.toml
 
+          # Detach from the monorepo workspace: the release job clones
+          # cdk-swift inside the checkout, so cargo would otherwise walk up
+          # to the root Cargo.toml and reject a non-member package.
+          printf '\n[workspace]\n' >> cdk-swift/rust/Cargo.toml
+
           # Add release profile
           printf '\n[profile.release]\nlto = true\nstrip = true\ncodegen-units = 1\n' >> cdk-swift/rust/Cargo.toml
 
@@ -210,6 +247,9 @@ jobs:
 
           echo "--- rust/Cargo.toml ---"
           cat cdk-swift/rust/Cargo.toml
+
+      - name: Seed Cargo.lock from the cdk-ffi source lockfile
+        run: ./.github/scripts/seed-binding-lockfile.sh cdk-swift/rust "${CDK_SOURCE_MANIFEST}"
 
       - name: Push to cdk-swift release branch
         working-directory: cdk-swift
@@ -270,10 +310,25 @@ jobs:
             clone --branch "${RELEASE_BRANCH}" \
             https://github.com/${{ vars.CDK_SWIFT_REPO }}.git cdk-swift
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+      - name: Install pinned Rust toolchain
+        working-directory: cdk-swift
+        shell: bash
+        run: |
+          # rust-toolchain.toml is the single source of truth here; rustup
+          # installs it on demand. Never resolve to floating stable.
+          rustup show active-toolchain
+          rustup target add ${{ matrix.target }}
+          CHANNEL=$(grep '^channel' rust-toolchain.toml | cut -d'"' -f2)
+          # Captured rather than piped into grep -q: a short-circuiting grep
+          # kills rustc with SIGPIPE, which pipefail reports as a failure even
+          # when the version matched.
+          RUSTC_VV=$(rustc -vV)
+          echo "${RUSTC_VV}"
+          RUSTC_RELEASE=$(awk '/^release:/ { print $2 }' <<< "${RUSTC_VV}")
+          if [[ "${RUSTC_RELEASE}" != "${CHANNEL}" ]]; then
+            echo "::error::expected rustc ${CHANNEL} per rust-toolchain.toml; got ${RUSTC_RELEASE}"
+            exit 1
+          fi
 
       - name: Build
         working-directory: cdk-swift/rust
@@ -281,9 +336,9 @@ jobs:
           export DEVELOPER_DIR=$(/usr/bin/xcrun xcode-select -p)
           if [[ "${{ matrix.unset_macos_env }}" == "true" ]]; then
             env -u MACOSX_DEPLOYMENT_TARGET -u SDKROOT \
-              cargo build --release --target ${{ matrix.target }}
+              cargo build --locked --release --target ${{ matrix.target }}
           else
-            cargo build --release --target ${{ matrix.target }}
+            cargo build --locked --release --target ${{ matrix.target }}
           fi
 
       - name: Fix dylib install name
@@ -327,8 +382,24 @@ jobs:
             clone --branch "${RELEASE_BRANCH}" \
             https://github.com/${{ vars.CDK_SWIFT_REPO }}.git cdk-swift
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install pinned Rust toolchain
+        working-directory: cdk-swift
+        shell: bash
+        run: |
+          # rust-toolchain.toml is the single source of truth here; rustup
+          # installs it on demand. Never resolve to floating stable.
+          rustup show active-toolchain
+          CHANNEL=$(grep '^channel' rust-toolchain.toml | cut -d'"' -f2)
+          # Captured rather than piped into grep -q: a short-circuiting grep
+          # kills rustc with SIGPIPE, which pipefail reports as a failure even
+          # when the version matched.
+          RUSTC_VV=$(rustc -vV)
+          echo "${RUSTC_VV}"
+          RUSTC_RELEASE=$(awk '/^release:/ { print $2 }' <<< "${RUSTC_VV}")
+          if [[ "${RUSTC_RELEASE}" != "${CHANNEL}" ]]; then
+            echo "::error::expected rustc ${CHANNEL} per rust-toolchain.toml; got ${RUSTC_RELEASE}"
+            exit 1
+          fi
 
       - name: Download all native artifacts
         uses: actions/download-artifact@v8
@@ -384,7 +455,7 @@ jobs:
         working-directory: cdk-swift/rust
         run: |
           # Build uniffi-bindgen-swift binary
-          cargo build --release --bin uniffi-bindgen-swift
+          cargo build --locked --release --bin uniffi-bindgen-swift
 
           BINDGEN="./target/release/uniffi-bindgen-swift"
 
@@ -456,6 +527,10 @@ jobs:
   swift-publish:
     name: "swift: Publish to cdk-swift"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     needs: [swift-assemble-xcframework]
     steps:
       - name: Clone cdk-swift
@@ -470,6 +545,14 @@ jobs:
           git -c "http.extraheader=$(auth_header)" \
             clone --branch "${RELEASE_BRANCH}" \
             https://github.com/${{ vars.CDK_SWIFT_REPO }}.git cdk-swift
+
+      - name: Checkout monorepo (for the build manifest)
+        uses: actions/checkout@v5
+        with:
+          path: cdk
+          ref: ${{ env.CDK_CHECKOUT_REF }}
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Download XCFramework
         uses: actions/download-artifact@v8
@@ -516,6 +599,15 @@ jobs:
           )
           EOF
 
+      - name: Write build manifest
+        working-directory: cdk
+        env:
+          CDK_VER: ${{ inputs.cdk_version }}
+          NIGHTLY: ${{ inputs.nightly }}
+        run: |
+          ./.github/scripts/write-build-manifest.sh swift \
+            ../cdk-swift ../cdk-swift/build-manifest.json
+
       - name: Commit to release branch
         working-directory: cdk-swift
         run: |
@@ -536,6 +628,12 @@ jobs:
           }
 
           git -c "http.extraheader=$(auth_header)" push origin "${RELEASE_BRANCH}"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            artifacts/CashuDevKitFFI.xcframework.zip
 
       - name: Create release on cdk-swift (creates tag and uploads asset atomically)
         working-directory: cdk-swift
@@ -559,7 +657,8 @@ jobs:
             --target "${COMMIT_SHA}" \
             --title "Release ${TAG}" \
             "${RELEASE_OPTIONS[@]}" \
-            ../artifacts/CashuDevKitFFI.xcframework.zip
+            ../artifacts/CashuDevKitFFI.xcframework.zip \
+            build-manifest.json
 
       - name: Merge to default branch
         if: ${{ !inputs.nightly }}

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -198,6 +198,71 @@ just ffi-release-go 0.17.0
   the authenticated Cachix cache
 - `gh` CLI must be authenticated for just commands
 
+## Build provenance
+
+Every release records what it was built from, and that record can be checked
+afterwards without re-running the release.
+
+### Same dependencies everywhere
+
+The workspace `Cargo.lock` is the single source of truth for dependency
+versions. During the sync step, `.github/scripts/seed-binding-lockfile.sh`
+copies it into the downstream binding crate, resolves it minimally with
+`cargo fetch` (only `cdk-ffi` itself moves from a path dependency to a registry
+or git source), and fails the release if the binding resolved anything the
+workspace lock did not pin. The resulting `rust/Cargo.lock` is committed to the
+release branch, and every build leg then compiles with `--locked`.
+
+Which lockfile counts as the reference follows `cdk_version` rather than the
+release tag. A binding pinned to a published `cdk-ffi` inherits that version's
+dependency requirements, frozen when it was published, so the sync job checks
+out the tag it was published from and seeds from there. Both are the same tag
+unless a release pins an older `cdk-ffi` than its own version.
+
+### Pinned toolchain
+
+`rust-toolchain.toml` is copied into each downstream repo and is the only thing
+that decides which compiler runs. Each build job installs it through `rustup`
+and then asserts that `rustc -vV` matches the pinned channel, so a release can
+never silently fall back to whatever stable happens to be current. The Kotlin
+job additionally cross-checks that the compiler its Nix shell provides agrees
+with `rust-toolchain.toml`.
+
+### build-manifest.json
+
+Each release ships a `build-manifest.json` recording the source commit, the
+`cdk-ffi` version it pins and the ref its lockfile was seeded from, the pinned
+Rust channel, and SHA-256 hashes of the workspace lockfile, the binding
+lockfile, and `flake.lock`.
+
+### Verifying a published release
+
+```bash
+git checkout <source commit from the manifest>
+just ffi-verify-lock kotlin v0.18.0
+just ffi-verify-lock-all v0.18.0
+```
+
+This confirms the release's dependency graph is a subset of what the lockfile
+pinned at the ref the manifest records, which is the tag that published the
+`cdk-ffi` the release depends on. The `FFI - Verify Published Bindings`
+workflow runs the same check weekly.
+
+Release artifacts also carry GitHub build provenance attestations, which bind a
+downstream asset to a workflow run and commit in this repository:
+
+```bash
+gh attestation verify <asset> --repo cashubtc/cdk
+```
+
+### What this does not cover
+
+Matching dependencies and a matching compiler do not make the binaries
+bit-for-bit identical. Absolute build paths, archive timestamps, and the
+unpinned Xcode and MSVC toolchains on the Apple and Windows legs all still vary
+between runs. The manifest records what would have to match; closing those gaps
+is separate work.
+
 ## Credits
 
 - [Bark FFI Bindings][bark] — the architectural model for this binding layer

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -32,13 +32,13 @@ func main() {
 
 ## Supported platforms
 
-| OS      | Arch  | Library            |
-|---------|-------|--------------------|
-| Linux   | amd64 | `libcdk_ffi.so`    |
-| Linux   | arm64 | `libcdk_ffi.so`    |
-| macOS   | arm64 | `libcdk_ffi.dylib` |
-| macOS   | amd64 | `libcdk_ffi.dylib` |
-| Windows | amd64 | `cdk_ffi.dll`      |
+| OS      | Arch  | Library               |
+|---------|-------|-----------------------|
+| Linux   | amd64 | `libcdk_ffi_go.so`    |
+| Linux   | arm64 | `libcdk_ffi_go.so`    |
+| macOS   | arm64 | `libcdk_ffi_go.dylib` |
+| macOS   | amd64 | `libcdk_ffi_go.dylib` |
+| Windows | amd64 | `cdk_ffi_go.dll`      |
 
 CGO link flags are automatically selected per platform via build tags. No manual setup required.
 

--- a/flake.nix
+++ b/flake.nix
@@ -714,7 +714,7 @@
               uniffiBindgenGo
             ];
             buildPhaseCargoCommand = ''
-              cargo build --release -p cdk-ffi-go
+              cargo build --locked --release -p cdk-ffi-go
 
               LIB_EXT="${if isDarwin then "dylib" else "so"}"
               CDK_FFI_LIB="target/release/libcdk_ffi_go.$LIB_EXT"

--- a/justfile
+++ b/justfile
@@ -1092,6 +1092,25 @@ ffi-test-live-python:
   echo "🧪 Running live Python FFI tests..."
   python3 crates/cdk-ffi/tests/test_live_async_onchain_melt.py
 
+# Verify a published binding release used only workspace-pinned dependencies
+ffi-verify-lock LANGUAGE TAG:
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  echo "🔍 Verifying {{LANGUAGE}} bindings at {{TAG}}..."
+  ./.github/scripts/verify-binding-lockfile.sh {{LANGUAGE}} {{TAG}}
+
+# Verify every published binding release at a tag
+ffi-verify-lock-all TAG:
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  rc=0
+  for lang in dart swift kotlin go; do
+    just ffi-verify-lock "$lang" {{TAG}} || rc=1
+  done
+  exit $rc
+
 # Trigger all FFI binding releases (Dart, Kotlin, Swift, Go)
 ffi-release-all VERSION:
   #!/usr/bin/env bash


### PR DESCRIPTION

### Description

Fixes #2097

### Problem

Binding releases resolved their dependencies from scratch on every run and on
every matrix leg. Nothing tied the crates a release compiled against to the
versions the monorepo had pinned, so the same tag rebuilt later could ship
different transitive versions, and afterward there was no record of what it
had shipped.

Go was in worse shape than the rest: it compiled `cdk-ffi` straight from the
monorepo checkout, so `cdk-go` published a wrapper crate that nothing built,
and the release recorded no binding lockfile at all.

### What this does

Every release now seeds the downstream binding crate's `Cargo.lock` from a
committed reference lockfile, builds each leg with `--locked`, and installs the
compiler from `rust-toolchain.toml` instead of whatever stable is current.

`.github/scripts/seed-binding-lockfile.sh` copies the reference lock into the
binding crate and resolves it minimally with `cargo fetch`, so only `cdk-ffi`
moves from a path dependency to a registry or git source. If the binding
resolves anything the reference lock did not pin, the release stops there
rather than shipping it.

### Which lockfile is the reference

Not the release checkout. A release pins `cdk-ffi` to a published version, and
that artifact's requirements were frozen when it was published. The reference
is therefore the lockfile at the tag that published it:

```mermaid
flowchart LR
  A["release tag<br/>binding sources, versions"] --> C["downstream release branch"]
  B["tag that published cdk-ffi<br/>Cargo.lock"] --> C
```

Both are the same tag for an ordinary release. They differ when only the
bindings change and the release pins an older published `cdk-ffi`, which is
exactly the case that used to fail: seeding from the newer tree downgraded the
nostr subtree to satisfy the older `cdk-ffi` and every downgrade was reported
as drift.

The workflows derive that tag from `cdk_version`, check it out alongside the
release checkout, and refuse to run if it does not exist or does not declare
the version it claims. Nightlies are unchanged: they build `cdk-ffi` from the
checked-out commit, so that checkout's own lock is already the right reference.

### Provenance

Each release ships a `build-manifest.json` recording the source commit, the
`cdk-ffi` version it pins, the ref its lockfile was seeded from, the pinned
Rust channel, and hashes of the lockfiles. `FFI - Verify Published Bindings`
re-checks published releases against that record weekly, so drift surfaces
without waiting for the next release.

### Go

`cdk-ffi-go` is now built from the seeded lockfile on the release branch like
the other bindings, which also makes the released library the one CI already
exercises through Nix. That costs a rename to `libcdk_ffi_go`.

## Also in here

- `cdk-sql-common`: `read_dir` order leaked into the generated `MIGRATIONS`
  array whenever two migrations shared a version prefix. Name parsing moved to
  `migration_name.rs` and the ordering is now explicit.
- `flake.nix`: the Go build passes `--locked`.
- `just ffi-verify-lock <language> <tag>` and `ffi-verify-lock-all <tag>` to run
  the verification locally.

## Verifying

```bash
git checkout <source commit from the manifest>
just ffi-verify-lock dart v0.18.0
just ffi-verify-lock-all v0.18.0
```

A dart release run has already exercised the two-tree path end to end:
`release_tag v0.19.0` with `cdk_version 0.18.0` seeded from `refs/tags/v0.18.0`
and pushed a release branch whose lock carries the `cdk-ffi 0.18.0` dependency
graph.


-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
