### PR TITLE
feat(ffi): expose NUT-27 mint backup

### DIFF
--- a/crates/cdk-ffi/src/wallet_repository.rs
+++ b/crates/cdk-ffi/src/wallet_repository.rs
@@ -183,6 +183,46 @@ impl WalletRepository {
         }
     }
 
+    /// Get the NUT-27 mint backup public key as hex.
+    pub fn mint_backup_public_key(&self) -> Result<String, FfiError> {
+        let keys = self.inner.backup_keys()?;
+        Ok(keys.public_key().to_hex())
+    }
+
+    /// Backup the current mint list to Nostr relays using NUT-27.
+    pub async fn backup_mints(
+        &self,
+        relays: Vec<String>,
+        options: BackupOptions,
+    ) -> Result<BackupResult, FfiError> {
+        let result = self.inner.backup_mints(relays, options.into()).await?;
+        Ok(result.into())
+    }
+
+    /// Restore the mint list from Nostr relays using NUT-27.
+    pub async fn restore_mints(
+        &self,
+        relays: Vec<String>,
+        add_mints: bool,
+        options: RestoreOptions,
+    ) -> Result<RestoreResult, FfiError> {
+        let result = self
+            .inner
+            .restore_mints(relays, add_mints, options.into())
+            .await?;
+        Ok(result.into())
+    }
+
+    /// Fetch the NUT-27 mint backup without adding mints to the repository.
+    pub async fn fetch_mint_backup(
+        &self,
+        relays: Vec<String>,
+        options: RestoreOptions,
+    ) -> Result<MintBackup, FfiError> {
+        let backup = self.inner.fetch_backup(relays, options.into()).await?;
+        Ok(backup.into())
+    }
+
     /// Get wallet balances for all mints
     pub async fn get_balances(&self) -> Result<HashMap<WalletKey, Amount>, FfiError> {
         let balances = self.inner.get_balances().await?;

--- a/crates/cdk/examples/nostr_backup.rs
+++ b/crates/cdk/examples/nostr_backup.rs
@@ -1,4 +1,4 @@
-//! # Nostr Mint Backup Example (NUT-XX)
+//! # Nostr Mint Backup Example (NUT-27)
 //!
 //! This example demonstrates how to backup and restore your mint list
 //! to/from Nostr relays using the WalletRepository.
@@ -35,7 +35,7 @@ async fn main() -> anyhow::Result<()> {
         .with_max_level(tracing::Level::ERROR)
         .init();
 
-    println!("NUT-XX Nostr Mint Backup Example");
+    println!("NUT-27 Nostr Mint Backup Example");
     println!("=================================\n");
 
     // Generate a random seed for the wallet

--- a/crates/cdk/src/wallet/nostr_backup.rs
+++ b/crates/cdk/src/wallet/nostr_backup.rs
@@ -3,6 +3,7 @@
 //! This module provides functionality to backup and restore the mint list
 //! to/from Nostr relays using NUT-27 specification.
 
+use std::collections::BTreeSet;
 use std::time::Duration;
 
 use nostr_sdk::prelude::*;
@@ -126,7 +127,12 @@ impl WalletRepository {
         let keys = self.backup_keys()?;
 
         let wallets = self.get_wallets().await;
-        let mint_urls: Vec<MintUrl> = wallets.iter().map(|w| w.mint_url.clone()).collect();
+        let mint_urls: Vec<MintUrl> = wallets
+            .iter()
+            .map(|w| w.mint_url.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
 
         let backup = MintBackup::new(mint_urls.clone());
 


### PR DESCRIPTION
Add WalletRepository FFI methods for deriving the backup public key, publishing mint backups, restoring mints, and fetching a backup preview. Also avoid duplicate mint URLs in backups and fix the example's NUT label.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
