### PR TITLE
perf(wallet): avoid network calls during repository startup

### DIFF
--- a/crates/cdk-ffi/src/wallet_repository.rs
+++ b/crates/cdk-ffi/src/wallet_repository.rs
@@ -19,7 +19,9 @@ pub struct WalletRepository {
 
 #[uniffi::export(async_runtime = "tokio")]
 impl WalletRepository {
-    /// Create a new WalletRepository
+    /// Create a new WalletRepository from locally persisted wallet state.
+    ///
+    /// Construction does not make network requests to configured mints.
     ///
     /// Accepts a `WalletStore` which can be:
     /// - `Sqlite { path }` — built-in Rust SQLite backend
@@ -51,7 +53,11 @@ impl WalletRepository {
         })
     }
 
-    /// Create a new WalletRepository with proxy configuration
+    /// Create a new WalletRepository with proxy configuration.
+    ///
+    /// Construction restores locally persisted wallet state without making
+    /// network requests to configured mints. The proxy is used by subsequent
+    /// mint operations.
     #[uniffi::constructor]
     pub fn new_with_proxy(
         mnemonic: String,

--- a/crates/cdk/src/wallet/wallet_repository.rs
+++ b/crates/cdk/src/wallet/wallet_repository.rs
@@ -205,7 +205,9 @@ impl WalletRepositoryBuilder {
         self
     }
 
-    /// Build the WalletRepository and load existing wallets from database
+    /// Build the WalletRepository and load existing wallets from the database.
+    ///
+    /// This only uses persisted mint metadata and does not make network requests.
     pub async fn build(self) -> Result<WalletRepository, Error> {
         let localstore = self
             .localstore
@@ -690,30 +692,26 @@ impl WalletRepository {
 
     /// Load all wallets from database
     ///
-    /// This loads wallets for all mints stored in the database.
-    /// For each mint, it fetches the mint info to discover supported units
-    /// and creates a wallet for each supported unit.
+    /// This loads wallets for all mints stored in the database. For each mint,
+    /// it uses the persisted mint info to discover supported units and creates
+    /// a wallet for each supported unit. This does not make network requests.
     #[instrument(skip(self))]
     async fn load_wallets(&self) -> Result<(), Error> {
         let mints = self.localstore.get_mints().await.map_err(Error::Database)?;
 
-        for (mint_url, _mint_info) in mints {
-            // Try to fetch mint info and create wallets for all supported units
-            // If fetch fails, fall back to creating just a Sat wallet
-            let units = match self.fetch_mint_info(&mint_url).await {
-                Ok(info) => {
-                    let supported = info.supported_units();
-                    if supported.is_empty() {
+        for (mint_url, mint_info) in mints {
+            let units = mint_info
+                .map(|info| {
+                    let supported_units = info.supported_units();
+                    if supported_units.is_empty() {
                         vec![CurrencyUnit::Sat]
                     } else {
-                        supported.into_iter().cloned().collect()
+                        supported_units.into_iter().cloned().collect()
                     }
-                }
-                Err(_) => {
-                    // If we can't fetch mint info, use default Sat unit for backward compatibility
-                    vec![CurrencyUnit::Sat]
-                }
-            };
+                })
+                // Older databases may not have mint metadata. Keep the
+                // established single-sat wallet behavior for those records.
+                .unwrap_or_else(|| vec![CurrencyUnit::Sat]);
 
             for unit in units {
                 let key = WalletKey::new(mint_url.clone(), unit.clone());
@@ -933,11 +931,15 @@ impl Drop for WalletRepository {
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::time::Duration;
 
     use cdk_common::database::WalletDatabase;
+    use cdk_common::nut00::KnownMethod;
+    use cdk_common::nuts::{MintInfo, MintMethodSettings};
     use tokio::net::TcpListener;
 
     use super::*;
+    use crate::nuts::{NUT04Settings, Nuts, PaymentMethod};
 
     async fn create_test_repository() -> WalletRepository {
         let localstore: Arc<dyn WalletDatabase<database::Error> + Send + Sync> = Arc::new(
@@ -1001,6 +1003,25 @@ mod tests {
             .expect("Failed to parse proxy URL")
     }
 
+    fn mint_info_with_units(units: Vec<CurrencyUnit>) -> MintInfo {
+        MintInfo::new().nuts(
+            Nuts::new().nut04(NUT04Settings::new(
+                units
+                    .into_iter()
+                    .map(|unit| MintMethodSettings {
+                        method: PaymentMethod::Known(KnownMethod::Bolt11),
+                        unit,
+                        method_name: None,
+                        min_amount: None,
+                        max_amount: None,
+                        options: None,
+                    })
+                    .collect(),
+                false,
+            )),
+        )
+    }
+
     #[test]
     fn builder_verifies_proxy_tls_certificates_by_default() {
         let builder = WalletRepositoryBuilder::new();
@@ -1019,6 +1040,77 @@ mod tests {
     async fn test_wallet_repository_creation() {
         let repo = create_test_repository().await;
         assert!(repo.wallets.try_read().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_load_wallets_uses_persisted_metadata_without_network() {
+        let localstore: Arc<dyn WalletDatabase<database::Error> + Send + Sync> = Arc::new(
+            cdk_sqlite::wallet::memory::empty()
+                .await
+                .expect("Failed to create in-memory database"),
+        );
+        let (mint_url, direct_connections, listener_handle) =
+            local_mint_url_with_connection_counter().await;
+        localstore
+            .add_mint(
+                mint_url.clone(),
+                Some(mint_info_with_units(vec![
+                    CurrencyUnit::Sat,
+                    CurrencyUnit::Usd,
+                ])),
+            )
+            .await
+            .expect("Failed to add mint metadata");
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            WalletRepositoryBuilder::new()
+                .localstore(localstore)
+                .seed([0u8; 64])
+                .build(),
+        )
+        .await;
+        listener_handle.abort();
+
+        let repo = result
+            .expect("Repository startup should not wait for a mint request")
+            .expect("Repository startup should succeed");
+
+        assert_eq!(direct_connections.load(Ordering::SeqCst), 0);
+        assert!(repo.has_wallet(&mint_url, &CurrencyUnit::Sat).await);
+        assert!(repo.has_wallet(&mint_url, &CurrencyUnit::Usd).await);
+    }
+
+    #[tokio::test]
+    async fn test_load_wallets_falls_back_to_sat_without_persisted_metadata() {
+        let localstore: Arc<dyn WalletDatabase<database::Error> + Send + Sync> = Arc::new(
+            cdk_sqlite::wallet::memory::empty()
+                .await
+                .expect("Failed to create in-memory database"),
+        );
+        let (mint_url, direct_connections, listener_handle) =
+            local_mint_url_with_connection_counter().await;
+        localstore
+            .add_mint(mint_url.clone(), None)
+            .await
+            .expect("Failed to add legacy mint");
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            WalletRepositoryBuilder::new()
+                .localstore(localstore)
+                .seed([0u8; 64])
+                .build(),
+        )
+        .await;
+        listener_handle.abort();
+
+        let repo = result
+            .expect("Repository startup should not wait for a mint request")
+            .expect("Repository startup should succeed");
+
+        assert_eq!(direct_connections.load(Ordering::SeqCst), 0);
+        assert!(repo.has_wallet(&mint_url, &CurrencyUnit::Sat).await);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Restore wallet units from persisted mint metadata instead of fetching mint info sequentially for every configured mint during repository construction. This keeps startup offline-first and preserves the sat fallback for legacy records without cached metadata.

Document the FFI behavior and add regression coverage for multi-unit restoration, missing metadata, and zero network connections during startup.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
