### PR TITLE
fix(nut17): decode notification payloads with subscription kind

### DIFF
--- a/crates/cashu/src/nuts/nut17/mod.rs
+++ b/crates/cashu/src/nuts/nut17/mod.rs
@@ -212,19 +212,154 @@ where
     CustomMeltQuoteResponse(String, MeltQuoteCustomResponse<T>),
 }
 
+fn fill_response_method<E>(value: &mut serde_json::Value, method: &str) -> Result<(), E>
+where
+    E: DeError,
+{
+    if let serde_json::Value::Object(object) = value {
+        match object.get("method") {
+            Some(serde_json::Value::String(existing))
+                if PaymentMethod::new(existing.to_string())
+                    == PaymentMethod::new(method.to_string()) => {}
+            Some(serde_json::Value::String(existing)) => {
+                return Err(E::custom(format!(
+                    "notification payload method {existing} does not match kind method {method}"
+                )));
+            }
+            Some(_) => {
+                return Err(E::custom("notification payload method must be a string"));
+            }
+            None => {
+                object.insert(
+                    "method".to_string(),
+                    serde_json::Value::String(method.to_string()),
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn fill_kind_response_method<E>(
+    mut value: serde_json::Value,
+    method: &str,
+) -> Result<serde_json::Value, E>
+where
+    E: DeError,
+{
+    fill_response_method::<E>(&mut value, method)?;
+    Ok(value)
+}
+
+/// Deserialize a notification payload using the subscription kind that produced
+/// it.
+///
+/// NUT-17 notification payloads are not self-describing. Quote responses share
+/// many fields and tolerate unknown fields, so deserializing the payload without
+/// the subscription kind can silently select the wrong variant.
+pub fn deserialize_payload_for_kind<T, E>(
+    kind: &Kind,
+    value: serde_json::Value,
+) -> Result<NotificationPayload<T>, E>
+where
+    T: Clone + Serialize + DeserializeOwned,
+    E: DeError,
+{
+    fn from_value<V, E>(value: serde_json::Value) -> Result<V, E>
+    where
+        V: DeserializeOwned,
+        E: DeError,
+    {
+        serde_json::from_value(value).map_err(E::custom)
+    }
+
+    fn custom_response<V, E>(
+        kind: &str,
+        expected_method: &str,
+        mut value: serde_json::Value,
+    ) -> Result<(String, V), E>
+    where
+        V: DeserializeOwned,
+        E: DeError,
+    {
+        match &mut value {
+            serde_json::Value::Array(items) if items.len() == 2 => {
+                let payload_method = items
+                    .first()
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| E::custom("custom notification method must be a string"))?
+                    .to_string();
+                if payload_method != expected_method {
+                    return Err(E::custom(format!(
+                        "custom notification method {payload_method} does not match kind {kind}"
+                    )));
+                }
+
+                let response = items
+                    .get_mut(1)
+                    .ok_or_else(|| E::custom("custom notification payload is missing response"))?;
+                if !response.is_object() {
+                    return Err(E::custom("custom notification response must be an object"));
+                }
+                fill_response_method::<E>(response, expected_method)?;
+
+                from_value(value)
+            }
+            serde_json::Value::Array(_) => {
+                Err(E::custom("custom notification payload must have two items"))
+            }
+            serde_json::Value::Object(_) => {
+                fill_response_method::<E>(&mut value, expected_method)?;
+                from_value(value).map(|response| (expected_method.to_string(), response))
+            }
+            _ => Err(E::custom("custom notification response must be an object")),
+        }
+    }
+
+    match kind {
+        Kind::ProofState => from_value(value).map(NotificationPayload::ProofState),
+        Kind::Bolt11MintQuote => fill_kind_response_method::<E>(value, "bolt11")
+            .and_then(from_value)
+            .map(NotificationPayload::MintQuoteBolt11Response),
+        Kind::Bolt11MeltQuote => fill_kind_response_method::<E>(value, "bolt11")
+            .and_then(from_value)
+            .map(NotificationPayload::MeltQuoteBolt11Response),
+        Kind::Bolt12MintQuote => fill_kind_response_method::<E>(value, "bolt12")
+            .and_then(from_value)
+            .map(NotificationPayload::MintQuoteBolt12Response),
+        Kind::Bolt12MeltQuote => fill_kind_response_method::<E>(value, "bolt12")
+            .and_then(from_value)
+            .map(NotificationPayload::MeltQuoteBolt12Response),
+        Kind::OnchainMintQuote => fill_kind_response_method::<E>(value, "onchain")
+            .and_then(from_value)
+            .map(NotificationPayload::MintQuoteOnchainResponse),
+        Kind::OnchainMeltQuote => fill_kind_response_method::<E>(value, "onchain")
+            .and_then(from_value)
+            .map(NotificationPayload::MeltQuoteOnchainResponse),
+        Kind::Custom(method) => {
+            if let Some(expected_method) = method.strip_suffix("_mint_quote") {
+                custom_response(method, expected_method, value).map(|(method, response)| {
+                    NotificationPayload::CustomMintQuoteResponse(method, response)
+                })
+            } else if let Some(expected_method) = method.strip_suffix("_melt_quote") {
+                custom_response(method, expected_method, value).map(|(method, response)| {
+                    NotificationPayload::CustomMeltQuoteResponse(method, response)
+                })
+            } else {
+                Err(E::custom(format!(
+                    "unsupported custom notification kind: {method}"
+                )))
+            }
+        }
+    }
+}
+
 /// Classify a notification payload by its discriminating fields instead of
 /// serde `untagged` variant order. The quote responses for different payment
 /// methods share most field names, and the structs tolerate unknown fields
 /// for forward compatibility, so untagged trial-and-error would pick the
 /// wrong variant.
-fn fill_response_method(value: &mut serde_json::Value, method: &str) {
-    if let serde_json::Value::Object(object) = value {
-        object
-            .entry("method".to_string())
-            .or_insert_with(|| serde_json::Value::String(method.to_string()));
-    }
-}
-
 fn deserialize_payload<T, E>(value: serde_json::Value) -> Result<NotificationPayload<T>, E>
 where
     T: Clone + Serialize + DeserializeOwned,
@@ -283,7 +418,7 @@ where
             let mut value = value;
             if let serde_json::Value::Array(items) = &mut value {
                 if let Some(response) = items.get_mut(1) {
-                    fill_response_method(response, &method);
+                    fill_response_method::<E>(response, &method)?;
                 }
             }
 
@@ -445,7 +580,11 @@ mod tests {
             NotificationPayload::MintQuoteOnchainResponse(resp.clone());
 
         let encoded = serde_json::to_string(&payload).unwrap();
-        let decoded: NotificationPayload<String> = serde_json::from_str(&encoded).unwrap();
+        let decoded = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::OnchainMintQuote,
+            serde_json::from_str(&encoded).unwrap(),
+        )
+        .unwrap();
 
         match decoded {
             NotificationPayload::MintQuoteOnchainResponse(r) => {
@@ -477,7 +616,11 @@ mod tests {
             NotificationPayload::MintQuoteBolt12Response(resp.clone());
 
         let encoded = serde_json::to_string(&payload).unwrap();
-        let decoded: NotificationPayload<String> = serde_json::from_str(&encoded).unwrap();
+        let decoded = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::Bolt12MintQuote,
+            serde_json::from_str(&encoded).unwrap(),
+        )
+        .unwrap();
 
         match decoded {
             NotificationPayload::MintQuoteBolt12Response(r) => {
@@ -510,7 +653,11 @@ mod tests {
             NotificationPayload::MeltQuoteOnchainResponse(resp.clone());
 
         let encoded = serde_json::to_string(&payload).unwrap();
-        let decoded: NotificationPayload<String> = serde_json::from_str(&encoded).unwrap();
+        let decoded = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::OnchainMeltQuote,
+            serde_json::from_str(&encoded).unwrap(),
+        )
+        .unwrap();
 
         match decoded {
             NotificationPayload::MeltQuoteOnchainResponse(r) => {
@@ -538,7 +685,11 @@ mod tests {
             NotificationPayload::MeltQuoteBolt12Response(resp.clone());
 
         let encoded = serde_json::to_string(&payload).unwrap();
-        let decoded: NotificationPayload<String> = serde_json::from_str(&encoded).unwrap();
+        let decoded = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::Bolt12MeltQuote,
+            serde_json::from_str(&encoded).unwrap(),
+        )
+        .unwrap();
 
         match decoded {
             NotificationPayload::MeltQuoteBolt12Response(r) => {
@@ -562,7 +713,12 @@ mod tests {
                 "expiry": 1701704757
             }
         ]"#;
-        let payload: NotificationPayload<String> = serde_json::from_str(custom_mint).unwrap();
+        let mint_kind = Kind::Custom("paypal_mint_quote".to_string());
+        let payload = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &mint_kind,
+            serde_json::from_str(custom_mint).unwrap(),
+        )
+        .unwrap();
         match payload {
             NotificationPayload::CustomMintQuoteResponse(method, response) => {
                 assert_eq!(method, "paypal");
@@ -584,7 +740,12 @@ mod tests {
                 "unit": "sat"
             }
         ]"#;
-        let payload: NotificationPayload<String> = serde_json::from_str(custom_melt).unwrap();
+        let melt_kind = Kind::Custom("paypal_melt_quote".to_string());
+        let payload = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &melt_kind,
+            serde_json::from_str(custom_melt).unwrap(),
+        )
+        .unwrap();
         match payload {
             NotificationPayload::CustomMeltQuoteResponse(method, response) => {
                 assert_eq!(method, "paypal");
@@ -594,9 +755,19 @@ mod tests {
             other => panic!("expected CustomMeltQuoteResponse, got {:?}", other),
         }
 
-        assert!(serde_json::from_str::<NotificationPayload<String>>(r#"["paypal"]"#).is_err());
-        assert!(serde_json::from_str::<NotificationPayload<String>>(
-            r#"["paypal", "not an object"]"#
+        assert!(deserialize_payload_for_kind::<String, serde_json::Error>(
+            &mint_kind,
+            serde_json::json!(["paypal"]),
+        )
+        .is_err());
+        assert!(deserialize_payload_for_kind::<String, serde_json::Error>(
+            &mint_kind,
+            serde_json::json!(["paypal", "not an object"]),
+        )
+        .is_err());
+        assert!(deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::Custom("paypal".to_string()),
+            serde_json::json!({}),
         )
         .is_err());
     }
@@ -616,7 +787,11 @@ mod tests {
             "some_future_extension": {"nested": true}
         }"#;
 
-        let decoded: NotificationPayload<String> = serde_json::from_str(encoded).unwrap();
+        let decoded = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::OnchainMintQuote,
+            serde_json::from_str(encoded).unwrap(),
+        )
+        .unwrap();
 
         match decoded {
             NotificationPayload::MintQuoteOnchainResponse(r) => {
@@ -624,5 +799,123 @@ mod tests {
             }
             other => panic!("expected MintQuoteOnchainResponse, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn notification_payload_onchain_mint_future_state_field_uses_kind() {
+        let encoded = r#"{
+            "quote": "abc",
+            "request": "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+            "unit": "sat",
+            "expiry": 1701704757,
+            "pubkey": "03d56ce4e446a85bbdaa547b4ec2b073d40ff802831352b8272b7dd7a4de5a7cac",
+            "amount_paid": 0,
+            "amount_issued": 0,
+            "state": "future-extension"
+        }"#;
+
+        let decoded = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::OnchainMintQuote,
+            serde_json::from_str(encoded).unwrap(),
+        )
+        .unwrap();
+
+        match decoded {
+            NotificationPayload::MintQuoteOnchainResponse(r) => {
+                assert_eq!(r.quote, "abc");
+            }
+            other => panic!("expected MintQuoteOnchainResponse, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn notification_payload_custom_tuple_uses_kind() {
+        let encoded = serde_json::json!([
+            "foo",
+            {
+                "quote": "abc",
+                "request": "custom-request",
+                "amount": 100,
+                "amount_paid": 0,
+                "amount_issued": 0,
+                "unit": "sat",
+                "expiry": 1701704757
+            }
+        ]);
+
+        let decoded = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::Custom("foo_mint_quote".to_string()),
+            encoded,
+        )
+        .unwrap();
+
+        match decoded {
+            NotificationPayload::CustomMintQuoteResponse(method, r) => {
+                assert_eq!(method, "foo");
+                assert_eq!(r.quote, "abc");
+            }
+            other => panic!("expected CustomMintQuoteResponse, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn notification_payload_kind_decoder_accepts_case_insensitive_method() {
+        let payload = serde_json::json!({
+            "quote": "abc",
+            "request": "lnbc1...",
+            "amount": 100,
+            "unit": "sat",
+            "method": "BOLT11",
+            "state": "UNPAID",
+            "expiry": 1701704757
+        });
+
+        let decoded = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::Bolt11MintQuote,
+            payload,
+        )
+        .unwrap();
+
+        match decoded {
+            NotificationPayload::MintQuoteBolt11Response(response) => {
+                assert_eq!(response.method, PaymentMethod::Known(KnownMethod::Bolt11));
+            }
+            other => panic!("expected MintQuoteBolt11Response, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn notification_payload_rejects_method_that_does_not_match_kind() {
+        let bolt12_payload = serde_json::json!({
+            "quote": "melt-quote",
+            "amount": 21,
+            "fee_reserve": 1,
+            "method": "bolt11",
+            "state": "PAID",
+            "expiry": 1234
+        });
+
+        assert!(deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::Bolt12MeltQuote,
+            bolt12_payload,
+        )
+        .is_err());
+
+        let custom_payload = serde_json::json!({
+            "quote": "custom-quote",
+            "request": "custom-request",
+            "method": "bar",
+            "amount": 100,
+            "amount_paid": 0,
+            "amount_issued": 0,
+            "unit": "sat",
+            "expiry": 1701704757
+        });
+
+        assert!(deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::Custom("foo_mint_quote".to_string()),
+            custom_payload,
+        )
+        .is_err());
     }
 }

--- a/crates/cdk-integration-tests/tests/happy_path_mint_wallet.rs
+++ b/crates/cdk-integration-tests/tests/happy_path_mint_wallet.rs
@@ -22,6 +22,7 @@ use cashu::{MeltRequest, PreMintSecrets};
 use cdk::amount::{Amount, SplitTarget};
 use cdk::mint_url::MintUrl;
 use cdk::nuts::nut00::{KnownMethod, ProofsMethods};
+use cdk::nuts::nut17::{deserialize_payload_for_kind, Kind};
 use cdk::nuts::{CurrencyUnit, MeltQuoteState, NotificationPayload, PaymentMethod, State};
 use cdk::wallet::{HttpClient, MintConnector, Wallet, WalletRepositoryBuilder};
 use cdk_integration_tests::{create_invoice_for_env, get_mint_url_from_env, pay_if_regtest};
@@ -43,6 +44,7 @@ fn get_test_temp_dir() -> PathBuf {
 
 async fn get_notifications<T: StreamExt<Item = Result<Message, E>> + Unpin, E: Debug>(
     reader: &mut T,
+    kind: &Kind,
     timeout_to_wait: Duration,
     total: usize,
 ) -> Vec<(String, NotificationPayload<String>)> {
@@ -72,7 +74,11 @@ async fn get_notifications<T: StreamExt<Item = Result<Message, E>> + Unpin, E: D
                 .as_str()
                 .unwrap()
                 .to_string(),
-            serde_json::from_value(params_map.remove("payload").unwrap()).unwrap(),
+            deserialize_payload_for_kind::<String, serde_json::Error>(
+                kind,
+                params_map.remove("payload").unwrap(),
+            )
+            .unwrap(),
         ))
     }
     results
@@ -180,8 +186,13 @@ async fn test_happy_mint_melt_round_trip() {
     assert_eq!(response_json, expected_json);
 
     // Read the initial state notification before starting the melt to ensure we capture Unpaid
-    let initial_notification =
-        get_notifications(&mut reader, Duration::from_millis(15000), 1).await;
+    let initial_notification = get_notifications(
+        &mut reader,
+        &Kind::Bolt11MeltQuote,
+        Duration::from_millis(15000),
+        1,
+    )
+    .await;
     let (sub_id, payload) = &initial_notification[0];
     assert_eq!("test-sub", sub_id);
     let initial_melt = match payload {
@@ -212,7 +223,13 @@ async fn test_happy_mint_melt_round_trip() {
     assert_eq!(tx.metadata, metadata);
 
     // Read remaining notifications (Pending -> Paid)
-    let notifications = get_notifications(&mut reader, Duration::from_millis(15000), 2).await;
+    let notifications = get_notifications(
+        &mut reader,
+        &Kind::Bolt11MeltQuote,
+        Duration::from_millis(15000),
+        2,
+    )
+    .await;
 
     let (sub_id, payload) = &notifications[0];
     assert_eq!("test-sub", sub_id);

--- a/crates/cdk/src/wallet/subscription.rs
+++ b/crates/cdk/src/wallet/subscription.rs
@@ -14,7 +14,7 @@ use cdk_common::nut00::KnownMethod;
 use cdk_common::nut17::ws::{
     WsErrorResponse, WsMethodRequest, WsNotification, WsRequest, WsResponse, WsUnsubscribeRequest,
 };
-use cdk_common::nut17::{Kind, NotificationId};
+use cdk_common::nut17::{deserialize_payload_for_kind, Kind, NotificationId};
 use cdk_common::parking_lot::RwLock;
 use cdk_common::pub_sub::remote_consumer::{
     Consumer, InternalRelay, RemoteActiveConsumer, StreamCtrl, SubscribeMessage, Transport,
@@ -22,12 +22,7 @@ use cdk_common::pub_sub::remote_consumer::{
 use cdk_common::pub_sub::{Error as PubsubError, Spec, Subscriber};
 use cdk_common::subscription::WalletParams;
 use cdk_common::ws_client::{connect as ws_connect, WsError};
-use cdk_common::{
-    CheckStateRequest, MeltQuoteBolt11Response, MeltQuoteBolt12Response, MeltQuoteCustomResponse,
-    MeltQuoteOnchainResponse, Method, MintQuoteBolt11Response, MintQuoteBolt12Response,
-    MintQuoteCustomResponse, MintQuoteOnchainResponse, PaymentMethod, ProofState, RoutePath,
-};
-use serde::de::DeserializeOwned;
+use cdk_common::{CheckStateRequest, Method, PaymentMethod, RoutePath};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -53,35 +48,6 @@ enum RawWsMessageOrResponse<I> {
 
 /// Notification Payload
 pub type NotificationPayload = crate::nuts::NotificationPayload<String>;
-
-fn fill_response_method(value: &mut serde_json::Value, method: &str) {
-    if let serde_json::Value::Object(object) = value {
-        object
-            .entry("method".to_string())
-            .or_insert_with(|| serde_json::Value::String(method.to_string()));
-    }
-}
-
-fn deserialize_custom_quote_payload<R>(
-    mut payload: serde_json::Value,
-    kind: &str,
-    suffix: &str,
-) -> Result<R, PubsubError>
-where
-    R: DeserializeOwned,
-{
-    let method = kind
-        .strip_suffix(suffix)
-        .filter(|method| !method.is_empty())
-        .ok_or_else(|| {
-            PubsubError::ParsingError(format!(
-                "Invalid custom websocket notification kind: {kind}"
-            ))
-        })?;
-
-    fill_response_method(&mut payload, method);
-    serde_json::from_value(payload).map_err(|err| PubsubError::ParsingError(err.to_string()))
-}
 
 /// Type alias
 pub type ActiveSubscription = RemoteActiveConsumer<SubscriptionClient>;
@@ -274,52 +240,8 @@ fn decode_notification_payload(
     kind: &Kind,
     payload: serde_json::Value,
 ) -> Result<NotificationPayload, PubsubError> {
-    match kind {
-        Kind::ProofState => serde_json::from_value::<ProofState>(payload)
-            .map(NotificationPayload::ProofState)
-            .map_err(|err| PubsubError::ParsingError(err.to_string())),
-        Kind::Bolt11MintQuote => serde_json::from_value::<MintQuoteBolt11Response<String>>(payload)
-            .map(NotificationPayload::MintQuoteBolt11Response)
-            .map_err(|err| PubsubError::ParsingError(err.to_string())),
-        Kind::Bolt11MeltQuote => serde_json::from_value::<MeltQuoteBolt11Response<String>>(payload)
-            .map(NotificationPayload::MeltQuoteBolt11Response)
-            .map_err(|err| PubsubError::ParsingError(err.to_string())),
-        Kind::Bolt12MintQuote => serde_json::from_value::<MintQuoteBolt12Response<String>>(payload)
-            .map(NotificationPayload::MintQuoteBolt12Response)
-            .map_err(|err| PubsubError::ParsingError(err.to_string())),
-        Kind::Bolt12MeltQuote => serde_json::from_value::<MeltQuoteBolt12Response<String>>(payload)
-            .map(NotificationPayload::MeltQuoteBolt12Response)
-            .map_err(|err| PubsubError::ParsingError(err.to_string())),
-        Kind::OnchainMintQuote => {
-            serde_json::from_value::<MintQuoteOnchainResponse<String>>(payload)
-                .map(NotificationPayload::MintQuoteOnchainResponse)
-                .map_err(|err| PubsubError::ParsingError(err.to_string()))
-        }
-        Kind::OnchainMeltQuote => {
-            serde_json::from_value::<MeltQuoteOnchainResponse<String>>(payload)
-                .map(NotificationPayload::MeltQuoteOnchainResponse)
-                .map_err(|err| PubsubError::ParsingError(err.to_string()))
-        }
-        Kind::Custom(method) if method.ends_with("_mint_quote") => {
-            deserialize_custom_quote_payload::<MintQuoteCustomResponse<String>>(
-                payload,
-                method,
-                "_mint_quote",
-            )
-            .map(|response| NotificationPayload::CustomMintQuoteResponse(method.clone(), response))
-        }
-        Kind::Custom(method) if method.ends_with("_melt_quote") => {
-            deserialize_custom_quote_payload::<MeltQuoteCustomResponse<String>>(
-                payload,
-                method,
-                "_melt_quote",
-            )
-            .map(|response| NotificationPayload::CustomMeltQuoteResponse(method.clone(), response))
-        }
-        Kind::Custom(method) => Err(PubsubError::ParsingError(format!(
-            "Unsupported custom websocket notification kind: {method}"
-        ))),
-    }
+    deserialize_payload_for_kind::<String, serde_json::Error>(kind, payload)
+        .map_err(|err| PubsubError::ParsingError(err.to_string()))
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -826,9 +748,32 @@ mod tests {
     }
 
     #[test]
+    fn decode_onchain_mint_notification_uses_subscription_kind() {
+        let payload = json!({
+            "quote": "onchain-quote",
+            "request": "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+            "unit": "sat",
+            "expiry": 1234,
+            "pubkey": "02194603ffa062682c4f10e2dfe8f53e17d5d0329db51c8d3935cc74a4c0e0d4cb",
+            "amount_paid": 0,
+            "amount_issued": 0,
+            "state": "future-extension"
+        });
+
+        let decoded = decode_notification_payload(&Kind::OnchainMintQuote, payload).unwrap();
+
+        assert!(matches!(
+            decoded,
+            NotificationPayload::MintQuoteOnchainResponse(_)
+        ));
+    }
+
+    #[test]
     fn decode_custom_notifications() {
-        let mint_method = "foo_mint_quote".to_string();
-        let melt_method = "foo_melt_quote".to_string();
+        let mint_method = "foo".to_string();
+        let melt_method = "foo".to_string();
+        let mint_kind = Kind::Custom(format!("{}_mint_quote", mint_method));
+        let melt_kind = Kind::Custom(format!("{}_melt_quote", melt_method));
         let mint_payload = json!({
             "quote": "mint-custom",
             "request": "custom-request",
@@ -852,10 +797,8 @@ mod tests {
             "extra_field": "value"
         });
 
-        let mint_decoded =
-            decode_notification_payload(&Kind::Custom(mint_method.clone()), mint_payload).unwrap();
-        let melt_decoded =
-            decode_notification_payload(&Kind::Custom(melt_method.clone()), melt_payload).unwrap();
+        let mint_decoded = decode_notification_payload(&mint_kind, mint_payload).unwrap();
+        let melt_decoded = decode_notification_payload(&melt_kind, melt_payload).unwrap();
 
         assert!(matches!(
             mint_decoded,


### PR DESCRIPTION
NUT-17 notification payloads are ambiguous without the subscription kind. Quote response shapes overlap and tolerate unknown fields, so shape-based decoding can select the wrong payload variant.

Add a kind-aware payload decoder and use it in the wallet subscription client while preserving the existing generic payload deserialization surface for backports.

This prevents onchain and custom quote notifications from being decoded as the wrong payload variant.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
