### PR TITLE
feat(ffi): expose mint quote query methods

### DIFF
--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -323,6 +323,24 @@ impl Wallet {
         Ok(quote.into())
     }
 
+    /// Get active mint quotes stored in the wallet.
+    ///
+    /// Returns mint quotes for this wallet's mint and unit that are not expired
+    /// and not yet issued.
+    pub async fn get_active_mint_quotes(&self) -> Result<Vec<MintQuote>, FfiError> {
+        let quotes = self.inner.get_active_mint_quotes().await?;
+        Ok(quotes.into_iter().map(Into::into).collect())
+    }
+
+    /// Get unissued mint quotes stored in the wallet.
+    ///
+    /// Returns mint quotes for this wallet's mint and unit that have not yet
+    /// issued proofs.
+    pub async fn get_unissued_mint_quotes(&self) -> Result<Vec<MintQuote>, FfiError> {
+        let quotes = self.inner.get_unissued_mint_quotes().await?;
+        Ok(quotes.into_iter().map(Into::into).collect())
+    }
+
     /// Mint tokens.
     ///
     /// This writes newly issued proofs and saga state to the local store while
@@ -972,5 +990,22 @@ mod tests {
             .await
             .expect("trait call should mint zero from empty quote store");
         assert!(trait_minted.is_zero());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mint_quote_query_methods_are_available_on_wallet() {
+        let wallet = test_wallet();
+
+        let active = wallet
+            .get_active_mint_quotes()
+            .await
+            .expect("should get active mint quotes");
+        assert!(active.is_empty());
+
+        let unissued = wallet
+            .get_unissued_mint_quotes()
+            .await
+            .expect("should get unissued mint quotes");
+        assert!(unissued.is_empty());
     }
 }

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -353,6 +353,25 @@ impl Wallet {
         Ok(quote.into())
     }
 
+    /// Get active mint quotes stored in the wallet.
+    ///
+    /// Returns mint quotes for this wallet's mint and unit that are not expired
+    /// and not yet issued.
+    pub async fn get_active_mint_quotes(&self) -> Result<Vec<MintQuote>, FfiError> {
+        let quotes = self.inner.get_active_mint_quotes().await?;
+        Ok(quotes.into_iter().map(Into::into).collect())
+    }
+
+    /// Get unissued mint quotes stored in the wallet.
+    ///
+    /// Returns bolt11 quotes for this wallet's mint and unit where nothing has
+    /// been issued yet (amount_issued = 0) and all bolt12 quotes. Expired quotes
+    /// are included so they can be rechecked with the mint.
+    pub async fn get_unissued_mint_quotes(&self) -> Result<Vec<MintQuote>, FfiError> {
+        let quotes = self.inner.get_unissued_mint_quotes().await?;
+        Ok(quotes.into_iter().map(Into::into).collect())
+    }
+
     /// Mint tokens.
     ///
     /// This writes newly issued proofs and saga state to the local store while
@@ -1095,5 +1114,22 @@ mod tests {
                 refill_per_minute: 0,
             })
             .is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mint_quote_query_methods_are_available_on_wallet() {
+        let wallet = test_wallet();
+
+        let active = wallet
+            .get_active_mint_quotes()
+            .await
+            .expect("should get active mint quotes");
+        assert!(active.is_empty());
+
+        let unissued = wallet
+            .get_unissued_mint_quotes()
+            .await
+            .expect("should get unissued mint quotes");
+        assert!(unissued.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

This PR exposes existing wallet mint quote query methods through the FFI `Wallet`.

Recent FFI work exposed quote recovery/sync methods such as `check_all_mint_quotes` and `mint_unissued_quotes`. This PR adds the complementary query methods so generated bindings can inspect active and unissued mint quotes.

## Changes

- Add `Wallet::get_active_mint_quotes` to `crates/cdk-ffi`
- Add `Wallet::get_unissued_mint_quotes` to `crates/cdk-ffi`
- Convert core return values into existing FFI-compatible quote types
- Keep generated binding outputs out of this PR

## Testing

- `cargo fmt`
- `cargo test -p cdk-ffi`

Partially addresses #1767