### PR TITLE
fix(cashu): accept unknown fields in onchain quote responses

### DIFF
--- a/crates/cashu/src/nuts/nut17/mod.rs
+++ b/crates/cashu/src/nuts/nut17/mod.rs
@@ -1,5 +1,5 @@
 //! Specific Subscription for the cdk crate
-use serde::de::DeserializeOwned;
+use serde::de::{DeserializeOwned, Error as DeError};
 use serde::{Deserialize, Serialize};
 
 use super::PublicKey;
@@ -184,19 +184,10 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(bound = "T: Serialize + DeserializeOwned")]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(bound(serialize = "T: Serialize + DeserializeOwned"))]
 #[serde(untagged)]
 /// Subscription response
-///
-/// Note on variant ordering: serde `untagged` deserialization tries variants
-/// in declaration order and selects the first that matches. The Onchain
-/// variants are declared before the Bolt11/Bolt12 variants because the
-/// Onchain response structs use `#[serde(deny_unknown_fields)]`, which makes
-/// them reject Bolt11/Bolt12 payloads cleanly. Placing them first ensures
-/// onchain payloads are classified correctly without being consumed by the
-/// more permissive Bolt12 variant (which carries a superset of Onchain's
-/// field names).
 pub enum NotificationPayload<T>
 where
     T: Clone,
@@ -204,14 +195,8 @@ where
     /// Proof State
     ProofState(ProofState),
     /// Mint Quote Onchain Response
-    ///
-    /// Declared before `MintQuoteBolt12Response` to ensure untagged
-    /// discrimination picks the onchain variant for onchain payloads.
     MintQuoteOnchainResponse(MintQuoteOnchainResponse<T>),
     /// Melt Quote Onchain Response
-    ///
-    /// Declared before `MeltQuoteBolt11Response`/`MeltQuoteBolt12Response`
-    /// for the same reason.
     MeltQuoteOnchainResponse(MeltQuoteOnchainResponse<T>),
     /// Melt Quote Bolt11 Response
     MeltQuoteBolt11Response(MeltQuoteBolt11Response<T>),
@@ -225,6 +210,81 @@ where
     CustomMintQuoteResponse(String, MintQuoteCustomResponse<T>),
     /// Custom Melt Quote Response (method, response)
     CustomMeltQuoteResponse(String, MeltQuoteCustomResponse<T>),
+}
+
+/// Classify a notification payload by its discriminating fields instead of
+/// serde `untagged` variant order. The quote responses for different payment
+/// methods share most field names, and the structs tolerate unknown fields
+/// for forward compatibility, so untagged trial-and-error would pick the
+/// wrong variant.
+fn deserialize_payload<T, E>(value: serde_json::Value) -> Result<NotificationPayload<T>, E>
+where
+    T: Clone + Serialize + DeserializeOwned,
+    E: DeError,
+{
+    fn from_value<V, E>(value: serde_json::Value) -> Result<V, E>
+    where
+        V: DeserializeOwned,
+        E: DeError,
+    {
+        serde_json::from_value(value).map_err(E::custom)
+    }
+
+    match &value {
+        serde_json::Value::Object(fields) => {
+            if fields.contains_key("Y") {
+                return from_value(value).map(NotificationPayload::ProofState);
+            }
+
+            if fields.contains_key("fee_options") {
+                return from_value(value).map(NotificationPayload::MeltQuoteOnchainResponse);
+            }
+
+            if fields.contains_key("fee_reserve") {
+                return from_value(value).map(NotificationPayload::MeltQuoteBolt11Response);
+            }
+
+            if fields.contains_key("state") {
+                return from_value(value).map(NotificationPayload::MintQuoteBolt11Response);
+            }
+
+            if fields.contains_key("amount") {
+                return from_value(value).map(NotificationPayload::MintQuoteBolt12Response);
+            }
+
+            from_value(value).map(NotificationPayload::MintQuoteOnchainResponse)
+        }
+        serde_json::Value::Array(items) if items.len() == 2 => {
+            let response = items
+                .get(1)
+                .ok_or_else(|| E::custom("custom notification payload is missing response"))?;
+            match response.as_object() {
+                Some(fields) if fields.contains_key("state") => {
+                    from_value(value).map(|(method, response)| {
+                        NotificationPayload::CustomMeltQuoteResponse(method, response)
+                    })
+                }
+                Some(_) => from_value(value).map(|(method, response)| {
+                    NotificationPayload::CustomMintQuoteResponse(method, response)
+                }),
+                None => Err(E::custom("custom notification response must be an object")),
+            }
+        }
+        _ => Err(E::custom("invalid notification payload")),
+    }
+}
+
+impl<'de, T> Deserialize<'de> for NotificationPayload<T>
+where
+    T: Clone + Serialize + DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        deserialize_payload(value)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Hash, Serialize)]
@@ -369,9 +429,8 @@ mod tests {
 
     #[test]
     fn notification_payload_bolt12_mint_roundtrip() {
-        // Ensure a Bolt12 payload (with `amount`) still decodes as Bolt12 after
-        // the Onchain variant was moved ahead of it and marked
-        // `deny_unknown_fields`.
+        // Ensure a Bolt12 payload (with `amount`) still decodes as Bolt12 and
+        // is not swallowed by the field-name overlap with the Onchain variant.
         let resp: MintQuoteBolt12Response<String> = MintQuoteBolt12Response {
             quote: "abc".to_string(),
             request: "lno1...".to_string(),
@@ -428,6 +487,31 @@ mod tests {
                 assert_eq!(r, resp);
             }
             other => panic!("expected MeltQuoteOnchainResponse, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn notification_payload_onchain_mint_tolerates_unknown_fields() {
+        // A newer mint may extend the onchain mint quote response with
+        // additional fields; classification and decoding must still succeed.
+        let encoded = r#"{
+            "quote": "abc",
+            "request": "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+            "unit": "sat",
+            "expiry": 1701704757,
+            "pubkey": "03d56ce4e446a85bbdaa547b4ec2b073d40ff802831352b8272b7dd7a4de5a7cac",
+            "amount_paid": 0,
+            "amount_issued": 0,
+            "some_future_extension": {"nested": true}
+        }"#;
+
+        let decoded: NotificationPayload<String> = serde_json::from_str(encoded).unwrap();
+
+        match decoded {
+            NotificationPayload::MintQuoteOnchainResponse(r) => {
+                assert_eq!(r.quote, "abc");
+            }
+            other => panic!("expected MintQuoteOnchainResponse, got {:?}", other),
         }
     }
 }

--- a/crates/cashu/src/nuts/nut30.rs
+++ b/crates/cashu/src/nuts/nut30.rs
@@ -27,14 +27,10 @@ pub struct MintQuoteOnchainRequest {
 ///
 /// Response containing the onchain quote details.
 ///
-/// `deny_unknown_fields` is intentional: the `NotificationPayload` enum is
-/// `#[serde(untagged)]` and several quote-response variants share a large
-/// overlap of field names. Rejecting unknown fields ensures an onchain payload
-/// cannot silently deserialize as another method (for example `MintQuoteBolt12Response`
-/// which carries an `amount` field Onchain does not have).
+/// Unknown fields are accepted to preserve forward compatibility when mints
+/// add optional onchain extensions.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound = "Q: Serialize + DeserializeOwned")]
-#[serde(deny_unknown_fields)]
 pub struct MintQuoteOnchainResponse<Q> {
     /// Quote Id
     pub quote: Q,
@@ -152,14 +148,10 @@ pub struct MeltQuoteOnchainFeeOption {
 /// The `POST /v1/melt/quote/onchain` endpoint returns one quote with one or
 /// more `fee_options`. The wallet chooses one option when executing the quote.
 ///
-/// `deny_unknown_fields` is intentional: the `NotificationPayload` enum is
-/// `#[serde(untagged)]` and melt-quote responses for different methods share
-/// many field names. Rejecting unknown fields ensures an onchain payload cannot
-/// silently deserialize as `MeltQuoteBolt11Response` (which carries `fee_reserve`
-/// at the top level, while onchain carries it inside `fee_options`).
+/// Unknown fields are accepted to preserve forward compatibility when mints
+/// add optional onchain extensions.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound = "Q: Serialize + DeserializeOwned")]
-#[serde(deny_unknown_fields)]
 pub struct MeltQuoteOnchainResponse<Q> {
     /// Quote Id
     pub quote: Q,
@@ -327,6 +319,46 @@ mod tests {
         let deserialized: MeltQuoteOnchainResponse<String> =
             serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized.outpoint, None);
+    }
+
+    #[test]
+    fn test_mint_quote_onchain_response_tolerates_unknown_fields() {
+        // Responses from newer mints may carry additional optional fields
+        // (e.g. payjoin instructions); released wallets must not reject them.
+        let encoded = r#"{
+            "quote": "DSGLX9kevM...",
+            "request": "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+            "unit": "sat",
+            "expiry": 1701704757,
+            "pubkey": "03d56ce4e446a85bbdaa547b4ec2b073d40ff802831352b8272b7dd7a4de5a7cac",
+            "amount_paid": 100000,
+            "amount_issued": 0,
+            "payjoin": {"endpoint": "https://payjoin.example/pj"}
+        }"#;
+
+        let deserialized: MintQuoteOnchainResponse<String> = serde_json::from_str(encoded).unwrap();
+        assert_eq!(deserialized.quote, "DSGLX9kevM...");
+        assert_eq!(deserialized.amount_paid, Amount::from(100000));
+    }
+
+    #[test]
+    fn test_melt_quote_onchain_response_tolerates_unknown_fields() {
+        let encoded = r#"{
+            "quote": "TRmjduhIsPxd...",
+            "amount": 100000,
+            "unit": "sat",
+            "state": "PENDING",
+            "expiry": 1701704757,
+            "request": "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+            "fee_options": [{"fee_index": 0, "fee_reserve": 5000, "estimated_blocks": 1}],
+            "selected_fee_index": null,
+            "outpoint": null,
+            "payjoin": {"endpoint": "https://payjoin.example/pj"}
+        }"#;
+
+        let deserialized: MeltQuoteOnchainResponse<String> = serde_json::from_str(encoded).unwrap();
+        assert_eq!(deserialized.quote, "TRmjduhIsPxd...");
+        assert_eq!(deserialized.state, MeltQuoteState::Pending);
     }
 
     #[test]


### PR DESCRIPTION
The attribute existed only to make serde(untagged) discrimination of NotificationPayload reject non-onchain payloads. Replace that mechanism with a hand-written Deserialize that classifies payloads by their discriminating fields (Y, fee_options, fee_reserve, state, amount), so websocket notification dispatch no longer depends on strict structs.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
