### PR TITLE
feat(nwc): add NIP-47 wallet service support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,6 +1257,7 @@ dependencies = [
  "cdk-common",
  "cdk-fake-wallet",
  "cdk-npubcash",
+ "cdk-nwc",
  "cdk-prometheus",
  "cdk-signatory",
  "cdk-sqlite",
@@ -1272,6 +1273,7 @@ dependencies = [
  "lightning",
  "lightning-invoice",
  "nostr-sdk",
+ "nwc",
  "rand 0.9.4",
  "regex",
  "ring 0.17.14",
@@ -1451,6 +1453,7 @@ dependencies = [
  "cdk",
  "cdk-common",
  "cdk-npubcash",
+ "cdk-nwc",
  "cdk-postgres",
  "cdk-sql-common",
  "cdk-sqlite",
@@ -1464,6 +1467,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uniffi",
@@ -1548,6 +1552,7 @@ dependencies = [
  "cdk-ldk-node",
  "cdk-lnd",
  "cdk-mintd",
+ "cdk-nwc",
  "cdk-redb",
  "cdk-sqlite",
  "clap",
@@ -1558,6 +1563,8 @@ dependencies = [
  "ldk-node",
  "lightning",
  "lightning-invoice",
+ "nostr-sdk",
+ "nwc",
  "once_cell",
  "rand 0.9.4",
  "serde",
@@ -1728,6 +1735,19 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "web-time",
+]
+
+[[package]]
+name = "cdk-nwc"
+version = "0.17.2"
+dependencies = [
+ "async-trait",
+ "nostr-sdk",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -5038,6 +5058,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "nwc"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f651e3c28dd9da0873151233e804a92b6240a1db1260f3c9d727950adb8e9036"
+dependencies = [
+ "nostr",
+ "nostr-relay-pool",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1257,6 +1257,7 @@ dependencies = [
  "cdk-common",
  "cdk-fake-wallet",
  "cdk-npubcash",
+ "cdk-nwc",
  "cdk-prometheus",
  "cdk-signatory",
  "cdk-sqlite",
@@ -1272,6 +1273,7 @@ dependencies = [
  "lightning",
  "lightning-invoice",
  "nostr-sdk",
+ "nwc",
  "rand 0.9.4",
  "regex",
  "ring 0.17.14",
@@ -1451,6 +1453,7 @@ dependencies = [
  "cdk",
  "cdk-common",
  "cdk-npubcash",
+ "cdk-nwc",
  "cdk-postgres",
  "cdk-sql-common",
  "cdk-sqlite",
@@ -1464,6 +1467,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uniffi",
@@ -1728,6 +1732,19 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "web-time",
+]
+
+[[package]]
+name = "cdk-nwc"
+version = "0.17.2"
+dependencies = [
+ "async-trait",
+ "nostr-sdk",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -5030,6 +5047,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "nwc"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f651e3c28dd9da0873151233e804a92b6240a1db1260f3c9d727950adb8e9036"
+dependencies = [
+ "nostr",
+ "nostr-relay-pool",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ cdk-mintd = { path = "./crates/cdk-mintd", version = "=0.17.2", default-features
 cdk-prometheus = { path = "./crates/cdk-prometheus", version = "=0.17.2", default-features = false }
 cdk-supabase = { path = "./crates/cdk-supabase", version = "=0.17.2", default-features = false }
 cdk-npubcash = { path = "./crates/cdk-npubcash", version = "=0.17.2" }
+cdk-nwc = { path = "./crates/cdk-nwc", version = "=0.17.2" }
 cdk-bdk = { path = "./crates/cdk-bdk", version = "=0.17.2", default-features = false }
 clap = { version = "4.5.31", features = ["derive"] }
 ciborium = { version = "0.2.2", default-features = false, features = ["std"] }
@@ -126,6 +127,7 @@ prometheus = { version = "0.13.4", features = ["process"], default-features = fa
 nostr-sdk = { version = "0.44.1", default-features = false, features = [
     "nip04",
     "nip44",
+    "nip47",
     "nip59"
 ]}
 bitcoin-payment-instructions = { version = "0.7.0", default-features = false }

--- a/bindings/dart/rust/Cargo.toml
+++ b/bindings/dart/rust/Cargo.toml
@@ -17,7 +17,7 @@ name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
 [dependencies]
-cdk-ffi = { workspace = true, features = ["npubcash", "bip353"] }
+cdk-ffi = { workspace = true, features = ["npubcash", "nwc", "bip353"] }
 uniffi = { workspace = true, features = ["cli"] }
 uniffi-dart = { git = "https://github.com/Uniffi-Dart/uniffi-dart", tag = "v0.1.0+v0.30.0"  }
 camino = "1.2"

--- a/bindings/go/rust/Cargo.toml
+++ b/bindings/go/rust/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 name = "cdk_ffi_go"
 
 [dependencies]
-cdk-ffi = { workspace = true, features = ["npubcash", "bip353"] }
+cdk-ffi = { workspace = true, features = ["npubcash", "nwc", "bip353"] }
 uniffi = { workspace = true, features = ["cli"] }
 
 [build-dependencies]

--- a/bindings/kotlin/rust/Cargo.toml
+++ b/bindings/kotlin/rust/Cargo.toml
@@ -17,7 +17,7 @@ name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
 [dependencies]
-cdk-ffi = { workspace = true, default-features = false, features = ["npubcash", "bip353"] }
+cdk-ffi = { workspace = true, default-features = false, features = ["npubcash", "nwc", "bip353"] }
 uniffi = { workspace = true, features = ["cli"] }
 
 [build-dependencies]

--- a/bindings/swift/rust/Cargo.toml
+++ b/bindings/swift/rust/Cargo.toml
@@ -18,7 +18,7 @@ name = "uniffi-bindgen-swift"
 path = "uniffi-bindgen-swift.rs"
 
 [dependencies]
-cdk-ffi = { workspace = true, default-features = false, features = ["npubcash", "bip353"] }
+cdk-ffi = { workspace = true, default-features = false, features = ["npubcash", "nwc", "bip353"] }
 uniffi = { workspace = true, features = ["cli"] }
 
 

--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -23,8 +23,7 @@ use cdk_common::payment::{
     WaitPaymentResponse,
 };
 use cdk_common::util::{hex, unix_time};
-use cdk_common::Bolt11Invoice;
-use cdk_common::QuoteId;
+use cdk_common::{Bolt11Invoice, QuoteId};
 use cln_rpc::model::requests::{
     DecodeRequest, FetchinvoiceRequest, InvoiceRequest, ListinvoicesRequest, ListpaysRequest,
     OfferRequest, PayRequest, WaitanyinvoiceRequest,

--- a/crates/cdk-ffi/Cargo.toml
+++ b/crates/cdk-ffi/Cargo.toml
@@ -20,7 +20,9 @@ cdk-sqlite = { workspace = true }
 cdk-postgres = { workspace = true, optional = true }
 cdk-supabase = { workspace = true, optional = true, features = ["wallet"] }
 cdk-npubcash = { workspace = true, optional = true }
+cdk-nwc = { workspace = true, optional = true }
 nostr-sdk = { workspace = true, optional = true }
+tokio-util = { workspace = true, optional = true }
 futures = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
@@ -42,7 +44,7 @@ log = "0.4"
 
 
 [features]
-default = ["npubcash", "bip353"]
+default = ["npubcash", "nwc", "bip353"]
 bip353 = ["cdk/bip353"]
 # Enable Postgres-backed wallet database support in FFI
 postgres = ["cdk-postgres"]
@@ -50,6 +52,8 @@ postgres = ["cdk-postgres"]
 supabase = ["cdk-supabase"]
 # Enable NpubCash client bindings
 npubcash = ["cdk/npubcash", "cdk-npubcash", "nostr-sdk"]
+# Enable Nostr Wallet Connect (NIP-47) wallet service bindings
+nwc = ["cdk/nwc", "cdk-nwc", "nostr-sdk", "dep:tokio-util"]
 
 [dev-dependencies]
 

--- a/crates/cdk-ffi/src/lib.rs
+++ b/crates/cdk-ffi/src/lib.rs
@@ -12,6 +12,8 @@ pub mod error;
 pub mod logging;
 #[cfg(feature = "npubcash")]
 pub mod npubcash;
+#[cfg(feature = "nwc")]
+pub mod nwc;
 #[cfg(feature = "postgres")]
 pub mod postgres;
 mod runtime;
@@ -29,6 +31,8 @@ pub use error::*;
 pub use logging::*;
 #[cfg(feature = "npubcash")]
 pub use npubcash::*;
+#[cfg(feature = "nwc")]
+pub use nwc::*;
 pub use types::*;
 pub use wallet::*;
 pub use wallet_repository::*;

--- a/crates/cdk-ffi/src/nwc.rs
+++ b/crates/cdk-ffi/src/nwc.rs
@@ -1,0 +1,294 @@
+//! FFI bindings for the Nostr Wallet Connect (NIP-47) wallet service.
+//!
+//! Exposes an [`NwcService`] object that turns a CDK [`Wallet`] into a NIP-47
+//! wallet service: it generates a `nostr+walletconnect://` connection URI to
+//! hand to a Nostr app, then listens on the configured relays and answers the
+//! supported commands (`get_info`, `get_balance`, `make_invoice`,
+//! `pay_invoice`, `lookup_invoice`, `list_transactions`) using the wallet.
+
+use std::sync::{Arc, Mutex};
+
+use cdk::wallet::WalletNwcHandler;
+use cdk_nwc::{NwcService as CdkNwcService, NwcServiceConfig};
+use nostr_sdk::{Keys, RelayUrl, SecretKey};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::error::FfiError;
+use crate::wallet::Wallet;
+
+/// A NIP-47 Nostr Wallet Connect wallet service bound to a CDK wallet.
+///
+/// Create one with [`NwcService::create`] (new connection) or
+/// [`NwcService::restore`] (existing connection from a persisted client
+/// secret), call [`NwcService::connection_uri`] to obtain the URI for the
+/// Nostr app, then [`NwcService::start`] to begin servicing requests.
+#[derive(uniffi::Object)]
+pub struct NwcService {
+    service: CdkNwcService,
+    handler: Arc<WalletNwcHandler>,
+    task: Mutex<Option<(JoinHandle<()>, CancellationToken)>>,
+}
+
+impl NwcService {
+    fn clear_finished_task(task: &mut Option<(JoinHandle<()>, CancellationToken)>) {
+        if task
+            .as_ref()
+            .is_some_and(|(handle, _)| handle.is_finished())
+        {
+            drop(task.take());
+        }
+    }
+
+    /// Shared construction logic for [`Self::create`] and [`Self::restore`].
+    fn build(
+        wallet: &Arc<Wallet>,
+        relays: Vec<String>,
+        service_keys: Keys,
+        client_secret: SecretKey,
+        max_payment_msat: Option<u64>,
+    ) -> Result<Self, FfiError> {
+        if relays.is_empty() {
+            return Err(FfiError::internal("at least one relay is required"));
+        }
+
+        let relays = relays
+            .iter()
+            .map(|r| {
+                RelayUrl::parse(r)
+                    .map_err(|e| FfiError::internal(format!("invalid relay {r}: {e}")))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let handler = Arc::new(WalletNwcHandler::new(
+            wallet.inner().clone(),
+            max_payment_msat,
+        ));
+
+        let service = CdkNwcService::new(NwcServiceConfig {
+            service_keys,
+            client_secret,
+            relays,
+            lud16: None,
+        })
+        .map_err(|e| FfiError::internal(e.to_string()))?;
+
+        Ok(Self {
+            service,
+            handler,
+            task: Mutex::new(None),
+        })
+    }
+}
+
+impl Drop for NwcService {
+    fn drop(&mut self) {
+        let Ok(mut guard) = self.task.lock() else {
+            return;
+        };
+
+        if let Some((handle, cancel)) = guard.take() {
+            cancel.cancel();
+            handle.abort();
+        }
+    }
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl NwcService {
+    /// Create a new wallet service with a freshly generated client connection.
+    ///
+    /// # Arguments
+    ///
+    /// * `wallet` - The CDK wallet that backs the service.
+    /// * `relays` - Relay URLs the service connects to and listens on.
+    /// * `service_secret_key` - Secret key of the wallet service (the signer).
+    ///   Accepts hex or bech32 `nsec`. Derive a stable one from the wallet seed
+    ///   with [`nwc_derive_service_secret_key_from_seed`].
+    /// * `max_payment_msat` - Optional cap (in millisatoshis) on any single
+    ///   `pay_invoice` request.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a key or relay URL is invalid, or no relays are given.
+    #[uniffi::constructor]
+    pub fn create(
+        wallet: Arc<Wallet>,
+        relays: Vec<String>,
+        service_secret_key: String,
+        max_payment_msat: Option<u64>,
+    ) -> Result<Self, FfiError> {
+        let service_keys = parse_keys(&service_secret_key)?;
+        let client_secret = SecretKey::generate();
+        Self::build(
+            &wallet,
+            relays,
+            service_keys,
+            client_secret,
+            max_payment_msat,
+        )
+    }
+
+    /// Restore a wallet service for an existing connection.
+    ///
+    /// Use this to rebuild a service after a restart from a persisted client
+    /// secret, so the previously issued connection URI keeps working.
+    ///
+    /// # Arguments
+    ///
+    /// * `client_secret_key` - The client secret from the original connection
+    ///   URI (hex or `nsec`).
+    ///
+    /// See [`Self::create`] for the other arguments.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a key or relay URL is invalid, or no relays are given.
+    #[uniffi::constructor]
+    pub fn restore(
+        wallet: Arc<Wallet>,
+        relays: Vec<String>,
+        service_secret_key: String,
+        client_secret_key: String,
+        max_payment_msat: Option<u64>,
+    ) -> Result<Self, FfiError> {
+        let service_keys = parse_keys(&service_secret_key)?;
+        let client_secret = parse_secret_key(&client_secret_key)?;
+        Self::build(
+            &wallet,
+            relays,
+            service_keys,
+            client_secret,
+            max_payment_msat,
+        )
+    }
+
+    /// The `nostr+walletconnect://` connection URI to hand to the Nostr app.
+    pub fn connection_uri(&self) -> String {
+        self.service.connection_uri().to_string()
+    }
+
+    /// Hex-encoded public key of the wallet service (advertised in the URI).
+    pub fn service_pubkey(&self) -> String {
+        self.service.service_pubkey().to_hex()
+    }
+
+    /// Hex-encoded public key of the authorized client.
+    pub fn client_pubkey(&self) -> String {
+        self.service.client_pubkey().to_hex()
+    }
+
+    /// Start servicing requests in the background.
+    ///
+    /// Connects to the relays, publishes the info event, and begins answering
+    /// commands. Returns immediately; the service runs until [`Self::stop`] is
+    /// called. Per-request failures are answered with NIP-47 error responses
+    /// and logged rather than surfaced here.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the service is already running.
+    // `async` is required so uniffi drives this on the tokio runtime, which
+    // `tokio::spawn` needs; the body itself does not await.
+    #[allow(clippy::unused_async)]
+    pub async fn start(&self) -> Result<(), FfiError> {
+        let mut guard = self
+            .task
+            .lock()
+            .map_err(|_| FfiError::internal("nwc service lock poisoned"))?;
+
+        Self::clear_finished_task(&mut guard);
+
+        if guard.is_some() {
+            return Err(FfiError::internal("nwc service is already running"));
+        }
+
+        let cancel = CancellationToken::new();
+        let service = self.service.clone();
+        let handler = self.handler.clone();
+        let run_cancel = cancel.clone();
+
+        let handle = tokio::spawn(async move {
+            if let Err(e) = service.run(handler, run_cancel).await {
+                tracing::error!("NWC service stopped with error: {e}");
+            }
+        });
+
+        *guard = Some((handle, cancel));
+        Ok(())
+    }
+
+    /// Stop the background service if it is running.
+    pub async fn stop(&self) -> Result<(), FfiError> {
+        let task = {
+            let mut guard = self
+                .task
+                .lock()
+                .map_err(|_| FfiError::internal("nwc service lock poisoned"))?;
+            guard.take()
+        };
+
+        if let Some((handle, cancel)) = task {
+            cancel.cancel();
+            handle.abort();
+            let _ = handle.await;
+        }
+
+        Ok(())
+    }
+
+    /// Whether the background service is currently running.
+    pub fn is_running(&self) -> bool {
+        let Ok(mut guard) = self.task.lock() else {
+            return false;
+        };
+
+        Self::clear_finished_task(&mut guard);
+        guard.is_some()
+    }
+}
+
+/// Derive the NWC wallet-service secret key from a wallet seed.
+///
+/// Returns a hex-encoded secret key for use as `service_secret_key`. Deriving
+/// from the seed keeps the connection URI stable across restarts. Uses the
+/// NIP-06 path `m/44'/1237'/1'/0/0`, distinct from the npub.cash key.
+///
+/// # Errors
+///
+/// Returns an error if the seed is shorter than 64 bytes or derivation fails.
+#[uniffi::export]
+pub fn nwc_derive_service_secret_key_from_seed(seed: Vec<u8>) -> Result<String, FfiError> {
+    if seed.len() < 64 {
+        return Err(FfiError::internal("Seed must be at least 64 bytes"));
+    }
+
+    let seed: [u8; 64] = seed[..64]
+        .try_into()
+        .map_err(|_| FfiError::internal("Failed to read wallet seed bytes"))?;
+
+    let secret_key = cdk::wallet::derive_nwc_secret_key_from_seed(&seed)
+        .map_err(|e| FfiError::internal(format!("Failed to derive secret key: {e}")))?;
+
+    Ok(secret_key.to_secret_hex())
+}
+
+/// Get the hex-encoded public key for a Nostr secret key (hex or `nsec`).
+///
+/// # Errors
+///
+/// Returns an error if the secret key is invalid.
+#[uniffi::export]
+pub fn nwc_get_pubkey(nostr_secret_key: String) -> Result<String, FfiError> {
+    Ok(parse_keys(&nostr_secret_key)?.public_key().to_hex())
+}
+
+/// Parse a Nostr secret key (hex or bech32 `nsec`) into [`Keys`].
+fn parse_keys(key: &str) -> Result<Keys, FfiError> {
+    Ok(Keys::new(parse_secret_key(key)?))
+}
+
+/// Parse a Nostr secret key from either hex or bech32 `nsec`.
+fn parse_secret_key(key: &str) -> Result<SecretKey, FfiError> {
+    SecretKey::parse(key).map_err(|e| FfiError::internal(format!("invalid secret key: {e}")))
+}

--- a/crates/cdk-integration-tests/Cargo.toml
+++ b/crates/cdk-integration-tests/Cargo.toml
@@ -20,7 +20,7 @@ rand.workspace = true
 bip39 = { workspace = true, features = ["rand"] }
 anyhow.workspace = true
 cashu = { workspace = true, features = ["mint", "wallet"] }
-cdk = { workspace = true, features = ["mint", "wallet", "bip353"] }
+cdk = { workspace = true, features = ["mint", "wallet", "bip353", "nwc"] }
 cdk-cln = { workspace = true }
 cdk-lnd = { workspace = true }
 cdk-ldk-node = { workspace = true }
@@ -30,6 +30,8 @@ cdk-redb = { workspace = true }
 cdk-fake-wallet = { workspace = true }
 cdk-common = { workspace = true, features = ["mint", "wallet", "http"] }
 cdk-http-client = { workspace = true }
+cdk-nwc = { workspace = true }
+nostr-sdk = { workspace = true }
 cdk-mintd = { workspace = true, features = ["cln", "lnd", "fakewallet", "grpc-processor", "lnbits", "management-rpc", "sqlite", "postgres", "ldk-node", "bdk", "prometheus"] }
 futures = { workspace = true, default-features = false, features = [
     "executor",
@@ -69,6 +71,7 @@ cdk-axum = { workspace = true }
 cdk-fake-wallet = { workspace = true }
 cdk-ffi = { workspace = true, features = ["npubcash", "bip353"] }
 tower-http = { workspace = true, features = ["cors"] }
+nwc = { version = "0.44.0", default-features = false }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/cdk-integration-tests/tests/nwc_e2e.rs
+++ b/crates/cdk-integration-tests/tests/nwc_e2e.rs
@@ -1,0 +1,294 @@
+//! End-to-end NWC (NIP-47) integration test.
+//!
+//! This test spins up a local `nostr-rs-relay`, creates a pure test mint with
+//! a funded wallet, starts the CDK NWC service backed by a [`WalletNwcHandler`],
+//! and uses the `nwc` client crate to exercise the full NIP-47 request/response
+//! flow over Nostr:
+//!
+//! 1. `get_info` — capability advertisement
+//! 2. `get_balance` — wallet balance in msat
+//! 3. `make_invoice` — create a mint quote (bolt11 invoice)
+//! 4. `pay_invoice` — pay a fake invoice via melt
+//! 5. `lookup_invoice` — look up a transaction by payment hash
+//! 6. `list_transactions` — list wallet transaction history
+//!
+//! ## Requirements
+//!
+//! - `nostr-rs-relay` must be on `PATH` (provided by the Nix `regtest` devShell).
+//! - `CDK_TEST_DB_TYPE` must be set (e.g. `memory`, `sqlite`).
+
+use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+use std::time::Duration;
+
+use cdk::wallet::WalletNwcHandler;
+use cdk_fake_wallet::create_fake_invoice;
+use cdk_integration_tests::init_pure_tests::*;
+use cdk_nwc::nip47::{
+    ListTransactionsRequest, LookupInvoiceRequest, MakeInvoiceRequest, PayInvoiceRequest,
+    TransactionState,
+};
+use cdk_nwc::{NwcService, NwcServiceConfig};
+use nostr_sdk::{Client as NostrClient, Filter, Keys, Kind, PublicKey, RelayUrl, SecretKey};
+use nwc::prelude::{NostrWalletConnectOptions, NostrWalletConnectURI, NWC};
+use tokio_util::sync::CancellationToken;
+
+/// Manage a local `nostr-rs-relay` subprocess on a free port.
+struct NostrRelay {
+    child: Option<Child>,
+    port: u16,
+}
+
+impl NostrRelay {
+    /// Start a local `nostr-rs-relay` on a free TCP port.
+    ///
+    /// Returns `None` if `nostr-rs-relay` is not on `PATH` (e.g. running
+    /// outside the Nix devShell), so the test can be skipped.
+    fn start() -> Option<Self> {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").ok()?;
+        let port = listener.local_addr().ok()?.port();
+        drop(listener);
+
+        let db_dir = std::env::temp_dir().join(format!("nostr-relay-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&db_dir).ok()?;
+
+        let config_path = db_dir.join("config.toml");
+        let config = format!(
+            r#"[network]
+port = {port}
+address = "127.0.0.1"
+"#
+        );
+        std::fs::write(&config_path, config).ok()?;
+
+        let child = Command::new("nostr-rs-relay")
+            .arg("--config")
+            .arg(&config_path)
+            .arg("--db")
+            .arg(&db_dir)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .ok()?;
+
+        Some(Self {
+            child: Some(child),
+            port,
+        })
+    }
+
+    fn ws_url(&self) -> String {
+        format!("ws://127.0.0.1:{}", self.port)
+    }
+}
+
+impl Drop for NostrRelay {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// Poll the relay's TCP port until it accepts connections or the timeout expires.
+async fn wait_for_relay(port: u16, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Wait until the service's kind `13194` info event is visible on the relay.
+///
+/// The service subscribes for requests *before* publishing the info event, so
+/// once the info event is fetchable the service is guaranteed to be receiving
+/// requests — no arbitrary sleep needed.
+async fn wait_for_info_event(
+    relay_url: &RelayUrl,
+    service_pubkey: PublicKey,
+    timeout: Duration,
+) -> bool {
+    let client = NostrClient::new(Keys::generate());
+    if client.add_relay(relay_url.clone()).await.is_err() {
+        return false;
+    }
+    client.connect().await;
+
+    let filter = Filter::new()
+        .kind(Kind::WalletConnectInfo)
+        .author(service_pubkey);
+
+    let deadline = tokio::time::Instant::now() + timeout;
+    let found = loop {
+        if tokio::time::Instant::now() >= deadline {
+            break false;
+        }
+        match client
+            .fetch_events(filter.clone(), Duration::from_secs(2))
+            .await
+        {
+            Ok(events) if !events.is_empty() => break true,
+            _ => tokio::time::sleep(Duration::from_millis(100)).await,
+        }
+    };
+
+    client.disconnect().await;
+    found
+}
+
+/// Full end-to-end NWC flow: client → relay → service → wallet → mint.
+#[tokio::test]
+async fn nwc_e2e_full_flow() {
+    let relay = match NostrRelay::start() {
+        Some(r) => r,
+        None => {
+            // In CI a missing relay means a broken devShell — fail loudly
+            // instead of silently passing.
+            if std::env::var("CI").is_ok() {
+                panic!("nostr-rs-relay not on PATH in CI; the regtest devShell must provide it");
+            }
+            eprintln!("skipping NWC e2e test: nostr-rs-relay not on PATH");
+            return;
+        }
+    };
+
+    assert!(
+        wait_for_relay(relay.port, Duration::from_secs(10)).await,
+        "nostr-rs-relay did not start"
+    );
+
+    setup_tracing();
+
+    let mint = create_and_start_test_mint().await.expect("mint");
+    let wallet = create_test_wallet_for_mint(mint.clone())
+        .await
+        .expect("wallet");
+
+    fund_wallet(wallet.clone(), 1000, None)
+        .await
+        .expect("fund wallet");
+
+    let wallet = Arc::new(wallet);
+
+    let service_secret_key = wallet.derive_nwc_secret_key().expect("nwc key");
+    let service_keys = Keys::parse(&service_secret_key.to_secret_hex()).expect("keys");
+    let client_secret = SecretKey::generate();
+    let relay_url = RelayUrl::parse(&relay.ws_url()).expect("relay url");
+
+    let service = NwcService::new(NwcServiceConfig {
+        service_keys,
+        client_secret: client_secret.clone(),
+        relays: vec![relay_url.clone()],
+        lud16: None,
+    })
+    .expect("nwc service");
+
+    let connection_uri = service.connection_uri().to_string();
+    let service_pubkey = service.service_pubkey();
+
+    let cancel = CancellationToken::new();
+    let service_cancel = cancel.clone();
+    let handler = Arc::new(WalletNwcHandler::new(wallet.clone(), None));
+    let service_task = tokio::spawn(async move {
+        if let Err(err) = service.run(handler, service_cancel).await {
+            tracing::error!("NWC service stopped: {err}");
+        }
+    });
+
+    // The service publishes its info event only after its request subscription
+    // is live, so seeing the info event means it is ready to serve.
+    assert!(
+        wait_for_info_event(&relay_url, service_pubkey, Duration::from_secs(10)).await,
+        "NWC service did not publish its info event"
+    );
+
+    let uri: NostrWalletConnectURI = connection_uri.parse().expect("uri");
+    let opts = NostrWalletConnectOptions::new().timeout(Duration::from_secs(30));
+    let nwc_client = NWC::with_opts(uri, opts);
+
+    // 1. get_info
+    let info = nwc_client.get_info().await.expect("get_info");
+    assert_eq!(info.alias.as_deref(), Some("CDK Cashu Wallet"));
+    assert!(!info.methods.is_empty());
+
+    // 2. get_balance — 1000 sats = 1,000,000 msat
+    let balance = nwc_client.get_balance().await.expect("get_balance");
+    assert_eq!(balance, 1_000_000);
+
+    // 3. make_invoice — create a 500 sat mint quote
+    let make_invoice_resp = nwc_client
+        .make_invoice(MakeInvoiceRequest {
+            amount: 500_000,
+            description: Some("test invoice".to_string()),
+            description_hash: None,
+            expiry: None,
+        })
+        .await
+        .expect("make_invoice");
+    assert!(!make_invoice_resp.invoice.is_empty());
+    let mint_payment_hash = make_invoice_resp.payment_hash.clone();
+
+    // 4. pay_invoice — pay a 100 sat fake invoice via melt
+    let fake_invoice = create_fake_invoice(100_000, "test payment".to_string());
+    let pay_resp = nwc_client
+        .pay_invoice(PayInvoiceRequest {
+            id: None,
+            invoice: fake_invoice.to_string(),
+            amount: None,
+        })
+        .await
+        .expect("pay_invoice");
+    // Fake wallet may not return a preimage; the key assertion is that the
+    // full NWC round-trip (client → relay → service → wallet → mint) succeeded.
+    assert!(pay_resp.fees_paid.is_some());
+
+    // 5. lookup_invoice — the unpaid mint quote should be pending
+    let lookup_resp = nwc_client
+        .lookup_invoice(LookupInvoiceRequest {
+            payment_hash: mint_payment_hash,
+            invoice: None,
+        })
+        .await
+        .expect("lookup_invoice");
+    assert_eq!(
+        lookup_resp.state,
+        Some(TransactionState::Pending),
+        "unpaid mint quote should be pending"
+    );
+
+    // 6. list_transactions — at least the melt (outgoing) transaction
+    let transactions = nwc_client
+        .list_transactions(ListTransactionsRequest {
+            from: None,
+            until: None,
+            limit: None,
+            offset: None,
+            unpaid: None,
+            transaction_type: None,
+        })
+        .await
+        .expect("list_transactions");
+    assert!(
+        !transactions.is_empty(),
+        "should have at least one transaction"
+    );
+
+    nwc_client.shutdown().await;
+
+    // Cancellation alone must stop the service promptly — no abort.
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_secs(5), service_task)
+        .await
+        .expect("service should stop on cancellation")
+        .expect("service task should not panic");
+}

--- a/crates/cdk-nwc/Cargo.toml
+++ b/crates/cdk-nwc/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "cdk-nwc"
+version.workspace = true
+authors = ["CDK Developers"]
+description = "Nostr Wallet Connect (NIP-47) wallet service for CDK"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+nostr-sdk = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "test-util"] }
+
+[lints]
+workspace = true

--- a/crates/cdk-nwc/src/error.rs
+++ b/crates/cdk-nwc/src/error.rs
@@ -1,0 +1,38 @@
+//! Error types for the Nostr Wallet Connect service
+
+use thiserror::Error;
+
+/// Result type for the NWC service
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors that can occur while running the NWC wallet service
+#[derive(Debug, Error)]
+pub enum Error {
+    /// No relays were configured for the service
+    #[error("at least one relay is required")]
+    NoRelays,
+
+    /// Failed to add or connect to a relay
+    #[error("relay error: {0}")]
+    Relay(String),
+
+    /// Failed to build, sign, or publish a Nostr event
+    #[error("nostr event error: {0}")]
+    Event(String),
+
+    /// Failed to subscribe to the relay pool
+    #[error("subscription error: {0}")]
+    Subscription(String),
+
+    /// NIP-47 protocol error (encoding/decoding)
+    #[error("nip47 protocol error: {0}")]
+    Protocol(String),
+
+    /// Encryption or decryption of an event payload failed
+    #[error("encryption error: {0}")]
+    Encryption(String),
+
+    /// JSON serialization/deserialization error
+    #[error("json error: {0}")]
+    Serde(#[from] serde_json::Error),
+}

--- a/crates/cdk-nwc/src/handler.rs
+++ b/crates/cdk-nwc/src/handler.rs
@@ -1,0 +1,56 @@
+//! Handler trait implemented by wallet backends.
+//!
+//! A backend (e.g. a Cashu wallet) implements [`NwcRequestHandler`] to service
+//! the NIP-47 commands. The handler is intentionally decoupled from any
+//! relay/transport concerns: the [`crate::NwcService`] owns the Nostr relay
+//! connection, decryption, authorization and response encoding, and only calls
+//! into the handler with already-validated, decrypted requests.
+//!
+//! Every method returns either a typed NIP-47 response or a [`NIP47Error`],
+//! which the service serializes into the encrypted response event. Handlers
+//! must never panic: any internal failure should be surfaced as a
+//! [`NIP47Error`] with an appropriate [`ErrorCode`](nostr_sdk::nips::nip47::ErrorCode).
+
+use async_trait::async_trait;
+use nostr_sdk::nips::nip47::{
+    GetBalanceResponse, GetInfoResponse, ListTransactionsRequest, LookupInvoiceRequest,
+    LookupInvoiceResponse, MakeInvoiceRequest, MakeInvoiceResponse, NIP47Error, PayInvoiceRequest,
+    PayInvoiceResponse,
+};
+
+/// Backend that services NIP-47 Nostr Wallet Connect requests.
+///
+/// Implementations are expected to be cheap to clone/share (e.g. wrap an
+/// `Arc`), since the service may dispatch requests concurrently.
+#[async_trait]
+pub trait NwcRequestHandler: Send + Sync {
+    /// Handle a `get_info` request.
+    async fn get_info(&self) -> Result<GetInfoResponse, NIP47Error>;
+
+    /// Handle a `get_balance` request. The returned balance is in millisatoshis.
+    async fn get_balance(&self) -> Result<GetBalanceResponse, NIP47Error>;
+
+    /// Handle a `make_invoice` request.
+    async fn make_invoice(
+        &self,
+        request: MakeInvoiceRequest,
+    ) -> Result<MakeInvoiceResponse, NIP47Error>;
+
+    /// Handle a `pay_invoice` request.
+    async fn pay_invoice(
+        &self,
+        request: PayInvoiceRequest,
+    ) -> Result<PayInvoiceResponse, NIP47Error>;
+
+    /// Handle a `lookup_invoice` request.
+    async fn lookup_invoice(
+        &self,
+        request: LookupInvoiceRequest,
+    ) -> Result<LookupInvoiceResponse, NIP47Error>;
+
+    /// Handle a `list_transactions` request.
+    async fn list_transactions(
+        &self,
+        request: ListTransactionsRequest,
+    ) -> Result<Vec<LookupInvoiceResponse>, NIP47Error>;
+}

--- a/crates/cdk-nwc/src/lib.rs
+++ b/crates/cdk-nwc/src/lib.rs
@@ -1,0 +1,40 @@
+//! # CDK Nostr Wallet Connect (NIP-47)
+//!
+//! A [NIP-47 Nostr Wallet Connect](https://github.com/nostr-protocol/nips/blob/master/47.md)
+//! **wallet service**: the side that holds funds and answers commands sent by a
+//! connected Nostr client (Damus, Amethyst, a website, …).
+//!
+//! The protocol wire types (connection URI, requests, responses, error codes)
+//! come from [`nostr_sdk::nips::nip47`] and are re-exported here for
+//! convenience. This crate adds:
+//!
+//! - [`NwcRequestHandler`]: the trait a wallet backend implements to service
+//!   the supported commands.
+//! - [`NwcService`]: owns the Nostr relay connection, advertises capabilities,
+//!   authorizes and decrypts requests, dispatches to the handler, and publishes
+//!   encrypted responses.
+//!
+//! The crate has no dependency on the `cdk` wallet crate; the Cashu-wallet
+//! backed handler lives in `cdk::wallet::nwc`, keeping this layer reusable and
+//! independently testable.
+//!
+//! ## Supported commands (first cut)
+//!
+//! `get_info`, `get_balance`, `make_invoice`, `pay_invoice`, `lookup_invoice`,
+//! `list_transactions`. Any other command is answered with
+//! [`ErrorCode::NotImplemented`](nostr_sdk::nips::nip47::ErrorCode::NotImplemented).
+//!
+//! All amounts in the NIP-47 protocol are denominated in **millisatoshis**.
+
+#![warn(missing_docs)]
+
+pub mod error;
+pub mod handler;
+pub mod service;
+
+pub use error::{Error, Result};
+pub use handler::NwcRequestHandler;
+// Re-export the NIP-47 protocol types so downstream crates depend on a single
+// source of truth without pulling `nostr_sdk` paths into their signatures.
+pub use nostr_sdk::nips::nip47;
+pub use service::{NwcService, NwcServiceConfig, SUPPORTED_METHODS};

--- a/crates/cdk-nwc/src/service.rs
+++ b/crates/cdk-nwc/src/service.rs
@@ -1,0 +1,579 @@
+//! Nostr Wallet Connect (NIP-47) wallet **service**.
+//!
+//! This is the side that holds the funds and answers commands. It owns the
+//! Nostr relay connection, publishes the kind `13194` info event advertising
+//! capabilities, listens for kind `23194` requests from the authorized client,
+//! decrypts and validates them, dispatches to a [`NwcRequestHandler`], and
+//! publishes the encrypted kind `23195` response.
+//!
+//! Security properties enforced here (monetary software — defense in depth):
+//! - **Authorization**: only events authored by the single client public key
+//!   issued in the connection URI are processed (enforced both by the relay
+//!   subscription filter and an explicit author check).
+//! - **Replay / idempotency**: each request event id is processed at most once,
+//!   so relay re-delivery cannot trigger a duplicate `pay_invoice`.
+//! - **Freshness**: requests carrying an expired NIP-40 `expiration` tag are
+//!   dropped, and only events created after the service started are considered.
+//! - **No information leak / no panics**: every handler error is mapped to a
+//!   NIP-47 error response; the relay loop never aborts on a single bad request.
+
+use std::collections::{HashSet, VecDeque};
+use std::sync::Arc;
+
+use nostr_sdk::nips::nip47::{
+    ErrorCode, NIP47Error, NostrWalletConnectURI, Request, RequestParams, Response, ResponseResult,
+};
+use nostr_sdk::nips::{nip04, nip44};
+use nostr_sdk::prelude::*;
+use nostr_sdk::{Client as NostrClient, Keys, PublicKey, RelayUrl, SecretKey};
+use tokio::sync::broadcast::error::RecvError;
+use tokio_util::sync::CancellationToken;
+
+use crate::error::{Error, Result};
+use crate::handler::NwcRequestHandler;
+
+/// Commands advertised in the info event and reported by `get_info`.
+///
+/// Order is the canonical advertisement order; it is also the set of commands
+/// this service will actually dispatch — anything else returns
+/// [`ErrorCode::NotImplemented`].
+pub const SUPPORTED_METHODS: [&str; 6] = [
+    "pay_invoice",
+    "make_invoice",
+    "lookup_invoice",
+    "list_transactions",
+    "get_balance",
+    "get_info",
+];
+
+const SUPPORTED_ENCRYPTION_SCHEMES: &str = "nip44_v2 nip04";
+
+/// Maximum number of recently-seen request event ids kept for replay
+/// protection. Bounded to keep memory usage flat on long-running services.
+const DEDUP_CAPACITY: usize = 10_000;
+
+/// Encryption scheme negotiated for a single request/response exchange.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Encryption {
+    /// NIP-44 v2 (preferred).
+    Nip44,
+    /// NIP-04 (legacy, still widely used by NWC clients).
+    Nip04,
+}
+
+/// Configuration for an [`NwcService`].
+#[derive(Debug, Clone)]
+pub struct NwcServiceConfig {
+    /// Keys of the wallet service (the "signer"). Its public key is the one
+    /// advertised in the connection URI.
+    pub service_keys: Keys,
+    /// The client secret embedded in the connection URI. The public key derived
+    /// from it is the only key authorized to send requests.
+    pub client_secret: SecretKey,
+    /// Relays the service connects to and listens on. Must be non-empty.
+    pub relays: Vec<RelayUrl>,
+    /// Optional lightning address advertised in the connection URI (`lud16`).
+    pub lud16: Option<String>,
+}
+
+/// A NIP-47 wallet service bound to a single client connection.
+#[derive(Debug, Clone)]
+pub struct NwcService {
+    service_keys: Keys,
+    client_secret: SecretKey,
+    client_pubkey: PublicKey,
+    relays: Vec<RelayUrl>,
+    lud16: Option<String>,
+}
+
+impl NwcService {
+    /// Create a new service from configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NoRelays`] if no relays are configured.
+    pub fn new(config: NwcServiceConfig) -> Result<Self> {
+        if config.relays.is_empty() {
+            return Err(Error::NoRelays);
+        }
+
+        let client_pubkey = Keys::new(config.client_secret.clone()).public_key();
+
+        Ok(Self {
+            service_keys: config.service_keys,
+            client_secret: config.client_secret,
+            client_pubkey,
+            relays: config.relays,
+            lud16: config.lud16,
+        })
+    }
+
+    /// Public key of the wallet service (advertised in the connection URI).
+    pub fn service_pubkey(&self) -> PublicKey {
+        self.service_keys.public_key()
+    }
+
+    /// Public key of the authorized client.
+    pub fn client_pubkey(&self) -> PublicKey {
+        self.client_pubkey
+    }
+
+    /// Build the `nostr+walletconnect://` connection URI to hand to the client.
+    pub fn connection_uri(&self) -> NostrWalletConnectURI {
+        NostrWalletConnectURI::new(
+            self.service_keys.public_key(),
+            self.relays.clone(),
+            self.client_secret.clone(),
+            self.lud16.clone(),
+        )
+    }
+
+    /// Connect to the relays, publish the info event, and service requests
+    /// until `cancel` is triggered.
+    ///
+    /// The subscription is established *before* the info event is published,
+    /// so a client that observes the info event is guaranteed the service is
+    /// already receiving requests.
+    ///
+    /// Each request is dispatched on its own task: a slow `pay_invoice` never
+    /// delays other requests. Cancellation is observed promptly even when no
+    /// notifications arrive; in-flight request tasks are left to finish on
+    /// their own.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if relays cannot be added, the info event cannot be
+    /// published, the subscription cannot be created, or the notification
+    /// channel closes unexpectedly. Per-request failures never bubble up
+    /// here — they are answered with a NIP-47 error response. Cancellation
+    /// returns `Ok(())`.
+    pub async fn run<H>(&self, handler: Arc<H>, cancel: CancellationToken) -> Result<()>
+    where
+        H: NwcRequestHandler + 'static,
+    {
+        let client = NostrClient::new(self.service_keys.clone());
+
+        for relay in &self.relays {
+            client
+                .add_relay(relay.clone())
+                .await
+                .map_err(|e| Error::Relay(format!("add relay {relay}: {e}")))?;
+        }
+
+        client.connect().await;
+
+        // Only consider requests created from now on, addressed to us, authored
+        // by the authorized client.
+        let filter = Filter::new()
+            .kind(Kind::WalletConnectRequest)
+            .author(self.client_pubkey)
+            .pubkey(self.service_keys.public_key())
+            .since(Timestamp::now());
+
+        // Take the notification stream before subscribing so no request can
+        // slip between subscription creation and the receive loop.
+        let mut notifications = client.notifications();
+
+        client
+            .subscribe(filter, None)
+            .await
+            .map_err(|e| Error::Subscription(e.to_string()))?;
+
+        self.publish_info_event(&client).await?;
+
+        // The loop is the only consumer, so dedup needs no locking; it must be
+        // checked before spawning so concurrent duplicates cannot race.
+        let mut dedup = Dedup::new(DEDUP_CAPACITY);
+
+        let res = loop {
+            let notification = tokio::select! {
+                _ = cancel.cancelled() => break Ok(()),
+                notification = notifications.recv() => notification,
+            };
+
+            let notification = match notification {
+                Ok(notification) => notification,
+                Err(RecvError::Lagged(skipped)) => {
+                    tracing::warn!("NWC notification stream lagged; skipped {skipped}");
+                    continue;
+                }
+                Err(RecvError::Closed) => {
+                    break Err(Error::Subscription(
+                        "notification channel closed".to_string(),
+                    ));
+                }
+            };
+
+            let RelayPoolNotification::Event { event, .. } = notification else {
+                continue;
+            };
+
+            // Defense in depth: the filter already constrains the author,
+            // but never trust a relay to honor it.
+            if event.pubkey != self.client_pubkey || event.kind != Kind::WalletConnectRequest {
+                continue;
+            }
+
+            if event.is_expired() {
+                tracing::debug!("Dropping expired NWC request {}", event.id);
+                continue;
+            }
+
+            // Replay protection: process each request id at most once.
+            if !dedup.insert(event.id) {
+                tracing::debug!("Dropping duplicate NWC request {}", event.id);
+                continue;
+            }
+
+            let handler = handler.clone();
+            let service_keys = self.service_keys.clone();
+            let client = client.clone();
+            tokio::spawn(async move {
+                handle_request(&service_keys, &client, handler.as_ref(), &event).await;
+            });
+        };
+
+        client.disconnect().await;
+
+        res
+    }
+
+    /// Publish the kind `13194` info event advertising supported commands and
+    /// encryption schemes.
+    async fn publish_info_event(&self, client: &NostrClient) -> Result<()> {
+        let content = SUPPORTED_METHODS.join(" ");
+
+        let event = EventBuilder::new(Kind::WalletConnectInfo, content)
+            .tags([info_event_encryption_tag()])
+            .sign_with_keys(&self.service_keys)
+            .map_err(|e| Error::Event(e.to_string()))?;
+
+        client
+            .send_event(&event)
+            .await
+            .map_err(|e| Error::Event(format!("publish info event: {e}")))?;
+
+        Ok(())
+    }
+}
+
+fn info_event_encryption_tag() -> Tag {
+    Tag::custom(
+        TagKind::custom("encryption"),
+        [SUPPORTED_ENCRYPTION_SCHEMES],
+    )
+}
+
+/// Decrypt, dispatch, and respond to a single request event.
+///
+/// Any failure is logged and (where possible) answered with a NIP-47 error
+/// response. This function never panics and never returns an error to the
+/// caller — keeping the relay loop alive is part of the security contract.
+async fn handle_request<H>(service_keys: &Keys, client: &NostrClient, handler: &H, event: &Event)
+where
+    H: NwcRequestHandler + ?Sized,
+{
+    let secret = service_keys.secret_key();
+
+    let (request, encryption) = match decrypt_request(secret, &event.pubkey, &event.content) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            tracing::warn!("Failed to decode NWC request {}: {e}", event.id);
+            return;
+        }
+    };
+
+    let response = dispatch(handler, request).await;
+
+    if let Err(e) = send_response(
+        service_keys,
+        client,
+        &event.pubkey,
+        event.id,
+        &response,
+        encryption,
+    )
+    .await
+    {
+        tracing::warn!("Failed to send NWC response for {}: {e}", event.id);
+    }
+}
+
+/// Try NIP-44 first, then fall back to NIP-04, and parse the request JSON.
+fn decrypt_request(
+    secret: &SecretKey,
+    author: &PublicKey,
+    content: &str,
+) -> Result<(Request, Encryption)> {
+    let (plaintext, encryption) = match nip44::decrypt(secret, author, content) {
+        Ok(plaintext) => (plaintext, Encryption::Nip44),
+        Err(_) => {
+            let plaintext = nip04::decrypt(secret, author, content)
+                .map_err(|e| Error::Encryption(e.to_string()))?;
+            (plaintext, Encryption::Nip04)
+        }
+    };
+
+    let request: Request =
+        serde_json::from_str(&plaintext).map_err(|e| Error::Protocol(e.to_string()))?;
+
+    Ok((request, encryption))
+}
+
+/// Dispatch a decoded request to the handler and build the NIP-47 response.
+async fn dispatch<H>(handler: &H, request: Request) -> Response
+where
+    H: NwcRequestHandler + ?Sized,
+{
+    let result_type = request.method;
+
+    let result: std::result::Result<ResponseResult, NIP47Error> = match request.params {
+        RequestParams::GetInfo => handler.get_info().await.map(ResponseResult::GetInfo),
+        RequestParams::GetBalance => handler.get_balance().await.map(ResponseResult::GetBalance),
+        RequestParams::MakeInvoice(params) => handler
+            .make_invoice(params)
+            .await
+            .map(ResponseResult::MakeInvoice),
+        RequestParams::PayInvoice(params) => handler
+            .pay_invoice(params)
+            .await
+            .map(ResponseResult::PayInvoice),
+        RequestParams::LookupInvoice(params) => handler
+            .lookup_invoice(params)
+            .await
+            .map(ResponseResult::LookupInvoice),
+        RequestParams::ListTransactions(params) => handler
+            .list_transactions(params)
+            .await
+            .map(ResponseResult::ListTransactions),
+        // Commands outside the supported set.
+        _ => Err(NIP47Error {
+            code: ErrorCode::NotImplemented,
+            message: format!("method {} is not implemented", result_type.as_str()),
+        }),
+    };
+
+    match result {
+        Ok(result) => Response {
+            result_type,
+            error: None,
+            result: Some(result),
+        },
+        Err(error) => Response {
+            result_type,
+            error: Some(error),
+            result: None,
+        },
+    }
+}
+
+/// Encrypt and publish the response event (kind `23195`).
+async fn send_response(
+    service_keys: &Keys,
+    client: &NostrClient,
+    client_pubkey: &PublicKey,
+    request_id: EventId,
+    response: &Response,
+    encryption: Encryption,
+) -> Result<()> {
+    let payload = serde_json::to_string(response)?;
+    let secret = service_keys.secret_key();
+
+    let content = match encryption {
+        Encryption::Nip44 => nip44::encrypt(secret, client_pubkey, payload, nip44::Version::V2)
+            .map_err(|e| Error::Encryption(e.to_string()))?,
+        Encryption::Nip04 => nip04::encrypt(secret, client_pubkey, payload)
+            .map_err(|e| Error::Encryption(e.to_string()))?,
+    };
+
+    let event = EventBuilder::new(Kind::WalletConnectResponse, content)
+        .tags([Tag::public_key(*client_pubkey), Tag::event(request_id)])
+        .sign_with_keys(service_keys)
+        .map_err(|e| Error::Event(e.to_string()))?;
+
+    client
+        .send_event(&event)
+        .await
+        .map_err(|e| Error::Event(format!("publish response: {e}")))?;
+
+    Ok(())
+}
+
+/// Bounded set of recently-seen request event ids for replay protection.
+#[derive(Debug)]
+struct Dedup {
+    seen: HashSet<EventId>,
+    order: VecDeque<EventId>,
+    capacity: usize,
+}
+
+impl Dedup {
+    fn new(capacity: usize) -> Self {
+        Self {
+            seen: HashSet::new(),
+            order: VecDeque::new(),
+            capacity,
+        }
+    }
+
+    /// Insert an id; returns `true` if it was newly inserted (i.e. should be
+    /// processed), `false` if it was already seen.
+    fn insert(&mut self, id: EventId) -> bool {
+        if !self.seen.insert(id) {
+            return false;
+        }
+        self.order.push_back(id);
+        if self.order.len() > self.capacity {
+            if let Some(oldest) = self.order.pop_front() {
+                self.seen.remove(&oldest);
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedup_rejects_repeat_and_evicts_oldest() {
+        let mut dedup = Dedup::new(2);
+        let keys = Keys::generate();
+        let mk = |content: &str| {
+            EventBuilder::new(Kind::TextNote, content)
+                .sign_with_keys(&keys)
+                .expect("sign dummy event")
+                .id
+        };
+        let a = mk("a");
+        let b = mk("b");
+        let c = mk("c");
+
+        assert!(dedup.insert(a));
+        assert!(!dedup.insert(a)); // duplicate
+        assert!(dedup.insert(b));
+        assert!(dedup.insert(c)); // evicts `a`
+        assert!(dedup.insert(a)); // `a` evicted, treated as new again
+    }
+
+    #[test]
+    fn info_event_encryption_tag_matches_nip47_shape() {
+        assert_eq!(
+            info_event_encryption_tag().to_vec(),
+            ["encryption", "nip44_v2 nip04"]
+        );
+    }
+
+    use async_trait::async_trait;
+    use nostr_sdk::nips::nip47::{
+        GetBalanceResponse, GetInfoResponse, ListTransactionsRequest, LookupInvoiceRequest,
+        LookupInvoiceResponse, MakeInvoiceRequest, MakeInvoiceResponse, PayInvoiceRequest,
+        PayInvoiceResponse, Request,
+    };
+
+    /// Canned handler: `get_balance` returns a fixed value, everything else errors.
+    struct MockHandler;
+
+    #[async_trait]
+    impl crate::handler::NwcRequestHandler for MockHandler {
+        async fn get_info(&self) -> std::result::Result<GetInfoResponse, NIP47Error> {
+            Err(NIP47Error {
+                code: ErrorCode::Internal,
+                message: "no".into(),
+            })
+        }
+        async fn get_balance(&self) -> std::result::Result<GetBalanceResponse, NIP47Error> {
+            Ok(GetBalanceResponse { balance: 5000 })
+        }
+        async fn make_invoice(
+            &self,
+            _: MakeInvoiceRequest,
+        ) -> std::result::Result<MakeInvoiceResponse, NIP47Error> {
+            unreachable!()
+        }
+        async fn pay_invoice(
+            &self,
+            _: PayInvoiceRequest,
+        ) -> std::result::Result<PayInvoiceResponse, NIP47Error> {
+            unreachable!()
+        }
+        async fn lookup_invoice(
+            &self,
+            _: LookupInvoiceRequest,
+        ) -> std::result::Result<LookupInvoiceResponse, NIP47Error> {
+            unreachable!()
+        }
+        async fn list_transactions(
+            &self,
+            _: ListTransactionsRequest,
+        ) -> std::result::Result<Vec<LookupInvoiceResponse>, NIP47Error> {
+            unreachable!()
+        }
+    }
+
+    /// Encrypt a request the way a client would, with the chosen scheme.
+    fn encrypt_request(
+        client_secret: &SecretKey,
+        service_pubkey: &PublicKey,
+        request: &Request,
+        scheme: Encryption,
+    ) -> String {
+        let json = serde_json::to_string(request).expect("serialize request");
+        match scheme {
+            Encryption::Nip44 => {
+                nip44::encrypt(client_secret, service_pubkey, json, nip44::Version::V2)
+                    .expect("nip44 encrypt")
+            }
+            Encryption::Nip04 => {
+                nip04::encrypt(client_secret, service_pubkey, json).expect("nip04 encrypt")
+            }
+        }
+    }
+
+    #[test]
+    fn decrypt_request_roundtrips_both_schemes() {
+        let service = Keys::generate();
+        let client = Keys::generate();
+        let request = Request::get_balance();
+
+        for scheme in [Encryption::Nip44, Encryption::Nip04] {
+            let content =
+                encrypt_request(client.secret_key(), &service.public_key(), &request, scheme);
+
+            let (decoded, detected) =
+                decrypt_request(service.secret_key(), &client.public_key(), &content)
+                    .expect("decrypt request");
+
+            assert_eq!(detected, scheme);
+            assert_eq!(decoded.method, request.method);
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_get_balance_ok() {
+        let response = dispatch(&MockHandler, Request::get_balance()).await;
+        assert!(response.error.is_none());
+        match response.result {
+            Some(ResponseResult::GetBalance(b)) => assert_eq!(b.balance, 5000),
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_unsupported_method_is_not_implemented() {
+        // pay_keysend is outside the supported set.
+        let request = Request::pay_keysend(nostr_sdk::nips::nip47::PayKeysendRequest {
+            id: None,
+            amount: 1000,
+            pubkey: "00".repeat(32),
+            preimage: None,
+            tlv_records: Vec::new(),
+        });
+
+        let response = dispatch(&MockHandler, request).await;
+        let error = response.error.expect("unsupported method should error");
+        assert_eq!(error.code, ErrorCode::NotImplemented);
+        assert!(response.result.is_none());
+    }
+}

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -15,6 +15,7 @@ default = ["mint", "wallet", "nostr", "bip353"]
 wallet = ["dep:futures", "cdk-common/wallet", "cdk-common/http", "dep:rustls"]
 nostr = ["wallet", "dep:nostr-sdk", "cdk-common/nostr"]
 npubcash = ["wallet", "nostr", "dep:cdk-npubcash"]
+nwc = ["wallet", "nostr", "dep:cdk-nwc"]
 mint = ["dep:futures", "cdk-common/mint", "cdk-common/http", "cdk-signatory"]
 bip353 = ["dep:hickory-resolver", "cdk-common/bip353"]
 bench = []
@@ -55,6 +56,7 @@ uuid.workspace = true
 jsonwebtoken.workspace = true
 nostr-sdk = { workspace = true, optional = true }
 cdk-npubcash = { workspace = true, optional = true }
+cdk-nwc = { workspace = true, optional = true }
 cdk-prometheus = {workspace = true, optional = true}
 bitcoin-payment-instructions = { workspace = true }
 web-time.workspace = true
@@ -160,6 +162,10 @@ name = "npubcash"
 required-features = ["npubcash"]
 
 [[example]]
+name = "nwc"
+required-features = ["nwc"]
+
+[[example]]
 name = "multimint-npubcash"
 required-features = ["npubcash"]
 
@@ -191,6 +197,7 @@ bip39.workspace = true
 tracing-subscriber.workspace = true
 criterion.workspace = true
 anyhow.workspace = true
+nwc = { version = "0.44.0", default-features = false }
 ureq = { version = "3.1.0", features = ["json"] }
 tokio = { workspace = true, features = ["full"] }
 

--- a/crates/cdk/examples/nwc.rs
+++ b/crates/cdk/examples/nwc.rs
@@ -1,0 +1,82 @@
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cdk::nuts::CurrencyUnit;
+use cdk::wallet::{Wallet, WalletNwcHandler};
+use cdk_nwc::{NwcService, NwcServiceConfig};
+use cdk_sqlite::wallet::memory;
+use nostr_sdk::{Keys, RelayUrl, SecretKey};
+use nwc::prelude::{NostrWalletConnectOptions, NostrWalletConnectURI, NWC};
+use rand::random;
+use tokio_util::sync::CancellationToken;
+use tracing_subscriber::EnvFilter;
+
+const DEFAULT_RELAY: &str = "wss://relay.damus.io";
+const DEFAULT_MINT_URL: &str = "https://testnut.cashudevkit.org";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let env_filter = EnvFilter::new("info,nostr_relay_pool=warn,nostr_sdk=warn");
+    tracing_subscriber::fmt().with_env_filter(env_filter).init();
+
+    let relay = std::env::var("NWC_RELAY").unwrap_or_else(|_| DEFAULT_RELAY.to_string());
+    let mint_url =
+        std::env::var("CDK_TEST_MINT_URL").unwrap_or_else(|_| DEFAULT_MINT_URL.to_string());
+
+    let wallet = Arc::new(Wallet::new(
+        &mint_url,
+        CurrencyUnit::Sat,
+        Arc::new(memory::empty().await?),
+        random::<[u8; 64]>(),
+        None,
+    )?);
+
+    let service_secret_key = wallet.derive_nwc_secret_key()?.to_secret_hex();
+    let service_keys = Keys::parse(&service_secret_key)?;
+    let client_secret = SecretKey::generate();
+    let relay_url = RelayUrl::parse(&relay)?;
+
+    let service = NwcService::new(NwcServiceConfig {
+        service_keys,
+        client_secret,
+        relays: vec![relay_url],
+        lud16: None,
+    })?;
+
+    let connection_uri = service.connection_uri().to_string();
+    println!("NWC connection URI:");
+    println!("{connection_uri}");
+
+    let cancel = CancellationToken::new();
+    let service_cancel = cancel.clone();
+    let handler = Arc::new(WalletNwcHandler::new(wallet.clone(), None));
+    let service_task = tokio::spawn(async move {
+        if let Err(err) = service.run(handler, service_cancel).await {
+            tracing::error!("NWC service stopped: {err}");
+        }
+    });
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let uri: NostrWalletConnectURI = connection_uri.parse()?;
+    let opts = NostrWalletConnectOptions::new().timeout(Duration::from_secs(15));
+    let client = NWC::with_opts(uri, opts);
+
+    let info = client.get_info().await?;
+    let balance = client.get_balance().await?;
+
+    println!(
+        "Wallet service alias: {}",
+        info.alias.unwrap_or_else(|| "unknown".to_string())
+    );
+    println!("Wallet balance: {balance} msat");
+
+    client.shutdown().await;
+    cancel.cancel();
+    service_task.abort();
+    let _ = service_task.await;
+
+    Ok(())
+}

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -54,6 +54,8 @@ mod mint_connector;
 mod mint_metadata_cache;
 #[cfg(feature = "npubcash")]
 mod npubcash;
+#[cfg(feature = "nwc")]
+pub mod nwc;
 mod p2pk;
 pub mod payment_request;
 mod proofs;
@@ -93,6 +95,8 @@ pub use mint_connector::{
 pub use nostr_backup::{BackupOptions, BackupResult, RestoreOptions, RestoreResult};
 #[cfg(feature = "npubcash")]
 pub use npubcash::derive_npubcash_secret_key_from_seed;
+#[cfg(feature = "nwc")]
+pub use nwc::{derive_nwc_secret_key_from_seed, WalletNwcHandler};
 pub use payment_request::CreateRequestParams;
 #[cfg(feature = "nostr")]
 pub use payment_request::NostrWaitInfo;

--- a/crates/cdk/src/wallet/nwc.rs
+++ b/crates/cdk/src/wallet/nwc.rs
@@ -1,0 +1,1312 @@
+//! Nostr Wallet Connect (NIP-47) integration for the CDK wallet.
+//!
+//! This module bridges the transport-agnostic [`cdk_nwc`] wallet service to a
+//! Cashu [`Wallet`]. [`WalletNwcHandler`] implements [`cdk_nwc::NwcRequestHandler`]
+//! by mapping each NIP-47 command onto wallet operations:
+//!
+//! | NIP-47 command      | Wallet operation                                   |
+//! |---------------------|----------------------------------------------------|
+//! | `get_info`          | static capability advertisement                    |
+//! | `get_balance`       | [`Wallet::total_balance`]                           |
+//! | `make_invoice`      | [`Wallet::mint_quote`] (bolt11)                     |
+//! | `pay_invoice`       | [`Wallet::melt_quote`] + [`Wallet::prepare_melt`]   |
+//! | `lookup_invoice`    | transaction history + active mint/melt quotes      |
+//! | `list_transactions` | [`Wallet::list_transactions`]                       |
+//!
+//! ## Units
+//!
+//! All NIP-47 amounts are **millisatoshis**. Cashu wallets denominated in `Sat`
+//! are converted with a ×1000 factor; sub-satoshi millisat amounts that cannot
+//! be represented exactly are rejected rather than silently rounded. Only `Sat`
+//! and `Msat` wallets are supported.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv};
+use bitcoin::Network;
+use cdk_common::nut00::KnownMethod;
+use cdk_common::wallet::{MeltQuote, MintQuote, Transaction, TransactionDirection};
+use cdk_common::{PaymentMethod, SECP256K1};
+use cdk_nwc::nip47::{
+    ErrorCode, GetBalanceResponse, GetInfoResponse, ListTransactionsRequest, LookupInvoiceRequest,
+    LookupInvoiceResponse, MakeInvoiceRequest, MakeInvoiceResponse, Method, NIP47Error,
+    PayInvoiceRequest, PayInvoiceResponse, TransactionType,
+};
+use cdk_nwc::service::SUPPORTED_METHODS;
+use lightning_invoice::Bolt11Invoice;
+use nostr_sdk::Timestamp;
+use tracing::instrument;
+
+use crate::error::Error;
+use crate::nuts::{CurrencyUnit, SecretKey};
+use crate::{amount, Amount, Wallet};
+
+/// Derive the NWC wallet-service secret key from a wallet seed.
+///
+/// Uses NIP-06 BIP-32 derivation under account index `1`
+/// (`m/44'/1237'/1'/0/0`), keeping it distinct from the npub.cash key
+/// (`m/44'/1237'/0'/0/0`) so a single seed yields independent identities. The
+/// derived key never equals raw seed material, so it cannot be used to recover
+/// the seed. Deriving from the seed keeps the connection URI stable across
+/// restarts.
+///
+/// # Errors
+///
+/// Returns an error if the key derivation fails.
+pub fn derive_nwc_secret_key_from_seed(seed: &[u8; 64]) -> Result<SecretKey, Error> {
+    let path = DerivationPath::from(vec![
+        ChildNumber::from_hardened_idx(44)?,
+        ChildNumber::from_hardened_idx(1237)?,
+        ChildNumber::from_hardened_idx(1)?,
+        ChildNumber::from_normal_idx(0)?,
+        ChildNumber::from_normal_idx(0)?,
+    ]);
+
+    let xpriv = Xpriv::new_master(Network::Bitcoin, seed)?;
+
+    Ok(SecretKey::from(
+        xpriv.derive_priv(&SECP256K1, &path)?.private_key,
+    ))
+}
+
+impl Wallet {
+    /// Derive the NWC wallet-service secret key from this wallet's seed.
+    ///
+    /// See [`derive_nwc_secret_key_from_seed`] for the derivation path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the key derivation fails.
+    pub fn derive_nwc_secret_key(&self) -> Result<SecretKey, Error> {
+        derive_nwc_secret_key_from_seed(&self.seed)
+    }
+
+    /// Build a [`WalletNwcHandler`] for this wallet.
+    ///
+    /// `max_payment_msat` optionally caps the amount of any single `pay_invoice`
+    /// request (in millisatoshis); pass `None` for no cap.
+    pub fn nwc_handler(&self, max_payment_msat: Option<u64>) -> WalletNwcHandler {
+        WalletNwcHandler::new(Arc::new(self.clone()), max_payment_msat)
+    }
+}
+
+/// A [`cdk_nwc::NwcRequestHandler`] backed by a Cashu [`Wallet`].
+#[derive(Debug, Clone)]
+pub struct WalletNwcHandler {
+    wallet: Arc<Wallet>,
+    max_payment_msat: Option<u64>,
+}
+
+impl WalletNwcHandler {
+    /// Create a new handler.
+    ///
+    /// `max_payment_msat` optionally caps the amount of any single `pay_invoice`
+    /// request (in millisatoshis).
+    pub fn new(wallet: Arc<Wallet>, max_payment_msat: Option<u64>) -> Self {
+        Self {
+            wallet,
+            max_payment_msat,
+        }
+    }
+}
+
+/// Build a NIP-47 error with the given code.
+fn nip47_err(code: ErrorCode, message: impl Into<String>) -> NIP47Error {
+    NIP47Error {
+        code,
+        message: message.into(),
+    }
+}
+
+/// Map an [`Amount`] conversion error to a NIP-47 error.
+fn amount_conversion_error(err: amount::Error, unit: &CurrencyUnit) -> NIP47Error {
+    match err {
+        amount::Error::CannotConvertUnits => {
+            nip47_err(ErrorCode::Other, format!("unsupported wallet unit: {unit}"))
+        }
+        amount::Error::AmountOverflow => nip47_err(
+            ErrorCode::Internal,
+            "amount overflow converting wallet units",
+        ),
+        other => nip47_err(ErrorCode::Internal, other.to_string()),
+    }
+}
+
+/// Convert a wallet [`Amount`] to millisatoshis for the given unit.
+fn amount_to_msat(amount: Amount, unit: &CurrencyUnit) -> Result<u64, NIP47Error> {
+    let value = u64::from(amount);
+    Amount::new(value, unit.clone())
+        .to_msat()
+        .map_err(|e| amount_conversion_error(e, unit))
+}
+
+/// Convert millisatoshis to a wallet [`Amount`] for the given unit.
+///
+/// For `Sat` wallets, millisat amounts that are not whole satoshis are rejected
+/// rather than rounded.
+fn msat_to_amount(msat: u64, unit: &CurrencyUnit) -> Result<Amount, NIP47Error> {
+    if unit == &CurrencyUnit::Sat && msat % 1000 != 0 {
+        return Err(nip47_err(
+            ErrorCode::Other,
+            "sub-satoshi amounts are not supported by this wallet",
+        ));
+    }
+
+    let amount = Amount::new(msat, CurrencyUnit::Msat);
+    match unit {
+        CurrencyUnit::Sat => amount.to_sat().map(Amount::from),
+        CurrencyUnit::Msat => amount.to_msat().map(Amount::from),
+        other => amount.convert_to(other).map(Into::into),
+    }
+    .map_err(|e| amount_conversion_error(e, unit))
+}
+
+/// Extract the hex payment hash from a bolt11 invoice string.
+fn payment_hash_of(invoice: &str) -> Option<String> {
+    Bolt11Invoice::from_str(invoice)
+        .ok()
+        .map(|i| i.payment_hash().to_string())
+}
+
+/// Extract the creation timestamp from a bolt11 invoice string.
+fn invoice_created_at(invoice: &str) -> Option<Timestamp> {
+    Bolt11Invoice::from_str(invoice)
+        .ok()
+        .map(|i| Timestamp::from(i.duration_since_epoch().as_secs()))
+}
+
+/// Map a wallet [`Error`] from a melt operation to the appropriate NIP-47 code.
+fn melt_error(err: &Error) -> NIP47Error {
+    match err {
+        Error::InsufficientFunds => nip47_err(
+            ErrorCode::InsufficientBalance,
+            "insufficient balance to pay invoice",
+        ),
+        Error::PaymentFailed => nip47_err(ErrorCode::PaymentFailed, "payment failed"),
+        other => nip47_err(ErrorCode::Internal, other.to_string()),
+    }
+}
+
+/// Map a wallet [`Error`] from a mint quote operation to the appropriate NIP-47 code.
+fn mint_quote_error(err: &Error) -> NIP47Error {
+    match err {
+        Error::InvoiceDescriptionUnsupported => nip47_err(
+            ErrorCode::Other,
+            "mint does not support invoice descriptions for bolt11 mint quotes",
+        ),
+        Error::UnsupportedUnit => nip47_err(
+            ErrorCode::Other,
+            "wallet unit is not supported by this mint for bolt11 mint quotes",
+        ),
+        other => nip47_err(ErrorCode::Internal, other.to_string()),
+    }
+}
+
+/// Convert a wallet [`Transaction`] into a NIP-47 transaction object.
+fn transaction_to_nip47(
+    tx: &Transaction,
+    unit: &CurrencyUnit,
+) -> Result<LookupInvoiceResponse, NIP47Error> {
+    let transaction_type = match tx.direction {
+        TransactionDirection::Incoming => TransactionType::Incoming,
+        TransactionDirection::Outgoing => TransactionType::Outgoing,
+    };
+
+    let payment_hash = tx
+        .payment_request
+        .as_deref()
+        .and_then(payment_hash_of)
+        .unwrap_or_default();
+
+    Ok(LookupInvoiceResponse {
+        transaction_type: Some(transaction_type),
+        state: Some(cdk_nwc::nip47::TransactionState::Settled),
+        invoice: tx.payment_request.clone(),
+        description: tx.memo.clone(),
+        description_hash: None,
+        preimage: tx.payment_proof.clone(),
+        payment_hash,
+        amount: amount_to_msat(tx.amount, unit)?,
+        fees_paid: amount_to_msat(tx.fee, unit)?,
+        created_at: Timestamp::from(tx.timestamp),
+        expires_at: None,
+        settled_at: Some(Timestamp::from(tx.timestamp)),
+        metadata: None,
+    })
+}
+
+/// Convert an active wallet melt quote into a pending outgoing NIP-47 transaction.
+fn pending_melt_quote_to_nip47(
+    quote: &MeltQuote,
+    unit: &CurrencyUnit,
+    payment_hash: String,
+) -> Result<LookupInvoiceResponse, NIP47Error> {
+    let created_at = invoice_created_at(&quote.request).unwrap_or_else(|| Timestamp::from(0));
+
+    Ok(LookupInvoiceResponse {
+        transaction_type: Some(TransactionType::Outgoing),
+        state: Some(cdk_nwc::nip47::TransactionState::Pending),
+        invoice: Some(quote.request.clone()),
+        description: None,
+        description_hash: None,
+        preimage: None,
+        payment_hash,
+        amount: amount_to_msat(quote.amount, unit)?,
+        fees_paid: amount_to_msat(quote.fee_reserve, unit)?,
+        created_at,
+        expires_at: Some(Timestamp::from(quote.expiry)),
+        settled_at: None,
+        metadata: None,
+    })
+}
+
+/// Convert an active wallet mint quote into a pending incoming NIP-47 transaction.
+fn pending_mint_quote_to_nip47(
+    quote: &MintQuote,
+    unit: &CurrencyUnit,
+    payment_hash: String,
+) -> Result<LookupInvoiceResponse, NIP47Error> {
+    let amount = quote
+        .amount
+        .map(|a| amount_to_msat(a, unit))
+        .transpose()?
+        .unwrap_or_default();
+    let created_at = invoice_created_at(&quote.request).unwrap_or_else(|| Timestamp::from(0));
+
+    Ok(LookupInvoiceResponse {
+        transaction_type: Some(TransactionType::Incoming),
+        state: Some(cdk_nwc::nip47::TransactionState::Pending),
+        invoice: Some(quote.request.clone()),
+        description: None,
+        description_hash: None,
+        preimage: None,
+        payment_hash,
+        amount,
+        fees_paid: 0,
+        created_at,
+        expires_at: Some(Timestamp::from(quote.expiry)),
+        settled_at: None,
+        metadata: None,
+    })
+}
+
+fn direction_matches(
+    requested: Option<TransactionDirection>,
+    candidate: TransactionDirection,
+) -> bool {
+    requested.is_none_or(|requested| requested == candidate)
+}
+
+fn timestamp_matches(timestamp: u64, from: Option<u64>, until: Option<u64>) -> bool {
+    from.is_none_or(|from| timestamp >= from) && until.is_none_or(|until| timestamp <= until)
+}
+
+fn transaction_time_matches(
+    transaction: &LookupInvoiceResponse,
+    from: Option<u64>,
+    until: Option<u64>,
+) -> bool {
+    timestamp_matches(transaction.created_at.as_secs(), from, until)
+}
+
+fn sort_nip47_transactions(transactions: &mut [LookupInvoiceResponse]) {
+    transactions.sort_by(|a, b| {
+        b.created_at
+            .as_secs()
+            .cmp(&a.created_at.as_secs())
+            .then_with(|| a.payment_hash.cmp(&b.payment_hash))
+    });
+}
+
+#[async_trait]
+impl cdk_nwc::NwcRequestHandler for WalletNwcHandler {
+    #[instrument(skip(self))]
+    async fn get_info(&self) -> Result<GetInfoResponse, NIP47Error> {
+        let methods = SUPPORTED_METHODS
+            .iter()
+            .filter_map(|m| Method::from_str(m).ok())
+            .collect();
+
+        Ok(GetInfoResponse {
+            alias: Some("CDK Cashu Wallet".to_string()),
+            color: None,
+            pubkey: None,
+            network: Some("mainnet".to_string()),
+            block_height: None,
+            block_hash: None,
+            methods,
+            notifications: Vec::new(),
+        })
+    }
+
+    #[instrument(skip(self))]
+    async fn get_balance(&self) -> Result<GetBalanceResponse, NIP47Error> {
+        let balance = self
+            .wallet
+            .total_balance()
+            .await
+            .map_err(|e| nip47_err(ErrorCode::Internal, e.to_string()))?;
+
+        Ok(GetBalanceResponse {
+            balance: amount_to_msat(balance, &self.wallet.unit)?,
+        })
+    }
+
+    #[instrument(skip(self))]
+    async fn make_invoice(
+        &self,
+        request: MakeInvoiceRequest,
+    ) -> Result<MakeInvoiceResponse, NIP47Error> {
+        if request.description_hash.is_some() {
+            return Err(nip47_err(
+                ErrorCode::Other,
+                "description_hash is not supported by Cashu mint quotes",
+            ));
+        }
+
+        if request.expiry.is_some() {
+            return Err(nip47_err(
+                ErrorCode::Other,
+                "expiry is not supported by Cashu mint quotes",
+            ));
+        }
+
+        let amount = msat_to_amount(request.amount, &self.wallet.unit)?;
+
+        let quote = self
+            .wallet
+            .mint_quote(
+                PaymentMethod::Known(KnownMethod::Bolt11),
+                Some(amount),
+                request.description.clone(),
+                None,
+            )
+            .await
+            .map_err(|e| mint_quote_error(&e))?;
+
+        let payment_hash = payment_hash_of(&quote.request);
+
+        Ok(MakeInvoiceResponse {
+            invoice: quote.request,
+            payment_hash,
+            description: request.description,
+            description_hash: request.description_hash,
+            preimage: None,
+            amount: Some(request.amount),
+            created_at: None,
+            expires_at: Some(Timestamp::from(quote.expiry)),
+        })
+    }
+
+    #[instrument(skip(self))]
+    async fn pay_invoice(
+        &self,
+        request: PayInvoiceRequest,
+    ) -> Result<PayInvoiceResponse, NIP47Error> {
+        let invoice = Bolt11Invoice::from_str(&request.invoice)
+            .map_err(|e| nip47_err(ErrorCode::Other, format!("invalid bolt11 invoice: {e}")))?;
+
+        // The invoice must carry its own amount: paying amountless invoices
+        // would require an amount override, which is not supported here.
+        let invoice_msat = invoice.amount_milli_satoshis().ok_or_else(|| {
+            nip47_err(
+                ErrorCode::Other,
+                "amountless invoices are not supported; invoice must specify an amount",
+            )
+        })?;
+
+        // A redundant `amount` is accepted only when it matches the invoice;
+        // a mismatch is rejected rather than silently paying a different sum.
+        if let Some(requested) = request.amount {
+            if requested != invoice_msat {
+                return Err(nip47_err(
+                    ErrorCode::Other,
+                    "requested amount does not match the invoice amount",
+                ));
+            }
+        }
+
+        // Per-payment cap enforcement (defense in depth, before any state changes).
+        if let Some(max_payment_msat) = self.max_payment_msat {
+            if invoice_msat > max_payment_msat {
+                return Err(nip47_err(
+                    ErrorCode::QuotaExceeded,
+                    "payment exceeds max_payment_msat",
+                ));
+            }
+        }
+
+        let quote = self
+            .wallet
+            .melt_quote(
+                PaymentMethod::Known(KnownMethod::Bolt11),
+                request.invoice.clone(),
+                None,
+                None,
+            )
+            .await
+            .map_err(|e| melt_error(&e))?;
+
+        let prepared = self
+            .wallet
+            .prepare_melt(&quote.id, HashMap::new())
+            .await
+            .map_err(|e| melt_error(&e))?;
+
+        let finalized = prepared.confirm().await.map_err(|e| melt_error(&e))?;
+
+        let preimage = finalized.payment_proof().unwrap_or_default().to_string();
+        let fees_paid = amount_to_msat(finalized.fee_paid(), &self.wallet.unit)?;
+
+        Ok(PayInvoiceResponse {
+            preimage,
+            fees_paid: Some(fees_paid),
+        })
+    }
+
+    #[instrument(skip(self))]
+    async fn lookup_invoice(
+        &self,
+        request: LookupInvoiceRequest,
+    ) -> Result<LookupInvoiceResponse, NIP47Error> {
+        let target_hash = request
+            .payment_hash
+            .clone()
+            .or_else(|| request.invoice.as_deref().and_then(payment_hash_of))
+            .ok_or_else(|| {
+                nip47_err(
+                    ErrorCode::Other,
+                    "either payment_hash or invoice is required",
+                )
+            })?;
+
+        let unit = &self.wallet.unit;
+
+        // Settled transactions (incoming and outgoing).
+        let transactions = self
+            .wallet
+            .list_transactions(None)
+            .await
+            .map_err(|e| nip47_err(ErrorCode::Internal, e.to_string()))?;
+
+        for tx in &transactions {
+            if tx
+                .payment_request
+                .as_deref()
+                .and_then(payment_hash_of)
+                .as_deref()
+                == Some(target_hash.as_str())
+            {
+                return transaction_to_nip47(tx, unit);
+            }
+        }
+
+        // Outstanding (unpaid) invoices we issued.
+        let quotes = self
+            .wallet
+            .get_active_mint_quotes()
+            .await
+            .map_err(|e| nip47_err(ErrorCode::Internal, e.to_string()))?;
+
+        for quote in quotes {
+            if payment_hash_of(&quote.request).as_deref() == Some(target_hash.as_str()) {
+                return pending_mint_quote_to_nip47(&quote, unit, target_hash);
+            }
+        }
+
+        // Outgoing payments that are quoted or in progress but not yet in history.
+        let quotes = self
+            .wallet
+            .get_active_melt_quotes()
+            .await
+            .map_err(|e| nip47_err(ErrorCode::Internal, e.to_string()))?;
+
+        for quote in quotes {
+            if payment_hash_of(&quote.request).as_deref() == Some(target_hash.as_str()) {
+                return pending_melt_quote_to_nip47(&quote, unit, target_hash);
+            }
+        }
+
+        Err(nip47_err(ErrorCode::NotFound, "invoice not found"))
+    }
+
+    #[instrument(skip(self))]
+    async fn list_transactions(
+        &self,
+        request: ListTransactionsRequest,
+    ) -> Result<Vec<LookupInvoiceResponse>, NIP47Error> {
+        let direction = request.transaction_type.map(|t| match t {
+            TransactionType::Incoming => TransactionDirection::Incoming,
+            TransactionType::Outgoing => TransactionDirection::Outgoing,
+        });
+
+        let unit = &self.wallet.unit;
+
+        let from = request.from.map(|t| t.as_secs());
+        let until = request.until.map(|t| t.as_secs());
+        let offset = request.offset.unwrap_or(0) as usize;
+        let limit = request.limit.map(|l| l as usize);
+
+        let transactions = self
+            .wallet
+            .list_transactions(direction)
+            .await
+            .map_err(|e| nip47_err(ErrorCode::Internal, e.to_string()))?;
+
+        if !request.unpaid.unwrap_or(false) {
+            let filtered = transactions
+                .into_iter()
+                .filter(|tx| timestamp_matches(tx.timestamp, from, until));
+
+            let mut out = Vec::new();
+            for tx in filtered.skip(offset) {
+                if let Some(limit) = limit {
+                    if out.len() >= limit {
+                        break;
+                    }
+                }
+                out.push(transaction_to_nip47(&tx, unit)?);
+            }
+
+            return Ok(out);
+        }
+
+        let mut out = Vec::new();
+        for tx in transactions {
+            let transaction = transaction_to_nip47(&tx, unit)?;
+            if transaction_time_matches(&transaction, from, until) {
+                out.push(transaction);
+            }
+        }
+
+        if direction_matches(direction, TransactionDirection::Incoming) {
+            let quotes = self
+                .wallet
+                .get_active_mint_quotes()
+                .await
+                .map_err(|e| nip47_err(ErrorCode::Internal, e.to_string()))?;
+
+            for quote in quotes {
+                if let Some(payment_hash) = payment_hash_of(&quote.request) {
+                    let transaction = pending_mint_quote_to_nip47(&quote, unit, payment_hash)?;
+                    if transaction_time_matches(&transaction, from, until) {
+                        out.push(transaction);
+                    }
+                }
+            }
+        }
+
+        if direction_matches(direction, TransactionDirection::Outgoing) {
+            let quotes = self
+                .wallet
+                .get_active_melt_quotes()
+                .await
+                .map_err(|e| nip47_err(ErrorCode::Internal, e.to_string()))?;
+
+            for quote in quotes {
+                if let Some(payment_hash) = payment_hash_of(&quote.request) {
+                    let transaction = pending_melt_quote_to_nip47(&quote, unit, payment_hash)?;
+                    if transaction_time_matches(&transaction, from, until) {
+                        out.push(transaction);
+                    }
+                }
+            }
+        }
+
+        sort_nip47_transactions(&mut out);
+
+        let transactions = out.into_iter().skip(offset);
+        match limit {
+            Some(limit) => Ok(transactions.take(limit).collect()),
+            None => Ok(transactions.collect()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use cdk_common::database::WalletDatabase;
+    use cdk_common::mint_url::MintUrl;
+    use cdk_common::wallet::{MeltQuote, MintQuote};
+    use cdk_common::MeltQuoteState;
+
+    use super::*;
+    use crate::nuts::{MintInfo, MintMethodSettings, NUT04Settings, Nuts};
+    use crate::wallet::test_utils::MockMintConnector;
+
+    const TEST_BOLT11: &str = "lnbc100n1pnvpufspp5djn8hrq49r8cghwye9kqw752qjncwyfnrprhprpqk43mwcy4yfsqdq5g9kxy7fqd9h8vmmfvdjscqzzsxqyz5vqsp5uhpjt36rj75pl7jq2sshaukzfkt7uulj456s4mh7uy7l6vx7lvxs9qxpqysgqedwz08acmqwtk8g4vkwm2w78suwt2qyzz6jkkwcgrjm3r3hs6fskyhvud4fan3keru7emjm8ygqpcrwtlmhfjfmer3afs5hhwamgr4cqtactdq";
+
+    #[test]
+    fn sat_amounts_convert_to_and_from_msat() {
+        assert_eq!(
+            amount_to_msat(Amount::from(5u64), &CurrencyUnit::Sat).expect("to msat"),
+            5000
+        );
+        assert_eq!(
+            amount_to_msat(Amount::from(7u64), &CurrencyUnit::Msat).expect("msat passthrough"),
+            7
+        );
+        assert_eq!(
+            msat_to_amount(5000, &CurrencyUnit::Sat).expect("from msat"),
+            Amount::from(5u64)
+        );
+        assert_eq!(
+            msat_to_amount(9, &CurrencyUnit::Msat).expect("msat passthrough"),
+            Amount::from(9u64)
+        );
+    }
+
+    #[test]
+    fn sub_satoshi_msat_is_rejected_for_sat_wallet() {
+        let err = msat_to_amount(500, &CurrencyUnit::Sat).expect_err("sub-sat rejected");
+        assert_eq!(err.code, ErrorCode::Other);
+    }
+
+    #[test]
+    fn nwc_service_key_is_distinct_from_npubcash_key() {
+        let seed = [0x24u8; 64];
+        let nwc = derive_nwc_secret_key_from_seed(&seed).expect("nwc key");
+
+        // npub.cash uses account index 0 (`m/44'/1237'/0'/0/0`); the NWC key
+        // must not collide with it.
+        let npub_path = DerivationPath::from_str("m/44'/1237'/0'/0/0").expect("npub path");
+        let xpriv = Xpriv::new_master(Network::Bitcoin, &seed).expect("master key");
+        let npub = xpriv
+            .derive_priv(&SECP256K1, &npub_path)
+            .expect("derive npub")
+            .private_key;
+
+        assert_ne!(nwc.to_secret_bytes(), npub.secret_bytes());
+        // Never raw seed material.
+        assert_ne!(&nwc.to_secret_bytes()[..], &seed[..32]);
+    }
+
+    fn sample_transaction(timestamp: u64) -> Transaction {
+        Transaction {
+            mint_url: MintUrl::from_str("https://mint.example.com").expect("mint url"),
+            direction: TransactionDirection::Incoming,
+            amount: Amount::from(10u64),
+            fee: Amount::from(1u64),
+            unit: CurrencyUnit::Sat,
+            ys: vec![SecretKey::generate().public_key()],
+            timestamp,
+            memo: Some("coffee".to_string()),
+            metadata: HashMap::new(),
+            quote_id: None,
+            payment_request: None,
+            payment_proof: None,
+            payment_method: None,
+            saga_id: None,
+        }
+    }
+
+    #[test]
+    fn transaction_maps_to_settled_nip47_object_in_msat() {
+        let tx = sample_transaction(1_700_000_000);
+        let mapped = transaction_to_nip47(&tx, &CurrencyUnit::Sat).expect("map tx");
+
+        assert_eq!(mapped.transaction_type, Some(TransactionType::Incoming));
+        assert_eq!(
+            mapped.state,
+            Some(cdk_nwc::nip47::TransactionState::Settled)
+        );
+        assert_eq!(mapped.amount, 10_000);
+        assert_eq!(mapped.fees_paid, 1_000);
+        assert_eq!(mapped.description.as_deref(), Some("coffee"));
+        assert!(mapped.settled_at.is_some());
+        assert_eq!(mapped.payment_hash, "");
+    }
+
+    #[tokio::test]
+    async fn list_transactions_keeps_newest_first_before_pagination() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore.clone(),
+            [0x42; 64],
+            None,
+        )
+        .expect("wallet");
+
+        localstore
+            .add_transaction(sample_transaction(1_700_000_000))
+            .await
+            .expect("add older transaction");
+        localstore
+            .add_transaction(sample_transaction(1_700_000_100))
+            .await
+            .expect("add newer transaction");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let transactions = cdk_nwc::NwcRequestHandler::list_transactions(
+            &handler,
+            ListTransactionsRequest {
+                limit: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("list transactions");
+
+        assert_eq!(transactions.len(), 1);
+        assert_eq!(transactions[0].created_at.as_secs(), 1_700_000_100);
+    }
+
+    #[tokio::test]
+    async fn list_transactions_omits_active_quotes_unless_unpaid_requested() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("mint url");
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore.clone(),
+            [0x42; 64],
+            None,
+        )
+        .expect("wallet");
+
+        localstore
+            .add_mint_quote(MintQuote::new(
+                "quote-id".to_string(),
+                mint_url,
+                PaymentMethod::Known(KnownMethod::Bolt11),
+                Some(Amount::from(10u64)),
+                CurrencyUnit::Sat,
+                TEST_BOLT11.to_string(),
+                9_999_999_999,
+                None,
+            ))
+            .await
+            .expect("add mint quote");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let transactions =
+            cdk_nwc::NwcRequestHandler::list_transactions(&handler, Default::default())
+                .await
+                .expect("list transactions");
+
+        assert!(transactions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_transactions_includes_active_mint_quotes_when_unpaid_requested() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("mint url");
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore.clone(),
+            [0x42; 64],
+            None,
+        )
+        .expect("wallet");
+        let expiry = 9_999_999_999;
+
+        localstore
+            .add_mint_quote(MintQuote::new(
+                "quote-id".to_string(),
+                mint_url,
+                PaymentMethod::Known(KnownMethod::Bolt11),
+                Some(Amount::from(10u64)),
+                CurrencyUnit::Sat,
+                TEST_BOLT11.to_string(),
+                expiry,
+                None,
+            ))
+            .await
+            .expect("add mint quote");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let payment_hash = payment_hash_of(TEST_BOLT11).expect("payment hash");
+        let transactions = cdk_nwc::NwcRequestHandler::list_transactions(
+            &handler,
+            ListTransactionsRequest {
+                unpaid: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("list transactions");
+        assert_eq!(transactions.len(), 1);
+        let transaction = &transactions[0];
+
+        assert_eq!(
+            transaction.transaction_type,
+            Some(TransactionType::Incoming)
+        );
+        assert_eq!(
+            transaction.state,
+            Some(cdk_nwc::nip47::TransactionState::Pending)
+        );
+        assert_eq!(transaction.invoice.as_deref(), Some(TEST_BOLT11));
+        assert_eq!(transaction.payment_hash, payment_hash);
+        assert_eq!(transaction.amount, 10_000);
+        assert_eq!(transaction.fees_paid, 0);
+        assert_eq!(transaction.expires_at, Some(Timestamp::from(expiry)));
+        assert_eq!(transaction.settled_at, None);
+    }
+
+    #[tokio::test]
+    async fn list_transactions_includes_active_melt_quotes_for_outgoing_unpaid_requests() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("mint url");
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore.clone(),
+            [0x42; 64],
+            None,
+        )
+        .expect("wallet");
+        let expiry = 9_999_999_999;
+
+        localstore
+            .add_melt_quote(MeltQuote {
+                id: "melt-quote-id".to_string(),
+                mint_url: Some(mint_url),
+                unit: CurrencyUnit::Sat,
+                amount: Amount::from(10u64),
+                request: TEST_BOLT11.to_string(),
+                fee_reserve: Amount::from(2u64),
+                state: MeltQuoteState::Unpaid,
+                expiry,
+                payment_proof: None,
+                estimated_blocks: None,
+                fee_index: None,
+                payment_method: PaymentMethod::Known(KnownMethod::Bolt11),
+                used_by_operation: None,
+                version: 0,
+            })
+            .await
+            .expect("add melt quote");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let payment_hash = payment_hash_of(TEST_BOLT11).expect("payment hash");
+        let transactions = cdk_nwc::NwcRequestHandler::list_transactions(
+            &handler,
+            ListTransactionsRequest {
+                unpaid: Some(true),
+                transaction_type: Some(TransactionType::Outgoing),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("list transactions");
+        assert_eq!(transactions.len(), 1);
+        let transaction = &transactions[0];
+
+        assert_eq!(
+            transaction.transaction_type,
+            Some(TransactionType::Outgoing)
+        );
+        assert_eq!(
+            transaction.state,
+            Some(cdk_nwc::nip47::TransactionState::Pending)
+        );
+        assert_eq!(transaction.invoice.as_deref(), Some(TEST_BOLT11));
+        assert_eq!(transaction.payment_hash, payment_hash);
+        assert_eq!(transaction.amount, 10_000);
+        assert_eq!(transaction.fees_paid, 2_000);
+        assert_eq!(transaction.expires_at, Some(Timestamp::from(expiry)));
+        assert_eq!(transaction.settled_at, None);
+    }
+
+    #[tokio::test]
+    async fn lookup_pending_invoice_uses_bolt11_created_at_and_quote_expiry() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("mint url");
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore.clone(),
+            [0x42; 64],
+            None,
+        )
+        .expect("wallet");
+        let expiry = 9_999_999_999;
+
+        localstore
+            .add_mint_quote(MintQuote::new(
+                "quote-id".to_string(),
+                mint_url,
+                PaymentMethod::Known(KnownMethod::Bolt11),
+                Some(Amount::from(10u64)),
+                CurrencyUnit::Sat,
+                TEST_BOLT11.to_string(),
+                expiry,
+                None,
+            ))
+            .await
+            .expect("add mint quote");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let payment_hash = payment_hash_of(TEST_BOLT11).expect("payment hash");
+        let invoice_created_at = invoice_created_at(TEST_BOLT11).expect("invoice created at");
+        let transaction = cdk_nwc::NwcRequestHandler::lookup_invoice(
+            &handler,
+            LookupInvoiceRequest {
+                payment_hash: Some(payment_hash),
+                invoice: None,
+            },
+        )
+        .await
+        .expect("lookup invoice");
+
+        assert_eq!(
+            transaction.state,
+            Some(cdk_nwc::nip47::TransactionState::Pending)
+        );
+        assert_eq!(transaction.created_at, invoice_created_at);
+        assert_eq!(transaction.expires_at, Some(Timestamp::from(expiry)));
+    }
+
+    #[tokio::test]
+    async fn lookup_active_melt_quote_returns_pending_outgoing_invoice() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("mint url");
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore.clone(),
+            [0x42; 64],
+            None,
+        )
+        .expect("wallet");
+        let expiry = 9_999_999_999;
+
+        localstore
+            .add_melt_quote(MeltQuote {
+                id: "melt-quote-id".to_string(),
+                mint_url: Some(mint_url),
+                unit: CurrencyUnit::Sat,
+                amount: Amount::from(10u64),
+                request: TEST_BOLT11.to_string(),
+                fee_reserve: Amount::from(2u64),
+                state: MeltQuoteState::Unpaid,
+                expiry,
+                payment_proof: None,
+                estimated_blocks: None,
+                fee_index: None,
+                payment_method: PaymentMethod::Known(KnownMethod::Bolt11),
+                used_by_operation: None,
+                version: 0,
+            })
+            .await
+            .expect("add melt quote");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let payment_hash = payment_hash_of(TEST_BOLT11).expect("payment hash");
+        let invoice_created_at = invoice_created_at(TEST_BOLT11).expect("invoice created at");
+        let transaction = cdk_nwc::NwcRequestHandler::lookup_invoice(
+            &handler,
+            LookupInvoiceRequest {
+                payment_hash: Some(payment_hash.clone()),
+                invoice: None,
+            },
+        )
+        .await
+        .expect("lookup invoice");
+
+        assert_eq!(
+            transaction.transaction_type,
+            Some(TransactionType::Outgoing)
+        );
+        assert_eq!(
+            transaction.state,
+            Some(cdk_nwc::nip47::TransactionState::Pending)
+        );
+        assert_eq!(transaction.invoice.as_deref(), Some(TEST_BOLT11));
+        assert_eq!(transaction.payment_hash, payment_hash);
+        assert_eq!(transaction.amount, 10_000);
+        assert_eq!(transaction.fees_paid, 2_000);
+        assert_eq!(transaction.created_at, invoice_created_at);
+        assert_eq!(transaction.expires_at, Some(Timestamp::from(expiry)));
+        assert_eq!(transaction.settled_at, None);
+    }
+
+    #[tokio::test]
+    async fn make_invoice_rejects_description_hash() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore,
+            [0x24; 64],
+            None,
+        )
+        .expect("wallet");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let err = cdk_nwc::NwcRequestHandler::make_invoice(
+            &handler,
+            MakeInvoiceRequest {
+                amount: 1_000,
+                description: None,
+                description_hash: Some("00".repeat(32)),
+                expiry: None,
+            },
+        )
+        .await
+        .expect_err("description hash is unsupported");
+
+        assert_eq!(err.code, ErrorCode::Other);
+        assert!(err.message.contains("description_hash"));
+    }
+
+    #[tokio::test]
+    async fn make_invoice_rejects_expiry() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore,
+            [0x24; 64],
+            None,
+        )
+        .expect("wallet");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let err = cdk_nwc::NwcRequestHandler::make_invoice(
+            &handler,
+            MakeInvoiceRequest {
+                amount: 1_000,
+                description: None,
+                description_hash: None,
+                expiry: Some(60),
+            },
+        )
+        .await
+        .expect_err("expiry is unsupported");
+
+        assert_eq!(err.code, ErrorCode::Other);
+        assert!(err.message.contains("expiry"));
+    }
+
+    #[tokio::test]
+    async fn make_invoice_rejects_description_when_mint_does_not_support_it() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.set_mint_info_response(Ok(MintInfo::new().nuts(Nuts::new().nut04(
+            NUT04Settings::new(
+                vec![MintMethodSettings {
+                    method: PaymentMethod::Known(KnownMethod::Bolt11),
+                    unit: CurrencyUnit::Sat,
+                    min_amount: Some(Amount::from(1_u64)),
+                    max_amount: Some(Amount::from(500_000_u64)),
+                    options: Some(crate::nuts::nut04::MintMethodOptions::Bolt11 {
+                        description: false,
+                    }),
+                }],
+                false,
+            ),
+        ))));
+
+        let wallet = crate::wallet::WalletBuilder::new()
+            .mint_url(MintUrl::from_str("https://mint.example.com").expect("mint url"))
+            .unit(CurrencyUnit::Sat)
+            .localstore(localstore)
+            .seed([0x42; 64])
+            .shared_client(mock_client)
+            .build()
+            .expect("wallet");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let err = cdk_nwc::NwcRequestHandler::make_invoice(
+            &handler,
+            MakeInvoiceRequest {
+                amount: 1_000,
+                description: Some("zap receipt".to_string()),
+                description_hash: None,
+                expiry: None,
+            },
+        )
+        .await
+        .expect_err("invoice descriptions are unsupported");
+
+        assert_eq!(err.code, ErrorCode::Other);
+        assert!(err.message.contains("invoice descriptions"));
+    }
+
+    #[tokio::test]
+    async fn get_info_advertises_supported_methods() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore,
+            [0x42; 64],
+            None,
+        )
+        .expect("wallet");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let info = cdk_nwc::NwcRequestHandler::get_info(&handler)
+            .await
+            .expect("get_info");
+
+        assert_eq!(info.alias.as_deref(), Some("CDK Cashu Wallet"));
+        assert!(!info.methods.is_empty());
+        assert!(info.network.as_deref() == Some("mainnet"));
+    }
+
+    #[tokio::test]
+    async fn get_balance_reports_zero_for_empty_wallet() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore,
+            [0x42; 64],
+            None,
+        )
+        .expect("wallet");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let balance = cdk_nwc::NwcRequestHandler::get_balance(&handler)
+            .await
+            .expect("get_balance");
+
+        assert_eq!(balance.balance, 0);
+    }
+
+    #[tokio::test]
+    async fn pay_invoice_rejects_amountless_invoice() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore,
+            [0x42; 64],
+            None,
+        )
+        .expect("wallet");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let err = cdk_nwc::NwcRequestHandler::pay_invoice(
+            &handler,
+            PayInvoiceRequest {
+                id: None,
+                invoice: "lnbc1u1p4ydwah".to_string(),
+                amount: None,
+            },
+        )
+        .await
+        .expect_err("invalid invoice should be rejected");
+
+        assert!(matches!(err.code, ErrorCode::Other));
+    }
+
+    #[tokio::test]
+    async fn pay_invoice_rejects_amount_mismatch() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore,
+            [0x42; 64],
+            None,
+        )
+        .expect("wallet");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let err = cdk_nwc::NwcRequestHandler::pay_invoice(
+            &handler,
+            PayInvoiceRequest {
+                id: None,
+                invoice: TEST_BOLT11.to_string(),
+                amount: Some(999_999),
+            },
+        )
+        .await
+        .expect_err("amount mismatch should be rejected");
+
+        assert_eq!(err.code, ErrorCode::Other);
+        assert!(err.message.contains("does not match"));
+    }
+
+    #[tokio::test]
+    async fn pay_invoice_rejects_over_max_payment_msat() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore,
+            [0x42; 64],
+            None,
+        )
+        .expect("wallet");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), Some(1_000));
+        let err = cdk_nwc::NwcRequestHandler::pay_invoice(
+            &handler,
+            PayInvoiceRequest {
+                id: None,
+                invoice: TEST_BOLT11.to_string(),
+                amount: None,
+            },
+        )
+        .await
+        .expect_err("over-cap payment should be rejected");
+
+        assert_eq!(err.code, ErrorCode::QuotaExceeded);
+    }
+
+    #[tokio::test]
+    async fn lookup_invoice_returns_not_found_for_unknown_hash() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore,
+            [0x42; 64],
+            None,
+        )
+        .expect("wallet");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let err = cdk_nwc::NwcRequestHandler::lookup_invoice(
+            &handler,
+            LookupInvoiceRequest {
+                payment_hash: Some("00".repeat(32)),
+                invoice: None,
+            },
+        )
+        .await
+        .expect_err("unknown invoice should return NotFound");
+
+        assert_eq!(err.code, ErrorCode::NotFound);
+    }
+
+    #[tokio::test]
+    async fn lookup_invoice_requires_payment_hash_or_invoice() {
+        let localstore = Arc::new(cdk_sqlite::wallet::memory::empty().await.expect("db"));
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            localstore,
+            [0x42; 64],
+            None,
+        )
+        .expect("wallet");
+
+        let handler = WalletNwcHandler::new(Arc::new(wallet), None);
+        let err = cdk_nwc::NwcRequestHandler::lookup_invoice(
+            &handler,
+            LookupInvoiceRequest {
+                payment_hash: None,
+                invoice: None,
+            },
+        )
+        .await
+        .expect_err("missing hash/invoice should error");
+
+        assert_eq!(err.code, ErrorCode::Other);
+        assert!(err.message.contains("required"));
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -880,6 +880,7 @@
           ])
           ++ (with pkgs; [
             mprocs
+            nostr-rs-relay
           ]);
 
         commonShellHook = ''

--- a/justfile
+++ b/justfile
@@ -133,6 +133,10 @@ coverage:
   echo "Running pure integration tests coverage (sqlite)..."
   CDK_TEST_DB_TYPE=sqlite cargo llvm-cov --no-report -p cdk-integration-tests --test integration_tests_pure
 
+  # Run NWC e2e tests with coverage (requires nostr-rs-relay on PATH)
+  echo "Running NWC e2e tests coverage (memory)..."
+  CDK_TEST_DB_TYPE=memory cargo llvm-cov --no-report -p cdk-integration-tests --test nwc_e2e
+
   # Generate report
   echo "Generating coverage report..."
   cargo llvm-cov report --lcov --output-path lcov.info
@@ -149,6 +153,7 @@ test-pure db="memory":
     CDK_TEST_DB_TYPE={{db}} cargo nextest run --archive-file "$CDK_ITEST_ARCHIVE" --workspace-remap . -E "binary(~integration_tests_pure)" -j 1
     CDK_TEST_DB_TYPE={{db}} cargo nextest run --archive-file "$CDK_ITEST_ARCHIVE" --workspace-remap . -E "binary(~test_swap_flow)" -j 1
     CDK_TEST_DB_TYPE={{db}} cargo nextest run --archive-file "$CDK_ITEST_ARCHIVE" --workspace-remap . -E "binary(~wallet_saga)" -j 1
+    CDK_TEST_DB_TYPE={{db}} cargo nextest run --archive-file "$CDK_ITEST_ARCHIVE" --workspace-remap . -E "binary(~nwc_e2e)" -j 1
   else
     # Run pure integration tests (cargo test will only build what's needed for the test)
     CDK_TEST_DB_TYPE={{db}} cargo test -p cdk-integration-tests --test integration_tests_pure -- --test-threads 1
@@ -158,6 +163,9 @@ test-pure db="memory":
 
     # Run wallet saga tests
     CDK_TEST_DB_TYPE={{db}} cargo test -p cdk-integration-tests --test wallet_saga -- --test-threads 1
+
+    # Run NWC (NIP-47) e2e tests (requires nostr-rs-relay on PATH; skipped locally if absent)
+    CDK_TEST_DB_TYPE={{db}} cargo test -p cdk-integration-tests --test nwc_e2e -- --test-threads 1
   fi
 
 # Mutation Testing Commands


### PR DESCRIPTION
Introduce a transport-agnostic cdk-nwc crate that connects to Nostr relays, advertises supported NWC commands, validates authorized requests, deduplicates event ids, and publishes encrypted responses.

Add a CDK wallet handler for get_info, get_balance, make_invoice, pay_invoice, lookup_invoice, and list_transactions, including msat/unit conversion, quote lookup, and per-payment limits.

Expose the service through UniFFI and add an example plus an end-to-end relay-backed NWC flow test.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
