### PR TITLE
test(dart): make live mint integration test configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,6 +556,9 @@ jobs:
       - name: Build native library and generate bindings
         run: nix develop -L .#bindings --command just binding-dart
       - name: Run Dart tests
+        env:
+          CDK_DART_TEST_MINT_URL: https://testnut.cashudevkit.org
+          CDK_DART_MINT_SETTLEMENT_DELAY_SECONDS: "5"
         run: nix develop -L .#bindings --command just test-dart
 
   kotlin-binding-tests:

--- a/bindings/dart/README.md
+++ b/bindings/dart/README.md
@@ -72,6 +72,27 @@ and variables must be configured in the **CDK monorepo** repository settings
 
 Set this under **Settings → Secrets and variables → Actions → Variables**.
 
+## Testing
+
+By default, running tests will skip live mint integration tests to allow offline/local testing:
+
+```bash
+dart test
+```
+
+To run the live mint integration tests, provide the `CDK_DART_TEST_MINT_URL` environment variable:
+
+```bash
+CDK_DART_TEST_MINT_URL=https://testnut.cashudevkit.org dart test
+```
+
+If the mint has a slower auto-payment settlement, you can optionally configure the settlement delay (in seconds):
+
+```bash
+CDK_DART_TEST_MINT_URL=https://testnut.cashudevkit.org CDK_DART_MINT_SETTLEMENT_DELAY_SECONDS=5 dart test
+```
+
 ## License
 
 [MIT](https://github.com/cashubtc/cdk/blob/main/LICENSE)
+

--- a/bindings/dart/test/wallet_test.dart
+++ b/bindings/dart/test/wallet_test.dart
@@ -6,11 +6,23 @@ void main() {
   late Wallet wallet;
   late String dbPath;
 
+  final String mintUrl =
+      Platform.environment['CDK_DART_TEST_MINT_URL'] ??
+      'https://dummy-mint-url-for-local-testing.invalid';
+  final bool runLiveMintTests =
+      Platform.environment.containsKey('CDK_DART_TEST_MINT_URL') &&
+      Platform.environment['CDK_DART_TEST_MINT_URL']!.isNotEmpty;
+  final int settlementDelaySeconds =
+      int.tryParse(
+        Platform.environment['CDK_DART_MINT_SETTLEMENT_DELAY_SECONDS'] ?? '',
+      ) ??
+      3;
+
   setUp(() {
     final tempDir = Directory.systemTemp;
     dbPath = '${tempDir.path}/${DateTime.now().microsecondsSinceEpoch}.sqlite';
     wallet = Wallet(
-      mintUrl: 'https://testnut.cashudevkit.org',
+      mintUrl: mintUrl,
       unit: SatCurrencyUnit(),
       mnemonic: generateMnemonic(),
       store: SqliteWalletStore(dbPath),
@@ -32,7 +44,7 @@ void main() {
 
   test('in-memory sqlite handles concurrent access', () async {
     final memoryWallet = Wallet(
-      mintUrl: 'https://testnut.cashudevkit.org',
+      mintUrl: mintUrl,
       unit: SatCurrencyUnit(),
       mnemonic: generateMnemonic(),
       store: SqliteWalletStore(':memory:'),
@@ -52,29 +64,35 @@ void main() {
     }
   });
 
-  test('mint flow', () async {
-    final quote = await wallet.mintQuote(
-      paymentMethod: Bolt11PaymentMethod(),
-      amount: Amount(value: 100),
-      description: null,
-      extra: null,
-    );
+  test(
+    'mint flow',
+    () async {
+      final quote = await wallet.mintQuote(
+        paymentMethod: Bolt11PaymentMethod(),
+        amount: Amount(value: 100),
+        description: null,
+        extra: null,
+      );
 
-    expect(quote.id, isNotEmpty);
-    expect(quote.request, isNotEmpty);
+      expect(quote.id, isNotEmpty);
+      expect(quote.request, isNotEmpty);
 
-    // testnut pays quotes automatically, wait briefly for payment to settle
-    await Future.delayed(Duration(seconds: 3));
+      // testnut pays quotes automatically, wait briefly for payment to settle
+      await Future.delayed(Duration(seconds: settlementDelaySeconds));
 
-    final proofs = await wallet.mint(
-      quoteId: quote.id,
-      amountSplitTarget: NoneSplitTarget(),
-      spendingConditions: null,
-    );
+      final proofs = await wallet.mint(
+        quoteId: quote.id,
+        amountSplitTarget: NoneSplitTarget(),
+        spendingConditions: null,
+      );
 
-    expect(proofs, isNotEmpty);
+      expect(proofs, isNotEmpty);
 
-    final balance = await wallet.totalBalance();
-    expect(balance.value, equals(100));
-  });
+      final balance = await wallet.totalBalance();
+      expect(balance.value, equals(100));
+    },
+    skip: !runLiveMintTests
+        ? 'Set CDK_DART_TEST_MINT_URL to run live mint integration tests'
+        : false,
+  );
 }


### PR DESCRIPTION
## Summary

This PR makes the Dart live mint integration test configurable instead of running against a hardcoded external mint by default.

The live mint test now only runs when `CDK_DART_TEST_MINT_URL` is provided. Without that environment variable, the test is skipped so local/basic Dart binding tests can run without depending on external network access or the availability of the test mint.

## Changes

- Read the live mint URL from `CDK_DART_TEST_MINT_URL`
- Skip the live mint integration test when the env var is not set
- Add optional `CDK_DART_MINT_SETTLEMENT_DELAY_SECONDS` support for configuring the settlement wait delay
- Keep the default delay at 3 seconds when no delay env var is provided
- Update the Dart README with instructions for running live mint tests

## Testing

Default local test:

```bash
just test-dart
```

Result: passed, with the live mint test skipped.

Live mint integration test:

```bash
CDK_DART_TEST_MINT_URL=https://testnut.cashudevkit.org CDK_DART_MINT_SETTLEMENT_DELAY_SECONDS=5 just test-dart
```

Result: passed.

Closes #2155
