### PR TITLE
fix(wallet/melt): replace panicking + with checked_add in saga

### DIFF
--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -576,8 +576,13 @@ impl<'a> PreparedMelt<'a> {
                 .total_amount()
                 .unwrap_or(Amount::ZERO);
         let quote = self.saga.quote();
-        let needed = quote.amount + quote.fee_reserve + self.input_fee_without_swap();
-        all_proofs_total.checked_sub(needed).unwrap_or(Amount::ZERO)
+        let needed = quote
+            .amount
+            .checked_add(quote.fee_reserve)
+            .and_then(|a| a.checked_add(self.input_fee_without_swap()));
+        needed
+            .and_then(|n| all_proofs_total.checked_sub(n))
+            .unwrap_or(Amount::ZERO)
     }
 
     /// Confirm the prepared melt and execute the payment.

--- a/crates/cdk/src/wallet/melt/saga/mod.rs
+++ b/crates/cdk/src/wallet/melt/saga/mod.rs
@@ -296,7 +296,10 @@ impl<'a> MeltSaga<'a, Initial> {
 
         let quote_info = self.initialize_melt(quote_id).await?;
 
-        let inputs_needed_amount = quote_info.amount + quote_info.fee_reserve;
+        let inputs_needed_amount = quote_info
+            .amount
+            .checked_add(quote_info.fee_reserve)
+            .ok_or(Error::AmountOverflow)?;
 
         let active_keyset_ids = self
             .wallet
@@ -386,7 +389,9 @@ impl<'a> MeltSaga<'a, Initial> {
             .get_keyset_count_fee(&active_keyset_id, estimated_output_count as u64)
             .await?;
 
-        let selection_amount = inputs_needed_amount + estimated_melt_fee;
+        let selection_amount = inputs_needed_amount
+            .checked_add(estimated_melt_fee)
+            .ok_or(Error::AmountOverflow)?;
 
         let input_proofs = Wallet::select_proofs(
             selection_amount,
@@ -484,7 +489,10 @@ impl<'a> MeltSaga<'a, Initial> {
         let quote_info = self.initialize_melt(quote_id).await?;
 
         let proofs_total = proofs.total_amount()?;
-        let inputs_needed = quote_info.amount + quote_info.fee_reserve;
+        let inputs_needed = quote_info
+            .amount
+            .checked_add(quote_info.fee_reserve)
+            .ok_or(Error::AmountOverflow)?;
         if proofs_total < inputs_needed {
             return Err(Error::InsufficientFunds);
         }
@@ -675,7 +683,12 @@ impl<'a> MeltSaga<'a, Prepared> {
                 final_proofs.extend(self.state_data.proofs_to_swap.clone());
             } else {
                 // Current behavior: swap first to get optimal denominations
-                let target_swap_amount = quote_info.amount + quote_info.fee_reserve + input_fee;
+                let target_swap_amount = quote_info
+                    .amount
+                    .checked_add(quote_info.fee_reserve)
+                    .ok_or(Error::AmountOverflow)?
+                    .checked_add(input_fee)
+                    .ok_or(Error::AmountOverflow)?;
 
                 tracing::debug!(
                     "Swapping {} proofs (total: {}) for target amount {}",
@@ -703,7 +716,12 @@ impl<'a> MeltSaga<'a, Prepared> {
 
         // Recalculate the actual input_fee based on final_proofs
         let actual_input_fee = self.wallet.get_proofs_fee(&final_proofs).await?.total;
-        let inputs_needed_amount = quote_info.amount + quote_info.fee_reserve + actual_input_fee;
+        let inputs_needed_amount = quote_info
+            .amount
+            .checked_add(quote_info.fee_reserve)
+            .ok_or(Error::AmountOverflow)?
+            .checked_add(actual_input_fee)
+            .ok_or(Error::AmountOverflow)?;
 
         let proofs_total = final_proofs.total_amount()?;
         if proofs_total < inputs_needed_amount {
@@ -1327,6 +1345,38 @@ mod tests {
             stored[0].used_by_operation,
             Some(prepared.state_data.operation_id)
         );
+    }
+
+    /// Verify the Amount arithmetic used in prepare/request_melt does not panic on overflow.
+    ///
+    /// The saga uses checked_add to guard against malicious mint responses returning
+    /// quote amounts that would overflow u64.  Two storable i64-positive values cannot
+    /// overflow u64 when added, but three can (the triple-operand path in
+    /// request_melt_with_options).  This test documents both invariants.
+    #[test]
+    fn test_melt_amount_overflow_handled_gracefully() {
+        // Two-operand path (prepare / prepare_with_proofs): i64::MAX + i64::MAX = u64::MAX - 1
+        let a = Amount::from(i64::MAX as u64);
+        let b = Amount::from(i64::MAX as u64);
+        assert!(
+            a.checked_add(b).is_some(),
+            "two i64::MAX values must not overflow u64"
+        );
+
+        // Three-operand path (request_melt_with_options): can overflow when combined
+        let c = Amount::from(2u64); // pushes u64::MAX-1 over the top
+        assert!(
+            a.checked_add(b)
+                .expect("two i64::MAX fit in u64")
+                .checked_add(c)
+                .is_none(),
+            "three amounts summing to > u64::MAX must return None"
+        );
+
+        // Single overflow: u64::MAX + 1 must return None
+        assert!(Amount::from(u64::MAX)
+            .checked_add(Amount::from(1u64))
+            .is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Amount::add uses .expect() which panics on overflow. A malicious mint returning a melt quote with amount + fee_reserve near u64::MAX would crash the wallet process. Replace all 6 arithmetic additions on mint-supplied amounts in the melt saga with checked_add, propagating Error::AmountOverflow instead of panicking.

Affected sites:
- wallet/melt/saga/mod.rs: lines 299, 389, 487, 678, 706
- wallet/melt/mod.rs: change_amount_without_swap (line 476)

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
