### PR TITLE
fix: improve mint/melt limit ux

### DIFF
--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -120,10 +120,10 @@ connection_timeout_seconds = 10
 # NOTE: fakewallet is isolated testing mode and cannot be mixed with real payment backends.
 ln_backend = "fakewallet"
 # unit = "sat"          # Optional, defaults to "sat"
-# min_mint = 1          # Optional, defaults to 1
-# max_mint = 500000     # Optional, defaults to 500000
-# min_melt = 1          # Optional, defaults to 1
-# max_melt = 500000     # Optional, defaults to 500000
+min_mint = 1
+max_mint = 500000
+min_melt = 1
+max_melt = 500000
 
 [onchain]
 # Required onchain backend `bdk`, `fakewallet`, or `none`.
@@ -131,10 +131,10 @@ ln_backend = "fakewallet"
 # Use `fakewallet` with `ln_backend = "fakewallet"` for fully fake rails, or with
 # `ln_backend = "none"` for fake onchain-only testing.
 onchain_backend = "fakewallet"
-# min_mint = 1          # Optional, defaults to 1
-# max_mint = 500000     # Optional, defaults to 500000
-# min_melt = 1          # Optional, defaults to 1
-# max_melt = 500000     # Optional, defaults to 500000
+min_mint = 1000
+max_mint = 1000000
+min_melt = 546
+max_melt = 1000000
 
 # [bdk]
 # mnemonic = "your twelve or twenty-four word mnemonic phrase here"

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -120,10 +120,10 @@ connection_timeout_seconds = 10
 # NOTE: fakewallet is isolated testing mode and cannot be mixed with real payment backends.
 ln_backend = "fakewallet"
 # unit = "sat"          # Optional, defaults to "sat"
-# min_mint=1
-# max_mint=500000
-# min_melt=1
-# max_melt=500000
+# min_mint = 1          # Optional, defaults to 1
+# max_mint = 500000     # Optional, defaults to 500000
+# min_melt = 1          # Optional, defaults to 1
+# max_melt = 500000     # Optional, defaults to 500000
 
 [onchain]
 # Required onchain backend `bdk`, `fakewallet`, or `none`.
@@ -131,10 +131,10 @@ ln_backend = "fakewallet"
 # Use `fakewallet` with `ln_backend = "fakewallet"` for fully fake rails, or with
 # `ln_backend = "none"` for fake onchain-only testing.
 onchain_backend = "fakewallet"
-# min_mint=1000
-# max_mint=1000000
-# min_melt=1000
-# max_melt=1000000
+# min_mint = 1          # Optional, defaults to 1
+# max_mint = 500000     # Optional, defaults to 500000
+# min_melt = 1          # Optional, defaults to 1
+# max_melt = 500000     # Optional, defaults to 500000
 
 # [bdk]
 # mnemonic = "your twelve or twenty-four word mnemonic phrase here"

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -166,15 +166,35 @@ impl std::str::FromStr for LnBackend {
     }
 }
 
+fn default_min_mint() -> Amount {
+    1.into()
+}
+
+fn default_max_mint() -> Amount {
+    500_000.into()
+}
+
+fn default_min_melt() -> Amount {
+    1.into()
+}
+
+fn default_max_melt() -> Amount {
+    500_000.into()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Ln {
     pub ln_backend: LnBackend,
     #[serde(default)]
     pub unit: CurrencyUnit,
     pub invoice_description: Option<String>,
+    #[serde(default = "default_min_mint")]
     pub min_mint: Amount,
+    #[serde(default = "default_max_mint")]
     pub max_mint: Amount,
+    #[serde(default = "default_min_melt")]
     pub min_melt: Amount,
+    #[serde(default = "default_max_melt")]
     pub max_melt: Amount,
 }
 
@@ -184,10 +204,10 @@ impl Default for Ln {
             ln_backend: LnBackend::default(),
             unit: CurrencyUnit::default(),
             invoice_description: None,
-            min_mint: 1.into(),
-            max_mint: 500_000.into(),
-            min_melt: 1.into(),
-            max_melt: 500_000.into(),
+            min_mint: default_min_mint(),
+            max_mint: default_max_mint(),
+            min_melt: default_min_melt(),
+            max_melt: default_max_melt(),
         }
     }
 }
@@ -238,9 +258,13 @@ impl std::str::FromStr for OnchainBackend {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Onchain {
     pub onchain_backend: OnchainBackend,
+    #[serde(default = "default_min_mint")]
     pub min_mint: Amount,
+    #[serde(default = "default_max_mint")]
     pub max_mint: Amount,
+    #[serde(default = "default_min_melt")]
     pub min_melt: Amount,
+    #[serde(default = "default_max_melt")]
     pub max_melt: Amount,
 }
 
@@ -248,10 +272,10 @@ impl Default for Onchain {
     fn default() -> Self {
         Onchain {
             onchain_backend: OnchainBackend::default(),
-            min_mint: 1.into(),
-            max_mint: 500_000.into(),
-            min_melt: 1.into(),
-            max_melt: 500_000.into(),
+            min_mint: default_min_mint(),
+            max_mint: default_max_mint(),
+            min_melt: default_min_melt(),
+            max_melt: default_max_melt(),
         }
     }
 }
@@ -1812,6 +1836,72 @@ max_melt = 500000
         assert_eq!(settings.ln.len(), 1);
         assert_eq!(settings.ln[0].ln_backend, LnBackend::FakeWallet);
         assert_eq!(settings.ln[0].unit, CurrencyUnit::Sat);
+
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[cfg(feature = "fakewallet")]
+    #[test]
+    fn test_legacy_ln_block_without_bounds_parses() {
+        use std::{env, fs};
+
+        let temp_dir = env::temp_dir().join("cdk_test_ln_block_without_bounds");
+        fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
+        let config_path = temp_dir.join("config.toml");
+
+        // A single `[ln]` table without explicit bounds uses the default bounds.
+        let config_content = r#"
+[ln]
+ln_backend = "fakewallet"
+"#;
+        fs::write(&config_path, config_content).expect("Failed to write config file");
+
+        let settings = Settings::try_new(Some(&config_path)).expect("config should parse");
+
+        assert_eq!(settings.ln.len(), 1);
+        assert_eq!(settings.ln[0].ln_backend, LnBackend::FakeWallet);
+
+        let min_mint: u64 = settings.ln[0].min_mint.into();
+        let max_mint: u64 = settings.ln[0].max_mint.into();
+        let min_melt: u64 = settings.ln[0].min_melt.into();
+        let max_melt: u64 = settings.ln[0].max_melt.into();
+        assert_eq!(min_mint, 1);
+        assert_eq!(max_mint, 500_000);
+        assert_eq!(min_melt, 1);
+        assert_eq!(max_melt, 500_000);
+
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[cfg(feature = "fakewallet")]
+    #[test]
+    fn test_onchain_block_without_bounds_parses() {
+        use std::{env, fs};
+
+        let temp_dir = env::temp_dir().join("cdk_test_onchain_block_without_bounds");
+        fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
+        let config_path = temp_dir.join("config.toml");
+
+        // A single `[onchain]` table without explicit bounds uses the default bounds.
+        let config_content = r#"
+[onchain]
+onchain_backend = "fakewallet"
+"#;
+        fs::write(&config_path, config_content).expect("Failed to write config file");
+
+        let settings = Settings::try_new(Some(&config_path)).expect("config should parse");
+
+        let onchain = settings.onchain.expect("onchain config should be present");
+        assert_eq!(onchain.onchain_backend, OnchainBackend::FakeWallet);
+
+        let min_mint: u64 = onchain.min_mint.into();
+        let max_mint: u64 = onchain.max_mint.into();
+        let min_melt: u64 = onchain.min_melt.into();
+        let max_melt: u64 = onchain.max_melt.into();
+        assert_eq!(min_mint, 1);
+        assert_eq!(max_mint, 500_000);
+        assert_eq!(min_melt, 1);
+        assert_eq!(max_melt, 500_000);
 
         let _ = fs::remove_dir_all(&temp_dir);
     }

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -166,35 +166,15 @@ impl std::str::FromStr for LnBackend {
     }
 }
 
-fn default_min_mint() -> Amount {
-    1.into()
-}
-
-fn default_max_mint() -> Amount {
-    500_000.into()
-}
-
-fn default_min_melt() -> Amount {
-    1.into()
-}
-
-fn default_max_melt() -> Amount {
-    500_000.into()
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Ln {
     pub ln_backend: LnBackend,
     #[serde(default)]
     pub unit: CurrencyUnit,
     pub invoice_description: Option<String>,
-    #[serde(default = "default_min_mint")]
     pub min_mint: Amount,
-    #[serde(default = "default_max_mint")]
     pub max_mint: Amount,
-    #[serde(default = "default_min_melt")]
     pub min_melt: Amount,
-    #[serde(default = "default_max_melt")]
     pub max_melt: Amount,
 }
 
@@ -204,29 +184,46 @@ impl Default for Ln {
             ln_backend: LnBackend::default(),
             unit: CurrencyUnit::default(),
             invoice_description: None,
-            min_mint: default_min_mint(),
-            max_mint: default_max_mint(),
-            min_melt: default_min_melt(),
-            max_melt: default_max_melt(),
+            min_mint: 1.into(),
+            max_mint: 500_000.into(),
+            min_melt: 1.into(),
+            max_melt: 500_000.into(),
         }
     }
 }
 
+/// Accepts `[ln]` or `[[ln]]` and preserves clear missing-field errors.
+struct LnOneOrManyVisitor;
+
+impl<'de> serde::de::Visitor<'de> for LnOneOrManyVisitor {
+    type Value = Vec<Ln>;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a single [ln] table or an array of [[ln]] tables")
+    }
+
+    fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let ln = Ln::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+        Ok(vec![ln])
+    }
+
+    fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        Vec::<Ln>::deserialize(serde::de::value::SeqAccessDeserializer::new(seq))
+    }
+}
+
+/// Accepts a single `[ln]` table or an array of `[[ln]]` tables.
 fn deserialize_ln<'de, D>(deserializer: D) -> Result<Vec<Ln>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum LnOneOrMany {
-        Many(Vec<Ln>),
-        One(Ln),
-    }
-
-    match LnOneOrMany::deserialize(deserializer)? {
-        LnOneOrMany::Many(ln) => Ok(ln),
-        LnOneOrMany::One(ln) => Ok(vec![ln]),
-    }
+    deserializer.deserialize_any(LnOneOrManyVisitor)
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
@@ -258,13 +255,9 @@ impl std::str::FromStr for OnchainBackend {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Onchain {
     pub onchain_backend: OnchainBackend,
-    #[serde(default = "default_min_mint")]
     pub min_mint: Amount,
-    #[serde(default = "default_max_mint")]
     pub max_mint: Amount,
-    #[serde(default = "default_min_melt")]
     pub min_melt: Amount,
-    #[serde(default = "default_max_melt")]
     pub max_melt: Amount,
 }
 
@@ -272,10 +265,10 @@ impl Default for Onchain {
     fn default() -> Self {
         Onchain {
             onchain_backend: OnchainBackend::default(),
-            min_mint: default_min_mint(),
-            max_mint: default_max_mint(),
-            min_melt: default_min_melt(),
-            max_melt: default_max_melt(),
+            min_mint: 1.into(),
+            max_mint: 500_000.into(),
+            min_melt: 1.into(),
+            max_melt: 500_000.into(),
         }
     }
 }
@@ -1842,66 +1835,47 @@ max_melt = 500000
 
     #[cfg(feature = "fakewallet")]
     #[test]
-    fn test_legacy_ln_block_without_bounds_parses() {
+    fn test_legacy_ln_block_missing_bounds_errors() {
         use std::{env, fs};
 
-        let temp_dir = env::temp_dir().join("cdk_test_ln_block_without_bounds");
+        let temp_dir = env::temp_dir().join("cdk_test_ln_block_missing_bounds");
         fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
         let config_path = temp_dir.join("config.toml");
 
-        // A single `[ln]` table without explicit bounds uses the default bounds.
+        // Bounds are required; omitting them must error, naming the field.
         let config_content = r#"
 [ln]
 ln_backend = "fakewallet"
 "#;
         fs::write(&config_path, config_content).expect("Failed to write config file");
 
-        let settings = Settings::try_new(Some(&config_path)).expect("config should parse");
-
-        assert_eq!(settings.ln.len(), 1);
-        assert_eq!(settings.ln[0].ln_backend, LnBackend::FakeWallet);
-
-        let min_mint: u64 = settings.ln[0].min_mint.into();
-        let max_mint: u64 = settings.ln[0].max_mint.into();
-        let min_melt: u64 = settings.ln[0].min_melt.into();
-        let max_melt: u64 = settings.ln[0].max_melt.into();
-        assert_eq!(min_mint, 1);
-        assert_eq!(max_mint, 500_000);
-        assert_eq!(min_melt, 1);
-        assert_eq!(max_melt, 500_000);
+        let err = Settings::try_new(Some(&config_path))
+            .expect_err("missing bounds should fail")
+            .to_string();
+        assert!(err.contains("min_mint"), "unexpected error: {err}");
 
         let _ = fs::remove_dir_all(&temp_dir);
     }
 
     #[cfg(feature = "fakewallet")]
     #[test]
-    fn test_onchain_block_without_bounds_parses() {
+    fn test_onchain_block_missing_bounds_errors() {
         use std::{env, fs};
 
-        let temp_dir = env::temp_dir().join("cdk_test_onchain_block_without_bounds");
+        let temp_dir = env::temp_dir().join("cdk_test_onchain_block_missing_bounds");
         fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
         let config_path = temp_dir.join("config.toml");
 
-        // A single `[onchain]` table without explicit bounds uses the default bounds.
         let config_content = r#"
 [onchain]
 onchain_backend = "fakewallet"
 "#;
         fs::write(&config_path, config_content).expect("Failed to write config file");
 
-        let settings = Settings::try_new(Some(&config_path)).expect("config should parse");
-
-        let onchain = settings.onchain.expect("onchain config should be present");
-        assert_eq!(onchain.onchain_backend, OnchainBackend::FakeWallet);
-
-        let min_mint: u64 = onchain.min_mint.into();
-        let max_mint: u64 = onchain.max_mint.into();
-        let min_melt: u64 = onchain.min_melt.into();
-        let max_melt: u64 = onchain.max_melt.into();
-        assert_eq!(min_mint, 1);
-        assert_eq!(max_mint, 500_000);
-        assert_eq!(min_melt, 1);
-        assert_eq!(max_melt, 500_000);
+        let err = Settings::try_new(Some(&config_path))
+            .expect_err("missing bounds should fail")
+            .to_string();
+        assert!(err.contains("min_mint"), "unexpected error: {err}");
 
         let _ = fs::remove_dir_all(&temp_dir);
     }


### PR DESCRIPTION
`[ln]`/`[onchain]` mint/melt bounds stay required, but a missing config now reports explicitly instead of an opaque error. Example config also sets values to more appropriate default values to align with network policy.

### Description

Since 0.17.0 a single `[ln]`/`[onchain]` block missing the mint/melt bounds fails with:

```
data did not match any variant of untagged enum LnOneOrMany for key `ln`
```

The `#[serde(untagged)]` deserializer (from the multi-backend `Vec<Ln>` change) masks the real cause. This swaps it for a visitor that deserializes the single table directly, yielding `missing field "ln.min_mint"`.

-----

### Notes to the reviewers

- Fixes the diagnostic; bounds remain mandatory by design.
- Improves example values; onchain mirrors bdk configs: `min_receive_amount_sat`,  `min_send_amount_sat`

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### FIXED
- `cdk-mintd`: `[ln]`/`[onchain]` missing `min_mint`/`max_mint`/`min_melt`/`max_melt` now fails with a clear "missing field" error instead of the untagged-enum message (regressed in 0.17.0).

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`) — N/A