### PR TITLE
refactor(cashu)!: borrow secret key

### DIFF
--- a/crates/cashu/src/nuts/nut12.rs
+++ b/crates/cashu/src/nuts/nut12.rs
@@ -202,7 +202,7 @@ impl BlindSignature {
         blinded_signature: PublicKey,
         keyset_id: Id,
         blinded_message: &PublicKey,
-        mint_secretkey: SecretKey,
+        mint_secretkey: &SecretKey,
     ) -> Result<Self, Error> {
         Ok(Self {
             amount,
@@ -211,7 +211,7 @@ impl BlindSignature {
             dleq: Some(calculate_dleq(
                 blinded_signature,
                 blinded_message,
-                &mint_secretkey,
+                mint_secretkey,
             )?),
         })
     }
@@ -294,7 +294,7 @@ mod tests {
             blinded_signature,
             Id::from_str("00882760bfa2eb41").expect("valid keyset id"),
             &blinded_message,
-            mint_secret_key.clone(),
+            &mint_secret_key,
         )
         .expect("deterministic DLEQ proof");
         let dleq = blind_signature.dleq.expect("DLEQ proof");

--- a/crates/cashu/src/nuts/nut20.rs
+++ b/crates/cashu/src/nuts/nut20.rs
@@ -47,7 +47,7 @@ where
     }
 
     /// Sign [`MintRequest`]
-    pub fn sign(&mut self, secret_key: SecretKey) -> Result<(), Error> {
+    pub fn sign(&mut self, secret_key: &SecretKey) -> Result<(), Error> {
         let msg = self.msg_to_sign();
 
         let signature: Signature = secret_key.sign(&msg)?;
@@ -132,7 +132,7 @@ mod tests {
             SecretKey::from_hex("50d7fd7aa2b2fe4607f41f4ce6f8794fc184dd47b8cdfbe4b3d1249aa02d35aa")
                 .unwrap();
 
-        request.sign(secret.clone()).unwrap();
+        request.sign(&secret).unwrap();
 
         assert!(request.verify_signature(secret.public_key()).is_ok());
     }

--- a/crates/cdk-integration-tests/src/lib.rs
+++ b/crates/cdk-integration-tests/src/lib.rs
@@ -250,13 +250,7 @@ pub async fn attempt_manual_mint(
     };
 
     request
-        .sign(
-            mint_quote
-                .secret_key
-                .as_ref()
-                .expect("Secret key on quote")
-                .clone(),
-        )
+        .sign(mint_quote.secret_key.as_ref().expect("Secret key on quote"))
         .unwrap();
 
     http_client.post_mint(&payment_method, request).await

--- a/crates/cdk-integration-tests/tests/bolt12.rs
+++ b/crates/cdk-integration-tests/tests/bolt12.rs
@@ -430,7 +430,7 @@ async fn test_regtest_bolt12_mint_extra() -> Result<()> {
     };
 
     if let Some(secret_key) = quote_info.secret_key {
-        mint_request.sign(secret_key)?;
+        mint_request.sign(&secret_key)?;
     }
 
     let http_client = HttpClient::new(get_mint_url_from_env().parse().unwrap(), None);

--- a/crates/cdk-integration-tests/tests/fake_wallet.rs
+++ b/crates/cdk-integration-tests/tests/fake_wallet.rs
@@ -685,7 +685,7 @@ async fn test_fake_mint_with_wrong_witness() {
     let secret_key = SecretKey::generate();
 
     request
-        .sign(secret_key)
+        .sign(&secret_key)
         .expect("failed to sign the mint request");
 
     let response = http_client
@@ -750,7 +750,7 @@ async fn test_fake_mint_inflated() {
 
     if let Some(secret_key) = quote_info.secret_key {
         mint_request
-            .sign(secret_key)
+            .sign(&secret_key)
             .expect("failed to sign the mint request");
     }
     let http_client = HttpClient::new(MINT_URL.parse().unwrap(), None);
@@ -823,7 +823,7 @@ async fn test_fake_mint_inflated_does_not_consume_quote() {
         signature: None,
     };
     inflated_request
-        .sign(secret_key.clone())
+        .sign(&secret_key)
         .expect("failed to sign inflated mint request");
 
     let http_client = HttpClient::new(MINT_URL.parse().unwrap(), None);
@@ -852,7 +852,7 @@ async fn test_fake_mint_inflated_does_not_consume_quote() {
         signature: None,
     };
     valid_request
-        .sign(secret_key.clone())
+        .sign(&secret_key)
         .expect("failed to sign valid mint request");
 
     let valid_response = http_client
@@ -882,7 +882,7 @@ async fn test_fake_mint_inflated_does_not_consume_quote() {
         signature: None,
     };
     second_valid_request
-        .sign(secret_key)
+        .sign(&secret_key)
         .expect("failed to sign second valid mint request");
 
     let second_response = http_client
@@ -953,7 +953,7 @@ async fn test_fake_mint_concurrent_same_quote_different_outputs() {
         signature: None,
     };
     request_one
-        .sign(secret_key.clone())
+        .sign(&secret_key)
         .expect("failed to sign first request");
 
     let mut request_two = MintRequest {
@@ -962,7 +962,7 @@ async fn test_fake_mint_concurrent_same_quote_different_outputs() {
         signature: None,
     };
     request_two
-        .sign(secret_key)
+        .sign(&secret_key)
         .expect("failed to sign second request");
 
     let (result_one, result_two) = tokio::join!(
@@ -1071,7 +1071,7 @@ async fn test_fake_mint_multiple_units() {
 
     if let Some(secret_key) = quote_info.secret_key {
         mint_request
-            .sign(secret_key)
+            .sign(&secret_key)
             .expect("failed to sign the mint request");
     }
     let http_client = HttpClient::new(MINT_URL.parse().unwrap(), None);

--- a/crates/cdk-integration-tests/tests/regtest.rs
+++ b/crates/cdk-integration-tests/tests/regtest.rs
@@ -384,11 +384,9 @@ async fn test_cached_mint() {
         signature: None,
     };
 
-    let secret_key = quote.secret_key;
+    let secret_key = quote.secret_key.expect("Secret key on quote");
 
-    request
-        .sign(secret_key.expect("Secret key on quote"))
-        .unwrap();
+    request.sign(&secret_key).unwrap();
 
     let response = http_client
         .post_mint(&PaymentMethod::Known(KnownMethod::Bolt11), request.clone())

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -150,7 +150,7 @@ impl Signatory for DbSignatory {
                     c,
                     keyset_id,
                     &blinded_message.blinded_secret,
-                    key_pair.secret_key.clone(),
+                    &key_pair.secret_key,
                 )?;
 
                 Ok(blinded_signature)

--- a/crates/cdk/src/wallet/issue/saga/mod.rs
+++ b/crates/cdk/src/wallet/issue/saga/mod.rs
@@ -238,7 +238,7 @@ impl<'a> MintSaga<'a, Initial> {
         };
 
         if let Some(secret_key) = self.wallet.mint_quote_signing_key(quote_info).await? {
-            request.sign(secret_key)?;
+            request.sign(&secret_key)?;
         } else if quote_info.payment_method.is_bolt12() {
             // Bolt12 requires signature
             tracing::error!("Signature is required for bolt12.");

--- a/crates/cdk/src/wallet/issue/saga/resume.rs
+++ b/crates/cdk/src/wallet/issue/saga/resume.rs
@@ -431,7 +431,7 @@ impl Wallet {
 
         // Sign the request if the quote has a signing key (required for bolt12)
         if let Some(secret_key) = self.mint_quote_signing_key(&quote).await? {
-            if let Err(e) = mint_request.sign(secret_key) {
+            if let Err(e) = mint_request.sign(&secret_key) {
                 tracing::warn!(
                     "Issue saga {} - failed to sign mint request: {}, cannot replay",
                     saga_id,


### PR DESCRIPTION
Avoid cloning the mint secret key when constructing blind signatures by borrowing it for DLEQ calculation.

BREAKING CHANGE: BlindSignature::new now takes &SecretKey instead of SecretKey.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
