### PR TITLE
feat(ffi): expose mint_unissued_quotes

### DIFF
--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -995,6 +995,9 @@ pub trait Wallet: Send + Sync {
         spending_conditions: Option<SpendingConditions>,
     ) -> Result<Proofs, Self::Error>;
 
+    /// Check and mint any paid but unissued mint quotes
+    async fn mint_unissued_quotes(&self) -> Result<Self::Amount, Self::Error>;
+
     /// Check mint quote status
     async fn check_mint_quote_status(&self, quote_id: &str)
         -> Result<Self::MintQuote, Self::Error>;

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -345,6 +345,15 @@ impl Wallet {
         Ok(proofs.into_iter().map(|p| p.into()).collect())
     }
 
+    /// Check and mint any paid but unissued mint quotes.
+    ///
+    /// This is useful during startup or recovery after incomplete mint quote flows.
+    /// It may perform network requests and write newly issued proofs to the wallet store.
+    pub async fn mint_unissued_quotes(&self) -> Result<Amount, FfiError> {
+        let minted = self.inner.mint_unissued_quotes().await?;
+        Ok(minted.into())
+    }
+
     /// Prepare a melt operation
     ///
     /// Returns a `PreparedMelt` that can be confirmed or cancelled.
@@ -924,4 +933,44 @@ pub fn mnemonic_to_entropy(mnemonic: String) -> Result<Vec<u8>, FfiError> {
     let m = Mnemonic::parse(&mnemonic)
         .map_err(|e| FfiError::internal(format!("Invalid mnemonic: {}", e)))?;
     Ok(m.to_entropy())
+}
+
+#[cfg(test)]
+mod tests {
+    use cdk_common::wallet::Wallet as WalletTrait;
+
+    use super::*;
+    use crate::database::custom_wallet_store;
+    use crate::sqlite::WalletSqliteDatabase;
+
+    fn test_wallet() -> Wallet {
+        let db = WalletSqliteDatabase::new_in_memory().expect("in-memory wallet db should open");
+        Wallet::new(
+            "https://mint.example.com".to_string(),
+            CurrencyUnit::Sat,
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+                .to_string(),
+            custom_wallet_store(db),
+            WalletConfig {
+                target_proof_count: None,
+            },
+        )
+        .expect("wallet should be created")
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mint_unissued_quotes_is_available_on_wallet_and_trait() {
+        let wallet = test_wallet();
+
+        let minted = wallet
+            .mint_unissued_quotes()
+            .await
+            .expect("empty quote store should mint zero");
+        assert!(minted.is_zero());
+
+        let trait_minted = <Wallet as WalletTrait>::mint_unissued_quotes(&wallet)
+            .await
+            .expect("trait call should mint zero from empty quote store");
+        assert!(trait_minted.is_zero());
+    }
 }

--- a/crates/cdk-ffi/src/wallet_trait.rs
+++ b/crates/cdk-ffi/src/wallet_trait.rs
@@ -286,6 +286,11 @@ impl WalletTraitDef for Wallet {
         Ok(proofs)
     }
 
+    async fn mint_unissued_quotes(&self) -> Result<Self::Amount, Self::Error> {
+        let amount = WalletTraitDef::mint_unissued_quotes(self.inner().as_ref()).await?;
+        Ok(amount.into())
+    }
+
     async fn check_mint_quote_status(
         &self,
         quote_id: &str,

--- a/crates/cdk/src/wallet/wallet_trait.rs
+++ b/crates/cdk/src/wallet/wallet_trait.rs
@@ -241,6 +241,11 @@ impl WalletTrait for super::Wallet {
     }
 
     #[instrument(skip(self))]
+    async fn mint_unissued_quotes(&self) -> Result<Amount, Self::Error> {
+        self.mint_unissued_quotes().await
+    }
+
+    #[instrument(skip(self))]
     async fn check_mint_quote_status(&self, quote_id: &str) -> Result<MintQuote, Self::Error> {
         self.check_mint_quote_status(quote_id).await
     }


### PR DESCRIPTION
## Summary

This PR exposes the existing CDK wallet `mint_unissued_quotes` method through the FFI `Wallet`.

The core Rust wallet already supports minting paid but unissued mint quotes as part of startup/recovery flows. Exposing this method through `cdk-ffi` makes the same capability available to generated bindings such as Dart.

## Changes

- Add `Wallet::mint_unissued_quotes` to `crates/cdk-ffi`
- Convert the core return value into the correct FFI-compatible type
- Generated binding outputs are not committed in this PR because the monorepo does not currently track the generated Dart file.

## Testing

- `cargo fmt`
- `cargo test -p cdk-ffi`
