### PR TITLE
fix(wallet): record recovered melt transactions

### DIFF
--- a/crates/cdk-common/src/wallet/saga/melt.rs
+++ b/crates/cdk-common/src/wallet/saga/melt.rs
@@ -1,6 +1,8 @@
 //! Melt saga types
 
-use cashu::BlindedMessage;
+use std::collections::HashMap;
+
+use cashu::{BlindedMessage, PublicKey};
 use serde::{Deserialize, Serialize};
 
 use crate::{Amount, Error};
@@ -54,6 +56,16 @@ pub struct MeltOperationData {
     pub counter_end: Option<u32>,
     /// Change amount (if any)
     pub change_amount: Option<Amount>,
+    /// User-defined metadata for the outgoing melt transaction.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
+    /// Proof Ys actually sent to the melt request.
+    ///
+    /// Stored separately from `used_by_operation` so recovery can record the
+    /// correct transaction inputs even after a pre-melt swap or after inputs
+    /// were already marked spent before a crash.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub final_proof_ys: Option<Vec<PublicKey>>,
     /// Blinded messages for change recovery
     ///
     /// Stored so that if a crash occurs after the mint accepts the melt,

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -1251,15 +1251,22 @@ impl Wallet {
 
         if !all_ys.is_empty() {
             let current = self.localstore.get_proofs_by_ys(all_ys).await?;
-            let ys_to_revert: Vec<_> = current
+            let mut proofs_to_revert: Vec<_> = current
                 .into_iter()
-                .filter(|proof| proof.state == State::Reserved)
-                .map(|proof| proof.y)
+                .filter(|proof| {
+                    proof.used_by_operation == Some(operation_id)
+                        && matches!(proof.state, State::Reserved | State::Pending)
+                })
                 .collect();
 
-            if !ys_to_revert.is_empty() {
+            for proof in proofs_to_revert.iter_mut() {
+                proof.state = State::Unspent;
+                proof.used_by_operation = None;
+            }
+
+            if !proofs_to_revert.is_empty() {
                 self.localstore
-                    .update_proofs_state(ys_to_revert, State::Unspent)
+                    .update_proofs(proofs_to_revert, vec![])
                     .await?;
             }
         }
@@ -1859,6 +1866,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_cancel_prepared_melt_reverts_operation_pending_proofs() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = crate::wallet::test_utils::test_keyset_id();
+
+        let proof_info = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Unspent);
+        let proof_y = proof_info.y;
+        let proof = proof_info.proof.clone();
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let quote = test_melt_quote();
+        let quote_id = quote.id.clone();
+        db.add_melt_quote(quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+        let prepared = wallet
+            .prepare_melt_proofs(&quote_id, vec![proof], HashMap::new())
+            .await
+            .unwrap();
+        let operation_id = prepared.operation_id();
+
+        db.update_proofs_state(vec![proof_y], State::Pending)
+            .await
+            .unwrap();
+
+        wallet
+            .cancel_prepared_melt(
+                operation_id,
+                prepared.proofs().clone(),
+                prepared.proofs_to_swap().clone(),
+            )
+            .await
+            .unwrap();
+
+        let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].state, State::Unspent);
+        assert_eq!(stored[0].used_by_operation, None);
+        assert!(db.get_saga(&operation_id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
     async fn test_cancel_prepared_melt_rejects_melt_requested_saga() {
         let db = create_test_db().await;
         let mint_url = test_mint_url();
@@ -2336,7 +2386,7 @@ mod tests {
             }
             _ => panic!("expected melt saga"),
         }
-        stored_saga.update_state(stored_saga.state.clone());
+        stored_saga.update_state(stored_saga.state);
         assert!(db.update_saga(stored_saga).await.unwrap());
 
         let outcome = prepared

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -43,7 +43,8 @@ use std::time::Duration;
 
 use cdk_common::util::unix_time;
 use cdk_common::wallet::{
-    MeltQuote, MeltSagaState, Transaction, TransactionDirection, WalletSagaState,
+    MeltQuote, MeltSagaState, OperationData, Transaction, TransactionDirection, WalletSaga,
+    WalletSagaState,
 };
 use cdk_common::{Error, MeltQuoteState, PaymentMethod, ProofsMethods, State};
 use tracing::instrument;
@@ -748,11 +749,20 @@ impl<'a> PreparedMelt<'a> {
         self,
         options: MeltConfirmOptions,
     ) -> Result<MeltOutcome<'a>, Error> {
-        let operation_id = self.saga.operation_id();
-        let wallet = self.saga.wallet;
+        let mut saga = self.saga;
+        let operation_id = saga.operation_id();
+        let wallet = saga.wallet;
         let metadata = self.metadata;
+        let db_saga = wallet
+            .localstore
+            .get_saga(&operation_id)
+            .await?
+            .ok_or(Error::Custom("Saga not found".to_string()))?;
+        wallet.ensure_melt_saga_state(&db_saga, MeltSagaState::ProofsReserved)?;
+        let metadata = wallet.melt_saga_metadata(&db_saga, metadata)?;
+        saga.state_data.saga = db_saga;
 
-        let melt_requested = match self.saga.request_melt_with_options(options).await {
+        let melt_requested = match saga.request_melt_with_options(options).await {
             Ok(melt_requested) => melt_requested,
             Err(err) => {
                 let finalized = wallet
@@ -806,6 +816,40 @@ impl Debug for PreparedMelt<'_> {
 }
 
 impl Wallet {
+    fn melt_saga_metadata(
+        &self,
+        saga: &WalletSaga,
+        fallback: HashMap<String, String>,
+    ) -> Result<HashMap<String, String>, Error> {
+        let OperationData::Melt(data) = &saga.data else {
+            return Err(Error::InvalidOperationState);
+        };
+
+        if data.metadata.is_empty() {
+            Ok(fallback)
+        } else {
+            Ok(data.metadata.clone())
+        }
+    }
+
+    fn ensure_melt_saga_state(
+        &self,
+        saga: &WalletSaga,
+        expected: MeltSagaState,
+    ) -> Result<(), Error> {
+        ensure_cdk!(
+            saga.mint_url == self.mint_url && saga.unit == self.unit,
+            Error::InvalidOperationState
+        );
+
+        let WalletSagaState::Melt(state) = saga.state else {
+            return Err(Error::InvalidOperationState);
+        };
+
+        ensure_cdk!(state == expected, Error::InvalidOperationState);
+        Ok(())
+    }
+
     /// Prepare a melt operation without executing it.
     #[instrument(skip(self, metadata))]
     pub async fn prepare_melt(
@@ -964,6 +1008,8 @@ impl Wallet {
             .get_saga(&operation_id)
             .await?
             .ok_or(Error::Custom("Saga not found".to_string()))?;
+        self.ensure_melt_saga_state(&db_saga, MeltSagaState::ProofsReserved)?;
+        let metadata = self.melt_saga_metadata(&db_saga, metadata)?;
 
         let saga = MeltSaga::from_prepared(
             self,
@@ -1029,6 +1075,8 @@ impl Wallet {
             .get_saga(&operation_id)
             .await?
             .ok_or(Error::Custom("Saga not found".to_string()))?;
+        self.ensure_melt_saga_state(&db_saga, MeltSagaState::ProofsReserved)?;
+        let metadata = self.melt_saga_metadata(&db_saga, metadata)?;
 
         let saga = MeltSaga::from_prepared(
             self,
@@ -1191,19 +1239,12 @@ impl Wallet {
     ) -> Result<(), Error> {
         tracing::info!("Cancelling prepared melt for operation {}", operation_id);
 
-        if let Some(saga) = self.localstore.get_saga(&operation_id).await? {
-            ensure_cdk!(
-                saga.mint_url == self.mint_url && saga.unit == self.unit,
-                Error::InvalidOperationState
-            );
-            ensure_cdk!(
-                matches!(
-                    saga.state,
-                    WalletSagaState::Melt(MeltSagaState::ProofsReserved)
-                ),
-                Error::InvalidOperationState
-            );
-        }
+        let db_saga = self
+            .localstore
+            .get_saga(&operation_id)
+            .await?
+            .ok_or(Error::InvalidOperationState)?;
+        self.ensure_melt_saga_state(&db_saga, MeltSagaState::ProofsReserved)?;
 
         let mut all_ys = proofs.ys()?;
         all_ys.extend(proofs_to_swap.ys()?);
@@ -1212,7 +1253,7 @@ impl Wallet {
             let current = self.localstore.get_proofs_by_ys(all_ys).await?;
             let ys_to_revert: Vec<_> = current
                 .into_iter()
-                .filter(|proof| proof.state == State::Reserved || proof.state == State::Pending)
+                .filter(|proof| proof.state == State::Reserved)
                 .map(|proof| proof.y)
                 .collect();
 
@@ -1238,7 +1279,6 @@ impl Wallet {
                 e
             );
         }
-
         Ok(())
     }
 
@@ -1299,6 +1339,27 @@ impl Wallet {
                         return Ok(());
                     }
                 };
+                let metadata = match self.localstore.get_saga(&operation_id).await? {
+                    Some(saga) => match saga.data {
+                        OperationData::Melt(data) => data.metadata,
+                        _ => {
+                            tracing::warn!(
+                                "Skipping transaction metadata for paid melt quote {} with non-melt saga {}",
+                                quote.id,
+                                operation_id
+                            );
+                            HashMap::new()
+                        }
+                    },
+                    None => {
+                        tracing::warn!(
+                            "Recording transaction for paid melt quote {} without saga metadata; saga {} not found",
+                            quote.id,
+                            operation_id
+                        );
+                        HashMap::new()
+                    }
+                };
                 let pending_proofs: Proofs = self
                     .localstore
                     .get_reserved_proofs(&operation_id)
@@ -1324,7 +1385,7 @@ impl Wallet {
                         ys: pending_proofs.ys()?,
                         timestamp: unix_time(),
                         memo: None,
-                        metadata: HashMap::new(),
+                        metadata,
                         quote_id: Some(quote.id.clone()),
                         payment_request: Some(quote.request.clone()),
                         payment_proof,
@@ -1725,7 +1786,9 @@ mod tests {
     use std::sync::Arc;
 
     use cdk_common::nuts::{CurrencyUnit, RestoreResponse, State};
-    use cdk_common::wallet::{MeltOperationData, OperationData, WalletSaga};
+    use cdk_common::wallet::{
+        MeltOperationData, MeltSagaState, OperationData, WalletSaga, WalletSagaState,
+    };
     use cdk_common::{Id, MeltQuoteBolt11Response, MeltQuoteResponse};
 
     use super::*;
@@ -1741,19 +1804,30 @@ mod tests {
     async fn test_cancel_prepared_melt_reverts_reserved_proofs() {
         let db = create_test_db().await;
         let mint_url = test_mint_url();
-        let keyset_id = test_keyset_id();
-        let operation_id = uuid::Uuid::new_v4();
+        let keyset_id = crate::wallet::test_utils::test_keyset_id();
 
-        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Reserved);
+        let proof_info = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Unspent);
         let proof_y = proof_info.y;
         let proof = proof_info.proof.clone();
         db.update_proofs(vec![proof_info], vec![]).await.unwrap();
 
+        let quote = test_melt_quote();
+        let quote_id = quote.id.clone();
+        db.add_melt_quote(quote).await.unwrap();
+
         let mock_client = Arc::new(MockMintConnector::new());
         let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+        let prepared = wallet
+            .prepare_melt_proofs(&quote_id, vec![proof], HashMap::new())
+            .await
+            .unwrap();
 
         wallet
-            .cancel_prepared_melt(operation_id, vec![proof], vec![])
+            .cancel_prepared_melt(
+                prepared.operation_id(),
+                prepared.proofs().clone(),
+                prepared.proofs_to_swap().clone(),
+            )
             .await
             .unwrap();
 
@@ -1763,28 +1837,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cancel_prepared_melt_reverts_pending_proofs() {
-        let db = create_test_db().await;
-        let mint_url = test_mint_url();
-        let keyset_id = test_keyset_id();
-        let operation_id = uuid::Uuid::new_v4();
+    async fn test_cancel_prepared_melt_rejects_pending_saga() {
+        let (db, proof_y, operation_id, _mock_client, pending) = pending_bolt11_melt(false).await;
 
-        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Pending);
-        let proof_y = proof_info.y;
-        let proof = proof_info.proof.clone();
-        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+        let result = pending
+            .saga
+            .wallet
+            .cancel_prepared_melt(
+                operation_id,
+                pending.saga.state_data.final_proofs.clone(),
+                vec![],
+            )
+            .await;
 
-        let mock_client = Arc::new(MockMintConnector::new());
-        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
-
-        wallet
-            .cancel_prepared_melt(operation_id, vec![proof], vec![])
-            .await
-            .unwrap();
+        assert!(matches!(result, Err(Error::InvalidOperationState)));
 
         let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
         assert_eq!(stored.len(), 1);
-        assert_eq!(stored[0].state, State::Unspent);
+        assert_eq!(stored[0].state, State::Pending);
+        assert!(db.get_saga(&operation_id).await.unwrap().is_some());
     }
 
     #[tokio::test]
@@ -1813,6 +1884,8 @@ mod tests {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
                 change_blinded_messages: None,
             }),
         );
@@ -1837,19 +1910,33 @@ mod tests {
     async fn test_cancel_prepared_melt_preserves_spent_proofs() {
         let db = create_test_db().await;
         let mint_url = test_mint_url();
-        let keyset_id = test_keyset_id();
-        let operation_id = uuid::Uuid::new_v4();
+        let keyset_id = crate::wallet::test_utils::test_keyset_id();
 
-        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Spent);
+        let proof_info = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Unspent);
         let proof_y = proof_info.y;
         let proof = proof_info.proof.clone();
         db.update_proofs(vec![proof_info], vec![]).await.unwrap();
 
+        let quote = test_melt_quote();
+        let quote_id = quote.id.clone();
+        db.add_melt_quote(quote).await.unwrap();
+
         let mock_client = Arc::new(MockMintConnector::new());
         let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+        let prepared = wallet
+            .prepare_melt_proofs(&quote_id, vec![proof], HashMap::new())
+            .await
+            .unwrap();
+        db.update_proofs_state(vec![proof_y], State::Spent)
+            .await
+            .unwrap();
 
         wallet
-            .cancel_prepared_melt(operation_id, vec![], vec![proof])
+            .cancel_prepared_melt(
+                prepared.operation_id(),
+                prepared.proofs().clone(),
+                prepared.proofs_to_swap().clone(),
+            )
             .await
             .unwrap();
 
@@ -1859,13 +1946,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cancel_prepared_melt_mixed_states_only_reverts_reserved_and_pending() {
+    async fn test_cancel_prepared_melt_only_reverts_reserved_proofs() {
         let db = create_test_db().await;
         let mint_url = test_mint_url();
-        let keyset_id = test_keyset_id();
-        let operation_id = uuid::Uuid::new_v4();
+        let keyset_id = crate::wallet::test_utils::test_keyset_id();
 
-        let reserved = test_proof_info(keyset_id, 100, mint_url.clone(), State::Reserved);
+        let reserved = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Unspent);
         let pending = test_proof_info(keyset_id, 200, mint_url.clone(), State::Pending);
         let spent = test_proof_info(keyset_id, 300, mint_url.clone(), State::Spent);
 
@@ -1881,14 +1967,22 @@ mod tests {
             .await
             .unwrap();
 
+        let quote = test_melt_quote();
+        let quote_id = quote.id.clone();
+        db.add_melt_quote(quote).await.unwrap();
+
         let mock_client = Arc::new(MockMintConnector::new());
         let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+        let prepared = wallet
+            .prepare_melt_proofs(&quote_id, vec![reserved_proof], HashMap::new())
+            .await
+            .unwrap();
 
         wallet
             .cancel_prepared_melt(
-                operation_id,
-                vec![reserved_proof, pending_proof],
-                vec![spent_proof],
+                prepared.operation_id(),
+                prepared.proofs().clone(),
+                vec![pending_proof, spent_proof],
             )
             .await
             .unwrap();
@@ -1904,7 +1998,7 @@ mod tests {
                 .map(|proof| proof.state)
         };
         assert_eq!(state_for(reserved_y), Some(State::Unspent));
-        assert_eq!(state_for(pending_y), Some(State::Unspent));
+        assert_eq!(state_for(pending_y), Some(State::Pending));
         assert_eq!(state_for(spent_y), Some(State::Spent));
     }
 
@@ -1963,6 +2057,63 @@ mod tests {
         assert!(!tx.ys.contains(&operation_a_spent_y));
         assert_eq!(tx.fee, Amount::from(50));
         assert_eq!(tx.saga_id, Some(operation_a_id));
+    }
+
+    #[tokio::test]
+    async fn test_add_transaction_for_pending_melt_uses_saga_metadata() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let operation_id = uuid::Uuid::new_v4();
+
+        let mut pending = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Pending);
+        pending.used_by_operation = Some(operation_id);
+        db.update_proofs(vec![pending], vec![]).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        let mut quote = test_melt_quote();
+        quote.used_by_operation = Some(operation_id.to_string());
+        let quote_id = quote.id.clone();
+
+        let mut metadata = HashMap::new();
+        metadata.insert("memo".to_string(), "pending metadata".to_string());
+
+        let saga = WalletSaga::new(
+            operation_id,
+            WalletSagaState::Melt(MeltSagaState::PaymentPending),
+            quote.amount,
+            mint_url,
+            CurrencyUnit::Sat,
+            OperationData::Melt(MeltOperationData {
+                quote_id: quote_id.clone(),
+                amount: quote.amount,
+                fee_reserve: quote.fee_reserve,
+                counter_start: None,
+                counter_end: None,
+                change_amount: None,
+                metadata: metadata.clone(),
+                final_proof_ys: None,
+                change_blinded_messages: None,
+            }),
+        );
+        db.add_saga(saga).await.unwrap();
+
+        wallet
+            .add_transaction_for_pending_melt(
+                &quote,
+                MeltQuoteState::Paid,
+                quote.amount,
+                Some(Amount::from(150)),
+                Some("payment-proof".to_string()),
+            )
+            .await
+            .unwrap();
+
+        let transactions = db.list_transactions(None, None, None).await.unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].metadata, metadata);
     }
 
     #[tokio::test]
@@ -2101,6 +2252,150 @@ mod tests {
         assert_eq!(prepared.metadata(), &metadata);
     }
 
+    #[tokio::test]
+    async fn test_confirm_prepared_melt_prefers_persisted_saga_metadata() {
+        let db = create_test_db().await;
+        let quote = test_melt_quote();
+        let quote_id = quote.id.clone();
+        db.add_melt_quote(quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.reset_default_mint_state();
+        mock_client.set_post_melt_response(Ok(MeltQuoteResponse::Bolt11(bolt11_status(
+            &quote_id,
+            MeltQuoteState::Paid,
+            Some("preimage123".to_string()),
+        ))));
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        let mut saga_metadata = HashMap::new();
+        saga_metadata.insert("memo".to_string(), "persisted saga metadata".to_string());
+        let mut stale_metadata = HashMap::new();
+        stale_metadata.insert("memo".to_string(), "stale handle metadata".to_string());
+
+        let proof = test_proof(crate::wallet::test_utils::test_keyset_id(), 1200);
+        let prepared = wallet
+            .prepare_melt_proofs(&quote_id, vec![proof], saga_metadata.clone())
+            .await
+            .unwrap();
+
+        wallet
+            .confirm_prepared_melt_with_options(
+                prepared.operation_id(),
+                prepared.quote().clone(),
+                prepared.proofs().clone(),
+                prepared.proofs_to_swap().clone(),
+                prepared.input_fee(),
+                prepared.input_fee_without_swap(),
+                stale_metadata,
+                MeltConfirmOptions::new(),
+            )
+            .await
+            .unwrap();
+
+        let transactions = db.list_transactions(None, None, None).await.unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].metadata, saga_metadata);
+    }
+
+    #[tokio::test]
+    async fn test_confirm_prefer_async_prefers_persisted_saga_metadata() {
+        let db = create_test_db().await;
+        let quote = test_melt_quote();
+        let quote_id = quote.id.clone();
+        db.add_melt_quote(quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.reset_default_mint_state();
+        mock_client.set_post_melt_response(Ok(MeltQuoteResponse::Bolt11(bolt11_status(
+            &quote_id,
+            MeltQuoteState::Paid,
+            Some("preimage123".to_string()),
+        ))));
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        let mut stale_metadata = HashMap::new();
+        stale_metadata.insert("memo".to_string(), "stale handle metadata".to_string());
+        let mut saga_metadata = HashMap::new();
+        saga_metadata.insert("memo".to_string(), "persisted saga metadata".to_string());
+
+        let proof = test_proof(crate::wallet::test_utils::test_keyset_id(), 1200);
+        let prepared = wallet
+            .prepare_melt_proofs(&quote_id, vec![proof], stale_metadata)
+            .await
+            .unwrap();
+
+        let mut stored_saga = db
+            .get_saga(&prepared.operation_id())
+            .await
+            .unwrap()
+            .unwrap();
+        match &mut stored_saga.data {
+            OperationData::Melt(data) => {
+                data.metadata = saga_metadata.clone();
+            }
+            _ => panic!("expected melt saga"),
+        }
+        stored_saga.update_state(stored_saga.state.clone());
+        assert!(db.update_saga(stored_saga).await.unwrap());
+
+        let outcome = prepared
+            .confirm_prefer_async_with_options(MeltConfirmOptions::new())
+            .await
+            .unwrap();
+        assert!(matches!(outcome, MeltOutcome::Paid(_)));
+
+        let transactions = db.list_transactions(None, None, None).await.unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].metadata, saga_metadata);
+    }
+
+    #[tokio::test]
+    async fn test_confirm_prepared_melt_prefer_async_prefers_persisted_saga_metadata() {
+        let db = create_test_db().await;
+        let quote = test_melt_quote();
+        let quote_id = quote.id.clone();
+        db.add_melt_quote(quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.reset_default_mint_state();
+        mock_client.set_post_melt_response(Ok(MeltQuoteResponse::Bolt11(bolt11_status(
+            &quote_id,
+            MeltQuoteState::Paid,
+            Some("preimage123".to_string()),
+        ))));
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        let mut saga_metadata = HashMap::new();
+        saga_metadata.insert("memo".to_string(), "persisted saga metadata".to_string());
+        let mut stale_metadata = HashMap::new();
+        stale_metadata.insert("memo".to_string(), "stale handle metadata".to_string());
+
+        let proof = test_proof(crate::wallet::test_utils::test_keyset_id(), 1200);
+        let prepared = wallet
+            .prepare_melt_proofs(&quote_id, vec![proof], saga_metadata.clone())
+            .await
+            .unwrap();
+
+        wallet
+            .confirm_prepared_melt_prefer_async_with_options(
+                prepared.operation_id(),
+                prepared.quote().clone(),
+                prepared.proofs().clone(),
+                prepared.proofs_to_swap().clone(),
+                prepared.input_fee(),
+                prepared.input_fee_without_swap(),
+                stale_metadata,
+                MeltConfirmOptions::new(),
+            )
+            .await
+            .unwrap();
+
+        let transactions = db.list_transactions(None, None, None).await.unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].metadata, saga_metadata);
+    }
+
     /// Build a bolt11 melt-quote status response with the given state/preimage.
     fn bolt11_status(
         quote_id: &str,
@@ -2130,6 +2425,19 @@ mod tests {
     /// the mock (which has no WebSocket endpoint).
     async fn pending_bolt11_melt(
         http_subscription: bool,
+    ) -> (
+        Arc<dyn cdk_common::database::WalletDatabase<cdk_common::database::Error> + Send + Sync>,
+        crate::nuts::PublicKey,
+        uuid::Uuid,
+        Arc<MockMintConnector>,
+        PendingMelt<'static>,
+    ) {
+        pending_bolt11_melt_with_metadata(http_subscription, HashMap::new()).await
+    }
+
+    async fn pending_bolt11_melt_with_metadata(
+        http_subscription: bool,
+        metadata: HashMap<String, String>,
     ) -> (
         Arc<dyn cdk_common::database::WalletDatabase<cdk_common::database::Error> + Send + Sync>,
         crate::nuts::PublicKey,
@@ -2172,7 +2480,7 @@ mod tests {
         };
 
         let prepared = wallet
-            .prepare_melt_proofs(&quote_id, vec![proof], HashMap::new())
+            .prepare_melt_proofs(&quote_id, vec![proof], metadata)
             .await
             .unwrap();
         let operation_id = prepared.operation_id();
@@ -2403,5 +2711,32 @@ mod tests {
         let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
         assert_eq!(stored[0].state, State::Spent);
         assert!(db.get_saga(&operation_id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_wait_pending_melt_records_persisted_metadata() {
+        let mut metadata = HashMap::new();
+        metadata.insert("label".to_string(), "ffi wait".to_string());
+        let (db, _proof_y, _operation_id, mock_client, pending) =
+            pending_bolt11_melt_with_metadata(true, metadata.clone()).await;
+        let quote_id = pending.saga.quote().id.clone();
+
+        mock_client.push_melt_quote_status_response(Ok(MeltQuoteBolt11Response {
+            payment_preimage: Some("preimage123".to_string()),
+            ..bolt11_status(&quote_id, MeltQuoteState::Paid, None)
+        }));
+        mock_client.push_melt_quote_status_response(Ok(MeltQuoteBolt11Response {
+            payment_preimage: Some("preimage123".to_string()),
+            ..bolt11_status(&quote_id, MeltQuoteState::Paid, None)
+        }));
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), pending.into_future())
+            .await
+            .expect("wait timed out")
+            .expect("melt should finalize");
+
+        let transactions = db.list_transactions(None, None, None).await.unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].metadata, metadata);
     }
 }

--- a/crates/cdk/src/wallet/melt/saga/mod.rs
+++ b/crates/cdk/src/wallet/melt/saga/mod.rs
@@ -218,7 +218,6 @@ async fn finalize_melt_common<'a>(
             e
         );
     }
-
     Ok(MeltSaga {
         wallet,
         compensations,
@@ -293,7 +292,7 @@ impl<'a> MeltSaga<'a, Initial> {
     pub async fn prepare(
         mut self,
         quote_id: &str,
-        _metadata: HashMap<String, String>,
+        metadata: HashMap<String, String>,
     ) -> Result<MeltSaga<'a, Prepared>, Error> {
         tracing::info!(
             "Preparing melt for quote {} with operation {}",
@@ -356,6 +355,8 @@ impl<'a> MeltSaga<'a, Initial> {
                     counter_start: None,
                     counter_end: None,
                     change_amount: None,
+                    metadata: metadata.clone(),
+                    final_proof_ys: None,
                     change_blinded_messages: None,
                 }),
             );
@@ -452,6 +453,8 @@ impl<'a> MeltSaga<'a, Initial> {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata,
+                final_proof_ys: None,
                 change_blinded_messages: None, // Will be set when melt is requested
             }),
         );
@@ -501,7 +504,7 @@ impl<'a> MeltSaga<'a, Initial> {
         mut self,
         quote_id: &str,
         proofs: Proofs,
-        _metadata: HashMap<String, String>,
+        metadata: HashMap<String, String>,
     ) -> Result<MeltSaga<'a, Prepared>, Error> {
         tracing::info!(
             "Preparing melt with specific proofs for quote {} with operation {}",
@@ -558,6 +561,8 @@ impl<'a> MeltSaga<'a, Initial> {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata,
+                final_proof_ys: None,
                 change_blinded_messages: None,
             }),
         );
@@ -831,6 +836,8 @@ impl<'a> MeltSaga<'a, Prepared> {
             None
         };
 
+        let final_proof_ys = final_proofs.ys()?;
+
         // Update saga state to MeltRequested BEFORE making the melt call
         let mut saga = self.state_data.saga.clone();
         saga.update_state(WalletSagaState::Melt(MeltSagaState::MeltRequested));
@@ -842,6 +849,7 @@ impl<'a> MeltSaga<'a, Prepared> {
             } else {
                 None
             };
+            data.final_proof_ys = Some(final_proof_ys);
             data.change_blinded_messages = change_blinded_messages.clone();
         }
 
@@ -1344,7 +1352,7 @@ mod tests {
         let db = create_test_db().await;
         let mint_url = test_mint_url();
         let keyset_id = test_keyset_id();
-        let proof_info = test_proof_info(keyset_id, 1010, mint_url.clone());
+        let proof_info = test_proof_info(keyset_id, 2000, mint_url.clone());
         let proof_y = proof_info.y;
         let proof = proof_info.proof.clone();
         db.update_proofs(vec![proof_info], vec![]).await.unwrap();
@@ -1378,6 +1386,77 @@ mod tests {
             stored[0].used_by_operation,
             Some(prepared.state_data.operation_id)
         );
+    }
+
+    #[tokio::test]
+    async fn test_prepare_melt_persists_metadata_in_saga() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let proof_info = test_proof_info(keyset_id, 2000, mint_url.clone());
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let quote = test_melt_quote();
+        let quote_id = quote.id.clone();
+        db.add_melt_quote(quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.reset_default_mint_state();
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        let mut metadata = HashMap::new();
+        metadata.insert("purpose".to_string(), "ffi-pending".to_string());
+
+        let prepared = MeltSaga::new(&wallet)
+            .prepare(&quote_id, metadata.clone())
+            .await
+            .unwrap();
+
+        let saga = db
+            .get_saga(&prepared.state_data.operation_id)
+            .await
+            .unwrap()
+            .expect("saga should be stored");
+        match saga.data {
+            OperationData::Melt(data) => assert_eq!(data.metadata, metadata),
+            _ => panic!("expected melt saga data"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_prepare_melt_proofs_persists_metadata_in_saga() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let proof_info = test_proof_info(keyset_id, 1010, mint_url.clone());
+        let proof = proof_info.proof.clone();
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let quote = test_melt_quote();
+        let quote_id = quote.id.clone();
+        db.add_melt_quote(quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.reset_default_mint_state();
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        let mut metadata = HashMap::new();
+        metadata.insert("purpose".to_string(), "ffi-pending-proofs".to_string());
+
+        let prepared = MeltSaga::new(&wallet)
+            .prepare_with_proofs(&quote_id, vec![proof], metadata.clone())
+            .await
+            .unwrap();
+
+        let saga = db
+            .get_saga(&prepared.state_data.operation_id)
+            .await
+            .unwrap()
+            .expect("saga should be stored");
+        match saga.data {
+            OperationData::Melt(data) => assert_eq!(data.metadata, metadata),
+            _ => panic!("expected melt saga data"),
+        }
     }
 
     /// Verify the Amount arithmetic used in prepare/request_melt does not panic on overflow.

--- a/crates/cdk/src/wallet/melt/saga/resume.rs
+++ b/crates/cdk/src/wallet/melt/saga/resume.rs
@@ -4,8 +4,6 @@
 //! by a crash. It determines the payment status by querying the mint and
 //! either completes the operation or compensates.
 
-use std::collections::HashMap;
-
 use cdk_common::wallet::{
     MeltOperationData, MeltSagaState, OperationData, Transaction, TransactionDirection,
     TransactionId, WalletSaga,
@@ -18,7 +16,7 @@ use crate::types::FinalizedMelt;
 use crate::util::unix_time;
 use crate::wallet::melt::saga::compensation::ReleaseMeltQuote;
 use crate::wallet::melt::MeltQuoteStatusResponse;
-use crate::wallet::recovery::RecoveryHelpers;
+use crate::wallet::recovery::OutputRecoveryResult;
 use crate::wallet::saga::{CompensatingAction, RevertProofReservation};
 use crate::{Error, Wallet};
 
@@ -103,10 +101,8 @@ impl Wallet {
                 MeltQuoteState::Paid => {
                     // Payment succeeded - mark proofs as spent and recover change
                     tracing::info!("Melt saga {} - payment succeeded, finalizing", saga_id);
-                    let melted = self
-                        .complete_melt_from_restore(saga_id, data, &quote_status)
-                        .await?;
-                    Ok(melted)
+                    self.complete_melt_from_restore(saga_id, data, &quote_status)
+                        .await
                 }
                 MeltQuoteState::Unpaid | MeltQuoteState::Failed => {
                     // Safety: refuse to compensate while the mint still
@@ -159,9 +155,32 @@ impl Wallet {
         data: &MeltOperationData,
         quote_status: &MeltQuoteStatusResponse,
     ) -> Result<Option<FinalizedMelt>, Error> {
-        // Mark input proofs as spent
         let reserved_proofs = self.localstore.get_reserved_proofs(saga_id).await?;
-        if reserved_proofs.is_empty() {
+        let melt_input_proofs: Vec<_> = match data.final_proof_ys.as_ref() {
+            Some(final_proof_ys) => reserved_proofs
+                .into_iter()
+                .filter(|proof| {
+                    final_proof_ys.contains(&proof.y)
+                        && matches!(proof.state, State::Pending | State::Spent)
+                })
+                .collect(),
+            None => {
+                let (pending, spent): (Vec<_>, Vec<_>) = reserved_proofs
+                    .into_iter()
+                    .filter(|proof| matches!(proof.state, State::Pending | State::Spent))
+                    .partition(|proof| proof.state == State::Pending);
+
+                if pending.is_empty() {
+                    // Legacy sagas did not persist final_proof_ys. If a crash
+                    // happened after inputs were marked spent, the reserved
+                    // spent proofs are the only remaining recovery candidates.
+                    spent
+                } else {
+                    pending
+                }
+            }
+        };
+        if melt_input_proofs.is_empty() {
             tracing::warn!(
                 "Melt saga {} - payment succeeded but no melt inputs were found; \
                  skipping final transaction recording.",
@@ -170,7 +189,7 @@ impl Wallet {
             return Ok(None);
         }
 
-        let proof_ys: Vec<_> = reserved_proofs.iter().map(|p| p.y).collect();
+        let proof_ys: Vec<_> = melt_input_proofs.iter().map(|p| p.y).collect();
         let transaction_id = TransactionId::new(proof_ys.clone());
         let status_payment_proof = quote_status.payment_proof();
         if let Some(existing_transaction) = self.localstore.get_transaction(transaction_id).await? {
@@ -219,64 +238,89 @@ impl Wallet {
             }
         }
 
-        let input_amount =
-            Amount::try_sum(reserved_proofs.iter().map(|p| p.proof.amount)).unwrap_or(Amount::ZERO);
+        let input_amount = Amount::try_sum(melt_input_proofs.iter().map(|p| p.proof.amount))
+            .unwrap_or(Amount::ZERO);
 
-        self.localstore
-            .update_proofs_state(proof_ys.clone(), State::Spent)
-            .await?;
-
-        // Try to recover change proofs using stored blinded messages
-        let change_proofs = if let Some(ref change_blinded_messages) = data.change_blinded_messages
-        {
-            if !change_blinded_messages.is_empty() {
-                match self
-                    .restore_outputs(
-                        saga_id,
-                        "Melt",
-                        Some(change_blinded_messages.as_slice()),
-                        data.counter_start,
-                        data.counter_end,
-                    )
-                    .await
-                {
-                    Ok(Some(change_proof_infos)) => {
-                        let proofs: Vec<_> =
-                            change_proof_infos.iter().map(|p| p.proof.clone()).collect();
-                        self.localstore
-                            .update_proofs(change_proof_infos, vec![])
-                            .await?;
-                        Some(proofs)
-                    }
-                    Ok(None) => {
-                        tracing::warn!(
-                            "Melt saga {} - couldn't restore change proofs. \
-                             Run wallet.restore() to recover any missing change.",
-                            saga_id
-                        );
-                        None
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "Melt saga {} - failed to recover change: {}. \
-                             Run wallet.restore() to recover any missing change.",
+        // Try to recover change proofs using the persisted saga data. A paid
+        // quote status can omit change signatures even when change was expected.
+        let expects_change = data
+            .change_amount
+            .is_some_and(|amount| amount > Amount::ZERO)
+            || data
+                .change_blinded_messages
+                .as_ref()
+                .is_some_and(|messages| !messages.is_empty());
+        let change_proofs = if expects_change {
+            match data.change_blinded_messages.as_ref() {
+                Some(change_blinded_messages) if !change_blinded_messages.is_empty() => {
+                    match self
+                        .restore_outputs_with_result(
                             saga_id,
-                            e
-                        );
-                        None
+                            "Melt",
+                            Some(change_blinded_messages.as_slice()),
+                            data.counter_start,
+                            data.counter_end,
+                        )
+                        .await
+                    {
+                        Ok(OutputRecoveryResult::Restored(change_proof_infos)) => {
+                            let proofs: Vec<_> =
+                                change_proof_infos.iter().map(|p| p.proof.clone()).collect();
+                            self.localstore
+                                .update_proofs(change_proof_infos, vec![])
+                                .await?;
+                            Some(proofs)
+                        }
+                        Ok(OutputRecoveryResult::EmptyResponse) => {
+                            tracing::warn!(
+                                "Melt saga {} - mint returned no change signatures on restore; \
+                                 finalizing with no recovered change.",
+                                saga_id
+                            );
+                            None
+                        }
+                        Ok(OutputRecoveryResult::Unavailable) => {
+                            tracing::warn!(
+                                "Melt saga {} - couldn't restore change proofs; finalizing \
+                                 paid melt with no recovered change.",
+                                saga_id
+                            );
+                            None
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Melt saga {} - failed to recover change: {}. \
+                                 Skipping final transaction recording until change can be recovered.",
+                                saga_id,
+                                e
+                            );
+                            return Err(e);
+                        }
                     }
                 }
-            } else {
-                None
+                _ => {
+                    tracing::warn!(
+                        "Melt saga {} - payment succeeded but no change blinded messages stored; \
+                         finalizing paid melt with no recovered change.",
+                        saga_id
+                    );
+                    None
+                }
             }
         } else {
-            tracing::warn!(
-                "Melt saga {} - payment succeeded but no change blinded messages stored. \
-                 Run wallet.restore() to recover any missing change.",
-                saga_id
-            );
             None
         };
+
+        let pending_proof_ys: Vec<_> = melt_input_proofs
+            .iter()
+            .filter(|proof| proof.state == State::Pending)
+            .map(|proof| proof.y)
+            .collect();
+        if !pending_proof_ys.is_empty() {
+            self.localstore
+                .update_proofs_state(pending_proof_ys, State::Spent)
+                .await?;
+        }
 
         // Calculate fee paid
         let change_amount = change_proofs
@@ -312,7 +356,7 @@ impl Wallet {
                 ys: proof_ys,
                 timestamp: unix_time(),
                 memo: None,
-                metadata: HashMap::new(),
+                metadata: data.metadata.clone(),
                 quote_id: Some(data.quote_id.clone()),
                 payment_request,
                 payment_proof: payment_proof.clone(),
@@ -368,7 +412,9 @@ impl Wallet {
             saga_id: *saga_id,
         }
         .execute()
-        .await
+        .await?;
+
+        Ok(())
     }
 }
 
@@ -377,19 +423,47 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use bip39::Mnemonic;
     use cdk_common::nuts::{CurrencyUnit, PaymentMethod, State};
     use cdk_common::wallet::{
         MeltOperationData, MeltSagaState, OperationData, Transaction, TransactionDirection,
         WalletSaga, WalletSagaState,
     };
-    use cdk_common::{Amount, MeltQuoteBolt11Response, MeltQuoteState};
+    use cdk_common::{Amount, MeltQuoteBolt11Response, MeltQuoteState, RestoreResponse};
 
+    use crate::nuts::{BlindSignature, BlindedMessage, PreMintSecrets};
     use crate::wallet::saga::test_utils::{
         create_test_db, test_keyset_id, test_mint_url, test_proof_info,
     };
     use crate::wallet::test_utils::{
         create_test_wallet_with_mock, test_melt_quote, MockMintConnector,
     };
+
+    fn restore_response_with_amounts(
+        blinded_messages: &[BlindedMessage],
+        amounts: &[u64],
+    ) -> RestoreResponse {
+        let outputs = blinded_messages
+            .iter()
+            .take(amounts.len())
+            .cloned()
+            .collect();
+        let signatures = blinded_messages
+            .iter()
+            .zip(amounts)
+            .map(|(message, amount)| BlindSignature {
+                amount: Amount::from(*amount),
+                keyset_id: message.keyset_id,
+                c: message.blinded_secret,
+                dleq: None,
+            })
+            .collect();
+
+        RestoreResponse {
+            outputs,
+            signatures,
+        }
+    }
 
     #[tokio::test]
     async fn test_recover_melt_proofs_reserved() {
@@ -426,6 +500,8 @@ mod tests {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
                 change_blinded_messages: None,
             }),
         );
@@ -488,6 +564,8 @@ mod tests {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
                 change_blinded_messages: None,
             }),
         );
@@ -520,11 +598,10 @@ mod tests {
         let saga_id = uuid::Uuid::new_v4();
         let quote_id = format!("test_melt_quote_{}", uuid::Uuid::new_v4());
 
-        // Create and reserve proofs
-        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Unspent);
-        let proof_y = proof_info.y;
+        // Create pending proofs as they would be after a melt request is sent.
+        let mut proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Pending);
+        proof_info.used_by_operation = Some(saga_id);
         db.update_proofs(vec![proof_info], vec![]).await.unwrap();
-        db.reserve_proofs(vec![proof_y], &saga_id).await.unwrap();
 
         // Create saga in MeltRequested state
         let saga = WalletSaga::new(
@@ -540,6 +617,8 @@ mod tests {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
                 change_blinded_messages: None,
             }),
         );
@@ -615,10 +694,9 @@ mod tests {
         let saga_id = uuid::Uuid::new_v4();
         let quote_id = format!("test_melt_quote_{}", uuid::Uuid::new_v4());
 
-        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Unspent);
-        let proof_y = proof_info.y;
+        let mut proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Pending);
+        proof_info.used_by_operation = Some(saga_id);
         db.update_proofs(vec![proof_info], vec![]).await.unwrap();
-        db.reserve_proofs(vec![proof_y], &saga_id).await.unwrap();
 
         let saga = WalletSaga::new(
             saga_id,
@@ -634,6 +712,8 @@ mod tests {
                 counter_end: None,
                 change_amount: None,
                 change_blinded_messages: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
             }),
         );
         db.add_saga(saga).await.unwrap();
@@ -702,6 +782,8 @@ mod tests {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
                 change_blinded_messages: None,
             }),
         );
@@ -749,10 +831,13 @@ mod tests {
         let saga_id = uuid::Uuid::new_v4();
         let quote_id = format!("test_melt_quote_{}", uuid::Uuid::new_v4());
 
-        let mut proof_info = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Pending);
-        proof_info.used_by_operation = Some(saga_id);
-        let proof_y = proof_info.y;
-        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+        let mut pending_input = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Pending);
+        pending_input.used_by_operation = Some(saga_id);
+        let pending_input_y = pending_input.y;
+        db.update_proofs(vec![pending_input], vec![]).await.unwrap();
+
+        let mut metadata = HashMap::new();
+        metadata.insert("label".to_string(), "recovery metadata".to_string());
 
         let saga = WalletSaga::new(
             saga_id,
@@ -766,7 +851,9 @@ mod tests {
                 fee_reserve: Amount::from(10),
                 counter_start: None,
                 counter_end: None,
-                change_amount: None,
+                change_amount: Some(Amount::from(150)),
+                metadata,
+                final_proof_ys: Some(vec![pending_input_y]),
                 change_blinded_messages: None,
             }),
         );
@@ -781,12 +868,12 @@ mod tests {
         let mut existing_metadata = HashMap::new();
         existing_metadata.insert("label".to_string(), "original metadata".to_string());
         db.add_transaction(Transaction {
-            mint_url,
+            mint_url: mint_url.clone(),
             direction: TransactionDirection::Outgoing,
             amount: Amount::from(1000),
             fee: Amount::from(50),
             unit: CurrencyUnit::Sat,
-            ys: vec![proof_y],
+            ys: vec![pending_input_y],
             timestamp: 42,
             memo: Some("original memo".to_string()),
             metadata: existing_metadata.clone(),
@@ -839,7 +926,7 @@ mod tests {
             Some("original proof")
         );
 
-        let stored_input = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        let stored_input = db.get_proofs_by_ys(vec![pending_input_y]).await.unwrap();
         assert_eq!(stored_input.len(), 1);
         assert_eq!(stored_input[0].state, State::Spent);
 
@@ -876,6 +963,8 @@ mod tests {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
                 change_blinded_messages: None,
             }),
         );
@@ -972,6 +1061,8 @@ mod tests {
                 counter_end: None,
                 change_amount: None,
                 change_blinded_messages: None,
+                metadata: HashMap::new(),
+                final_proof_ys: Some(vec![proof_y]),
             }),
         );
         db.add_saga(saga).await.unwrap();
@@ -1059,6 +1150,682 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_recover_melt_paid_uses_only_pending_melt_inputs() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let saga_id = uuid::Uuid::new_v4();
+        let other_saga_id = uuid::Uuid::new_v4();
+        let quote_id = format!("test_melt_quote_{}", uuid::Uuid::new_v4());
+
+        let mut pending_input = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Pending);
+        pending_input.used_by_operation = Some(saga_id);
+        let pending_input_y = pending_input.y;
+
+        let mut spent_swap_input = test_proof_info(keyset_id, 300, mint_url.clone(), State::Spent);
+        spent_swap_input.used_by_operation = Some(saga_id);
+        let spent_swap_input_y = spent_swap_input.y;
+
+        let mut other_pending = test_proof_info(keyset_id, 900, mint_url.clone(), State::Pending);
+        other_pending.used_by_operation = Some(other_saga_id);
+        let other_pending_y = other_pending.y;
+
+        db.update_proofs(vec![pending_input, spent_swap_input, other_pending], vec![])
+            .await
+            .unwrap();
+
+        let saga = WalletSaga::new(
+            saga_id,
+            WalletSagaState::Melt(MeltSagaState::MeltRequested),
+            Amount::from(1000),
+            mint_url.clone(),
+            CurrencyUnit::Sat,
+            OperationData::Melt(MeltOperationData {
+                quote_id: quote_id.clone(),
+                amount: Amount::from(1000),
+                fee_reserve: Amount::from(10),
+                counter_start: None,
+                counter_end: None,
+                change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
+                change_blinded_messages: None,
+            }),
+        );
+        db.add_saga(saga).await.unwrap();
+
+        let mut melt_quote = test_melt_quote();
+        melt_quote.id = quote_id.clone();
+        db.add_melt_quote(melt_quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.reset_default_mint_state();
+        mock_client.set_melt_quote_status_response(Ok(MeltQuoteBolt11Response {
+            quote: quote_id,
+            state: MeltQuoteState::Paid,
+            expiry: 9999999999,
+            fee_reserve: Amount::from(10),
+            amount: Amount::from(1000),
+            request: Some("lnbc1000...".to_string()),
+            payment_preimage: Some("preimage123".to_string()),
+            change: None,
+            unit: Some(CurrencyUnit::Sat),
+            method: PaymentMethod::BOLT11,
+        }));
+
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+        let result = wallet
+            .resume_melt_saga(&db.get_saga(&saga_id).await.unwrap().unwrap())
+            .await
+            .unwrap();
+
+        assert!(result.is_some());
+
+        let transactions = db.list_transactions(None, None, None).await.unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].ys, vec![pending_input_y]);
+        assert!(!transactions[0].ys.contains(&spent_swap_input_y));
+        assert!(!transactions[0].ys.contains(&other_pending_y));
+        assert_eq!(transactions[0].fee, Amount::from(200));
+    }
+
+    #[tokio::test]
+    async fn test_recover_melt_paid_legacy_finalizes_after_inputs_spent() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let saga_id = uuid::Uuid::new_v4();
+        let quote_id = format!("test_melt_quote_{}", uuid::Uuid::new_v4());
+
+        let mut spent_input = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Spent);
+        spent_input.used_by_operation = Some(saga_id);
+        let spent_input_y = spent_input.y;
+
+        db.update_proofs(vec![spent_input], vec![]).await.unwrap();
+
+        let saga = WalletSaga::new(
+            saga_id,
+            WalletSagaState::Melt(MeltSagaState::MeltRequested),
+            Amount::from(1000),
+            mint_url.clone(),
+            CurrencyUnit::Sat,
+            OperationData::Melt(MeltOperationData {
+                quote_id: quote_id.clone(),
+                amount: Amount::from(1000),
+                fee_reserve: Amount::from(10),
+                counter_start: None,
+                counter_end: None,
+                change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
+                change_blinded_messages: None,
+            }),
+        );
+        db.add_saga(saga).await.unwrap();
+
+        let mut melt_quote = test_melt_quote();
+        melt_quote.id = quote_id.clone();
+        db.add_melt_quote(melt_quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.set_melt_quote_status_response(Ok(MeltQuoteBolt11Response {
+            quote: quote_id,
+            state: MeltQuoteState::Paid,
+            expiry: 9999999999,
+            fee_reserve: Amount::from(10),
+            amount: Amount::from(1000),
+            request: Some("lnbc1000...".to_string()),
+            payment_preimage: Some("preimage123".to_string()),
+            change: None,
+            unit: Some(CurrencyUnit::Sat),
+            method: PaymentMethod::BOLT11,
+        }));
+
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+        let result = wallet
+            .resume_melt_saga(&db.get_saga(&saga_id).await.unwrap().unwrap())
+            .await
+            .unwrap();
+
+        let finalized = result.expect("legacy spent input should finalize");
+        assert_eq!(finalized.fee_paid(), Amount::from(200));
+        assert!(db.get_saga(&saga_id).await.unwrap().is_none());
+
+        let transactions = db.list_transactions(None, None, None).await.unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].ys, vec![spent_input_y]);
+        assert_eq!(transactions[0].fee, Amount::from(200));
+
+        let stored_input = db.get_proofs_by_ys(vec![spent_input_y]).await.unwrap();
+        assert_eq!(stored_input.len(), 1);
+        assert_eq!(stored_input[0].state, State::Spent);
+    }
+
+    #[tokio::test]
+    async fn test_recover_melt_paid_uses_final_input_ys_after_inputs_spent() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let saga_id = uuid::Uuid::new_v4();
+        let quote_id = format!("test_melt_quote_{}", uuid::Uuid::new_v4());
+
+        let mut spent_melt_input = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Spent);
+        spent_melt_input.used_by_operation = Some(saga_id);
+        let spent_melt_input_y = spent_melt_input.y;
+
+        let mut spent_swap_input = test_proof_info(keyset_id, 300, mint_url.clone(), State::Spent);
+        spent_swap_input.used_by_operation = Some(saga_id);
+        let spent_swap_input_y = spent_swap_input.y;
+
+        db.update_proofs(vec![spent_melt_input, spent_swap_input], vec![])
+            .await
+            .unwrap();
+
+        let saga = WalletSaga::new(
+            saga_id,
+            WalletSagaState::Melt(MeltSagaState::MeltRequested),
+            Amount::from(1000),
+            mint_url.clone(),
+            CurrencyUnit::Sat,
+            OperationData::Melt(MeltOperationData {
+                quote_id: quote_id.clone(),
+                amount: Amount::from(1000),
+                fee_reserve: Amount::from(10),
+                counter_start: None,
+                counter_end: None,
+                change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: Some(vec![spent_melt_input_y]),
+                change_blinded_messages: None,
+            }),
+        );
+        db.add_saga(saga).await.unwrap();
+
+        let mut melt_quote = test_melt_quote();
+        melt_quote.id = quote_id.clone();
+        db.add_melt_quote(melt_quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.set_melt_quote_status_response(Ok(MeltQuoteBolt11Response {
+            quote: quote_id,
+            state: MeltQuoteState::Paid,
+            expiry: 9999999999,
+            fee_reserve: Amount::from(10),
+            amount: Amount::from(1000),
+            request: Some("lnbc1000...".to_string()),
+            payment_preimage: Some("preimage123".to_string()),
+            change: None,
+            unit: Some(CurrencyUnit::Sat),
+            method: PaymentMethod::BOLT11,
+        }));
+
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        let result = wallet
+            .resume_melt_saga(&db.get_saga(&saga_id).await.unwrap().unwrap())
+            .await
+            .unwrap();
+
+        assert!(result.is_some());
+
+        let transactions = db.list_transactions(None, None, None).await.unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].ys, vec![spent_melt_input_y]);
+        assert!(!transactions[0].ys.contains(&spent_swap_input_y));
+        assert_eq!(transactions[0].fee, Amount::from(200));
+        assert!(db.get_saga(&saga_id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_recover_melt_paid_restores_persisted_change_when_status_omits_change() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset = crate::wallet::test_utils::test_keyset();
+        let keyset_id = keyset.id;
+        let saga_id = uuid::Uuid::new_v4();
+        let quote_id = format!("test_melt_quote_{}", uuid::Uuid::new_v4());
+        let seed = Mnemonic::generate(12).unwrap().to_seed_normalized("");
+        db.add_mint(mint_url.clone(), None).await.unwrap();
+        db.add_mint_keysets(
+            mint_url.clone(),
+            vec![cdk_common::nuts::KeySetInfo {
+                id: keyset.id,
+                unit: keyset.unit.clone(),
+                active: keyset.active.unwrap_or(true),
+                input_fee_ppk: keyset.input_fee_ppk,
+                final_expiry: keyset.final_expiry,
+            }],
+        )
+        .await
+        .unwrap();
+        db.add_keys(keyset.clone()).await.unwrap();
+
+        let mut pending_input = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Pending);
+        pending_input.used_by_operation = Some(saga_id);
+        let pending_input_y = pending_input.y;
+        db.update_proofs(vec![pending_input], vec![]).await.unwrap();
+
+        let premint_secrets =
+            PreMintSecrets::from_seed_blank(keyset_id, 0, &seed, Amount::from(150))
+                .expect("blank premint secrets");
+        let blinded_messages = premint_secrets.blinded_messages();
+        let counter_end = blinded_messages.len() as u32;
+
+        let saga = WalletSaga::new(
+            saga_id,
+            WalletSagaState::Melt(MeltSagaState::MeltRequested),
+            Amount::from(1000),
+            mint_url.clone(),
+            CurrencyUnit::Sat,
+            OperationData::Melt(MeltOperationData {
+                quote_id: quote_id.clone(),
+                amount: Amount::from(1000),
+                fee_reserve: Amount::from(10),
+                counter_start: Some(0),
+                counter_end: Some(counter_end),
+                change_amount: Some(Amount::from(150)),
+                metadata: HashMap::new(),
+                final_proof_ys: None,
+                change_blinded_messages: Some(blinded_messages.clone()),
+            }),
+        );
+        db.add_saga(saga).await.unwrap();
+
+        let mut melt_quote = test_melt_quote();
+        melt_quote.id = quote_id.clone();
+        db.add_melt_quote(melt_quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.set_melt_quote_status_response(Ok(MeltQuoteBolt11Response {
+            quote: quote_id.clone(),
+            state: MeltQuoteState::Paid,
+            expiry: 9999999999,
+            fee_reserve: Amount::from(10),
+            amount: Amount::from(1000),
+            request: Some("lnbc1000...".to_string()),
+            payment_preimage: Some("preimage123".to_string()),
+            change: None,
+            unit: Some(CurrencyUnit::Sat),
+            method: PaymentMethod::BOLT11,
+        }));
+        mock_client._set_restore_response(Ok(restore_response_with_amounts(
+            &blinded_messages,
+            &[128, 16, 4, 2],
+        )));
+        let wallet = crate::wallet::WalletBuilder::new()
+            .mint_url(mint_url)
+            .unit(CurrencyUnit::Sat)
+            .localstore(db.clone())
+            .seed(seed)
+            .shared_client(mock_client)
+            .build()
+            .unwrap();
+        let result = wallet
+            .resume_melt_saga(&db.get_saga(&saga_id).await.unwrap().unwrap())
+            .await
+            .unwrap();
+
+        let finalized = result.expect("melt should finalize");
+        assert_eq!(finalized.fee_paid(), Amount::from(50));
+        assert_eq!(
+            Amount::try_sum(
+                finalized
+                    .change()
+                    .expect("change should be recovered")
+                    .iter()
+                    .map(|proof| proof.amount)
+            )
+            .unwrap(),
+            Amount::from(150)
+        );
+        assert!(db.get_saga(&saga_id).await.unwrap().is_none());
+        let transactions = db.list_transactions(None, None, None).await.unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].fee, Amount::from(50));
+
+        let stored_input = db.get_proofs_by_ys(vec![pending_input_y]).await.unwrap();
+        assert_eq!(stored_input.len(), 1);
+        assert_eq!(stored_input[0].state, State::Spent);
+
+        let quote = db.get_melt_quote(&quote_id).await.unwrap().unwrap();
+        assert_eq!(quote.state, MeltQuoteState::Paid);
+        assert_eq!(quote.payment_proof.as_deref(), Some("preimage123"));
+    }
+
+    #[tokio::test]
+    async fn test_recover_melt_paid_finalizes_when_restore_returns_no_change_signatures() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let saga_id = uuid::Uuid::new_v4();
+        let quote_id = format!("test_melt_quote_{}", uuid::Uuid::new_v4());
+
+        let mut pending_input = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Pending);
+        pending_input.used_by_operation = Some(saga_id);
+        let pending_input_y = pending_input.y;
+        db.update_proofs(vec![pending_input], vec![]).await.unwrap();
+
+        let premint_secrets =
+            PreMintSecrets::blank(keyset_id, Amount::from(150)).expect("blank premint secrets");
+        let blinded_messages = premint_secrets.blinded_messages();
+        let counter_end = blinded_messages.len() as u32;
+
+        let saga = WalletSaga::new(
+            saga_id,
+            WalletSagaState::Melt(MeltSagaState::MeltRequested),
+            Amount::from(1000),
+            mint_url.clone(),
+            CurrencyUnit::Sat,
+            OperationData::Melt(MeltOperationData {
+                quote_id: quote_id.clone(),
+                amount: Amount::from(1000),
+                fee_reserve: Amount::from(10),
+                counter_start: Some(0),
+                counter_end: Some(counter_end),
+                change_amount: Some(Amount::from(150)),
+                metadata: HashMap::new(),
+                final_proof_ys: None,
+                change_blinded_messages: Some(blinded_messages),
+            }),
+        );
+        db.add_saga(saga).await.unwrap();
+
+        let mut melt_quote = test_melt_quote();
+        melt_quote.id = quote_id.clone();
+        db.add_melt_quote(melt_quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.set_melt_quote_status_response(Ok(MeltQuoteBolt11Response {
+            quote: quote_id.clone(),
+            state: MeltQuoteState::Paid,
+            expiry: 9999999999,
+            fee_reserve: Amount::from(10),
+            amount: Amount::from(1000),
+            request: Some("lnbc1000...".to_string()),
+            payment_preimage: Some("preimage123".to_string()),
+            change: None,
+            unit: Some(CurrencyUnit::Sat),
+            method: PaymentMethod::BOLT11,
+        }));
+        mock_client._set_restore_response(Ok(RestoreResponse {
+            outputs: vec![],
+            signatures: vec![],
+        }));
+
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+        let result = wallet
+            .resume_melt_saga(&db.get_saga(&saga_id).await.unwrap().unwrap())
+            .await
+            .unwrap();
+
+        let finalized = result.expect("empty restore should finalize");
+        assert_eq!(finalized.fee_paid(), Amount::from(200));
+        assert!(finalized.change().is_none());
+        assert!(db.get_saga(&saga_id).await.unwrap().is_none());
+        let transactions = db.list_transactions(None, None, None).await.unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].fee, Amount::from(200));
+
+        let stored_input = db.get_proofs_by_ys(vec![pending_input_y]).await.unwrap();
+        assert_eq!(stored_input.len(), 1);
+        assert_eq!(stored_input[0].state, State::Spent);
+
+        let quote = db.get_melt_quote(&quote_id).await.unwrap().unwrap();
+        assert_eq!(quote.state, MeltQuoteState::Paid);
+        assert_eq!(quote.payment_proof.as_deref(), Some("preimage123"));
+    }
+
+    #[tokio::test]
+    async fn test_recover_melt_paid_keeps_saga_when_restore_fails_ambiguously() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let saga_id = uuid::Uuid::new_v4();
+        let quote_id = format!("test_melt_quote_{}", uuid::Uuid::new_v4());
+
+        let mut pending_input = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Pending);
+        pending_input.used_by_operation = Some(saga_id);
+        let pending_input_y = pending_input.y;
+        db.update_proofs(vec![pending_input], vec![]).await.unwrap();
+
+        let premint_secrets =
+            PreMintSecrets::blank(keyset_id, Amount::from(150)).expect("blank premint secrets");
+        let blinded_messages = premint_secrets.blinded_messages();
+        let counter_end = blinded_messages.len() as u32;
+
+        let saga = WalletSaga::new(
+            saga_id,
+            WalletSagaState::Melt(MeltSagaState::MeltRequested),
+            Amount::from(1000),
+            mint_url.clone(),
+            CurrencyUnit::Sat,
+            OperationData::Melt(MeltOperationData {
+                quote_id: quote_id.clone(),
+                amount: Amount::from(1000),
+                fee_reserve: Amount::from(10),
+                counter_start: Some(0),
+                counter_end: Some(counter_end),
+                change_amount: Some(Amount::from(150)),
+                metadata: HashMap::new(),
+                final_proof_ys: None,
+                change_blinded_messages: Some(blinded_messages),
+            }),
+        );
+        db.add_saga(saga).await.unwrap();
+
+        let mut melt_quote = test_melt_quote();
+        melt_quote.id = quote_id.clone();
+        db.add_melt_quote(melt_quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.set_melt_quote_status_response(Ok(MeltQuoteBolt11Response {
+            quote: quote_id.clone(),
+            state: MeltQuoteState::Paid,
+            expiry: 9999999999,
+            fee_reserve: Amount::from(10),
+            amount: Amount::from(1000),
+            request: Some("lnbc1000...".to_string()),
+            payment_preimage: Some("preimage123".to_string()),
+            change: None,
+            unit: Some(CurrencyUnit::Sat),
+            method: PaymentMethod::BOLT11,
+        }));
+        mock_client._set_restore_response(Err(crate::Error::Timeout));
+
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+        let result = wallet
+            .resume_melt_saga(&db.get_saga(&saga_id).await.unwrap().unwrap())
+            .await;
+
+        assert!(result.is_err());
+        assert!(db.get_saga(&saga_id).await.unwrap().is_some());
+        assert!(db
+            .list_transactions(None, None, None)
+            .await
+            .unwrap()
+            .is_empty());
+
+        let stored_input = db.get_proofs_by_ys(vec![pending_input_y]).await.unwrap();
+        assert_eq!(stored_input.len(), 1);
+        assert_eq!(stored_input[0].state, State::Pending);
+
+        let quote = db.get_melt_quote(&quote_id).await.unwrap().unwrap();
+        assert_eq!(quote.state, MeltQuoteState::Unpaid);
+        assert!(quote.payment_proof.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_recover_melt_paid_finalizes_when_change_recovery_data_is_missing() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let saga_id = uuid::Uuid::new_v4();
+        let quote_id = format!("test_melt_quote_{}", uuid::Uuid::new_v4());
+
+        let mut pending_input = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Pending);
+        pending_input.used_by_operation = Some(saga_id);
+        let pending_input_y = pending_input.y;
+        db.update_proofs(vec![pending_input], vec![]).await.unwrap();
+
+        let saga = WalletSaga::new(
+            saga_id,
+            WalletSagaState::Melt(MeltSagaState::MeltRequested),
+            Amount::from(1000),
+            mint_url.clone(),
+            CurrencyUnit::Sat,
+            OperationData::Melt(MeltOperationData {
+                quote_id: quote_id.clone(),
+                amount: Amount::from(1000),
+                fee_reserve: Amount::from(10),
+                counter_start: None,
+                counter_end: None,
+                change_amount: Some(Amount::from(150)),
+                metadata: HashMap::new(),
+                final_proof_ys: None,
+                change_blinded_messages: None,
+            }),
+        );
+        db.add_saga(saga).await.unwrap();
+
+        let mut melt_quote = test_melt_quote();
+        melt_quote.id = quote_id.clone();
+        melt_quote.used_by_operation = Some(saga_id.to_string());
+        db.add_melt_quote(melt_quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.set_melt_quote_status_response(Ok(MeltQuoteBolt11Response {
+            quote: quote_id.clone(),
+            state: MeltQuoteState::Paid,
+            expiry: 9999999999,
+            fee_reserve: Amount::from(10),
+            amount: Amount::from(1000),
+            request: Some("lnbc1000...".to_string()),
+            payment_preimage: Some("preimage123".to_string()),
+            change: None,
+            unit: Some(CurrencyUnit::Sat),
+            method: PaymentMethod::BOLT11,
+        }));
+
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+        let result = wallet
+            .resume_melt_saga(&db.get_saga(&saga_id).await.unwrap().unwrap())
+            .await;
+
+        let finalized = result
+            .expect("missing recovery data should still finalize paid melt")
+            .expect("paid melt should finalize");
+        assert_eq!(finalized.state(), MeltQuoteState::Paid);
+        assert_eq!(finalized.fee_paid(), Amount::from(200));
+        assert!(finalized.change().is_none());
+        assert!(db.get_saga(&saga_id).await.unwrap().is_none());
+
+        let transactions = db.list_transactions(None, None, None).await.unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].fee, Amount::from(200));
+        assert_eq!(
+            transactions[0].payment_proof.as_deref(),
+            Some("preimage123")
+        );
+
+        let stored_input = db.get_proofs_by_ys(vec![pending_input_y]).await.unwrap();
+        assert_eq!(stored_input.len(), 1);
+        assert_eq!(stored_input[0].state, State::Spent);
+
+        let quote = db.get_melt_quote(&quote_id).await.unwrap().unwrap();
+        assert_eq!(quote.state, MeltQuoteState::Paid);
+        assert_eq!(quote.payment_proof.as_deref(), Some("preimage123"));
+        assert!(quote.used_by_operation.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_recover_incomplete_sagas_recovers_paid_melt_with_definitive_restore_failure() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let saga_id = uuid::Uuid::new_v4();
+        let quote_id = format!("test_melt_quote_{}", uuid::Uuid::new_v4());
+
+        let mut pending_input = test_proof_info(keyset_id, 1200, mint_url.clone(), State::Pending);
+        pending_input.used_by_operation = Some(saga_id);
+        let pending_input_y = pending_input.y;
+        db.update_proofs(vec![pending_input], vec![]).await.unwrap();
+
+        let premint_secrets =
+            PreMintSecrets::blank(keyset_id, Amount::from(150)).expect("blank premint secrets");
+        let blinded_messages = premint_secrets.blinded_messages();
+        let counter_end = blinded_messages.len() as u32;
+
+        let saga = WalletSaga::new(
+            saga_id,
+            WalletSagaState::Melt(MeltSagaState::MeltRequested),
+            Amount::from(1000),
+            mint_url.clone(),
+            CurrencyUnit::Sat,
+            OperationData::Melt(MeltOperationData {
+                quote_id: quote_id.clone(),
+                amount: Amount::from(1000),
+                fee_reserve: Amount::from(10),
+                counter_start: Some(0),
+                counter_end: Some(counter_end),
+                change_amount: Some(Amount::from(150)),
+                metadata: HashMap::new(),
+                final_proof_ys: None,
+                change_blinded_messages: Some(blinded_messages),
+            }),
+        );
+        db.add_saga(saga).await.unwrap();
+
+        let mut melt_quote = test_melt_quote();
+        melt_quote.id = quote_id.clone();
+        melt_quote.used_by_operation = Some(saga_id.to_string());
+        db.add_melt_quote(melt_quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.set_melt_quote_status_response(Ok(MeltQuoteBolt11Response {
+            quote: quote_id.clone(),
+            state: MeltQuoteState::Paid,
+            expiry: 9999999999,
+            fee_reserve: Amount::from(10),
+            amount: Amount::from(1000),
+            request: Some("lnbc1000...".to_string()),
+            payment_preimage: Some("preimage123".to_string()),
+            change: None,
+            unit: Some(CurrencyUnit::Sat),
+            method: PaymentMethod::BOLT11,
+        }));
+        mock_client._set_restore_response(Err(crate::Error::HttpError(
+            Some(404),
+            "Not Found".to_string(),
+        )));
+
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+        let report = wallet.recover_incomplete_sagas().await.unwrap();
+
+        assert_eq!(report.recovered, 1);
+        assert_eq!(report.compensated, 0);
+        assert_eq!(report.skipped, 0);
+        assert_eq!(report.failed, 0);
+        assert!(db.get_saga(&saga_id).await.unwrap().is_none());
+
+        let transactions = db.list_transactions(None, None, None).await.unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].fee, Amount::from(200));
+        assert_eq!(
+            transactions[0].payment_proof.as_deref(),
+            Some("preimage123")
+        );
+
+        let stored_input = db.get_proofs_by_ys(vec![pending_input_y]).await.unwrap();
+        assert_eq!(stored_input.len(), 1);
+        assert_eq!(stored_input[0].state, State::Spent);
+
+        let quote = db.get_melt_quote(&quote_id).await.unwrap().unwrap();
+        assert_eq!(quote.state, MeltQuoteState::Paid);
+        assert_eq!(quote.payment_proof.as_deref(), Some("preimage123"));
+        assert!(quote.used_by_operation.is_none());
+    }
+
+    #[tokio::test]
     async fn test_recover_melt_melt_requested_quote_unpaid() {
         // Mock: quote Unpaid → compensate
         let db = create_test_db().await;
@@ -1087,6 +1854,8 @@ mod tests {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
                 change_blinded_messages: None,
             }),
         );
@@ -1166,6 +1935,8 @@ mod tests {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
                 change_blinded_messages: None,
             }),
         );

--- a/crates/cdk/src/wallet/recovery.rs
+++ b/crates/cdk/src/wallet/recovery.rs
@@ -74,6 +74,17 @@ pub enum RecoveryAction {
     Skipped,
 }
 
+/// Detailed result of a restore attempt against the mint.
+#[derive(Debug, Clone)]
+pub(crate) enum OutputRecoveryResult {
+    /// The mint returned signatures and the wallet reconstructed proofs.
+    Restored(Vec<ProofInfo>),
+    /// The mint accepted the restore request but had no matching signatures.
+    EmptyResponse,
+    /// The restore attempt could not be made definitively.
+    Unavailable,
+}
+
 /// Shared recovery helpers for saga resume operations.
 ///
 /// These methods are used by individual saga resume modules to check
@@ -159,23 +170,19 @@ impl RecoveryHelpers for Wallet {
         counter_start: Option<u32>,
         counter_end: Option<u32>,
     ) -> Result<Option<Vec<ProofInfo>>, Error> {
-        // Clone blinded messages to avoid temporary lifetime issues
-        let blinded_messages_owned = blinded_messages.map(|bm| bm.to_vec());
-
-        // Extract and validate parameters
-        let params = match Self::extract_recovery_params(
-            saga_id,
-            saga_type,
-            blinded_messages_owned.as_ref(),
-            counter_start,
-            counter_end,
-        ) {
-            Some(p) => p,
-            None => return Ok(None),
-        };
-
-        self.recover_outputs_from_blinded_messages(saga_id, saga_type, params)
-            .await
+        match self
+            .restore_outputs_with_result(
+                saga_id,
+                saga_type,
+                blinded_messages,
+                counter_start,
+                counter_end,
+            )
+            .await?
+        {
+            OutputRecoveryResult::Restored(proofs) => Ok(Some(proofs)),
+            OutputRecoveryResult::EmptyResponse | OutputRecoveryResult::Unavailable => Ok(None),
+        }
     }
 
     /// Attempt to replay a swap request using stored data.
@@ -294,6 +301,32 @@ impl RecoveryHelpers for Wallet {
 }
 
 impl Wallet {
+    /// Restore outputs and preserve whether the mint returned an empty response.
+    pub(crate) async fn restore_outputs_with_result(
+        &self,
+        saga_id: &uuid::Uuid,
+        saga_type: &str,
+        blinded_messages: Option<&[BlindedMessage]>,
+        counter_start: Option<u32>,
+        counter_end: Option<u32>,
+    ) -> Result<OutputRecoveryResult, Error> {
+        let blinded_messages_owned = blinded_messages.map(|bm| bm.to_vec());
+
+        let params = match Self::extract_recovery_params(
+            saga_id,
+            saga_type,
+            blinded_messages_owned.as_ref(),
+            counter_start,
+            counter_end,
+        ) {
+            Some(p) => p,
+            None => return Ok(OutputRecoveryResult::Unavailable),
+        };
+
+        self.recover_outputs_from_blinded_messages(saga_id, saga_type, params)
+            .await
+    }
+
     /// Recover from incomplete operations after a crash. Call on startup.
     ///
     /// Handles interrupted swap, send, receive, and melt operations to prevent
@@ -387,9 +420,9 @@ impl Wallet {
     ///
     /// # Returns
     ///
-    /// - `Ok(Some(proofs))` - Successfully recovered proofs
-    /// - `Ok(None)` - Could not recover (mint unreachable, no signatures, etc.)
-    ///   Caller should fall back to cleanup.
+    /// - `Ok(OutputRecoveryResult::Restored(proofs))` - Successfully recovered proofs
+    /// - `Ok(OutputRecoveryResult::EmptyResponse)` - Mint had no matching signatures
+    /// - `Ok(OutputRecoveryResult::Unavailable)` - Could not make a definitive restore attempt
     /// - `Err(_)` - Unrecoverable error (e.g., cryptographic failure)
     #[instrument(skip(self, params))]
     async fn recover_outputs_from_blinded_messages(
@@ -397,7 +430,7 @@ impl Wallet {
         saga_id: &uuid::Uuid,
         saga_type: &str,
         params: OutputRecoveryParams<'_>,
-    ) -> Result<Option<Vec<ProofInfo>>, Error> {
+    ) -> Result<OutputRecoveryResult, Error> {
         tracing::info!(
             "{} saga {} - attempting to recover {} outputs using stored blinded messages",
             saga_type,
@@ -420,7 +453,7 @@ impl Wallet {
                         saga_id,
                         e
                     );
-                    return Ok(None);
+                    return Ok(OutputRecoveryResult::Unavailable);
                 } else {
                     tracing::warn!(
                         "{} saga {} - failed to restore from mint (ambiguous): {}. \
@@ -441,7 +474,7 @@ impl Wallet {
                 saga_type,
                 saga_id
             );
-            return Ok(None);
+            return Ok(OutputRecoveryResult::EmptyResponse);
         }
 
         // Get keyset ID from the first blinded message
@@ -522,7 +555,7 @@ impl Wallet {
             .map(|p| ProofInfo::new(p, self.mint_url.clone(), State::Unspent, self.unit.clone()))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Some(proof_infos))
+        Ok(OutputRecoveryResult::Restored(proof_infos))
     }
 
     /// Extract recovery parameters from operation data.
@@ -679,6 +712,7 @@ impl Wallet {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::str::FromStr;
     use std::sync::Arc;
 
@@ -686,7 +720,7 @@ mod tests {
     use cdk_common::nuts::{MeltQuoteBolt11Response, MeltQuoteState, PaymentMethod, State};
     use cdk_common::wallet::{
         IssueSagaState, MeltOperationData, MeltSagaState, MintOperationData, OperationData,
-        ReceiveOperationData, ReceiveSagaState, WalletSaga, WalletSagaState,
+        ReceiveOperationData, ReceiveSagaState, TransactionDirection, WalletSaga, WalletSagaState,
     };
     use cdk_common::Amount;
 
@@ -811,6 +845,8 @@ mod tests {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
                 change_blinded_messages: None,
             }),
         );
@@ -886,6 +922,8 @@ mod tests {
                     counter_start: None,
                     counter_end: None,
                     change_amount: None,
+                    metadata: HashMap::new(),
+                    final_proof_ys: None,
                     change_blinded_messages: None,
                 }),
             );
@@ -959,11 +997,11 @@ mod tests {
         let keyset_id = test_keyset_id();
         let saga_id = uuid::Uuid::new_v4();
 
-        // Create and reserve proofs
-        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone());
-        let proof_y = proof_info.y;
+        // Create pending proofs as they would be after a melt request is sent.
+        let mut proof_info = test_proof_info(keyset_id, 100, mint_url.clone());
+        proof_info.state = State::Pending;
+        proof_info.used_by_operation = Some(saga_id);
         db.update_proofs(vec![proof_info], vec![]).await.unwrap();
-        db.reserve_proofs(vec![proof_y], &saga_id).await.unwrap();
 
         // Create a melt quote
         let mut quote = test_melt_quote();
@@ -985,6 +1023,8 @@ mod tests {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
                 change_blinded_messages: None,
             }),
         );
@@ -1061,6 +1101,8 @@ mod tests {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
                 change_blinded_messages: None,
             }),
         );
@@ -1131,6 +1173,8 @@ mod tests {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: None,
                 change_blinded_messages: None,
             }),
         );
@@ -1182,17 +1226,20 @@ mod tests {
         let keyset_id = test_keyset_id();
         let saga_id = uuid::Uuid::new_v4();
 
-        // Create and reserve proofs
-        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone());
-        let proof_y = proof_info.y;
-        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
-        db.reserve_proofs(vec![proof_y], &saga_id).await.unwrap();
-
         // Create a melt quote
         let mut quote = test_melt_quote();
         quote.used_by_operation = Some(saga_id.to_string());
         let quote_id = quote.id.clone();
         db.add_melt_quote(quote).await.unwrap();
+
+        let mut metadata = HashMap::new();
+        metadata.insert("label".to_string(), "restored melt".to_string());
+
+        // Create pending proofs as they would be after a melt request is sent.
+        let mut proof_info = test_proof_info(keyset_id, 100, mint_url.clone());
+        proof_info.state = State::Pending;
+        proof_info.used_by_operation = Some(saga_id);
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
 
         // Create saga in MeltRequested state (no change blinded messages for simplicity)
         let saga = WalletSaga::new(
@@ -1208,6 +1255,8 @@ mod tests {
                 counter_start: None,
                 counter_end: None,
                 change_amount: None,
+                metadata: metadata.clone(),
+                final_proof_ys: None,
                 change_blinded_messages: None, // No change to recover
             }),
         );
@@ -1245,6 +1294,21 @@ mod tests {
 
         // Saga should be deleted
         assert!(db.get_saga(&saga_id).await.unwrap().is_none());
+
+        let transactions = db
+            .list_transactions(None, Some(TransactionDirection::Outgoing), None)
+            .await
+            .unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].metadata, metadata);
+        assert_eq!(transactions[0].saga_id, Some(saga_id));
+        assert_eq!(
+            transactions[0].payment_proof,
+            Some("preimage123".to_string())
+        );
+
+        let recovered_quote = db.get_melt_quote(&quote_id).await.unwrap().unwrap();
+        assert_eq!(recovered_quote.state, MeltQuoteState::Paid);
     }
 
     #[tokio::test]


### PR DESCRIPTION
When a pending melt is recovered as paid, persist the outgoing transaction, update the stored quote with the payment proof, and release the quote reservation before deleting the saga.

Also persist melt quote payment_proof in the SQL wallet store so restored quotes keep the preimage or on-chain outpoint.

- [x] depends on: https://github.com/cashubtc/cdk/pull/2172

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
