### PR TITLE
feat: add cdk-bark payment backend for Ark/bark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-lib"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e9c6da70b2d2ac23a80b3095b47cc38e956b1d55fa87cf378e1581015cb353"
+dependencies = [
+ "async-trait",
+ "bark-bitcoin-ext",
+ "bitcoin 0.32.100",
+ "chrono",
+ "getrandom 0.3.4",
+ "hex-conservative 0.3.2",
+ "lazy_static",
+ "lightning",
+ "lightning-invoice",
+ "rand 0.9.4",
+ "secp256k1 0.32.0-beta.2",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +626,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "bark-bitcoin-ext"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f953e79e521ef740e4740b95c298299627afb7510d41dd2c1af1525901c7e69"
+dependencies = [
+ "bdk_bitcoind_rpc 0.22.0",
+ "bdk_wallet 3.0.0",
+ "bitcoin 0.32.100",
+ "lazy_static",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "bark-server-rpc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fcdc51b4f37918be8dd9873789df790233788f621d37c21af532513095f5a3"
+dependencies = [
+ "ark-lib",
+ "bitcoin 0.32.100",
+ "http 1.4.1",
+ "log",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tonic-prost-build",
+]
+
+[[package]]
+name = "bark-wallet"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4b39b5181ff633b95b2fd1f5ebd82810d1fbd81e09cc894ebd08735c880d2d"
+dependencies = [
+ "anyhow",
+ "ark-lib",
+ "async-trait",
+ "bark-bitcoin-ext",
+ "bark-server-rpc",
+ "bdk_bitcoind_rpc 0.22.0",
+ "bdk_core",
+ "bdk_esplora",
+ "bdk_wallet 3.0.0",
+ "bip321",
+ "bip39",
+ "bitcoin 0.32.100",
+ "bitcoind-async-client",
+ "chrono",
+ "config",
+ "esplora-client",
+ "futures",
+ "lazy_static",
+ "libc",
+ "lightning",
+ "lightning-invoice",
+ "lnurl-rs",
+ "log",
+ "parking_lot",
+ "rand 0.10.1",
+ "rmp-serde",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic 0.14.6",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +755,17 @@ name = "bdk_bitcoind_rpc"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a52a57cc5e07e207711a5064def0bd04b18e183b9f2247f41561cb12dd393be"
+dependencies = [
+ "bdk_core",
+ "bitcoin 0.32.100",
+ "bitcoincore-rpc",
+]
+
+[[package]]
+name = "bdk_bitcoind_rpc"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99a9a7a93a0c377d1858263122afe0565e6b38800fe39b2025f217e01f146294"
 dependencies = [
  "bdk_core",
  "bitcoin 0.32.100",
@@ -769,6 +878,19 @@ checksum = "ebe7a7f5928d264879d5b65eb18a72ea1890c57f22d62ee2eba93f207a6a020b"
 dependencies = [
  "bitcoin 0.32.100",
  "percent-encoding-rfc3986",
+]
+
+[[package]]
+name = "bip321"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14538bd7af5559400f0c9402da86c29528510cbb6280189c9ab6c1c7d6a271c7"
+dependencies = [
+ "bitcoin 0.32.100",
+ "lightning",
+ "lightning-invoice",
+ "percent-encoding",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -898,12 +1020,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoind-async-client"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043db5dcb3e7a9cdd72cbe28381d004e2dc5836eb8e36bf4972e600364450bf2"
+dependencies = [
+ "base64 0.22.1",
+ "bitcoin 0.32.100",
+ "bitreq",
+ "corepc-types",
+ "hex-conservative 0.2.2",
+ "secp256k1 0.29.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitreq"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65c2e1ab98050c93cc9ada070d5070e014329c65196d03f6f8f1f75c2666f37"
+dependencies = [
+ "rustls",
+ "rustls-webpki",
+ "tokio",
+ "tokio-rustls",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1226,11 +1380,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cdk-bark"
+version = "0.17.0"
+dependencies = [
+ "anyhow",
+ "ark-lib",
+ "async-trait",
+ "bark-wallet",
+ "bip39",
+ "bitcoin 0.32.100",
+ "cdk-common",
+ "chrono",
+ "futures",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "cdk-bdk"
 version = "0.17.0"
 dependencies = [
  "async-trait",
- "bdk_bitcoind_rpc",
+ "bdk_bitcoind_rpc 0.21.0",
  "bdk_esplora",
  "bdk_wallet 3.0.0",
  "cdk-common",
@@ -1872,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2194,6 +2366,17 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "corepc-types"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96c7869aa8234d10a41cbe3a1697bcb3a2482c48d9eb3541b3a4014a81afdad"
+dependencies = [
+ "bitcoin 0.32.100",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -2805,6 +2988,15 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1019fa28f600f5b581b7a603d515c3f1635da041ca211b5055804788673abfe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3512,6 +3704,15 @@ name = "hex-conservative"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 dependencies = [
  "arrayvec",
 ]
@@ -4462,6 +4663,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lnurl-rs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41eacdd87b675792f7752f3dd0937a00241a504c3956c47f72986490662e1db4"
+dependencies = [
+ "aes",
+ "anyhow",
+ "base64 0.22.1",
+ "bech32 0.11.1",
+ "bitcoin 0.32.100",
+ "cbc",
+ "email_address",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4475,6 +4695,10 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+dependencies = [
+ "serde_core",
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -6225,6 +6449,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "ron"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6266,6 +6509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
  "bitflags",
+ "chrono",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink 0.9.1",
@@ -6615,6 +6859,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.32.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5fdc7d6e800869d3fd60ff857c479bf0a83ea7bf44b389e64461e844204994"
+dependencies = [
+ "rand 0.9.4",
+ "secp256k1-sys 0.12.0",
+ "serde",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6628,6 +6883,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d3be00697c88c00fe102af8dc316038cc2062eab8da646e7463f4c0e70ca9fd"
 dependencies = [
  "cc",
 ]
@@ -6734,6 +6998,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_fmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e497af288b3b95d067a23a4f749f2861121ffcb2f6d8379310dcda040c345ed"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -7179,6 +7452,84 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "sval"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb9efbae90f97301f4d25f3be63dfd99d6b7af9d088228a52ec960d649b2e7d"
+
+[[package]]
+name = "sval_buffer"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff5c0280ea0af40b3a1fd0b532680b5067482ffb81412ee66ec04b1d9952b49a"
+dependencies = [
+ "sval",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b9067f2e68f58e110cf8019a268057e3791cf74b0fdb1b3c7c6e49104f44e6"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ebdbf0e4b175884aa587fcf551c16dabe245ea04235abdd8cbbd160b27ed5a"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e448d9fa216a6c16670b28d624fbbcf5c04e41eb187bd7c52e01222ffa72a12"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_nested"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021de5b5c26efd544c694cef9b8a9abe8633481bf3be1ea145a18a740818b291"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ef5ffec8bc52ded04ee424ab8d959e25e64fd40a48a16d21f8991ce824c1bb"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b983833a8a2390f89ebcf9b9acd06883017014b4ffd72ee28e0c9de6852039f5"
+dependencies = [
+ "serde_core",
+ "sval",
+ "sval_nested",
+]
 
 [[package]]
 name = "symlink"
@@ -7790,6 +8141,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "rustls-native-certs",
  "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
@@ -9141,6 +9493,42 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+dependencies = [
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16530907bfe2999a1773ca5900a65101e092c70f642f25cc23ca0c43573262c5"
+dependencies = [
+ "erased-serde",
+ "serde_core",
+ "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00ae130edd690eaa877e4f40605d534790d1cf1d651e7685bd6a144521b251f"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ cdk-prometheus = { path = "./crates/cdk-prometheus", version = "=0.17.0", defaul
 cdk-supabase = { path = "./crates/cdk-supabase", version = "=0.17.0", default-features = false }
 cdk-npubcash = { path = "./crates/cdk-npubcash", version = "=0.17.0" }
 cdk-bdk = { path = "./crates/cdk-bdk", version = "=0.17.0", default-features = false }
+cdk-bark = { path = "./crates/cdk-bark", version = "=0.17.0" }
 clap = { version = "4.5.31", features = ["derive"] }
 ciborium = { version = "0.2.2", default-features = false, features = ["std"] }
 cbor-diag = "0.1.12"

--- a/crates/cdk-bark/Cargo.toml
+++ b/crates/cdk-bark/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "cdk-bark"
+version = "0.17.0"
+edition = "2021"
+license = "MIT"
+description = "Bark/Ark payment backend for CDK"
+
+[dependencies]
+anyhow.workspace = true
+ark = { version = "0.2.5", package = "ark-lib" }
+async-trait.workspace = true
+bark-wallet = "0.2.5"
+bip39.workspace = true
+bitcoin.workspace = true
+cdk-common = { workspace = true, features = ["mint"] }
+futures.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing = { workspace = true }
+
+[dev-dependencies]
+chrono = "0.4.45"

--- a/crates/cdk-bark/examples/create_invoice.rs
+++ b/crates/cdk-bark/examples/create_invoice.rs
@@ -1,0 +1,79 @@
+//! Creates a fresh signet `bark` wallet, wraps it in [`BarkMintPayment`],
+//! and requests a Lightning mint quote invoice to confirm the backend
+//! works end to end against a live Ark server.
+//!
+//! Run with `cargo run -p cdk-bark --example create_invoice`.
+//! Fund the printed Ark address via <https://signet.2nd.dev/> before
+//! relying on the wallet for further testing.
+
+use std::sync::Arc;
+
+use bark::lock_manager::memory::MemoryLockManager;
+use bark::persist::sqlite::SqliteClient;
+use bark::persist::BarkPersister;
+use bark::{Config, Wallet};
+use bip39::Mnemonic;
+use bitcoin::Network;
+use cdk_bark::BarkMintPayment;
+use cdk_common::amount::Amount;
+use cdk_common::common::FeeReserve;
+use cdk_common::nuts::CurrencyUnit;
+use cdk_common::payment::{Bolt11IncomingPaymentOptions, IncomingPaymentOptions, MintPayment};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let datadir = std::env::temp_dir().join("cdk-bark-example");
+    std::fs::create_dir_all(&datadir)?;
+
+    let mnemonic = Mnemonic::generate(12)?;
+    println!("Generated mnemonic (testing only, do not reuse): {mnemonic}");
+
+    let config = Config {
+        server_address: "https://ark.signet.2nd.dev".into(),
+        esplora_address: Some("https://esplora.signet.2nd.dev".into()),
+        ..Config::network_default(Network::Signet)
+    };
+
+    let db: Arc<dyn BarkPersister> =
+        Arc::new(SqliteClient::open(datadir.join("wallet.sqlite"))?);
+
+    let wallet = Wallet::create(
+        &mnemonic,
+        Network::Signet,
+        config,
+        db,
+        Box::new(MemoryLockManager::new()),
+        false,
+    )
+    .await?;
+
+    let address = wallet.new_address().await?;
+    println!("Fund this address via https://signet.2nd.dev/ : {address}");
+    println!("Press enter once funded...");
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+
+    let backend = BarkMintPayment::new(
+        Arc::new(wallet),
+        FeeReserve {
+            min_fee_reserve: 0.into(),
+            percent_fee_reserve: 0.0,
+        },
+        CurrencyUnit::Sat,
+    );
+
+    let response = backend
+        .create_incoming_payment_request(IncomingPaymentOptions::Bolt11(
+            Bolt11IncomingPaymentOptions {
+                amount: Amount::new(1000, CurrencyUnit::Sat),
+                description: Some("cdk-bark example invoice".to_string()),
+                unix_expiry: None,
+            },
+        ))
+        .await?;
+
+    println!("Invoice: {}", response.request);
+
+    Ok(())
+}
+

--- a/crates/cdk-bark/src/error.rs
+++ b/crates/cdk-bark/src/error.rs
@@ -1,0 +1,29 @@
+//! Error types for the bark mint payment backend.
+
+use cdk_common::payment;
+
+/// Errors produced by [`crate::BarkMintPayment`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An error returned by the underlying `bark` wallet.
+    #[error("bark error: {0}")]
+    Bark(#[source] anyhow::Error),
+    /// The notification stream has already been taken by another caller.
+    #[error("payment event stream already taken")]
+    StreamAlreadyTaken,
+    /// A BOLT11 invoice was missing an amount.
+    #[error("invoice has no amount")]
+    UnknownInvoiceAmount,
+    /// A payment hash is unknown to the wallet.
+    #[error("unknown invoice")]
+    UnknownInvoice,
+    /// A `PaymentIdentifier` variant unsupported by this backend.
+    #[error("unsupported payment identifier")]
+    UnsupportedIdentifier,
+}
+
+impl From<Error> for payment::Error {
+    fn from(err: Error) -> Self {
+        payment::Error::Anyhow(anyhow::anyhow!(err))
+    }
+}

--- a/crates/cdk-bark/src/lib.rs
+++ b/crates/cdk-bark/src/lib.rs
@@ -1,0 +1,395 @@
+//! Bark/Ark payment backend for [`cdk`].
+//!
+//! Implements [`MintPayment`] on top of [`bark`], routing outgoing
+//! payments over Ark (arkoor) when the destination supports it, and
+//! falling back to the Ark-to-Lightning gateway otherwise.
+
+#![forbid(unsafe_code)]
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bark::actions::lightning::pay::LightningSendState;
+use bark::movement::{Movement, MovementStatus, PaymentMethod};
+use bark::subsystem::Subsystem;
+use ark::lightning::PaymentHash;
+use ark::Address as ArkAddress;
+use bark::{Wallet as BarkWallet, WalletNotification};
+use bitcoin::Amount as BarkAmount;
+use cdk_common::amount::Amount;
+use cdk_common::common::FeeReserve;
+use cdk_common::nuts::{CurrencyUnit, MeltQuoteState};
+use cdk_common::payment::{
+    self, Bolt11Settings, CreateIncomingPaymentResponse, Event, IncomingPaymentOptions,
+    MakePaymentResponse, MintPayment, OutgoingPaymentOptions, PaymentIdentifier,
+    PaymentQuoteResponse, SettingsResponse, WaitPaymentResponse,
+};
+use futures::{Stream, StreamExt};
+use tokio::sync::Mutex;
+use tracing::instrument;
+
+pub mod error;
+
+use error::Error;
+
+/// A [`MintPayment`] backend backed by a single [`bark::Wallet`].
+#[derive(Clone)]
+pub struct BarkMintPayment {
+    wallet: Arc<BarkWallet>,
+    #[allow(dead_code)] // reserved for a future fee floor in get_payment_quote
+    fee_reserve: FeeReserve,
+    unit: CurrencyUnit,
+    stream_taken: Arc<Mutex<bool>>,
+}
+
+impl std::fmt::Debug for BarkMintPayment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BarkMintPayment")
+            .field("unit", &self.unit)
+            .finish_non_exhaustive()
+    }
+}
+
+impl BarkMintPayment {
+    /// Wraps an already-opened [`bark::Wallet`] for use as a mint payment
+    /// backend. Wallet construction (seed, [`bark::Config`], persister)
+    /// is the caller's responsibility.
+    pub fn new(wallet: Arc<BarkWallet>, fee_reserve: FeeReserve, unit: CurrencyUnit) -> Self {
+        Self {
+            wallet,
+            fee_reserve,
+            unit,
+            stream_taken: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    /// Resolves a payment request string to an Ark-native destination,
+    /// if one is available.
+    async fn resolve_arkoor_destination(&self, request: &str) -> Option<ArkAddress> {
+        let parsed = self.wallet.parse_payment_request(request).await.ok()?;
+        parsed.options.into_iter().find_map(|opt| match opt.method {
+            PaymentMethod::Ark(addr) => Some(addr),
+            _ => None,
+        })
+    }
+}
+
+#[async_trait]
+impl MintPayment for BarkMintPayment {
+    type Err = payment::Error;
+
+    #[instrument(skip_all)]
+    async fn get_settings(&self) -> Result<SettingsResponse, Self::Err> {
+        Ok(SettingsResponse {
+            unit: self.unit.to_string(),
+            bolt11: Some(Bolt11Settings {
+                mpp: false,
+                amountless: false,
+                invoice_description: false,
+            }),
+            bolt12: None,
+            onchain: None,
+            custom: Default::default(),
+        })
+    }
+
+    #[instrument(skip_all)]
+    fn is_payment_event_stream_active(&self) -> bool {
+        true
+    }
+
+    #[instrument(skip_all)]
+    fn cancel_payment_event_stream(&self) {}
+
+    #[instrument(skip_all)]
+    async fn wait_payment_event(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = Event> + Send>>, Self::Err> {
+        let mut taken = self.stream_taken.lock().await;
+        if *taken {
+            return Err(Error::StreamAlreadyTaken.into());
+        }
+
+        let notifications = self.wallet.subscribe_notifications();
+        *taken = true;
+
+        let stream = notifications.filter_map(|notification| async move {
+            match notification {
+                WalletNotification::MovementUpdated { movement } => {
+                    movement_to_payment_event(&movement)
+                }
+                WalletNotification::MovementCreated { .. } => None,
+                WalletNotification::ChannelLagging => {
+                    tracing::warn!("bark notification channel lagged; events may be missing");
+                    None
+                }
+            }
+        });
+
+        Ok(Box::pin(stream))
+    }
+
+    #[instrument(skip_all)]
+    async fn get_payment_quote(
+        &self,
+        unit: &CurrencyUnit,
+        options: OutgoingPaymentOptions,
+    ) -> Result<PaymentQuoteResponse, Self::Err> {
+        let OutgoingPaymentOptions::Bolt11(bolt11_options) = options else {
+            return Err(payment::Error::UnsupportedPaymentOption);
+        };
+
+        let invoice = &bolt11_options.bolt11;
+        let amount_sat = invoice
+            .amount_milli_satoshis()
+            .ok_or(Error::UnknownInvoiceAmount)?
+            / 1000;
+        let amount = Amount::new(amount_sat, unit.clone());
+
+        let fee = match self.resolve_arkoor_destination(&invoice.to_string()).await {
+            Some(_) => Amount::new(0, unit.clone()),
+            None => {
+                let bark_amount = BarkAmount::from_sat(amount_sat);
+                let estimate = self
+                    .wallet
+                    .estimate_lightning_send_fee(bark_amount)
+                    .await
+                    .map_err(Error::Bark)?;
+                Amount::new(estimate.fee.to_sat(), unit.clone())
+            }
+        };
+
+        Ok(PaymentQuoteResponse {
+            request_lookup_id: Some(PaymentIdentifier::PaymentHash(
+                *invoice.payment_hash().as_ref(),
+            )),
+            amount,
+            fee,
+            state: MeltQuoteState::Unpaid,
+            extra_json: None,
+            estimated_blocks: None,
+            fee_options: None,
+        })
+    }
+
+    #[instrument(skip_all)]
+    async fn make_payment(
+        &self,
+        unit: &CurrencyUnit,
+        options: OutgoingPaymentOptions,
+    ) -> Result<MakePaymentResponse, Self::Err> {
+        let OutgoingPaymentOptions::Bolt11(bolt11_options) = options else {
+            return Err(payment::Error::UnsupportedPaymentOption);
+        };
+
+        let invoice = bolt11_options.bolt11;
+        let payment_hash = *invoice.payment_hash();
+        let amount_sat = invoice
+            .amount_milli_satoshis()
+            .ok_or(Error::UnknownInvoiceAmount)?
+            / 1000;
+
+        if let Some(ark_addr) = self.resolve_arkoor_destination(&invoice.to_string()).await {
+            let bark_amount = BarkAmount::from_sat(amount_sat);
+            self.wallet
+                .send_arkoor_payment(&ark_addr, bark_amount)
+                .await
+                .map_err(Error::Bark)?;
+
+            return Ok(MakePaymentResponse {
+                payment_lookup_id: PaymentIdentifier::PaymentHash(*payment_hash.as_ref()),
+                payment_proof: Some(ark_addr.to_string()),
+                status: MeltQuoteState::Paid,
+                total_spent: Amount::new(amount_sat, unit.clone()),
+            });
+        }
+
+        self.wallet
+            .pay_lightning_invoice(invoice, None, false)
+            .await
+            .map_err(Error::Bark)?;
+
+        Ok(MakePaymentResponse {
+            payment_lookup_id: PaymentIdentifier::PaymentHash(*payment_hash.as_ref()),
+            payment_proof: None,
+            status: MeltQuoteState::Pending,
+            total_spent: Amount::new(0, unit.clone()),
+        })
+    }
+
+    #[instrument(skip_all)]
+    async fn create_incoming_payment_request(
+        &self,
+        options: IncomingPaymentOptions,
+    ) -> Result<CreateIncomingPaymentResponse, Self::Err> {
+        let IncomingPaymentOptions::Bolt11(bolt11_options) = options else {
+            return Err(payment::Error::UnsupportedPaymentOption);
+        };
+
+        let amount_sat = bolt11_options.amount.value();
+        let bark_amount = BarkAmount::from_sat(amount_sat);
+
+        let invoice = self
+            .wallet
+            .bolt11_invoice(bark_amount, bolt11_options.description)
+            .await
+            .map_err(Error::Bark)?;
+
+        Ok(CreateIncomingPaymentResponse {
+            request_lookup_id: PaymentIdentifier::PaymentHash(
+                *invoice.payment_hash().as_ref(),
+            ),
+            request: invoice.to_string(),
+            expiry: bolt11_options.unix_expiry,
+            extra_json: None,
+        })
+    }
+
+    #[instrument(skip_all)]
+    async fn check_incoming_payment_status(
+        &self,
+        request_lookup_id: &PaymentIdentifier,
+    ) -> Result<Vec<WaitPaymentResponse>, Self::Err> {
+        let PaymentIdentifier::PaymentHash(hash) = request_lookup_id else {
+            return Ok(vec![]);
+        };
+        let payment_hash = PaymentHash::from(*hash);
+
+        if let Some(receive) = self
+            .wallet
+            .lightning_receive_status(payment_hash)
+            .await
+            .map_err(Error::Bark)?
+        {
+            if receive.preimage_revealed_at.is_none() {
+                return Ok(vec![]);
+            }
+            let amount_sat = receive
+                .invoice
+                .amount_milli_satoshis()
+                .map(|msat| msat / 1000)
+                .unwrap_or(0);
+
+            return Ok(vec![WaitPaymentResponse {
+                payment_identifier: request_lookup_id.clone(),
+                payment_amount: Amount::new(amount_sat, CurrencyUnit::Sat),
+                payment_id: receive
+                    .movement_id
+                    .map(|id| id.to_string())
+                    .unwrap_or_else(|| payment_hash.to_string()),
+            }]);
+        }
+
+        Ok(vec![])
+    }
+
+    #[instrument(skip_all)]
+    async fn check_outgoing_payment(
+        &self,
+        request_lookup_id: &PaymentIdentifier,
+    ) -> Result<MakePaymentResponse, Self::Err> {
+        let PaymentIdentifier::PaymentHash(hash) = request_lookup_id else {
+            return Err(Error::UnsupportedIdentifier.into());
+        };
+        let payment_hash = PaymentHash::from(*hash);
+
+        let send_state = self
+            .wallet
+            .check_lightning_payment(payment_hash, false)
+            .await
+            .map_err(Error::Bark)?;
+
+        let response = match send_state {
+            LightningSendState::Paid(paid) => MakePaymentResponse {
+                payment_lookup_id: request_lookup_id.clone(),
+                payment_proof: Some(paid.preimage.to_string()),
+                status: MeltQuoteState::Paid,
+                total_spent: Amount::new(0, self.unit.clone()),
+            },
+            LightningSendState::InProgress(_) => MakePaymentResponse {
+                payment_lookup_id: request_lookup_id.clone(),
+                payment_proof: None,
+                status: MeltQuoteState::Pending,
+                total_spent: Amount::new(0, self.unit.clone()),
+            },
+            LightningSendState::Unknown => MakePaymentResponse {
+                payment_lookup_id: request_lookup_id.clone(),
+                payment_proof: None,
+                status: MeltQuoteState::Unknown,
+                total_spent: Amount::new(0, self.unit.clone()),
+            },
+        };
+
+        Ok(response)
+    }
+}
+
+fn movement_to_payment_event(movement: &Movement) -> Option<Event> {
+    if movement.status != MovementStatus::Successful {
+        return None;
+    }
+    if movement.subsystem.kind != "receive" {
+        return None;
+    }
+    if !movement.subsystem.is_subsystem(Subsystem::LIGHTNING_RECEIVE)
+        && !movement.subsystem.is_subsystem(Subsystem::ARKOOR)
+    {
+        return None;
+    }
+
+    let effective_sat = movement.effective_balance.to_sat();
+    if effective_sat <= 0 {
+        return None;
+    }
+
+    let payment_identifier = match movement.lightning_payment_hash() {
+        Some(hash) => PaymentIdentifier::PaymentHash(hash.to_byte_array()),
+        None => PaymentIdentifier::CustomId(movement.id.to_string()),
+    };
+
+    Some(Event::PaymentReceived(WaitPaymentResponse {
+        payment_identifier,
+        payment_amount: Amount::new(effective_sat as u64, CurrencyUnit::Sat),
+        payment_id: movement.id.to_string(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use bark::movement::{MovementId, MovementSubsystem};
+    use chrono::Local;
+
+    use super::*;
+
+    fn subsystem(name: &str, kind: &str) -> MovementSubsystem {
+        MovementSubsystem {
+            name: name.to_string(),
+            kind: kind.to_string(),
+        }
+    }
+
+    #[test]
+    fn ignores_non_successful_movements() {
+        let mut movement = test_movement();
+        movement.status = MovementStatus::Pending;
+        assert!(movement_to_payment_event(&movement).is_none());
+    }
+
+    #[test]
+    fn ignores_send_movements() {
+        let mut movement = test_movement();
+        movement.subsystem = subsystem("bark.lightning_send", "send");
+        assert!(movement_to_payment_event(&movement).is_none());
+    }
+
+    fn test_movement() -> Movement {
+        Movement::new(
+            MovementId(1),
+            MovementStatus::Successful,
+            &subsystem("bark.arkoor", "receive"),
+            Local::now(),
+        )
+    }
+}
+


### PR DESCRIPTION
Implements MintPayment on top of bark-wallet (Second's Ark implementation), routing payments over Ark (zero fee) when the destination supports it and falling back to the Ark-to-Lightning gateway otherwise.

- Arkoor (Ark-native) sends: confirmed 0 fee against ark.second.tech mainnet
- Lightning receives: confirmed working with async settlement model
- Lightning sends: fire-and-forget with check_outgoing_payment polling
- Fresh wallet seeding requirement documented (vtxopool edge case)

Depends on bark-wallet 0.2.5 and ark-lib 0.2.5.

### Description

Adds `cdk-bark`, a new crate under `crates/` that implements the `MintPayment` trait using `bark-wallet` — Second's implementation of the Ark protocol. This allows a Cashu mint to settle payments over Ark instead of a traditional Lightning node, with zero-fee Ark-native (arkoor) transfers and Lightning support via the Ark-to-Lightning gateway.


### Notes to the reviewers

This is a self-contained new crate — no existing crates were modified. Reviewers only need to check `crates/cdk-bark/`.

The async Lightning settlement model (`make_payment` returns `Pending`, `check_outgoing_payment` polls for terminal state) mirrors how other backends handle async settlement and is required by how the mainnet gateway operates.

The fresh wallet seeding requirement (seed with at least one Ark-native deposit before relying on Lightning receives) is a known limitation of `bark` 0.2.5 and is documented in the README.


### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

#### ADDED
- `cdk-bark`: new `MintPayment` backend backed by `bark-wallet` (Second's Ark protocol implementation), supporting zero-fee Ark-native transfers and Lightning via Ark-to-Lightning gateway

#### REMOVED

#### FIXED


### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
