### PR TITLE
release(dart): sync README install ref with release tag

### DIFF
--- a/.github/workflows/dart-publish.yml
+++ b/.github/workflows/dart-publish.yml
@@ -140,6 +140,9 @@ jobs:
           # Update pubspec.yaml version
           sed -i "s/^version: \".*\"/version: \"${RELEASE_VER}\"/" cdk-dart/pubspec.yaml
 
+          # Update README.md version ref
+          sed -i "s/ref: vX.Y.Z/ref: ${TAG}/" cdk-dart/README.md
+
           # Resolve workspace package fields in rust/Cargo.toml
           sed -i \
             -e "s/^edition\.workspace = true/edition = \"${WS_EDITION}\"/" \

--- a/bindings/dart/README.md
+++ b/bindings/dart/README.md
@@ -11,7 +11,7 @@ dependencies:
   cdk:
     git:
       url: https://github.com/cashubtc/cdk-dart
-      ref: v0.16.0  # replace with desired version
+      ref: vX.Y.Z  # replace with desired version
 ```
 
 ## Requirements


### PR DESCRIPTION
## Summary

This PR updates the Dart README/release flow so the installation snippet does not keep pointing users to a stale hardcoded release ref.

Dart and Flutter users often copy the README dependency snippet directly into `pubspec.yaml`, so keeping the release ref accurate helps avoid users installing an older Dart binding version by mistake.

## Changes

- Update the Dart README install ref handling
- Avoid shipping stale Dart install instructions
- Keep the change focused on the Dart README/release-tag sync flow

## Testing

- Checked the README install snippet
- Checked the branch diff to confirm the change is limited to the Dart README/release flow

Closes #2189
