### PR TITLE
ADR for append-only change log in mint database

### DIFF
--- a/docs/adr/0001-append-only-change-log.md
+++ b/docs/adr/0001-append-only-change-log.md
@@ -19,33 +19,39 @@ The mint database uses mutable tables for current state. After an update the pre
 
 ## Considered Options
 
-* **Single generic `event_log` table** -- one shared table with `table_name`, `entity_id`, `change_type`, and a JSON `data` blob. Simple to set up, but the untyped JSON blob prevents column-level queries and schema validation, and mixing heterogeneous entities in one table makes indexing awkward.
+* **Single append-only delta table with a typed delta enum** -- one shared insert-only table keyed by a global record id (`table_name:pk`). Each change is stored as a `delta` value, a typed enum with one variant per writable field, serialized to JSON or a compact binary form. The variants are derived from the mutation method signatures: every parameter a method writes becomes a variant. The enum is forward compatible: a new writable field is a new variant, and existing rows never need rewriting. One migration and one insert path, at the cost of losing column-level SQL queries over the delta payload.
 
-* **Per-table log tables with typed columns** -- each tracked entity gets its own `_log` table containing only identity columns and the columns that actually change. More tables to maintain, but each one is small, focused, schema-validated, and directly queryable. Insert-only entities need no log table at all.
+* **Per-table log tables with typed columns** -- each tracked entity gets its own `_log` table containing only identity columns and the columns that actually change. Each table is small, focused, schema-validated, and directly queryable, but every new tracked field is a schema migration, and the write path fans out across several tables and helpers.
 
-* **Database triggers** -- automatic capture at the SQL level with no application code changes. Not viable because SQLite and PostgreSQL have incompatible trigger syntax, triggers cannot access the application-level `change_id` generation logic, and they are harder to test and debug.
+* **Single generic `event_log` table** -- one shared table with `table_name`, `entity_id`, `change_type`, and a JSON `data` blob. Simple to set up, but the untyped JSON blob prevents schema validation and forward-compatible typing of the payload.
+
+* **Database triggers** -- automatic capture at the SQL level with no application code changes. Not viable because SQLite and PostgreSQL have incompatible trigger syntax, triggers cannot access the application-level `id` generation logic, and they are harder to test and debug.
 
 ## Proposed Decision
 
-Per-table log tables with typed columns.
+Single append-only delta table with a typed delta enum.
 
-This approach is preferred over a single generic event log because each log table carries only the columns that actually change for that entity, making the schema self-documenting and queryable without JSON parsing. It is preferred over database triggers because the mint must support both SQLite and PostgreSQL, and triggers have incompatible syntax, cannot call application-level ID generation, and are harder to test.
+This approach is preferred over per-table log tables because it keeps the write path and schema small: one table, one insert helper, and one `Delta` enum. A new tracked field is a new enum variant, not a schema migration and a new `_log` table. Forward compatibility comes from the enum and its serialization rather than from `ALTER TABLE`.
 
-The scope is deliberately narrow: only 3 of the mint's 12+ tables need log tables. Most entities are insert-only (their source table is already an immutable record) or ephemeral (deleted after use, with no audit value). By limiting logging to the entities whose rows actually mutate after creation, the system avoids duplicating data that is already preserved elsewhere.
+It is preferred over the single generic `event_log` table because the `delta` is a typed, versioned enum rather than an untyped JSON blob, so the set of possible changes is defined in code and derived directly from the mutation method signatures.
+
+It is preferred over database triggers because the mint must support both SQLite and PostgreSQL, and triggers have incompatible syntax, cannot call application-level id generation, and are harder to test.
+
+The scope is deliberately narrow: only 3 of the mint's 12+ tables have rows that mutate after creation, so only their mutations are logged. Most entities are insert-only (their source table is already an immutable record) or ephemeral (deleted after use, with no audit value). By logging only the mutations that actually change or remove existing rows, the system avoids duplicating data that is already preserved elsewhere.
 
 ## Design
 
-### Which entities need log tables
+### Which mutations are logged
 
-Only entities whose rows are **updated or deleted** after creation need a log table. The rest are either immutable (source table is the complete record) or ephemeral (no audit value).
+Only entities whose rows are **updated or deleted** after creation contribute to the log. The rest are either immutable (source table is the complete record) or ephemeral (no audit value).
 
-| Entity | Mutable columns | Log table |
-|--------|----------------|-----------|
-| **melt_quote** | `state`, `request_lookup_id`, `payment_proof`, `paid_time` | `melt_quote_log` |
-| **proof** | `state` (+ deletions on compensation) | `proof_log` |
-| **keyset** | `active` | `keyset_log` |
+| Entity | Mutable columns | Logged |
+|--------|----------------|--------|
+| **melt_quote** | `state`, `request_lookup_id`, `payment_proof`, `paid_time` | yes |
+| **proof** | `state` (+ deletions on compensation) | yes |
+| **keyset** | `active` | yes |
 
-### Entities that do NOT need log tables
+Entities that are NOT logged:
 
 | Entity | Reason |
 |--------|--------|
@@ -55,115 +61,177 @@ Only entities whose rows are **updated or deleted** after creation need a log ta
 | **melt_request** | Ephemeral staging data, always deleted on operation completion. The melt quote state transition captures the meaningful event. |
 | **blinded_message** | Pending-signature placeholders. Cleaned up after signing. |
 | **saga_state** | Process-private crash recovery state. Always deleted after completion. |
-| **kv_store** | Generic key-value store. Too heterogeneous for a typed log. |
+| **kv_store** | Generic key-value store. Too heterogeneous for a typed delta. |
 | **protected_endpoint** | Configuration, not a financial event. |
 | **auth tables** | Same patterns as non-auth counterparts. Deferred to follow-up. |
 
-### Log table schemas
+### Schema
 
-#### `melt_quote_log`
-
-Triggered by `update_melt_quote_state` and `update_melt_quote_request_lookup_id`.
+A single insert-only table records every change as a serialized delta.
 
 ```sql
-CREATE TABLE melt_quote_log (
-    change_id           BIGINT PRIMARY KEY,
-    quote_id            TEXT NOT NULL,
-    state               TEXT,
-    request_lookup_id   TEXT,
-    payment_proof       TEXT,
-    paid_time           BIGINT
+CREATE TABLE change_log (
+    id          BIGINT PRIMARY KEY,   -- application-generated, time-sortable
+    record      TEXT NOT NULL,        -- global record id: "table_name:pk"
+    delta       BLOB NOT NULL,        -- serialized Delta enum (JSON or compact)
+    reason      TEXT,                 -- human-readable why the change happened
+    created_at  BIGINT NOT NULL       -- wall-clock millis at insert time
 );
-CREATE INDEX idx_melt_quote_log_quote ON melt_quote_log(quote_id, change_id);
+CREATE INDEX idx_change_log_record ON change_log(record, id);
 ```
 
-Lifecycle: Unpaid -> Pending (inputs locked) -> Paid (payment confirmed) or Failed (can retry). Each transition appends one row.
+* `id` is a time-sortable application-generated `i64` (see [id generation](#id-generation)). Ordering by `id` gives a global timeline.
+* `record` identifies the mutated row across all tables in a single string, `table_name:pk` (for example `melt_quote:0f3a...` or `proof:<Y hex>`). All changes to one row share the same `record`, so the index on `(record, id)` reconstructs that row's history in order.
+* `delta` is the serialized `Delta` enum described below.
+* `reason` is optional free text for the operator or the calling code to explain the change (for example `"melt payment confirmed"` or `"compensation rollback"`).
+* `created_at` is stored explicitly rather than folded into `id`, so replay and auditing do not have to decode the id to get a timestamp.
 
-#### `proof_log`
+### The `Delta` enum
 
-Triggered by `update_proofs_state` and `remove_proofs`.
+`Delta` is a forward-compatible enum with **one variant per writable field**. The variants are read straight off the mutation method signatures: every parameter a method writes to a row becomes one variant carrying only that field's new value. The `record` column already identifies which row changed, so the delta only has to say which field moved and to what.
 
-```sql
-CREATE TABLE proof_log (
-    change_id       BIGINT PRIMARY KEY,
-    change_type     SMALLINT NOT NULL,  -- 0 = Updated, 1 = Deleted
-    ys              TEXT NOT NULL,      -- JSON array of Y hex values
-    state           TEXT,               -- new state (Updated) or final state (Deleted)
-    count           INTEGER NOT NULL
-);
-CREATE INDEX idx_proof_log_change ON proof_log(change_id);
+Deriving the variants from the current signatures:
+
+| Method (from the trait) | Parameters written | Field variant |
+|-------------------------|--------------------|---------------|
+| `update_melt_quote_state(_, new_state: MeltQuoteState, payment_proof: Option<String>)` | `state`, `payment_proof` | `MeltQuoteState`, `MeltQuotePaymentProof` |
+| `update_melt_quote_request_lookup_id(_, new_request_lookup_id: &PaymentIdentifier)` | `request_lookup_id` | `MeltQuoteRequestLookupId` |
+| `update_proofs_state(_, new_state: State)` | `state` | `ProofState` |
+| `remove_proofs(ys, _)` | row deletion | `ProofRemoved` |
+| `set_active_keyset(unit, id)` | `active` | `KeysetActive` |
+
+```rust
+/// One field-level state change. Serialized into `change_log.delta`.
+///
+/// Each variant maps to exactly one writable field and carries only that
+/// field's new value. Variants come directly from the mutation method
+/// signatures: a method that writes N fields appends N rows, one per field.
+///
+/// Forward compatible: a new writable field is a new variant, added without
+/// migrating existing rows. Deserialization tolerates unknown variants so older
+/// binaries can read logs written by newer ones.
+#[non_exhaustive]
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "field", content = "value")]
+enum Delta {
+    /// melt_quote.state
+    MeltQuoteState(MeltQuoteState),
+    /// melt_quote.payment_proof
+    MeltQuotePaymentProof(Option<String>),
+    /// melt_quote.request_lookup_id
+    MeltQuoteRequestLookupId(PaymentIdentifier),
+    /// proof.state
+    ProofState(State),
+    /// proof row removed (tombstone; carries no value)
+    ProofRemoved,
+    /// keyset.active
+    KeysetActive(bool),
+}
 ```
 
-Lifecycle: Unspent -> Pending -> Spent. On compensation, pending proofs may be deleted. Each batch operation appends one row.
+The `#[serde(tag = "field", content = "value")]` tagging keeps the payload self-describing, so a change written today stays readable after the enum grows. `#[non_exhaustive]` signals that callers must handle future variants.
 
-#### `keyset_log`
+### Serialization format
 
-Triggered by `set_active_keyset`.
+The `delta` column is a `BLOB`, so the enum's wire format is an internal choice that can be picked for compactness without changing the schema. The format must preserve forward compatibility: an old reader must be able to decode, or at least skip, a variant written by a newer writer. Options, from most to least self-describing:
 
-```sql
-CREATE TABLE keyset_log (
-    change_id       BIGINT PRIMARY KEY,
-    keyset_id       TEXT NOT NULL,
-    active          BOOLEAN NOT NULL
-);
-CREATE INDEX idx_keyset_log_keyset ON keyset_log(keyset_id, change_id);
-```
+| Format | Size | Forward compatibility | Dependency | Notes |
+|--------|------|-----------------------|------------|-------|
+| **JSON** (`serde_json`) | largest | excellent (named tags, skips unknown keys) | already in tree | Human-readable, easiest to debug, verbose on the wire. |
+| **CBOR** (`ciborium`) | small | excellent (self-describing, tolerates unknown map keys and integer tags) | already in tree | Already used for Cashu token encoding. Binary JSON: same forward-compat model at a fraction of the size. |
+| **Protobuf** (`prost`) | small | excellent (field numbers, unknown fields preserved) | already in tree | Requires a `.proto` schema and codegen. Field-number discipline gives strong forward compatibility. |
+| **Postcard / bincode** | smallest | fragile | new crate | Non-self-describing. Enum variants are encoded by positional index, so reordering or removing a variant breaks old data; unknown variants cannot be skipped without a length prefix. |
+| **Hand-rolled tag byte + fields** | smallest | manual | none | One discriminant byte per variant, then the value. Fully controlled and dependency-free, but every variant's encode/decode and skip logic is written and tested by hand. |
 
-Lifecycle: Created (active=true) -> rotated (active=false). Each rotation produces two entries (old deactivated, new activated).
+Recommended: **CBOR via `ciborium`**. It is already a workspace dependency (it encodes Cashu tokens), it is roughly as forward compatible as JSON because it is self-describing, and it is several times more compact. Representing the enum as a single-key map (`{tag: value}`), or as `#[serde(tag = "field")]` where the tag is a small integer rather than a string, keeps each row down to a few bytes while still letting a reader skip a tag it does not recognize.
 
-### `change_id`
+Postcard and bincode are the most compact but are a poor fit here: their positional enum encoding is not forward compatible, which is the whole point of the `Delta` enum. Reach for the hand-rolled tag byte only if a dependency-free binary format becomes a hard requirement; it buys a little more compactness than CBOR at the cost of hand-written, per-variant skip logic.
 
-Application-generated `i64`:
+### id generation
+
+`id` is an application-generated Snowflake `i64`, implemented in-house with no external crate:
 
 ```
 Bit 63:      always 0 (positive signed i64)
-Bits 62..22: 41 bits of millisecond timestamp since custom epoch
-Bits 21..0:  22 bits of hash(changeset)
+Bits 62..22: 41 bits of millisecond timestamp since a custom epoch
+Bits 21..12: 10 bits of node id
+Bits 11..0:  12 bits of per-millisecond sequence
 ```
 
-The hash is derived from `(table_name, entity_id, change_type)`. Time-sortable by high bits, content-aware by low bits. No separate `changed_at` column needed.
+The generator holds the last timestamp and a sequence counter behind an atomic/mutex. On each call it reads the clock: if the millisecond is unchanged it increments the sequence, and if the sequence overflows 12 bits (4096 ids in one millisecond) it spins until the next millisecond. This yields monotonic, time-sortable ids that stay unique across concurrent writers and across mint instances (distinguished by the 10-bit node id, from config). The custom epoch maximizes the usable timestamp range.
+
+`created_at` is still stored as its own column so readers do not have to decode the id to get a timestamp.
 
 ### Implementation approach
 
-Each mutation method in `crates/cdk-sql-common/src/mint/*.rs` appends an `INSERT INTO <entity>_log` after the primary mutation, on the same database connection/transaction. If the transaction rolls back, the log entry rolls back too.
+Every mutation method appends one `INSERT INTO change_log` per field it writes, on the same database connection/transaction as the primary mutation. If the transaction rolls back, the log entries roll back too. All methods target the same table and build `Delta` values instead of writing typed columns.
 
-This is the same pattern already used for `keyset_amounts` updates piggy-backed onto proof/signature mutations.
+This is the same piggy-backing pattern already used for `keyset_amounts` updates on proof/signature mutations.
 
-#### Affected methods
+Because `record` is a single row id, a method that touches several rows appends one entry per row, and a method that writes several fields on one row appends one entry per field. The history of any one row is the entries sharing its `record`, ordered by `id`.
 
-| File | Method | Log table |
-|------|--------|-----------|
-| `quotes.rs` | `update_melt_quote_state` | `melt_quote_log` |
-| `quotes.rs` | `update_melt_quote_request_lookup_id` | `melt_quote_log` |
-| `proofs.rs` | `update_proofs_state` | `proof_log` |
-| `proofs.rs` | `remove_proofs` | `proof_log` |
-| `keys.rs` | `set_active_keyset` | `keyset_log` |
+| File | Method | Rows/fields written | Delta variant(s) appended |
+|------|--------|---------------------|---------------------------|
+| `quotes.rs` | `update_melt_quote_state` | one row, `state` + `payment_proof` | `MeltQuoteState`, and `MeltQuotePaymentProof` when `Some` |
+| `quotes.rs` | `update_melt_quote_request_lookup_id` | one row, `request_lookup_id` | `MeltQuoteRequestLookupId` |
+| `proofs.rs` | `update_proofs_state` | one row per `Y` | `ProofState` per affected `Y` |
+| `proofs.rs` | `remove_proofs` | one row per `Y` | `ProofRemoved` per removed `Y` |
+| `keys.rs` | `set_active_keyset` | activated keyset, plus the previously active one | `KeysetActive(true)`, `KeysetActive(false)` |
 
-#### New files
+### Using the log as an event stream (poor man's Kafka)
+
+Because the table is append-only and every row carries a monotonic, time-sortable `id`, `change_log` doubles as a durable, ordered event stream. Any process that wants to react to state changes (replication to a read replica, cache invalidation, analytics, feeding an external system, cross-instance synchronization) can consume it like a single-partition Kafka topic, without adding a message broker.
+
+The consumption pattern is a cursor over `id`:
+
+```sql
+SELECT id, record, delta, reason, created_at
+FROM change_log
+WHERE id > :last_seen_id
+ORDER BY id
+LIMIT :batch;
+```
+
+Each consumer stores its own `last_seen_id` cursor and advances it after processing a batch. Because `id` is monotonic and the table is insert-only, this gives:
+
+* **Total order.** `ORDER BY id` is a stable global sequence; the 10-bit node id in the Snowflake keeps ids unique across mint instances even under concurrent writes.
+* **At-least-once delivery.** A consumer that crashes before persisting its cursor simply re-reads from the last committed `id`. Consumers must be idempotent (keying off `id` or `(record, id)` makes this trivial).
+* **Independent consumers.** Cursors are per-consumer state, so many readers can consume at their own pace, similar to Kafka consumer groups reading one partition.
+* **Replay.** Resetting a cursor to `0` (or any `id`) replays history from that point, which is the same mechanism used for reconciliation and debugging.
+
+Two caveats to note for a real deployment:
+
+* **Visibility ordering under concurrency.** Ids are assigned before commit, so a transaction with a lower `id` can commit after one with a higher `id`. A naive `id > cursor` poll could then skip a row that committed late. Consumers that need strict completeness should either read only up to a watermark that lags the newest `id` by a safety margin, or track gaps explicitly. This is the same read-committed race that log-based CDC systems handle with a low-watermark.
+* **Retention.** Stream consumers and the audit-trail retention policy interact: history cannot be pruned past the slowest consumer's cursor without losing events for it.
+
+### New files
 
 | File | Purpose |
 |------|---------|
-| `crates/cdk-common/src/database/event_log.rs` | `ChangeType` enum, `generate_change_id()` |
-| `crates/cdk-sql-common/src/mint/event_log.rs` | Per-table `append_*_log()` SQL helpers |
-| `migrations/sqlite/20260629000000_create_log_tables.sql` | 3 log tables |
-| `migrations/postgres/20260629000000_create_log_tables.sql` | 3 log tables |
+| `crates/cdk-common/src/database/event_log.rs` | `Delta` enum, `generate_id()`, `record` helpers |
+| `crates/cdk-sql-common/src/mint/event_log.rs` | Single `append_delta()` SQL helper |
+| `migrations/sqlite/20260629000000_create_change_log.sql` | `change_log` table |
+| `migrations/postgres/20260629000000_create_change_log.sql` | `change_log` table |
 
 ### Invariants
 
 1. Existing tables remain the source of current state
-2. Log tables are append-only. No updates, no deletes
+2. The `change_log` table is append-only. No updates, no deletes
 3. Every logged state change is appended in the same transaction as the mutation
-4. Events are ordered by `change_id` (primarily by embedded timestamp)
-5. The database enforces uniqueness via `change_id` primary key
+4. Events are ordered by `id` (primarily by embedded timestamp)
+5. The database enforces uniqueness via the `id` primary key
 
 ### Positive Consequences
 
 * Full audit trail of every financially meaningful state transition
-* Enables replay, reconciliation, and debugging without changing operational model
-* Typed columns allow schema-validated, indexable queries
-* Minimal scope: only 3 tables, 5 methods
+* Enables replay, reconciliation, and debugging without changing the operational model
+* Single table and single insert path keep the change surface small
+* A new tracked field is a new enum variant, with no schema migration
+* Doubles as an ordered, durable event stream for replication, cache invalidation, and cross-instance sync, consumed by a cursor over `id` with no separate message broker
 
 ### Negative Consequences
 
-* Small write amplification (one extra INSERT per state change)
-* Log tables grow without bound and will eventually need a retention or archival policy
+* Small write amplification (one extra INSERT per written field)
+* The table grows without bound and will eventually need a retention or archival policy
+* The `delta` payload is opaque to SQL: column-level filtering (for example, by state or amount) requires deserializing rows in the application, or backend-specific JSON functions whose support differs between SQLite and PostgreSQL
+* No database-level schema validation of the payload; validity of a `delta` lives entirely in the enum and its serialization

--- a/docs/adr/0001-append-only-change-log.md
+++ b/docs/adr/0001-append-only-change-log.md
@@ -1,237 +1,454 @@
-# Append-only change log for the mint database
+# Append-only journal for the mint database
 
 * Status: proposed
 * Authors: [@crodas](https://github.com/crodas)
-* Date: 2026-06-29
-* Targeted modules: `cdk-common`, `cdk-sql-common`
-* Associated tickets/PRs: none yet
+* Date: 2026-06-29 (revised 2026-07-04)
+* Targeted modules: `cdk-common`, `cdk-sql-common`, `cdk`, `cdk-signatory`
+* Associated tickets/PRs: reference implementation on branch
+  [`prototype/append-only`](https://github.com/cashubtc/cdk/tree/prototype/append-only)
+
+> This document is a proposal. A working reference implementation exists on the
+> `prototype/append-only` branch and is described throughout so the design can
+> be evaluated against real code, but nothing here is committed to `main`. The
+> record keys, entity coverage, and serialization choices are all open to
+> change during review.
 
 ## Context and Problem Statement
 
-The mint database uses mutable tables for current state. After an update the previous value is gone; after a delete the row disappears. This makes auditing, debugging, replay, and reconciliation difficult. How can we preserve the history of state changes without replacing the existing storage model?
+The mint database uses mutable tables for current state. After an update the
+previous value is gone; after a delete the row disappears. This makes auditing,
+debugging, replay, and reconciliation difficult. How can we preserve the
+history of state changes, and reconstruct current state from that history,
+without replacing the existing storage model?
 
 ## Decision Drivers
 
-* Auditability: every financially meaningful state transition must be recoverable
-* Minimal disruption: the existing read and write paths must not change
-* Atomicity: log entries must live in the same transaction as the mutation they describe
+* Auditability: every financially meaningful state transition must be
+  recoverable
+* Replayability: current state must be reconstructable from the log alone,
+  starting from an empty database
+* Minimal disruption: the existing read and write paths must keep working
+* Atomicity: log entries must live in the same transaction as the mutation they
+  describe
 * Portability: must work across both SQLite and PostgreSQL backends
 
 ## Considered Options
 
-* **Single append-only delta table with a typed delta enum** -- one shared insert-only table keyed by a global record id (`table_name:pk`). Each change is stored as a `delta` value, a typed enum with one variant per writable field, serialized to JSON or a compact binary form. The variants are derived from the mutation method signatures: every parameter a method writes becomes a variant. The enum is forward compatible: a new writable field is a new variant, and existing rows never need rewriting. One migration and one insert path, at the cost of losing column-level SQL queries over the delta payload.
+* **Single append-only journal of snapshots and deltas** -- one shared
+  insert-only table keyed by a compound `(entity, record)`: a small `entity`
+  discriminant naming the source table plus the row's primary key. Each row
+  stores a serialized `Event`, which is either a `Snapshot` (the full base
+  object, written when an entity is created) or a `Delta` (one field-level
+  change, written when an entity is mutated). Replaying a row's events in
+  `id` order, snapshot first then deltas, reconstructs its current state, so
+  the journal is self-contained and does not depend on the source tables to be
+  replayable. One migration and one append path, at the cost of losing
+  column-level SQL queries over the event payload.
 
-* **Per-table log tables with typed columns** -- each tracked entity gets its own `_log` table containing only identity columns and the columns that actually change. Each table is small, focused, schema-validated, and directly queryable, but every new tracked field is a schema migration, and the write path fans out across several tables and helpers.
+* **Delta-only change log** -- the same single table, but storing only
+  field-level deltas and relying on the existing source tables for the base
+  object. Smaller rows, but the log is not replayable on its own: reconstructing
+  state needs both the log and a consistent snapshot of the source tables at
+  some point in time. This was the design in the first draft of this ADR; the
+  reference implementation moved to snapshots plus deltas so the journal alone
+  is sufficient.
 
-* **Single generic `event_log` table** -- one shared table with `table_name`, `entity_id`, `change_type`, and a JSON `data` blob. Simple to set up, but the untyped JSON blob prevents schema validation and forward-compatible typing of the payload.
+* **Per-table log tables with typed columns** -- each tracked entity gets its
+  own `_log` table containing only identity columns and the columns that
+  change. Each table is small, focused, schema-validated, and directly
+  queryable, but every new tracked field is a schema migration, and the write
+  path fans out across several tables and helpers.
 
-* **Database triggers** -- automatic capture at the SQL level with no application code changes. Not viable because SQLite and PostgreSQL have incompatible trigger syntax, triggers cannot access the application-level `id` generation logic, and they are harder to test and debug.
+* **Single generic `event_log` table** -- one shared table with `table_name`,
+  `entity_id`, `change_type`, and a JSON `data` blob. Simple to set up, but the
+  untyped JSON blob prevents typing the payload in code.
+
+* **Database triggers** -- automatic capture at the SQL level with no
+  application code changes. Not viable because SQLite and PostgreSQL have
+  incompatible trigger syntax, triggers cannot access the application-level `id`
+  generation logic, and they are harder to test and debug.
 
 ## Proposed Decision
 
-Single append-only delta table with a typed delta enum.
+Single append-only journal of snapshots and deltas, with the mint layer
+deciding which events to emit and the SQL layer providing only the durable
+append.
 
-This approach is preferred over per-table log tables because it keeps the write path and schema small: one table, one insert helper, and one `Delta` enum. A new tracked field is a new enum variant, not a schema migration and a new `_log` table. Forward compatibility comes from the enum and its serialization rather than from `ALTER TABLE`.
+This is preferred over the delta-only change log because storing a creation
+snapshot makes the journal replayable from an empty database. A consumer loads
+each entity's snapshot and applies its deltas in `id` order to rebuild current
+state, with no dependency on the mutable source tables.
 
-It is preferred over the single generic `event_log` table because the `delta` is a typed, versioned enum rather than an untyped JSON blob, so the set of possible changes is defined in code and derived directly from the mutation method signatures.
+It is preferred over per-table log tables because it keeps the write path and
+schema small: one table, one append primitive, and one `Event` enum. A new
+tracked field is a new enum variant, not a schema migration and a new `_log`
+table.
 
-It is preferred over database triggers because the mint must support both SQLite and PostgreSQL, and triggers have incompatible syntax, cannot call application-level id generation, and are harder to test.
+It is preferred over the single generic `event_log` table because the `Event`
+is a typed enum rather than an untyped blob, so the set of possible changes is
+defined in code and derived directly from the domain types and mutation method
+signatures.
 
-The scope is deliberately narrow: only 3 of the mint's 12+ tables have rows that mutate after creation, so only their mutations are logged. Most entities are insert-only (their source table is already an immutable record) or ephemeral (deleted after use, with no audit value). By logging only the mutations that actually change or remove existing rows, the system avoids duplicating data that is already preserved elsewhere.
+It is preferred over database triggers because the mint must support both
+SQLite and PostgreSQL, and triggers have incompatible syntax, cannot call
+application-level id generation, and are harder to test.
 
 ## Design
 
-### Which mutations are logged
+### Snapshots and deltas
 
-Only entities whose rows are **updated or deleted** after creation contribute to the log. The rest are either immutable (source table is the complete record) or ephemeral (no audit value).
+An `Event` is either a `Snapshot` or a `Delta`.
 
-| Entity | Mutable columns | Logged |
-|--------|----------------|--------|
-| **melt_quote** | `state`, `request_lookup_id`, `payment_proof`, `paid_time` | yes |
-| **proof** | `state` (+ deletions on compensation) | yes |
-| **keyset** | `active` | yes |
+* A **snapshot** is the full base object, captured once when an entity is
+  created (a new melt quote, a new proof, an issued blind signature, a new
+  keyset).
+* A **delta** is one writable field's new value, captured when an existing
+  entity is mutated. The `(entity, record)` key already says which row changed,
+  so a delta only carries which field moved and to what.
 
-Entities that are NOT logged:
+Replaying a row means loading its snapshot and applying its deltas in `id`
+order. Because every entity that later mutates also has a creation snapshot,
+the journal reconstructs current state on its own.
+
+### Which entities are journaled
+
+| Entity | Snapshot at creation | Deltas on mutation |
+|--------|----------------------|--------------------|
+| **mint_quote** | `MintQuote` | `MintQuotePayment`, `MintQuoteIssuance` |
+| **melt_quote** | `MeltQuote` | `MeltQuoteState`, `MeltQuotePaymentProof`, `MeltQuoteRequestLookupId` |
+| **proof** | `Proof` (initial state `Unspent`) | `ProofState`, `ProofRemoved` (tombstone) |
+| **blind_signature** | `BlindSignature` | none (immutable once created) |
+| **keyset** | `MintKeySetInfo` | `KeysetActive(bool)` |
+
+The delta-only draft logged only the three entities that mutate after creation
+(melt_quote, proof, keyset) and treated the source tables as the base object.
+The reference implementation adds creation snapshots for those, plus mint_quote
+and blind_signature, so the issuance side is replayable too. `blind_signature`
+has a snapshot but no deltas: it is immutable, so its creation event is the
+whole story.
+
+Still not journaled, because they are ephemeral or process-private:
 
 | Entity | Reason |
 |--------|--------|
-| **mint_quote** | Already append-only. `update_mint_quote` writes to `mint_quote_payments` and `mint_quote_issued` detail tables. The `amount_paid`/`amount_issued` on the quote row are materialized sums. |
-| **blind_signature** | Insert-only, never updated or deleted. |
-| **completed_operation** | Insert-only, never updated or deleted. |
-| **melt_request** | Ephemeral staging data, always deleted on operation completion. The melt quote state transition captures the meaningful event. |
-| **blinded_message** | Pending-signature placeholders. Cleaned up after signing. |
-| **saga_state** | Process-private crash recovery state. Always deleted after completion. |
-| **kv_store** | Generic key-value store. Too heterogeneous for a typed delta. |
+| **melt_request** | Ephemeral staging data, deleted on completion. The melt quote transitions capture the meaningful event. |
+| **blinded_message** | Pending-signature placeholders, cleaned up after signing. |
+| **saga_state** | Process-private crash recovery state, deleted after completion. |
+| **kv_store** | Generic key-value store. Too heterogeneous for a typed event. |
 | **protected_endpoint** | Configuration, not a financial event. |
-| **auth tables** | Same patterns as non-auth counterparts. Deferred to follow-up. |
+| **auth tables** | Same patterns as their non-auth counterparts. Deferred to a follow-up. |
 
 ### Schema
 
-A single insert-only table records every change as a serialized delta.
+A single insert-only table records every event. The row it refers to is
+identified by a compound `(entity, record)` key: `entity` is a small integer
+discriminant naming the source table, and `record` is the primary key within
+that table.
 
 ```sql
-CREATE TABLE change_log (
-    id          BIGINT PRIMARY KEY,   -- application-generated, time-sortable
-    record      TEXT NOT NULL,        -- global record id: "table_name:pk"
-    delta       BLOB NOT NULL,        -- serialized Delta enum (JSON or compact)
-    reason      TEXT,                 -- human-readable why the change happened
-    created_at  BIGINT NOT NULL       -- wall-clock millis at insert time
+-- Append-only journal of entity creations (snapshots) and mutations (deltas).
+-- Replaying a row's events in id order reconstructs its current state.
+CREATE TABLE IF NOT EXISTS journal (
+    id          INTEGER PRIMARY KEY,   -- Snowflake i64, time-sortable
+    entity      INTEGER NOT NULL,      -- Entity enum discriminant (source table)
+    record      TEXT    NOT NULL,      -- primary key within that entity
+    event       BLOB    NOT NULL,      -- serialized Event (Snapshot | Delta)
+    created_at  INTEGER NOT NULL       -- unix seconds at insert time
 );
-CREATE INDEX idx_change_log_record ON change_log(record, id);
+
+CREATE INDEX IF NOT EXISTS idx_journal_entity_record ON journal(entity, record, id);
 ```
 
-* `id` is a time-sortable application-generated `i64` (see [id generation](#id-generation)). Ordering by `id` gives a global timeline.
-* `record` identifies the mutated row across all tables in a single string, `table_name:pk` (for example `melt_quote:0f3a...` or `proof:<Y hex>`). All changes to one row share the same `record`, so the index on `(record, id)` reconstructs that row's history in order.
-* `delta` is the serialized `Delta` enum described below.
-* `reason` is optional free text for the operator or the calling code to explain the change (for example `"melt payment confirmed"` or `"compensation rollback"`).
-* `created_at` is stored explicitly rather than folded into `id`, so replay and auditing do not have to decode the id to get a timestamp.
+The PostgreSQL migration is the same shape with `BIGINT` for `id`/`created_at`,
+`SMALLINT` for `entity`, and `BYTEA` for `event`.
 
-### The `Delta` enum
+* `id` is a time-sortable application-generated `i64` (see
+  [id generation](#id-generation)). Ordering by `id` gives a global timeline.
+* `(entity, record)` identifies the mutated row. `entity` is the `Entity` enum
+  discriminant (a small int, so the source-table name is not repeated as text
+  on every row), and `record` is that row's primary key. All events for one row
+  share the same `(entity, record)`, so the index on `(entity, record, id)`
+  reconstructs that row's history in order, and querying one entity type
+  (`WHERE entity = :e`) is an indexed range scan.
+* `event` is the serialized `Event` (a snapshot or a delta).
+* `created_at` is unix seconds at insert time, stored as its own column so
+  replay and auditing do not have to decode the `id` to get a timestamp.
 
-`Delta` is a forward-compatible enum with **one variant per writable field**. The variants are read straight off the mutation method signatures: every parameter a method writes to a row becomes one variant carrying only that field's new value. The `record` column already identifies which row changed, so the delta only has to say which field moved and to what.
+This is a refinement over the reference implementation, which stores a single
+`record TEXT` holding a concatenated `"table_name:pk"` string (for example
+`melt_quote:0f3a...`). Splitting it into a typed `entity` discriminant plus the
+bare primary key avoids repeating the table name as text on every row, makes
+"all events for entity X" a clean indexed predicate, and removes the ambiguity
+of parsing a string whose primary key may itself contain the delimiter.
 
-Deriving the variants from the current signatures:
+The first draft also had a `reason` free-text column; the reference
+implementation dropped it to keep the append primitive minimal. It can be added
+back if operators need per-event annotations.
 
-| Method (from the trait) | Parameters written | Field variant |
-|-------------------------|--------------------|---------------|
-| `update_melt_quote_state(_, new_state: MeltQuoteState, payment_proof: Option<String>)` | `state`, `payment_proof` | `MeltQuoteState`, `MeltQuotePaymentProof` |
-| `update_melt_quote_request_lookup_id(_, new_request_lookup_id: &PaymentIdentifier)` | `request_lookup_id` | `MeltQuoteRequestLookupId` |
-| `update_proofs_state(_, new_state: State)` | `state` | `ProofState` |
-| `remove_proofs(ys, _)` | row deletion | `ProofRemoved` |
-| `set_active_keyset(unit, id)` | `active` | `KeysetActive` |
+### The `Entity` enum
+
+`entity` is stored as the discriminant of a small `#[repr(u8)]` enum, one
+variant per journaled source table. The stored value is a stable integer, so
+variants must keep their discriminants for old rows to stay readable.
 
 ```rust
-/// One field-level state change. Serialized into `change_log.delta`.
-///
-/// Each variant maps to exactly one writable field and carries only that
-/// field's new value. Variants come directly from the mutation method
-/// signatures: a method that writes N fields appends N rows, one per field.
-///
-/// Forward compatible: a new writable field is a new variant, added without
-/// migrating existing rows. Deserialization tolerates unknown variants so older
-/// binaries can read logs written by newer ones.
+/// The source table a journal row refers to. Stored as its `u8` discriminant
+/// in `journal.entity`; the row's primary key goes in `journal.record`.
 #[non_exhaustive]
-#[derive(Serialize, Deserialize)]
-#[serde(tag = "field", content = "value")]
-enum Delta {
-    /// melt_quote.state
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Entity {
+    MintQuote = 1,
+    MeltQuote = 2,
+    Proof = 3,
+    BlindSignature = 4,
+    Keyset = 5,
+}
+```
+
+Every `Event` variant belongs to exactly one `Entity`, so the enum can be
+derived from the event (`event.entity()`) rather than passed separately. Storing
+it as its own indexed column is still worthwhile: it lets a consumer filter or
+range-scan by entity type without deserializing the `event` blob.
+
+### The `Event`, `Snapshot`, and `Delta` types
+
+`Event` wraps either a `Snapshot` or a `Delta`. All three are
+`#[non_exhaustive]` so callers must handle future variants, and a new writable
+field or tracked entity is a new variant added without migrating existing rows.
+
+```rust
+/// A single journal event: either a full-object snapshot or a field delta.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Event {
+    /// Full base object, written when an entity is created. Boxed because a
+    /// snapshot is far larger than a delta.
+    Snapshot(Box<Snapshot>),
+    /// One field-level change, written when an entity is mutated.
+    Delta(Delta),
+}
+
+/// Full base object captured at creation time.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Snapshot {
+    MeltQuote(MeltQuote),
+    MintQuote(MintQuote),
+    Proof(Proof),
+    BlindSignature(BlindSignature),
+    Keyset(MintKeySetInfo),
+}
+
+/// One writable field's new value. The journal's `(entity, record)` key
+/// identifies which row changed; each variant carries only that field's new value.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Delta {
     MeltQuoteState(MeltQuoteState),
-    /// melt_quote.payment_proof
     MeltQuotePaymentProof(Option<String>),
-    /// melt_quote.request_lookup_id
     MeltQuoteRequestLookupId(PaymentIdentifier),
-    /// proof.state
+    /// A payment received for a mint quote (increments `amount_paid`).
+    MintQuotePayment(IncomingPayment),
+    /// An issuance recorded against a mint quote (increments `amount_issued`).
+    MintQuoteIssuance(Amount),
     ProofState(State),
-    /// proof row removed (tombstone; carries no value)
+    /// A proof row was removed (tombstone, carries no value).
     ProofRemoved,
-    /// keyset.active
     KeysetActive(bool),
 }
 ```
 
-The `#[serde(tag = "field", content = "value")]` tagging keeps the payload self-describing, so a change written today stays readable after the enum grows. `#[non_exhaustive]` signals that callers must handle future variants.
+`From` conversions on `Event` let call sites write `value.into()` instead of
+spelling out `Event::Delta(Delta::Variant(value))` or the snapshot boxing. For
+example `new_state.into()` produces a `ProofState` delta and `quote.into()`
+produces a `MeltQuote` snapshot.
 
 ### Serialization format
 
-The `delta` column is a `BLOB`, so the enum's wire format is an internal choice that can be picked for compactness without changing the schema. The format must preserve forward compatibility: an old reader must be able to decode, or at least skip, a variant written by a newer writer. Options, from most to least self-describing:
+`Event` is serialized to the `event` column with **JSON** (`serde_json`), the
+same encoding the mint already uses to persist these domain types (quote
+requests, options, keyset amounts).
 
-| Format | Size | Forward compatibility | Dependency | Notes |
-|--------|------|-----------------------|------------|-------|
-| **JSON** (`serde_json`) | largest | excellent (named tags, skips unknown keys) | already in tree | Human-readable, easiest to debug, verbose on the wire. |
-| **CBOR** (`ciborium`) | small | excellent (self-describing, tolerates unknown map keys and integer tags) | already in tree | Already used for Cashu token encoding. Binary JSON: same forward-compat model at a fraction of the size. |
-| **Protobuf** (`prost`) | small | excellent (field numbers, unknown fields preserved) | already in tree | Requires a `.proto` schema and codegen. Field-number discipline gives strong forward compatibility. |
-| **Postcard / bincode** | smallest | fragile | new crate | Non-self-describing. Enum variants are encoded by positional index, so reordering or removing a variant breaks old data; unknown variants cannot be skipped without a length prefix. |
-| **Hand-rolled tag byte + fields** | smallest | manual | none | One discriminant byte per variant, then the value. Fully controlled and dependency-free, but every variant's encode/decode and skip logic is written and tested by hand. |
+The first draft recommended CBOR via `ciborium` for compactness. The reference
+implementation found that several cashu types serialize differently under a
+non-human-readable serializer and do not round-trip through CBOR, so JSON is
+used instead. JSON is verbose on the wire but human-readable, easy to debug,
+and forward compatible: named tags let an old reader skip unknown fields. The
+`event` column stays a `BLOB`/`BYTEA`, so the wire format remains an internal
+choice that can be revisited without a schema change if the round-trip issues
+are resolved.
 
-Recommended: **CBOR via `ciborium`**. It is already a workspace dependency (it encodes Cashu tokens), it is roughly as forward compatible as JSON because it is self-describing, and it is several times more compact. Representing the enum as a single-key map (`{tag: value}`), or as `#[serde(tag = "field")]` where the tag is a small integer rather than a string, keeps each row down to a few bytes while still letting a reader skip a tag it does not recognize.
+To support snapshots, a few domain types (`MintQuote`, `IncomingPayment`,
+`Issuance`) gained serde derives; they were previously persisted by column
+mapping only. This reuses the existing `amount_currency_serde` helper plus a
+new `amount_currency_serde_opt` module for the optional amount field.
 
-Postcard and bincode are the most compact but are a poor fit here: their positional enum encoding is not forward compatible, which is the whole point of the `Delta` enum. Reach for the hand-rolled tag byte only if a dependency-free binary format becomes a hard requirement; it buys a little more compactness than CBOR at the cost of hand-written, per-variant skip logic.
+### Orchestration: mint decides, SQL appends
+
+Journaling is a method on the mint write-transaction trait:
+
+```rust
+/// Append-only journal writer.
+#[async_trait]
+pub trait JournalTransaction {
+    type Err: Into<Error> + From<Error>;
+
+    /// Appends one Event for the row identified by `(entity, record)` within
+    /// the current transaction. `record` is that row's primary key; `entity`
+    /// can be derived from the event, so an implementation may take just
+    /// `(record, event)` and call `event.entity()`.
+    async fn add_journal(
+        &mut self,
+        entity: Entity,
+        record: String,
+        event: Event,
+    ) -> Result<(), Self::Err>;
+}
+```
+
+`JournalTransaction` is a supertrait shared by both the main write transaction
+and the keyset transaction. The SQL layer implements only the append: one
+`INSERT INTO journal` on the transaction's own connection, so it commits or
+rolls back with the mutation it records.
+
+The mint layer (and the signatory, for keyset rotation) decides which events to
+emit and wires them into each flow: quote creation, payments, issuance, melt
+state transitions, proof state changes, proof removal on compensation and
+rollback, blind-signature issuance across issue/melt/swap, and keyset rotation.
+This is a deliberate move away from the first draft, which piggy-backed the
+inserts inside the database-layer mutation methods. Keeping "what to log" in the
+mint and "how to append" in the SQL layer means the log reflects
+business-meaningful events rather than raw column writes, and the append
+primitive stays backend-agnostic.
+
+Representative call sites from the reference implementation:
+
+| Flow | Event appended | `(entity, record)` |
+|------|----------------|--------------------|
+| mint quote created | `MintQuote` snapshot | `(MintQuote, id)` |
+| mint quote paid | `MintQuotePayment` delta | `(MintQuote, id)` |
+| mint quote issued | `MintQuoteIssuance` delta | `(MintQuote, id)` |
+| melt quote created | `MeltQuote` snapshot | `(MeltQuote, id)` |
+| melt quote paid | `MeltQuoteState` + `MeltQuotePaymentProof` deltas | `(MeltQuote, id)` |
+| proof state change | `ProofState` delta per `Y` | `(Proof, y_hex)` |
+| proof removed (compensation/rollback) | `ProofRemoved` tombstone per `Y` | `(Proof, y_hex)` |
+| blind signature issued | `BlindSignature` snapshot | `(BlindSignature, blinded_secret_hex)` |
+| keyset rotation | `Keyset` snapshot, `KeysetActive(true)`, `KeysetActive(false)` on the previous | `(Keyset, id)` |
 
 ### id generation
 
-`id` is an application-generated Snowflake `i64`, implemented in-house with no external crate:
+`id` is an application-generated Snowflake `i64`, implemented in-house with no
+external crate:
 
 ```
 Bit 63:      always 0 (positive signed i64)
-Bits 62..22: 41 bits of millisecond timestamp since a custom epoch
+Bits 62..22: 41 bits of millisecond timestamp since a custom epoch (2024-01-01)
 Bits 21..12: 10 bits of node id
 Bits 11..0:  12 bits of per-millisecond sequence
 ```
 
-The generator holds the last timestamp and a sequence counter behind an atomic/mutex. On each call it reads the clock: if the millisecond is unchanged it increments the sequence, and if the sequence overflows 12 bits (4096 ids in one millisecond) it spins until the next millisecond. This yields monotonic, time-sortable ids that stay unique across concurrent writers and across mint instances (distinguished by the 10-bit node id, from config). The custom epoch maximizes the usable timestamp range.
+The generator is lock-free. A single `AtomicU64` packs the last-used
+`(timestamp_ms << SEQ_BITS) | sequence`, and a compare-and-swap loop advances
+it: if the clock moved forward the sequence resets to zero, if it is the same
+millisecond the sequence increments, and if the sequence overflows 12 bits
+(4096 ids in one millisecond) it borrows the next millisecond. This yields
+monotonic, time-sortable ids that stay unique across concurrent writers and
+across mint instances, distinguished by the 10-bit node id set once at startup.
+A clock reading before the unix epoch is clamped to zero rather than panicking.
+The custom epoch maximizes the usable timestamp range.
 
-`created_at` is still stored as its own column so readers do not have to decode the id to get a timestamp.
+### New and changed files (reference implementation)
 
-### Implementation approach
+| File | Purpose |
+|------|---------|
+| `crates/cdk-common/src/database/event_log.rs` | `Entity`, `Event`/`Snapshot`/`Delta`, `From` conversions, Snowflake `generate_id()`/`init_event_id_generator()` |
+| `crates/cdk-common/src/database/mint/mod.rs` | `JournalTransaction` supertrait |
+| `crates/cdk-sql-common/src/mint/event_log.rs` | `add_journal()` append primitive |
+| `crates/cdk-sql-common/src/mint/migrations/{sqlite,postgres}/20260702000000_create_journal.sql` | `journal` table |
+| `crates/cdk-common/src/mint.rs`, `.../amount_currency_serde_opt.rs` | serde derives for snapshotted types |
+| `crates/cdk/src/mint/{issue,melt,swap,ln,proofs}...` | mint-layer emission sites |
+| `crates/cdk-signatory/src/db_signatory.rs` | keyset-rotation emission |
 
-Every mutation method appends one `INSERT INTO change_log` per field it writes, on the same database connection/transaction as the primary mutation. If the transaction rolls back, the log entries roll back too. All methods target the same table and build `Delta` values instead of writing typed columns.
+The reference implementation currently uses the single `record TEXT` string;
+the `(entity, record)` compound key and the `Entity` enum described above are a
+proposed refinement to that schema and the `add_journal` signature.
 
-This is the same piggy-backing pattern already used for `keyset_amounts` updates on proof/signature mutations.
+### Invariants
 
-Because `record` is a single row id, a method that touches several rows appends one entry per row, and a method that writes several fields on one row appends one entry per field. The history of any one row is the entries sharing its `record`, ordered by `id`.
+1. Existing tables remain the source of current state for the read path
+2. The `journal` table is append-only. No updates, no deletes
+3. Every journaled event is appended in the same transaction as the mutation
+4. Every entity that can mutate has a creation snapshot, so replaying the
+   journal from empty reconstructs current state
+5. Events are ordered by `id` (primarily by embedded timestamp)
+6. The database enforces uniqueness via the `id` primary key
 
-| File | Method | Rows/fields written | Delta variant(s) appended |
-|------|--------|---------------------|---------------------------|
-| `quotes.rs` | `update_melt_quote_state` | one row, `state` + `payment_proof` | `MeltQuoteState`, and `MeltQuotePaymentProof` when `Some` |
-| `quotes.rs` | `update_melt_quote_request_lookup_id` | one row, `request_lookup_id` | `MeltQuoteRequestLookupId` |
-| `proofs.rs` | `update_proofs_state` | one row per `Y` | `ProofState` per affected `Y` |
-| `proofs.rs` | `remove_proofs` | one row per `Y` | `ProofRemoved` per removed `Y` |
-| `keys.rs` | `set_active_keyset` | activated keyset, plus the previously active one | `KeysetActive(true)`, `KeysetActive(false)` |
+### Using the journal as an event stream (poor man's Kafka)
 
-### Using the log as an event stream (poor man's Kafka)
-
-Because the table is append-only and every row carries a monotonic, time-sortable `id`, `change_log` doubles as a durable, ordered event stream. Any process that wants to react to state changes (replication to a read replica, cache invalidation, analytics, feeding an external system, cross-instance synchronization) can consume it like a single-partition Kafka topic, without adding a message broker.
+Because the table is append-only and every row carries a monotonic,
+time-sortable `id`, `journal` doubles as a durable, ordered event stream. Any
+process that wants to react to state changes (replication to a read replica,
+cache invalidation, analytics, cross-instance synchronization) can consume it
+like a single-partition Kafka topic, without a message broker.
 
 The consumption pattern is a cursor over `id`:
 
 ```sql
-SELECT id, record, delta, reason, created_at
-FROM change_log
+SELECT id, entity, record, event, created_at
+FROM journal
 WHERE id > :last_seen_id
 ORDER BY id
 LIMIT :batch;
 ```
 
-Each consumer stores its own `last_seen_id` cursor and advances it after processing a batch. Because `id` is monotonic and the table is insert-only, this gives:
+Each consumer stores its own `last_seen_id` cursor and advances it after a
+batch. This gives total order, at-least-once delivery (a consumer that crashes
+before persisting its cursor re-reads from the last committed `id`; consumers
+must be idempotent), independent per-consumer cursors, and replay by resetting a
+cursor.
 
-* **Total order.** `ORDER BY id` is a stable global sequence; the 10-bit node id in the Snowflake keeps ids unique across mint instances even under concurrent writes.
-* **At-least-once delivery.** A consumer that crashes before persisting its cursor simply re-reads from the last committed `id`. Consumers must be idempotent (keying off `id` or `(record, id)` makes this trivial).
-* **Independent consumers.** Cursors are per-consumer state, so many readers can consume at their own pace, similar to Kafka consumer groups reading one partition.
-* **Replay.** Resetting a cursor to `0` (or any `id`) replays history from that point, which is the same mechanism used for reconciliation and debugging.
+Two caveats for a real deployment:
 
-Two caveats to note for a real deployment:
+* **Visibility ordering under concurrency.** Ids are assigned before commit, so
+  a transaction with a lower `id` can commit after one with a higher `id`. A
+  naive `id > cursor` poll could skip a row that committed late. Consumers that
+  need strict completeness should read up to a watermark that lags the newest
+  `id` by a safety margin, or track gaps explicitly. This is the same
+  read-committed race that log-based CDC systems handle with a low-watermark.
+* **Retention.** History cannot be pruned past the slowest consumer's cursor
+  without losing events for it.
 
-* **Visibility ordering under concurrency.** Ids are assigned before commit, so a transaction with a lower `id` can commit after one with a higher `id`. A naive `id > cursor` poll could then skip a row that committed late. Consumers that need strict completeness should either read only up to a watermark that lags the newest `id` by a safety margin, or track gaps explicitly. This is the same read-committed race that log-based CDC systems handle with a low-watermark.
-* **Retention.** Stream consumers and the audit-trail retention policy interact: history cannot be pruned past the slowest consumer's cursor without losing events for it.
+### Testing
 
-### New files
-
-| File | Purpose |
-|------|---------|
-| `crates/cdk-common/src/database/event_log.rs` | `Delta` enum, `generate_id()`, `record` helpers |
-| `crates/cdk-sql-common/src/mint/event_log.rs` | Single `append_delta()` SQL helper |
-| `migrations/sqlite/20260629000000_create_change_log.sql` | `change_log` table |
-| `migrations/postgres/20260629000000_create_change_log.sql` | `change_log` table |
-
-### Invariants
-
-1. Existing tables remain the source of current state
-2. The `change_log` table is append-only. No updates, no deletes
-3. Every logged state change is appended in the same transaction as the mutation
-4. Events are ordered by `id` (primarily by embedded timestamp)
-5. The database enforces uniqueness via the `id` primary key
+The reference implementation is covered end to end by tests that drive a real
+swap and a real melt and assert that the emitted journal rows replay to the
+expected state (`crates/cdk/src/mint/{melt,swap}/tests/journal_tests.rs`, plus
+an issuance test in `issue/mod.rs`). A `read_journal` test helper loads the
+`journal` rows from a SQLite file and decodes them back into `Event`s.
 
 ### Positive Consequences
 
 * Full audit trail of every financially meaningful state transition
-* Enables replay, reconciliation, and debugging without changing the operational model
-* Single table and single insert path keep the change surface small
-* A new tracked field is a new enum variant, with no schema migration
-* Doubles as an ordered, durable event stream for replication, cache invalidation, and cross-instance sync, consumed by a cursor over `id` with no separate message broker
+* The journal is self-contained: current state replays from an empty database,
+  which enables reconciliation and debugging without the source tables
+* Single table and single append primitive keep the change surface small
+* A new tracked field or entity is a new enum variant, with no schema migration
+* Mint-orchestrated emission means the log records business events, not raw
+  column writes, and the append primitive stays backend-agnostic
+* Doubles as an ordered, durable event stream consumed by a cursor over `id`,
+  with no separate message broker
 
 ### Negative Consequences
 
-* Small write amplification (one extra INSERT per written field)
-* The table grows without bound and will eventually need a retention or archival policy
-* The `delta` payload is opaque to SQL: column-level filtering (for example, by state or amount) requires deserializing rows in the application, or backend-specific JSON functions whose support differs between SQLite and PostgreSQL
-* No database-level schema validation of the payload; validity of a `delta` lives entirely in the enum and its serialization
+* Write amplification: a snapshot at creation plus one insert per mutated field,
+  and snapshots are larger than deltas
+* The table grows without bound and will eventually need a retention or archival
+  policy, which interacts with stream consumers' cursors
+* The `event` payload is opaque to SQL: column-level filtering requires
+  deserializing rows in the application, or backend-specific JSON functions
+  whose support differs between SQLite and PostgreSQL
+* JSON is verbose; a more compact binary format is blocked until the affected
+  cashu types round-trip through a non-human-readable serializer
+* No database-level schema validation of the payload; validity of an `Event`
+  lives entirely in the enum and its serialization

--- a/docs/adr/0001-append-only-change-log.md
+++ b/docs/adr/0001-append-only-change-log.md
@@ -1,0 +1,169 @@
+# Append-only change log for the mint database
+
+* Status: proposed
+* Authors: [@crodas](https://github.com/crodas)
+* Date: 2026-06-29
+* Targeted modules: `cdk-common`, `cdk-sql-common`
+* Associated tickets/PRs: none yet
+
+## Context and Problem Statement
+
+The mint database uses mutable tables for current state. After an update the previous value is gone; after a delete the row disappears. This makes auditing, debugging, replay, and reconciliation difficult. How can we preserve the history of state changes without replacing the existing storage model?
+
+## Decision Drivers
+
+* Auditability: every financially meaningful state transition must be recoverable
+* Minimal disruption: the existing read and write paths must not change
+* Atomicity: log entries must live in the same transaction as the mutation they describe
+* Portability: must work across both SQLite and PostgreSQL backends
+
+## Considered Options
+
+* **Single generic `event_log` table** -- one shared table with `table_name`, `entity_id`, `change_type`, and a JSON `data` blob. Simple to set up, but the untyped JSON blob prevents column-level queries and schema validation, and mixing heterogeneous entities in one table makes indexing awkward.
+
+* **Per-table log tables with typed columns** -- each tracked entity gets its own `_log` table containing only identity columns and the columns that actually change. More tables to maintain, but each one is small, focused, schema-validated, and directly queryable. Insert-only entities need no log table at all.
+
+* **Database triggers** -- automatic capture at the SQL level with no application code changes. Not viable because SQLite and PostgreSQL have incompatible trigger syntax, triggers cannot access the application-level `change_id` generation logic, and they are harder to test and debug.
+
+## Proposed Decision
+
+Per-table log tables with typed columns.
+
+This approach is preferred over a single generic event log because each log table carries only the columns that actually change for that entity, making the schema self-documenting and queryable without JSON parsing. It is preferred over database triggers because the mint must support both SQLite and PostgreSQL, and triggers have incompatible syntax, cannot call application-level ID generation, and are harder to test.
+
+The scope is deliberately narrow: only 3 of the mint's 12+ tables need log tables. Most entities are insert-only (their source table is already an immutable record) or ephemeral (deleted after use, with no audit value). By limiting logging to the entities whose rows actually mutate after creation, the system avoids duplicating data that is already preserved elsewhere.
+
+## Design
+
+### Which entities need log tables
+
+Only entities whose rows are **updated or deleted** after creation need a log table. The rest are either immutable (source table is the complete record) or ephemeral (no audit value).
+
+| Entity | Mutable columns | Log table |
+|--------|----------------|-----------|
+| **melt_quote** | `state`, `request_lookup_id`, `payment_proof`, `paid_time` | `melt_quote_log` |
+| **proof** | `state` (+ deletions on compensation) | `proof_log` |
+| **keyset** | `active` | `keyset_log` |
+
+### Entities that do NOT need log tables
+
+| Entity | Reason |
+|--------|--------|
+| **mint_quote** | Already append-only. `update_mint_quote` writes to `mint_quote_payments` and `mint_quote_issued` detail tables. The `amount_paid`/`amount_issued` on the quote row are materialized sums. |
+| **blind_signature** | Insert-only, never updated or deleted. |
+| **completed_operation** | Insert-only, never updated or deleted. |
+| **melt_request** | Ephemeral staging data, always deleted on operation completion. The melt quote state transition captures the meaningful event. |
+| **blinded_message** | Pending-signature placeholders. Cleaned up after signing. |
+| **saga_state** | Process-private crash recovery state. Always deleted after completion. |
+| **kv_store** | Generic key-value store. Too heterogeneous for a typed log. |
+| **protected_endpoint** | Configuration, not a financial event. |
+| **auth tables** | Same patterns as non-auth counterparts. Deferred to follow-up. |
+
+### Log table schemas
+
+#### `melt_quote_log`
+
+Triggered by `update_melt_quote_state` and `update_melt_quote_request_lookup_id`.
+
+```sql
+CREATE TABLE melt_quote_log (
+    change_id           BIGINT PRIMARY KEY,
+    quote_id            TEXT NOT NULL,
+    state               TEXT,
+    request_lookup_id   TEXT,
+    payment_proof       TEXT,
+    paid_time           BIGINT
+);
+CREATE INDEX idx_melt_quote_log_quote ON melt_quote_log(quote_id, change_id);
+```
+
+Lifecycle: Unpaid -> Pending (inputs locked) -> Paid (payment confirmed) or Failed (can retry). Each transition appends one row.
+
+#### `proof_log`
+
+Triggered by `update_proofs_state` and `remove_proofs`.
+
+```sql
+CREATE TABLE proof_log (
+    change_id       BIGINT PRIMARY KEY,
+    change_type     SMALLINT NOT NULL,  -- 0 = Updated, 1 = Deleted
+    ys              TEXT NOT NULL,      -- JSON array of Y hex values
+    state           TEXT,               -- new state (Updated) or final state (Deleted)
+    count           INTEGER NOT NULL
+);
+CREATE INDEX idx_proof_log_change ON proof_log(change_id);
+```
+
+Lifecycle: Unspent -> Pending -> Spent. On compensation, pending proofs may be deleted. Each batch operation appends one row.
+
+#### `keyset_log`
+
+Triggered by `set_active_keyset`.
+
+```sql
+CREATE TABLE keyset_log (
+    change_id       BIGINT PRIMARY KEY,
+    keyset_id       TEXT NOT NULL,
+    active          BOOLEAN NOT NULL
+);
+CREATE INDEX idx_keyset_log_keyset ON keyset_log(keyset_id, change_id);
+```
+
+Lifecycle: Created (active=true) -> rotated (active=false). Each rotation produces two entries (old deactivated, new activated).
+
+### `change_id`
+
+Application-generated `i64`:
+
+```
+Bit 63:      always 0 (positive signed i64)
+Bits 62..22: 41 bits of millisecond timestamp since custom epoch
+Bits 21..0:  22 bits of hash(changeset)
+```
+
+The hash is derived from `(table_name, entity_id, change_type)`. Time-sortable by high bits, content-aware by low bits. No separate `changed_at` column needed.
+
+### Implementation approach
+
+Each mutation method in `crates/cdk-sql-common/src/mint/*.rs` appends an `INSERT INTO <entity>_log` after the primary mutation, on the same database connection/transaction. If the transaction rolls back, the log entry rolls back too.
+
+This is the same pattern already used for `keyset_amounts` updates piggy-backed onto proof/signature mutations.
+
+#### Affected methods
+
+| File | Method | Log table |
+|------|--------|-----------|
+| `quotes.rs` | `update_melt_quote_state` | `melt_quote_log` |
+| `quotes.rs` | `update_melt_quote_request_lookup_id` | `melt_quote_log` |
+| `proofs.rs` | `update_proofs_state` | `proof_log` |
+| `proofs.rs` | `remove_proofs` | `proof_log` |
+| `keys.rs` | `set_active_keyset` | `keyset_log` |
+
+#### New files
+
+| File | Purpose |
+|------|---------|
+| `crates/cdk-common/src/database/event_log.rs` | `ChangeType` enum, `generate_change_id()` |
+| `crates/cdk-sql-common/src/mint/event_log.rs` | Per-table `append_*_log()` SQL helpers |
+| `migrations/sqlite/20260629000000_create_log_tables.sql` | 3 log tables |
+| `migrations/postgres/20260629000000_create_log_tables.sql` | 3 log tables |
+
+### Invariants
+
+1. Existing tables remain the source of current state
+2. Log tables are append-only. No updates, no deletes
+3. Every logged state change is appended in the same transaction as the mutation
+4. Events are ordered by `change_id` (primarily by embedded timestamp)
+5. The database enforces uniqueness via `change_id` primary key
+
+### Positive Consequences
+
+* Full audit trail of every financially meaningful state transition
+* Enables replay, reconciliation, and debugging without changing operational model
+* Typed columns allow schema-validated, indexable queries
+* Minimal scope: only 3 tables, 5 methods
+
+### Negative Consequences
+
+* Small write amplification (one extra INSERT per state change)
+* Log tables grow without bound and will eventually need a retention or archival policy

--- a/docs/adr/0001-append-only-change-log.md
+++ b/docs/adr/0001-append-only-change-log.md
@@ -174,12 +174,15 @@ The PostgreSQL migration is the same shape with `BIGINT` for `id`/`created_at`,
 * `created_at` is unix seconds at insert time, stored as its own column so
   replay and auditing do not have to decode the `id` to get a timestamp.
 
-This is a refinement over the reference implementation, which stores a single
-`record TEXT` holding a concatenated `"table_name:pk"` string (for example
-`melt_quote:0f3a...`). Splitting it into a typed `entity` discriminant plus the
-bare primary key avoids repeating the table name as text on every row, makes
-"all events for entity X" a clean indexed predicate, and removes the ambiguity
-of parsing a string whose primary key may itself contain the delimiter.
+The compound key is a typed `entity` discriminant plus the bare primary key,
+rather than a single `record TEXT` holding a concatenated `"table_name:pk"`
+string (for example `melt_quote:0f3a...`). The split avoids repeating the table
+name as text on every row, makes "all events for entity X" a clean indexed
+predicate, and removes the ambiguity of parsing a string whose primary key may
+itself contain the delimiter. The reference implementation uses this compound
+key: the migration has the `entity` column and callers pass the bare primary
+key. (One stale doc comment on `add_journal` still describes `record` as a
+`"table_name:pk"` string; the actual value passed is the bare primary key.)
 
 The first draft also had a `reason` free-text column; the reference
 implementation dropped it to keep the append primitive minimal. It can be added
@@ -196,7 +199,7 @@ variants must keep their discriminants for old rows to stay readable.
 /// in `journal.entity`; the row's primary key goes in `journal.record`.
 #[non_exhaustive]
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Entity {
     MintQuote = 1,
     MeltQuote = 2,
@@ -295,15 +298,10 @@ pub trait JournalTransaction {
     type Err: Into<Error> + From<Error>;
 
     /// Appends one Event for the row identified by `(entity, record)` within
-    /// the current transaction. `record` is that row's primary key; `entity`
-    /// can be derived from the event, so an implementation may take just
-    /// `(record, event)` and call `event.entity()`.
-    async fn add_journal(
-        &mut self,
-        entity: Entity,
-        record: String,
-        event: Event,
-    ) -> Result<(), Self::Err>;
+    /// the current transaction. `record` is that row's bare primary key;
+    /// `entity` is derived from the event (`event.entity()`), so it is not
+    /// passed separately and is always consistent with the payload.
+    async fn add_journal(&mut self, record: String, event: Event) -> Result<(), Self::Err>;
 }
 ```
 
@@ -312,13 +310,21 @@ and the keyset transaction. The SQL layer implements only the append: one
 `INSERT INTO journal` on the transaction's own connection, so it commits or
 rolls back with the mutation it records.
 
-The mint layer (and the signatory, for keyset rotation) decides which events to
-emit and wires them into each flow: quote creation, payments, issuance, melt
-state transitions, proof state changes, proof removal on compensation and
-rollback, blind-signature issuance across issue/melt/swap, and keyset rotation.
-This is a deliberate move away from the first draft, which piggy-backed the
-inserts inside the database-layer mutation methods. Keeping "what to log" in the
-mint and "how to append" in the SQL layer means the log reflects
+Emission is driven by a `JournaledDatabase` decorator that wraps the mint
+database (`cdk-common/src/database/journaled.rs`). Each entity-mutation method
+on the wrapped transaction (`add_mint_quote`, `update_melt_quote_state`,
+`add_proofs`, `update_proofs_state`, `remove_proofs`, `add_blind_signatures`,
+`set_active_keyset`, and the rest) emits the relevant snapshot or delta on the
+inner transaction as part of the same mutation. Direct `add_journal` calls on
+the decorator are rejected with `Error::JournalNotPermitted`, so journaling is
+only ever driven from inside a known mutation rather than by ad hoc callers. The
+decorator is installed once around the database: `cdk/src/mint/mod.rs` for the
+mint and `cdk-signatory/src/db_signatory.rs` for keyset rotation.
+
+This centralizes "what to log" in one place, a deliberate move away from the
+first draft, which piggy-backed the inserts inside the database-layer mutation
+methods and would have scattered emission across each flow. Keeping emission in
+the decorator and "how to append" in the SQL layer means the log reflects
 business-meaningful events rather than raw column writes, and the append
 primitive stays backend-agnostic.
 
@@ -364,15 +370,12 @@ The custom epoch maximizes the usable timestamp range.
 |------|---------|
 | `crates/cdk-common/src/database/event_log.rs` | `Entity`, `Event`/`Snapshot`/`Delta`, `From` conversions, Snowflake `generate_id()`/`init_event_id_generator()` |
 | `crates/cdk-common/src/database/mint/mod.rs` | `JournalTransaction` supertrait |
+| `crates/cdk-common/src/database/journaled.rs` | `JournaledDatabase` decorator that drives emission and rejects direct `add_journal` |
 | `crates/cdk-sql-common/src/mint/event_log.rs` | `add_journal()` append primitive |
 | `crates/cdk-sql-common/src/mint/migrations/{sqlite,postgres}/20260702000000_create_journal.sql` | `journal` table |
 | `crates/cdk-common/src/mint.rs`, `.../amount_currency_serde_opt.rs` | serde derives for snapshotted types |
-| `crates/cdk/src/mint/{issue,melt,swap,ln,proofs}...` | mint-layer emission sites |
-| `crates/cdk-signatory/src/db_signatory.rs` | keyset-rotation emission |
-
-The reference implementation currently uses the single `record TEXT` string;
-the `(entity, record)` compound key and the `Entity` enum described above are a
-proposed refinement to that schema and the `add_journal` signature.
+| `crates/cdk/src/mint/mod.rs` | installs `JournaledDatabase` around the mint store |
+| `crates/cdk-signatory/src/db_signatory.rs` | installs `JournaledDatabase` for keyset rotation |
 
 ### Invariants
 
@@ -386,11 +389,12 @@ proposed refinement to that schema and the `add_journal` signature.
 
 ### Using the journal as an event stream (poor man's Kafka)
 
-Because the table is append-only and every row carries a monotonic,
-time-sortable `id`, `journal` doubles as a durable, ordered event stream. Any
-process that wants to react to state changes (replication to a read replica,
-cache invalidation, analytics, cross-instance synchronization) can consume it
-like a single-partition Kafka topic, without a message broker.
+This is a design sketch: the reference implementation is write-only today and
+ships no consumer. Because the table is append-only and every row carries a
+monotonic, time-sortable `id`, `journal` doubles as a durable, ordered event
+stream. Any process that wants to react to state changes (replication to a read
+replica, cache invalidation, analytics, cross-instance synchronization) could
+consume it like a single-partition Kafka topic, without a message broker.
 
 The consumption pattern is a cursor over `id`:
 
@@ -422,10 +426,17 @@ Two caveats for a real deployment:
 ### Testing
 
 The reference implementation is covered end to end by tests that drive a real
-swap and a real melt and assert that the emitted journal rows replay to the
-expected state (`crates/cdk/src/mint/{melt,swap}/tests/journal_tests.rs`, plus
-an issuance test in `issue/mod.rs`). A `read_journal` test helper loads the
-`journal` rows from a SQLite file and decodes them back into `Event`s.
+swap, a real melt, and a keyset rotation and assert that the emitted journal
+rows replay to the expected state
+(`crates/cdk/src/mint/{melt,swap}/tests/journal_tests.rs`,
+`crates/cdk/src/mint/keyset_journal_tests.rs`, plus an issuance test in
+`issue/mod.rs`). Unit tests in `event_log.rs` cover delta round-tripping,
+entity discriminant stability, event-to-entity mapping, and id
+monotonicity/uniqueness (`delta_round_trip`, `entity_discriminant_round_trips`,
+`events_map_to_expected_entity`, `ids_are_monotonic_and_unique`,
+`ids_are_unique_across_threads`). Replay itself is exercised only by test
+helpers that load the `journal` rows and decode them back into `Event`s; there
+is no production read/replay path in the reference yet.
 
 ### Positive Consequences
 

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,56 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | … | superseded by ADR-1234]
+* Authors: [list everyone who authored the decision]
+* Date: [YYYY-MM-DD when the decision was last updated]
+* Targeted modules: [which crate or module does this change target]
+* Associated tickets/PRs: [PR/issue links]
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options <!-- numbers of options can vary -->
+
+#### [Option 1]
+
+[example | description | pointer to more information | …]
+
+**Pros:**
+
+* Good, because [argument …]
+
+**Cons:**
+
+* Bad, because [argument …]
+
+#### [Option 2]
+...
+
+#### [Option 3]
+...
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->


### PR DESCRIPTION

### Description

Proposal solution for append-only storage: here is the rendered. Feedback and inline comments are more than welcome

[Here is the rendered document](https://github.com/crodas/cdk/blob/proposal/append-only/docs/adr/0001-append-only-change-log.md)

Once this proposal is approved and merged I will open a PR.


-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
