### PR TITLE
fix(lightning): prioritize payment hash status checks

### DIFF
--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -30,7 +30,7 @@ use cln_rpc::model::requests::{
 };
 use cln_rpc::model::responses::{
     DecodeResponse, InvoiceResponse, ListinvoicesInvoices, ListinvoicesInvoicesStatus,
-    ListpaysPaysStatus, PayStatus, WaitanyinvoiceResponse, WaitanyinvoiceStatus,
+    ListpaysPays, ListpaysPaysStatus, PayStatus, WaitanyinvoiceResponse, WaitanyinvoiceStatus,
 };
 use cln_rpc::primitives::{Amount as CLN_Amount, AmountOrAny, Sha256};
 use cln_rpc::ClnRpc;
@@ -815,7 +815,7 @@ impl MintPayment for Cln {
             .await
             .map_err(Error::from)?;
 
-        match listpays_response.pays.first() {
+        match select_cln_payment(&listpays_response.pays) {
             Some(pays_response) => {
                 let status = cln_pays_status_to_mint_state(pays_response.status);
 
@@ -1047,6 +1047,14 @@ fn cln_pays_status_to_mint_state(status: ListpaysPaysStatus) -> MeltQuoteState {
     }
 }
 
+fn select_cln_payment(payments: &[ListpaysPays]) -> Option<&ListpaysPays> {
+    payments.iter().min_by_key(|payment| match payment.status {
+        ListpaysPaysStatus::COMPLETE => 0_u8,
+        ListpaysPaysStatus::PENDING => 1,
+        ListpaysPaysStatus::FAILED => 2,
+    })
+}
+
 async fn fetch_invoice_by_payment_hash(
     cln_client: &mut cln_rpc::ClnRpc,
     payment_hash: &sha256::Hash,
@@ -1156,6 +1164,27 @@ mod tests {
             secondary_namespace.to_string(),
             key.to_string(),
         )
+    }
+
+    fn test_listpays_payment(id: u8, status: ListpaysPaysStatus) -> ListpaysPays {
+        ListpaysPays {
+            amount_msat: None,
+            amount_sent_msat: None,
+            bolt11: None,
+            bolt12: None,
+            completed_at: None,
+            created_index: None,
+            description: None,
+            destination: None,
+            erroronion: None,
+            label: None,
+            number_of_parts: None,
+            preimage: None,
+            updated_index: None,
+            status,
+            created_at: 0,
+            payment_hash: *Sha256::from_bytes_ref(&[id; 32]),
+        }
     }
 
     #[async_trait::async_trait]
@@ -1474,6 +1503,45 @@ mod tests {
             stored_payment_hash,
             Bolt12QuotePaymentHashLookup::Found(second_payment_hash)
         );
+    }
+
+    #[test]
+    fn cln_payment_selection_prefers_pending_over_failed() {
+        let failed = test_listpays_payment(1, ListpaysPaysStatus::FAILED);
+        let pending = test_listpays_payment(2, ListpaysPaysStatus::PENDING);
+        let payments = [failed, pending];
+
+        let selected = select_cln_payment(&payments).expect("payment should be selected");
+
+        assert_eq!(selected.status, ListpaysPaysStatus::PENDING);
+        assert_eq!(selected.payment_hash, *Sha256::from_bytes_ref(&[2; 32]));
+    }
+
+    #[test]
+    fn cln_payment_selection_prefers_complete_over_pending() {
+        let pending = test_listpays_payment(1, ListpaysPaysStatus::PENDING);
+        let complete = test_listpays_payment(2, ListpaysPaysStatus::COMPLETE);
+        let payments = [pending, complete];
+
+        let selected = select_cln_payment(&payments).expect("payment should be selected");
+
+        assert_eq!(selected.status, ListpaysPaysStatus::COMPLETE);
+        assert_eq!(selected.payment_hash, *Sha256::from_bytes_ref(&[2; 32]));
+    }
+
+    #[test]
+    fn cln_payment_selection_returns_failed_when_all_failed() {
+        let failed = test_listpays_payment(1, ListpaysPaysStatus::FAILED);
+        let payments = [failed];
+
+        let selected = select_cln_payment(&payments).expect("payment should be selected");
+
+        assert_eq!(selected.status, ListpaysPaysStatus::FAILED);
+    }
+
+    #[test]
+    fn cln_payment_selection_returns_none_when_missing() {
+        assert!(select_cln_payment(&[]).is_none());
     }
 
     #[tokio::test]

--- a/crates/cdk-ldk-node/src/lib.rs
+++ b/crates/cdk-ldk-node/src/lib.rs
@@ -290,6 +290,23 @@ impl CdkLdkNode {
         })
     }
 
+    fn select_bolt11_payment_details(
+        payment_details: impl IntoIterator<Item = PaymentDetails>,
+    ) -> Option<PaymentDetails> {
+        payment_details.into_iter().min_by_key(|details| {
+            let status_order = match details.status {
+                PaymentStatus::Succeeded => 0_u8,
+                PaymentStatus::Pending => 1,
+                PaymentStatus::Failed => 2,
+            };
+
+            (
+                status_order,
+                std::cmp::Reverse(details.latest_update_timestamp),
+            )
+        })
+    }
+
     /// Start the CDK LDK Node
     ///
     /// Starts the underlying LDK node and begins event processing.
@@ -1097,13 +1114,12 @@ impl MintPayment for CdkLdkNode {
         request_lookup_id: &PaymentIdentifier,
     ) -> Result<MakePaymentResponse, Self::Err> {
         let payment_details = match request_lookup_id {
-            PaymentIdentifier::PaymentHash(id_hash) => self
-                .inner
-                .list_payments_with_filter(
-                    |p| matches!(&p.kind, PaymentKind::Bolt11 { hash, .. } if &hash.0 == id_hash),
-                )
-                .first()
-                .cloned(),
+            PaymentIdentifier::PaymentHash(id_hash) => {
+                Self::select_bolt11_payment_details(self.inner.list_payments_with_filter(|p| {
+                    p.direction == PaymentDirection::Outbound
+                        && matches!(&p.kind, PaymentKind::Bolt11 { hash, .. } if &hash.0 == id_hash)
+                }))
+            }
             PaymentIdentifier::PaymentId(id) => self.inner.payment(&PaymentId(*id)),
             _ => {
                 return Ok(MakePaymentResponse {
@@ -1156,6 +1172,18 @@ mod tests {
         }
     }
 
+    fn test_payment_details_with_id(
+        id: [u8; 32],
+        status: PaymentStatus,
+        latest_update_timestamp: u64,
+    ) -> PaymentDetails {
+        PaymentDetails {
+            id: PaymentId(id),
+            latest_update_timestamp,
+            ..test_payment_details(status, None)
+        }
+    }
+
     #[test]
     fn failed_payment_response_does_not_require_amount() {
         let details = test_payment_details(PaymentStatus::Failed, None);
@@ -1198,5 +1226,44 @@ mod tests {
         .expect_err("paid payment details without amount should fail");
 
         assert!(matches!(err, payment::Error::Lightning(_)));
+    }
+
+    #[test]
+    fn bolt11_payment_selection_prefers_pending_over_failed() {
+        let failed = test_payment_details_with_id([1; 32], PaymentStatus::Failed, 2);
+        let pending = test_payment_details_with_id([2; 32], PaymentStatus::Pending, 1);
+
+        let selected = CdkLdkNode::select_bolt11_payment_details([failed, pending])
+            .expect("payment details should be selected");
+
+        assert_eq!(selected.id, PaymentId([2; 32]));
+        assert_eq!(selected.status, PaymentStatus::Pending);
+    }
+
+    #[test]
+    fn bolt11_payment_selection_prefers_succeeded_over_pending() {
+        let pending = test_payment_details_with_id([1; 32], PaymentStatus::Pending, 2);
+        let succeeded = PaymentDetails {
+            amount_msat: Some(1000),
+            ..test_payment_details_with_id([2; 32], PaymentStatus::Succeeded, 1)
+        };
+
+        let selected = CdkLdkNode::select_bolt11_payment_details([pending, succeeded])
+            .expect("payment details should be selected");
+
+        assert_eq!(selected.id, PaymentId([2; 32]));
+        assert_eq!(selected.status, PaymentStatus::Succeeded);
+    }
+
+    #[test]
+    fn bolt11_payment_selection_uses_latest_failed_when_all_failed() {
+        let older_failed = test_payment_details_with_id([1; 32], PaymentStatus::Failed, 1);
+        let newer_failed = test_payment_details_with_id([2; 32], PaymentStatus::Failed, 2);
+
+        let selected = CdkLdkNode::select_bolt11_payment_details([older_failed, newer_failed])
+            .expect("payment details should be selected");
+
+        assert_eq!(selected.id, PaymentId([2; 32]));
+        assert_eq!(selected.status, PaymentStatus::Failed);
     }
 }


### PR DESCRIPTION
Select paid/complete records before pending records, and only treat a payment-hash lookup as failed when every matching record is failed. This avoids letting stale failed attempts override in-flight or settled payments in the CLN and LDK backends.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
