### PR TITLE
fix(swift): add framework bundle metadata

### DIFF
--- a/.github/workflows/swift-publish.yml
+++ b/.github/workflows/swift-publish.yml
@@ -73,8 +73,17 @@ jobs:
       - name: Resolve variables
         run: |
           CDK_VER="${{ inputs.cdk_version }}"
-          echo "CDK_VER=${CDK_VER:-${TAG#v}}" >> "$GITHUB_ENV"
-          echo "RELEASE_VER=${TAG#v}" >> "$GITHUB_ENV"
+          RELEASE_VER="${TAG#v}"
+          BUNDLE_SHORT_VERSION="${RELEASE_VER%%[-+]*}"
+
+          if [[ ! "${BUNDLE_SHORT_VERSION}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "::error::Could not derive App Store-safe CFBundleShortVersionString from ${TAG}; got ${BUNDLE_SHORT_VERSION}"
+            exit 1
+          fi
+
+          echo "CDK_VER=${CDK_VER:-${RELEASE_VER}}" >> "$GITHUB_ENV"
+          echo "RELEASE_VER=${RELEASE_VER}" >> "$GITHUB_ENV"
+          echo "BUNDLE_SHORT_VERSION=${BUNDLE_SHORT_VERSION}" >> "$GITHUB_ENV"
 
       - name: Checkout monorepo
         uses: actions/checkout@v5
@@ -106,7 +115,7 @@ jobs:
 
       - name: Update versions and resolve workspace references
         run: |
-          echo "Setting CDK version to ${CDK_VER}, release version to ${RELEASE_VER}"
+          echo "Setting CDK version to ${CDK_VER}, release version to ${RELEASE_VER}, framework bundle version to ${BUNDLE_SHORT_VERSION}"
 
           # Helper: extract a value from [workspace.package] in root Cargo.toml
           ws_pkg() {
@@ -161,6 +170,13 @@ jobs:
 
           # Add release profile
           printf '\n[profile.release]\nlto = true\nstrip = true\ncodegen-units = 1\n' >> cdk-swift/rust/Cargo.toml
+
+          # Stamp framework Info.plist bundle versions for App Store validation.
+          sed -i \
+            -e "s|__CDK_SWIFT_FRAMEWORK_VERSION__|${BUNDLE_SHORT_VERSION}|g" \
+            cdk-swift/resources/Info-iOS.plist \
+            cdk-swift/resources/Info-iOSSimulator.plist \
+            cdk-swift/resources/Info-macOS.plist
 
           echo "--- rust/Cargo.toml ---"
           cat cdk-swift/rust/Cargo.toml

--- a/bindings/swift/resources/Info-iOS.plist
+++ b/bindings/swift/resources/Info-iOS.plist
@@ -10,8 +10,12 @@
     <string>cdk-ffi</string>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>__CDK_SWIFT_FRAMEWORK_VERSION__</string>
     <key>CFBundlePackageType</key>
     <string>FMWK</string>
+    <key>MinimumOSVersion</key>
+    <string>14.0</string>
     <key>CFBundleSupportedPlatforms</key>
     <array>
         <string>iPhoneOS</string>

--- a/bindings/swift/resources/Info-iOSSimulator.plist
+++ b/bindings/swift/resources/Info-iOSSimulator.plist
@@ -10,8 +10,12 @@
     <string>cdk-ffi</string>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>__CDK_SWIFT_FRAMEWORK_VERSION__</string>
     <key>CFBundlePackageType</key>
     <string>FMWK</string>
+    <key>MinimumOSVersion</key>
+    <string>14.0</string>
     <key>CFBundleSupportedPlatforms</key>
     <array>
         <string>iPhoneSimulator</string>

--- a/bindings/swift/resources/Info-macOS.plist
+++ b/bindings/swift/resources/Info-macOS.plist
@@ -10,8 +10,12 @@
     <string>cdk-ffi</string>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>__CDK_SWIFT_FRAMEWORK_VERSION__</string>
     <key>CFBundlePackageType</key>
     <string>FMWK</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
     <key>CFBundleSupportedPlatforms</key>
     <array>
         <string>MacOSX</string>


### PR DESCRIPTION
Add missing Info.plist metadata to Swift framework templates so CashuDevKitFFI embeds App Store-required version and deployment target keys.

Stamp CFBundleShortVersionString from the release tag during the Swift publish workflow, keeping released XCFramework artifacts aligned with the cdk-swift package version.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
