### PR TITLE
feat(ffi): add waitable async melt confirmations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,6 +513,8 @@ jobs:
         continue-on-error: true
       - name: Run FFI tests
         run: nix build -L .#checks.x86_64-linux.ffi-tests
+      - name: Run live Python FFI tests
+        run: nix develop -i -L .#ffi --command just ffi-test-live-python
 
   coverage:
     name: "Code Coverage"

--- a/crates/cdk-ffi/README.md
+++ b/crates/cdk-ffi/README.md
@@ -39,6 +39,7 @@ just ffi-dev-python    # Generates bindings and opens Python REPL with cdk_ffi l
 
 # Test bindings
 just ffi-test-python   # Test Python bindings import
+just ffi-test-live-python # Run live Python test against testnut.cashudevkit.org
 ```
 
 ## Quick Start
@@ -51,6 +52,13 @@ just ffi-dev-python
 >>> dir(cdk_ffi)  # Explore available functions
 >>> help(cdk_ffi.generate_mnemonic)  # Get help
 ```
+
+## Live Tests
+
+The live Python test in `tests/test_live_async_onchain_melt.py` covers
+`PreparedMelt.confirm_prefer_async()`, immediate and pending melt outcomes,
+`PendingMelt.wait()`, and `Wallet.finalize_pending_melts()` against
+`https://testnut.cashudevkit.org`.
 
 ## Language Packages
 

--- a/crates/cdk-ffi/src/types/wallet.rs
+++ b/crates/cdk-ffi/src/types/wallet.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::Arc;
 
 use cdk_common::bitcoin;
 use serde::{Deserialize, Serialize};
@@ -627,6 +628,81 @@ impl From<cdk_common::common::FinalizedMelt> for FinalizedMelt {
     }
 }
 
+/// A pending async melt accepted by the mint.
+///
+/// FFI callers receive this handle when the mint accepts a melt for background
+/// processing. Call [`PendingMelt::wait`] from a background task/coroutine to
+/// poll existing wallet recovery until the melt settles.
+///
+/// Mobile apps should also call [`crate::Wallet::recover_incomplete_sagas`] or
+/// [`crate::Wallet::finalize_pending_melts`] on startup/resume, because
+/// operating systems may suspend or cancel long-running background waits.
+#[derive(uniffi::Object)]
+pub struct PendingMelt {
+    wallet: Arc<cdk::Wallet>,
+    quote_id: String,
+    operation_id: uuid::Uuid,
+    payment_method: cdk_common::PaymentMethod,
+}
+
+impl std::fmt::Debug for PendingMelt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PendingMelt")
+            .field("operation_id", &self.operation_id)
+            .field("quote_id", &self.quote_id)
+            .finish()
+    }
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl PendingMelt {
+    /// Quote ID for this pending melt.
+    pub fn quote_id(&self) -> String {
+        self.quote_id.clone()
+    }
+
+    /// Operation ID for this pending melt saga.
+    pub fn operation_id(&self) -> String {
+        self.operation_id.to_string()
+    }
+
+    /// Wait for this pending melt to complete.
+    ///
+    /// This method polls the wallet's existing melt recovery path until the
+    /// pending saga finalizes or fails.
+    ///
+    /// This can wait for an extended period. Swift/Kotlin callers should run it
+    /// in a cancellable background task or coroutine, not directly in UI
+    /// control flow. If the app is suspended or killed before this returns,
+    /// call `Wallet::recover_incomplete_sagas()` or
+    /// `Wallet::finalize_pending_melts()` after restart/resume.
+    pub async fn wait(&self) -> Result<FinalizedMelt, FfiError> {
+        let finalized = self
+            .wallet
+            .wait_pending_melt(
+                self.operation_id,
+                &self.quote_id,
+                self.payment_method.clone(),
+            )
+            .await?;
+
+        Ok(finalized.into())
+    }
+}
+
+/// Result of async-preferred melt confirmation.
+///
+/// `Paid` means the melt finalized during confirmation. `Pending` means the
+/// mint accepted the melt for asynchronous processing; call
+/// [`PendingMelt::wait`] to complete the normal app flow.
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum MeltConfirmOutcome {
+    /// Melt finalized during confirmation.
+    Paid { finalized: FinalizedMelt },
+    /// Mint accepted async melt processing and the payment is still pending.
+    Pending { pending: Arc<PendingMelt> },
+}
+
 /// FFI-compatible PreparedMelt
 ///
 /// This wraps the data from a prepared melt operation along with a reference
@@ -634,7 +710,7 @@ impl From<cdk_common::common::FinalizedMelt> for FinalizedMelt {
 /// that doesn't work with FFI, so we store the wallet and cached data separately.
 #[derive(uniffi::Object)]
 pub struct PreparedMelt {
-    wallet: std::sync::Arc<cdk::Wallet>,
+    wallet: Arc<cdk::Wallet>,
     operation_id: uuid::Uuid,
     quote: cdk_common::wallet::MeltQuote,
     proofs: cdk::nuts::Proofs,
@@ -657,10 +733,7 @@ impl std::fmt::Debug for PreparedMelt {
 
 impl PreparedMelt {
     /// Create a new FFI PreparedMelt from a cdk::wallet::PreparedMelt and wallet
-    pub fn new(
-        wallet: std::sync::Arc<cdk::Wallet>,
-        prepared: &cdk::wallet::PreparedMelt<'_>,
-    ) -> Self {
+    pub fn new(wallet: Arc<cdk::Wallet>, prepared: &cdk::wallet::PreparedMelt<'_>) -> Self {
         Self {
             wallet,
             operation_id: prepared.operation_id(),
@@ -671,6 +744,39 @@ impl PreparedMelt {
             input_fee: prepared.input_fee().into(),
             input_fee_without_swap: prepared.input_fee_without_swap().into(),
             metadata: prepared.metadata().clone(),
+        }
+    }
+
+    async fn confirm_prefer_async_with_options(
+        &self,
+        options: MeltConfirmOptions,
+    ) -> Result<MeltConfirmOutcome, FfiError> {
+        let outcome = self
+            .wallet
+            .confirm_prepared_melt_prefer_async_with_options(
+                self.operation_id,
+                self.quote.clone(),
+                self.proofs.clone(),
+                self.proofs_to_swap.clone(),
+                self.input_fee.into(),
+                self.input_fee_without_swap.into(),
+                self.metadata.clone(),
+                options.into(),
+            )
+            .await?;
+
+        match outcome {
+            cdk::wallet::MeltOutcome::Paid(finalized) => Ok(MeltConfirmOutcome::Paid {
+                finalized: finalized.into(),
+            }),
+            cdk::wallet::MeltOutcome::Pending(_) => Ok(MeltConfirmOutcome::Pending {
+                pending: Arc::new(PendingMelt {
+                    wallet: Arc::clone(&self.wallet),
+                    quote_id: self.quote.id.clone(),
+                    operation_id: self.operation_id,
+                    payment_method: self.quote.payment_method.clone(),
+                }),
+            }),
         }
     }
 }
@@ -785,6 +891,23 @@ impl PreparedMelt {
             .await?;
 
         Ok(finalized.into())
+    }
+
+    /// Confirm the prepared melt using NUT-05 async support when the mint accepts it.
+    ///
+    /// If the melt completes immediately, this returns
+    /// `MeltConfirmOutcome::Paid`. If the mint accepts the payment for
+    /// background processing, this returns `MeltConfirmOutcome::Pending` with a
+    /// `PendingMelt` handle.
+    ///
+    /// FFI callers should call `PendingMelt::wait()` from a background
+    /// task/coroutine to poll for completion. Mobile apps should also call
+    /// `recover_incomplete_sagas()` or `finalize_pending_melts()` on
+    /// startup/resume, because operating systems may suspend or cancel
+    /// long-running background waits.
+    pub async fn confirm_prefer_async(&self) -> Result<MeltConfirmOutcome, FfiError> {
+        self.confirm_prefer_async_with_options(MeltConfirmOptions::default())
+            .await
     }
 
     /// Cancel the prepared melt and release reserved proofs

--- a/crates/cdk-ffi/src/types/wallet.rs
+++ b/crates/cdk-ffi/src/types/wallet.rs
@@ -670,7 +670,7 @@ impl PreparedMelt {
             swap_fee: prepared.swap_fee().into(),
             input_fee: prepared.input_fee().into(),
             input_fee_without_swap: prepared.input_fee_without_swap().into(),
-            metadata: HashMap::new(),
+            metadata: prepared.metadata().clone(),
         }
     }
 }

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -486,6 +486,18 @@ impl Wallet {
         Ok(quote.into())
     }
 
+    /// Check melt quote status and attempt to complete any in-progress saga.
+    pub async fn check_melt_quote_status(&self, quote_id: String) -> Result<MeltQuote, FfiError> {
+        let quote = self.inner.check_melt_quote_status(&quote_id).await?;
+        Ok(quote.into())
+    }
+
+    /// Finalize pending melt operations for this wallet.
+    pub async fn finalize_pending_melts(&self) -> Result<Vec<FinalizedMelt>, FfiError> {
+        let finalized = self.inner.finalize_pending_melts().await?;
+        Ok(finalized.into_iter().map(Into::into).collect())
+    }
+
     /// Swap proofs
     pub async fn swap(
         &self,

--- a/crates/cdk-ffi/tests/test_live_async_onchain_melt.py
+++ b/crates/cdk-ffi/tests/test_live_async_onchain_melt.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Live CDK FFI async onchain melt test.
+
+This test uses https://testnut.cashudevkit.org and requires network access.
+It intentionally lives outside the deterministic Nix FFI check.
+"""
+
+import asyncio
+import os
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+MINT_URL = "https://testnut.cashudevkit.org"
+MINT_AMOUNT_SAT = 25_000
+MELT_AMOUNT_SAT = 1_000
+MINT_QUOTE_TIMEOUT = float(os.environ.get("CDK_FFI_LIVE_MINT_TIMEOUT", "60"))
+PENDING_MELT_TIMEOUT = float(os.environ.get("CDK_FFI_LIVE_MELT_TIMEOUT", "30"))
+POLL_INTERVAL = float(os.environ.get("CDK_FFI_LIVE_POLL_INTERVAL", "2"))
+
+# Valid mainnet address. The testnut onchain melt backend decides whether the
+# payment settles immediately or remains pending.
+ONCHAIN_ADDRESS = "1BoatSLRHtKNngkdXEeobR76b53LETtpyT"
+
+
+def load_bindings():
+    repo_root = Path(__file__).resolve().parents[3]
+    bindings_path = repo_root / "target" / "bindings" / "python"
+    lib_file = "libcdk_ffi.dylib" if sys.platform == "darwin" else "libcdk_ffi.so"
+
+    if not (bindings_path / "cdk_ffi.py").exists():
+        raise SystemExit("Python bindings not found. Run: just ffi-generate python --debug")
+
+    for profile in ("debug", "release"):
+        src_lib = repo_root / "target" / profile / lib_file
+        if src_lib.exists():
+            shutil.copy2(src_lib, bindings_path / lib_file)
+            break
+    else:
+        if not (bindings_path / lib_file).exists():
+            raise SystemExit("FFI library not found. Run: just ffi-generate python --debug")
+
+    sys.path.insert(0, str(bindings_path))
+
+    import cdk_ffi  # noqa: PLC0415
+
+    return cdk_ffi
+
+
+cdk_ffi = load_bindings()
+
+
+def assert_amount(amount, expected):
+    assert amount.value == expected, f"expected {expected} sats, got {amount.value}"
+
+
+async def wait_for_paid_mint_quote(wallet, quote_id):
+    deadline = time.monotonic() + MINT_QUOTE_TIMEOUT
+    last_quote = None
+
+    while time.monotonic() < deadline:
+        last_quote = await wallet.check_mint_quote_status(quote_id)
+        if last_quote.state == cdk_ffi.QuoteState.PAID:
+            return last_quote
+
+        await asyncio.sleep(POLL_INTERVAL)
+
+    raise AssertionError(f"mint quote did not become paid before timeout: {last_quote}")
+
+
+def assert_finalized_melt(finalized, quote_id):
+    assert finalized.quote_id == quote_id
+    assert finalized.state == cdk_ffi.QuoteState.PAID
+    assert_amount(finalized.amount, MELT_AMOUNT_SAT)
+    assert finalized.fee_paid.value >= 0
+
+
+async def assert_pending_remains_valid(wallet, pending):
+    status = await wallet.check_melt_quote_status(pending.quote_id())
+
+    if status.state == cdk_ffi.QuoteState.PAID:
+        finalized = await wallet.finalize_pending_melts()
+        for melt in finalized:
+            if melt.quote_id == pending.quote_id():
+                assert_finalized_melt(melt, pending.quote_id())
+                return
+
+        assert status.id == pending.quote_id()
+        assert_amount(status.amount, MELT_AMOUNT_SAT)
+        return
+
+    assert status.state == cdk_ffi.QuoteState.PENDING
+    assert status.id == pending.quote_id()
+    assert_amount(status.amount, MELT_AMOUNT_SAT)
+
+
+async def test_live_async_onchain_melt():
+    with tempfile.TemporaryDirectory(prefix="cdk-ffi-live-") as tmpdir:
+        db_path = str(Path(tmpdir) / "wallet.db")
+        wallet = cdk_ffi.Wallet(
+            mint_url=MINT_URL,
+            unit=cdk_ffi.CurrencyUnit.SAT(),
+            mnemonic=cdk_ffi.generate_mnemonic(),
+            store=cdk_ffi.WalletStore.SQLITE(path=db_path),
+            config=cdk_ffi.WalletConfig(target_proof_count=3),
+        )
+
+        mint_quote = await wallet.mint_quote(
+            cdk_ffi.PaymentMethod.BOLT11(),
+            cdk_ffi.Amount(value=MINT_AMOUNT_SAT),
+            None,
+            None,
+        )
+        await wait_for_paid_mint_quote(wallet, mint_quote.id)
+
+        proofs = await wallet.mint(mint_quote.id, cdk_ffi.SplitTarget.NONE(), None)
+        assert len(proofs) > 0
+
+        balance = await wallet.total_balance()
+        assert balance.value >= MINT_AMOUNT_SAT
+
+        options = await wallet.quote_onchain_melt_options(
+            ONCHAIN_ADDRESS,
+            cdk_ffi.Amount(value=MELT_AMOUNT_SAT),
+            None,
+        )
+        assert len(options) > 0
+
+        quote = await wallet.select_onchain_melt_quote(options[0])
+        assert quote.id
+        assert_amount(quote.amount, MELT_AMOUNT_SAT)
+        assert quote.fee_reserve.value >= 0
+
+        prepared = await wallet.prepare_melt(quote.id)
+        assert prepared.quote_id() == quote.id
+        assert_amount(prepared.amount(), MELT_AMOUNT_SAT)
+
+        outcome = await prepared.confirm_prefer_async()
+
+        if outcome.is_PAID():
+            assert_finalized_melt(outcome.finalized, quote.id)
+            return
+
+        if outcome.is_PENDING():
+            pending = outcome.pending
+            assert pending.quote_id() == quote.id
+            assert pending.operation_id()
+
+            try:
+                finalized = await asyncio.wait_for(
+                    pending.wait(),
+                    timeout=PENDING_MELT_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                await assert_pending_remains_valid(wallet, pending)
+            else:
+                assert_finalized_melt(finalized, quote.id)
+            return
+
+        raise AssertionError(f"unexpected melt outcome: {outcome}")
+
+
+async def main():
+    await test_live_async_onchain_melt()
+    print("Live async onchain melt test passed")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -39,9 +39,12 @@ use std::fmt::Debug;
 use std::future::{Future, IntoFuture};
 use std::pin::Pin;
 use std::str::FromStr;
+use std::time::Duration;
 
 use cdk_common::util::unix_time;
-use cdk_common::wallet::{MeltQuote, Transaction, TransactionDirection};
+use cdk_common::wallet::{
+    MeltQuote, MeltSagaState, Transaction, TransactionDirection, WalletSagaState,
+};
 use cdk_common::{Error, MeltQuoteState, PaymentMethod, ProofsMethods, State};
 use tracing::instrument;
 use uuid::Uuid;
@@ -1001,6 +1004,149 @@ impl Wallet {
         }
     }
 
+    /// Internal method called by `PreparedMelt::confirm_prefer_async_with_options`
+    /// with cached data.
+    ///
+    /// Not intended for direct use - use
+    /// [`PreparedMelt::confirm_prefer_async_with_options`] instead.
+    #[doc(hidden)]
+    #[instrument(skip(self, proofs, proofs_to_swap, metadata, options))]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn confirm_prepared_melt_prefer_async_with_options(
+        &self,
+        operation_id: Uuid,
+        quote: MeltQuote,
+        proofs: Proofs,
+        proofs_to_swap: Proofs,
+        input_fee: Amount,
+        input_fee_without_swap: Amount,
+        metadata: HashMap<String, String>,
+        options: MeltConfirmOptions,
+    ) -> Result<MeltOutcome<'_>, Error> {
+        let db_saga = self
+            .localstore
+            .get_saga(&operation_id)
+            .await?
+            .ok_or(Error::Custom("Saga not found".to_string()))?;
+
+        let saga = MeltSaga::from_prepared(
+            self,
+            operation_id,
+            quote,
+            proofs,
+            proofs_to_swap,
+            input_fee,
+            input_fee_without_swap,
+            db_saga,
+        );
+
+        let melt_requested = match saga.request_melt_with_options(options).await {
+            Ok(melt_requested) => melt_requested,
+            Err(err) => {
+                let finalized = self.recover_failed_melt_confirm(operation_id, err).await?;
+                return Ok(MeltOutcome::Paid(finalized));
+            }
+        };
+
+        let result = match melt_requested.execute_async(metadata.clone()).await {
+            Ok(result) => result,
+            Err(err) => {
+                let finalized = self.recover_failed_melt_confirm(operation_id, err).await?;
+                return Ok(MeltOutcome::Paid(finalized));
+            }
+        };
+
+        match result {
+            MeltSagaResult::Finalized(finalized) => Ok(MeltOutcome::Paid(FinalizedMelt::new(
+                finalized.quote_id().to_string(),
+                finalized.state(),
+                finalized.payment_proof().map(|s| s.to_string()),
+                finalized.amount(),
+                finalized.fee_paid(),
+                finalized.into_change(),
+            ))),
+            MeltSagaResult::Pending(pending_saga) => Ok(MeltOutcome::Pending(PendingMelt {
+                saga: pending_saga,
+                metadata,
+            })),
+        }
+    }
+
+    /// Wait for a pending melt identified by persisted saga details.
+    ///
+    /// This patch-compatible FFI helper polls the existing saga recovery path
+    /// until the mint reports a terminal state. The richer restart-safe
+    /// reconstruction path lives in the 0.18 melt recovery changes.
+    #[doc(hidden)]
+    #[instrument(skip(self))]
+    pub async fn wait_pending_melt(
+        &self,
+        operation_id: Uuid,
+        quote_id: &str,
+        payment_method: PaymentMethod,
+    ) -> Result<FinalizedMelt, Error> {
+        use cdk_common::wallet::{MeltSagaState, OperationData, WalletSagaState};
+
+        loop {
+            let db_saga = self
+                .localstore
+                .get_saga(&operation_id)
+                .await?
+                .ok_or(Error::Custom("Saga not found".to_string()))?;
+
+            ensure_cdk!(
+                db_saga.mint_url == self.mint_url && db_saga.unit == self.unit,
+                Error::Custom("Saga belongs to a different wallet".to_string())
+            );
+
+            let WalletSagaState::Melt(state) = &db_saga.state else {
+                return Err(Error::Custom(format!(
+                    "Invalid saga state type for melt saga {}",
+                    operation_id
+                )));
+            };
+
+            ensure_cdk!(
+                matches!(
+                    state,
+                    MeltSagaState::MeltRequested | MeltSagaState::PaymentPending
+                ),
+                Error::InvalidOperationState
+            );
+
+            let OperationData::Melt(data) = &db_saga.data else {
+                return Err(Error::Custom(format!(
+                    "Invalid operation data type for melt saga {}",
+                    operation_id
+                )));
+            };
+
+            ensure_cdk!(
+                data.quote_id == quote_id,
+                Error::Custom("Pending melt quote ID does not match saga".to_string())
+            );
+
+            let quote = self
+                .localstore
+                .get_melt_quote(quote_id)
+                .await?
+                .ok_or(Error::UnknownQuote)?;
+
+            ensure_cdk!(
+                quote.payment_method == payment_method,
+                Error::Custom("Pending melt payment method does not match quote".to_string())
+            );
+
+            match self.resume_melt_saga(&db_saga).await? {
+                Some(finalized) if finalized.state() == MeltQuoteState::Paid => {
+                    return Ok(finalized);
+                }
+                Some(_) => return Err(Error::PaymentFailed),
+                None => tokio::time::sleep(Duration::from_secs(1)).await,
+            }
+        }
+    }
+
     /// Run melt recovery after a failed confirm path.
     ///
     /// This uses the persisted saga state as the source of truth, matching crash
@@ -1043,6 +1189,20 @@ impl Wallet {
         proofs_to_swap: Proofs,
     ) -> Result<(), Error> {
         tracing::info!("Cancelling prepared melt for operation {}", operation_id);
+
+        if let Some(saga) = self.localstore.get_saga(&operation_id).await? {
+            ensure_cdk!(
+                saga.mint_url == self.mint_url && saga.unit == self.unit,
+                Error::InvalidOperationState
+            );
+            ensure_cdk!(
+                matches!(
+                    saga.state,
+                    WalletSagaState::Melt(MeltSagaState::ProofsReserved)
+                ),
+                Error::InvalidOperationState
+            );
+        }
 
         let mut all_ys = proofs.ys()?;
         all_ys.extend(proofs_to_swap.ys()?);
@@ -1563,7 +1723,8 @@ mod tests {
     use std::str::FromStr;
     use std::sync::Arc;
 
-    use cdk_common::nuts::{CurrencyUnit, State};
+    use cdk_common::nuts::{CurrencyUnit, RestoreResponse, State};
+    use cdk_common::wallet::{MeltOperationData, OperationData, WalletSaga};
     use cdk_common::{Id, MeltQuoteBolt11Response, MeltQuoteResponse};
 
     use super::*;
@@ -1623,6 +1784,52 @@ mod tests {
         let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
         assert_eq!(stored.len(), 1);
         assert_eq!(stored[0].state, State::Unspent);
+    }
+
+    #[tokio::test]
+    async fn test_cancel_prepared_melt_rejects_melt_requested_saga() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let operation_id = uuid::Uuid::new_v4();
+
+        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Pending);
+        let proof_y = proof_info.y;
+        let proof = proof_info.proof.clone();
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let quote = test_melt_quote();
+        let saga = WalletSaga::new(
+            operation_id,
+            WalletSagaState::Melt(MeltSagaState::MeltRequested),
+            quote.amount,
+            mint_url,
+            CurrencyUnit::Sat,
+            OperationData::Melt(MeltOperationData {
+                quote_id: quote.id,
+                amount: quote.amount,
+                fee_reserve: quote.fee_reserve,
+                counter_start: None,
+                counter_end: None,
+                change_amount: None,
+                change_blinded_messages: None,
+            }),
+        );
+        db.add_saga(saga).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        let err = wallet
+            .cancel_prepared_melt(operation_id, vec![proof], vec![])
+            .await
+            .expect_err("cancel should reject a melt that was already requested");
+
+        assert!(matches!(err, Error::InvalidOperationState));
+        let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].state, State::Pending);
+        assert!(db.get_saga(&operation_id).await.unwrap().is_some());
     }
 
     #[tokio::test]
@@ -2001,6 +2208,44 @@ mod tests {
         let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
         assert_eq!(stored.len(), 1);
         assert_eq!(stored[0].state, State::Spent);
+        assert!(db.get_saga(&operation_id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_wait_pending_melt_polls_saga_and_finalizes() {
+        let (db, proof_y, operation_id, mock_client, pending) = pending_bolt11_melt(true).await;
+        let wallet = pending.saga.wallet;
+        let quote_id = pending.saga.quote().id.clone();
+        let payment_method = pending.saga.quote().payment_method.clone();
+
+        let paid_status = MeltQuoteBolt11Response {
+            payment_preimage: Some("preimage123".to_string()),
+            ..bolt11_status(&quote_id, MeltQuoteState::Paid, None)
+        };
+        mock_client._set_restore_response(Ok(RestoreResponse {
+            outputs: vec![],
+            signatures: vec![],
+        }));
+        mock_client.push_melt_quote_status_response(Ok(paid_status.clone()));
+        mock_client.push_melt_quote_status_response(Ok(paid_status));
+
+        let finalized = tokio::time::timeout(
+            Duration::from_secs(5),
+            wallet.wait_pending_melt(operation_id, &quote_id, payment_method),
+        )
+        .await
+        .expect("wait timed out")
+        .expect("pending melt should finalize");
+
+        assert_eq!(finalized.state(), MeltQuoteState::Paid);
+        assert_eq!(finalized.payment_proof(), Some("preimage123"));
+
+        let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].state, State::Spent);
+        let transactions = db.list_transactions(None, None, None).await.unwrap();
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].ys, vec![proof_y]);
         assert!(db.get_saga(&operation_id).await.unwrap().is_none());
     }
 

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -525,6 +525,11 @@ impl<'a> PreparedMelt<'a> {
         self.saga.proofs()
     }
 
+    /// Get the transaction metadata for this melt.
+    pub fn metadata(&self) -> &HashMap<String, String> {
+        &self.metadata
+    }
+
     /// Get the proofs that need to be swapped
     pub fn proofs_to_swap(&self) -> &Proofs {
         self.saga.proofs_to_swap()
@@ -1863,6 +1868,29 @@ mod tests {
         assert_eq!(reserved.len(), 1);
         assert_eq!(reserved[0].state, State::Reserved);
         assert_eq!(reserved[0].proof.amount, Amount::from(1010_u64));
+    }
+
+    #[tokio::test]
+    async fn test_prepared_melt_exposes_metadata() {
+        let db = create_test_db().await;
+        let quote = test_melt_quote();
+        let quote_id = quote.id.clone();
+        db.add_melt_quote(quote).await.unwrap();
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.reset_default_mint_state();
+        let wallet = create_test_wallet_with_mock(db, mock_client).await;
+
+        let mut metadata = HashMap::new();
+        metadata.insert("memo".to_string(), "ffi metadata".to_string());
+
+        let proof = test_proof(crate::wallet::test_utils::test_keyset_id(), 1200);
+        let prepared = wallet
+            .prepare_melt_proofs(&quote_id, vec![proof], metadata.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(prepared.metadata(), &metadata);
     }
 
     /// Build a bolt11 melt-quote status response with the given state/preimage.

--- a/justfile
+++ b/justfile
@@ -898,6 +898,20 @@ ffi-test-bindings LANGUAGE: (ffi-generate LANGUAGE "--debug")
 ffi-test-python:
   just ffi-test-bindings python
 
+# Run live Python FFI tests against testnut.cashudevkit.org
+ffi-test-live-python:
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  just ffi-generate python --debug
+
+  LIB_EXT=$(just _ffi-lib-ext)
+  echo "📦 Copying debug library to Python bindings directory..."
+  cp target/debug/libcdk_ffi.$LIB_EXT target/bindings/python/
+
+  echo "🧪 Running live Python FFI tests..."
+  python3 crates/cdk-ffi/tests/test_live_async_onchain_melt.py
+
 # Trigger all FFI binding releases (Dart, Kotlin, Swift, Go)
 ffi-release-all VERSION:
   #!/usr/bin/env bash


### PR DESCRIPTION
Expose async-preferred melt confirmation through UniFFI as a paid-or-pending outcome, with a PendingMelt handle that can wait for finalization.

Keep Rust-native PreparedMelt confirmation on the in-memory saga while the FFI path reconstructs from cached prepared data and persisted pending state.



### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
