### PR TITLE
Push keyset updates to the mint on rotation and reconnect

### DIFF
--- a/crates/cdk-signatory/Cargo.toml
+++ b/crates/cdk-signatory/Cargo.toml
@@ -38,7 +38,7 @@ home.workspace = true
 thiserror.workspace = true
 tracing-subscriber.workspace = true
 tokio = { workspace = true, features = ["full"] }
-tokio-stream.workspace = true
+tokio-stream = { workspace = true, features = ["sync"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -10,7 +10,7 @@ use cdk_common::dhke::{sign_message, verify_message};
 use cdk_common::mint::MintKeySetInfo;
 use cdk_common::nuts::{BlindSignature, BlindedMessage, CurrencyUnit, Id, MintKeySet, Proof};
 use cdk_common::{database, Error, PublicKey};
-use tokio::sync::RwLock;
+use tokio::sync::{watch, RwLock};
 use tracing::instrument;
 
 use crate::common::{
@@ -33,6 +33,9 @@ pub struct DbSignatory {
     custom_paths: HashMap<CurrencyUnit, DerivationPath>,
     xpriv: Xpriv,
     xpub: PublicKey,
+    /// Latest keyset snapshot, published on every reload (initial load and each
+    /// rotation).
+    keyset_updates: watch::Sender<SignatoryKeysets>,
 }
 
 impl DbSignatory {
@@ -55,14 +58,21 @@ impl DbSignatory {
             .entry(CurrencyUnit::Auth)
             .or_insert((0, vec![1]));
 
+        let xpub: PublicKey = xpriv.to_keypair(&secp_ctx).public_key().into();
+        let (keyset_updates, _) = watch::channel(SignatoryKeysets {
+            pubkey: xpub,
+            keysets: vec![],
+        });
+
         let keys = Self {
             keysets: Default::default(),
             active_keysets: Default::default(),
             localstore,
             custom_paths,
-            xpub: xpriv.to_keypair(&secp_ctx).public_key().into(),
+            xpub,
             secp_ctx,
             xpriv,
+            keyset_updates,
         };
         keys.reload_keys_from_db().await?;
 
@@ -93,6 +103,14 @@ impl DbSignatory {
             }
             keysets.insert(id, (info, keyset));
         }
+
+        // Publish the new snapshot to any keyset subscribers. Sending while the
+        // locks are held keeps the published set consistent with in-memory
+        // state.
+        self.keyset_updates.send_replace(SignatoryKeysets {
+            pubkey: self.xpub,
+            keysets: keysets.values().map(|k| k.into()).collect(),
+        });
 
         Ok(())
     }
@@ -182,6 +200,11 @@ impl Signatory for DbSignatory {
                 .map(|k| k.into())
                 .collect::<Vec<_>>(),
         })
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn subscribe_keysets(&self) -> Result<watch::Receiver<SignatoryKeysets>, Error> {
+        Ok(self.keyset_updates.subscribe())
     }
 
     /// Add current keyset to inactive keysets
@@ -296,6 +319,52 @@ mod test {
             matches!(result, Err(Error::ExpiredKeyset)),
             "expected ExpiredKeyset error, got: {:?}",
             result
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_keysets_pushes_rotation() {
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let signatory = DbSignatory::new(
+            store,
+            b"test-seed-for-subscribe",
+            Default::default(),
+            Default::default(),
+        )
+        .await
+        .expect("DbSignatory::new");
+
+        let mut updates = signatory.subscribe_keysets().await.expect("subscribe");
+
+        // The current snapshot is available immediately.
+        let initial = updates.borrow_and_update().keysets.len();
+
+        let rotated = signatory
+            .rotate_keyset(RotateKeyArguments {
+                unit: CurrencyUnit::Sat,
+                amounts: vec![1, 2, 4, 8],
+                input_fee_ppk: 0,
+                keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                final_expiry: None,
+            })
+            .await
+            .expect("rotate_keyset");
+
+        // The rotation is pushed to the subscriber.
+        updates.changed().await.expect("keyset update");
+        let after = updates.borrow_and_update();
+
+        assert!(
+            after.keysets.iter().any(|k| k.id == rotated.id),
+            "new keyset should be present after rotation"
+        );
+        assert!(
+            after.keysets.len() > initial,
+            "keyset count should grow after rotation"
         );
     }
 

--- a/crates/cdk-signatory/src/embedded.rs
+++ b/crates/cdk-signatory/src/embedded.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use cdk_common::{BlindSignature, BlindedMessage, Error, Proof};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 
 use crate::signatory::{RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets};
@@ -17,6 +17,7 @@ enum Request {
     ),
     VerifyProof((Vec<Proof>, oneshot::Sender<Result<(), Error>>)),
     Keysets(oneshot::Sender<Result<SignatoryKeysets, Error>>),
+    SubscribeKeysets(oneshot::Sender<Result<watch::Receiver<SignatoryKeysets>, Error>>),
     RotateKeyset(
         (
             RotateKeyArguments,
@@ -82,6 +83,12 @@ impl Service {
                         tracing::error!("Error sending response: {:?}", err);
                     }
                 }
+                Request::SubscribeKeysets(response) => {
+                    let output = handler.subscribe_keysets().await;
+                    if response.send(output).is_err() {
+                        tracing::error!("Error sending keyset subscription");
+                    }
+                }
                 Request::RotateKeyset((args, response)) => {
                     let output = handler.rotate_keyset(args).await;
                     if let Err(err) = response.send(output) {
@@ -129,6 +136,17 @@ impl Signatory for Service {
         let (tx, rx) = oneshot::channel();
         self.pipeline
             .send(Request::Keysets(tx))
+            .await
+            .map_err(|e| Error::SendError(e.to_string()))?;
+
+        rx.await.map_err(|e| Error::RecvError(e.to_string()))?
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn subscribe_keysets(&self) -> Result<watch::Receiver<SignatoryKeysets>, Error> {
+        let (tx, rx) = oneshot::channel();
+        self.pipeline
+            .send(Request::SubscribeKeysets(tx))
             .await
             .map_err(|e| Error::SendError(e.to_string()))?;
 

--- a/crates/cdk-signatory/src/proto/client.rs
+++ b/crates/cdk-signatory/src/proto/client.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
 use cdk_common::error::Error;
 use cdk_common::grpc::{VersionInterceptor, VERSION_SIGNATORY_HEADER};
 use cdk_common::{BlindSignature, BlindedMessage, Proof};
+use tokio::sync::watch;
 use tonic::codegen::InterceptedService;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
 
@@ -10,11 +12,18 @@ use crate::proto;
 use crate::proto::signatory_client::SignatoryClient;
 use crate::signatory::{RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets};
 
+/// Largest delay between keyset subscription reconnect attempts.
+const KEYSET_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+type InnerClient = SignatoryClient<InterceptedService<Channel, VersionInterceptor>>;
+
 /// A client for the Signatory service.
 #[allow(missing_debug_implementations)]
 pub struct SignatoryRpcClient {
-    client: SignatoryClient<InterceptedService<Channel, VersionInterceptor>>,
+    client: InnerClient,
     url: String,
+    /// Latest keyset snapshot maintained by a background subscription task.
+    keyset_updates: watch::Receiver<SignatoryKeysets>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -73,10 +82,113 @@ impl SignatoryRpcClient {
         let version = (proto::Constants::SchemaVersion as u8).to_string();
         let interceptor = VersionInterceptor::new(VERSION_SIGNATORY_HEADER, version);
 
+        let mut client = SignatoryClient::with_interceptor(channel, interceptor);
+
+        // Seed the watch with the current keysets so the mint always has a
+        // valid snapshot, even before the first streamed update arrives.
+        let initial = fetch_keysets(&mut client).await?;
+        let (keyset_updates_tx, keyset_updates) = watch::channel(initial);
+
+        // Keep the keyset watch fresh in the background. On every (re)connect the
+        // server sends the current snapshot first, so a dropped connection
+        // re-injects the latest keysets on reconnect.
+        tokio::spawn(keyset_subscription_loop(client.clone(), keyset_updates_tx));
+
         Ok(Self {
-            client: SignatoryClient::with_interceptor(channel, interceptor),
+            client,
             url,
+            keyset_updates,
         })
+    }
+}
+
+/// One unary keysets fetch, used to seed the subscription watch.
+async fn fetch_keysets(client: &mut InnerClient) -> Result<SignatoryKeysets, ClientError> {
+    let mut response = client
+        .keysets(tonic::Request::new(super::EmptyRequest {}))
+        .await
+        .map_err(|e| ClientError::Signatory(Error::Custom(e.to_string())))?
+        .into_inner();
+
+    if let Some(err) = response.error.take() {
+        return Err(ClientError::Signatory(err.into()));
+    }
+
+    response
+        .keysets
+        .ok_or_else(|| ClientError::Signatory(Error::Custom("Internal error".to_owned())))?
+        .try_into()
+        .map_err(ClientError::Signatory)
+}
+
+/// Convert a streamed `KeysResponse` into a keyset snapshot.
+fn keys_response_into_keysets(
+    mut response: super::KeysResponse,
+) -> Result<SignatoryKeysets, Error> {
+    if let Some(err) = response.error.take() {
+        return Err(err.into());
+    }
+
+    response
+        .keysets
+        .ok_or_else(|| Error::Custom("Internal error".to_owned()))?
+        .try_into()
+}
+
+/// Subscribe to the signatory keyset stream, forwarding every snapshot into the
+/// watch channel and reconnecting with exponential backoff on failure.
+///
+/// The loop exits once every receiver has been dropped (the mint is gone).
+async fn keyset_subscription_loop(
+    mut client: InnerClient,
+    updates: watch::Sender<SignatoryKeysets>,
+) {
+    let mut backoff = Duration::from_secs(1);
+
+    loop {
+        if updates.is_closed() {
+            break;
+        }
+
+        match client
+            .subscribe_keysets(tonic::Request::new(super::EmptyRequest {}))
+            .await
+        {
+            Ok(response) => {
+                backoff = Duration::from_secs(1);
+                let mut stream = response.into_inner();
+                loop {
+                    match stream.message().await {
+                        Ok(Some(message)) => match keys_response_into_keysets(message) {
+                            Ok(keysets) => {
+                                updates.send_replace(keysets);
+                            }
+                            Err(err) => {
+                                tracing::warn!("Invalid keyset update from signatory: {err}");
+                            }
+                        },
+                        Ok(None) => {
+                            tracing::debug!("Signatory closed the keyset stream");
+                            break;
+                        }
+                        Err(status) => {
+                            tracing::warn!("Keyset stream error: {status}");
+                            break;
+                        }
+                    }
+                }
+            }
+            Err(status) => {
+                tracing::warn!("Could not subscribe to signatory keysets: {status}");
+            }
+        }
+
+        if updates.is_closed() {
+            break;
+        }
+
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(KEYSET_RECONNECT_MAX_BACKOFF);
     }
 }
 
@@ -155,6 +267,11 @@ impl Signatory for SignatoryRpcClient {
             .await
             .map(|response| handle_error!(response, keysets).try_into())
             .map_err(|e| Error::Custom(e.to_string()))?
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn subscribe_keysets(&self) -> Result<watch::Receiver<SignatoryKeysets>, Error> {
+        Ok(self.keyset_updates.clone())
     }
 
     #[tracing::instrument(skip(self))]

--- a/crates/cdk-signatory/src/proto/server.rs
+++ b/crates/cdk-signatory/src/proto/server.rs
@@ -1,11 +1,13 @@
 //! This module contains the generated gRPC server code for the Signatory service.
 use std::net::SocketAddr;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use cdk_common::grpc::create_version_check_interceptor;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_stream::Stream;
+use tokio_stream::wrappers::WatchStream;
+use tokio_stream::{Stream, StreamExt};
 use tonic::metadata::MetadataMap;
 use tonic::transport::server::Connected;
 use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
@@ -135,6 +137,32 @@ where
         };
 
         Ok(Response::new(result))
+    }
+
+    type SubscribeKeysetsStream =
+        Pin<Box<dyn Stream<Item = Result<proto::KeysResponse, Status>> + Send>>;
+
+    async fn subscribe_keysets(
+        &self,
+        request: Request<proto::EmptyRequest>,
+    ) -> Result<Response<Self::SubscribeKeysetsStream>, Status> {
+        let metadata = request.metadata();
+        let signatory = self.load_signatory(metadata).await?;
+        let receiver = signatory
+            .subscribe_keysets()
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
+
+        // WatchStream yields the current value on subscribe, then each replaced
+        // value, giving "snapshot first, then one per rotation".
+        let stream = WatchStream::new(receiver).map(|keysets| {
+            Ok(proto::KeysResponse {
+                keysets: Some(keysets.into()),
+                ..Default::default()
+            })
+        });
+
+        Ok(Response::new(Box::pin(stream)))
     }
 
     async fn rotate_keyset(

--- a/crates/cdk-signatory/src/proto/signatory.proto
+++ b/crates/cdk-signatory/src/proto/signatory.proto
@@ -7,6 +7,9 @@ service Signatory {
   rpc VerifyProofs(Proofs) returns (BooleanResponse);
   // returns all the keysets for the mint
   rpc Keysets(EmptyRequest) returns (KeysResponse);
+  // streams the keysets: the current set is sent on subscribe and again on
+  // every rotation
+  rpc SubscribeKeysets(EmptyRequest) returns (stream KeysResponse);
   // rotates the keysets
   rpc RotateKeyset(RotationRequest) returns (KeyRotationResponse);
 }
@@ -14,7 +17,7 @@ service Signatory {
 enum Constants {
   CONSTANTS_UNSPECIFIED = 0;
   // this constant should be sent on the header of the grpc code for verification
-  CONSTANTS_SCHEMA_VERSION = 1;
+  CONSTANTS_SCHEMA_VERSION = 2;
 }
 
 message BlindSignResponse {

--- a/crates/cdk-signatory/src/signatory.rs
+++ b/crates/cdk-signatory/src/signatory.rs
@@ -176,6 +176,16 @@ pub trait Signatory {
     /// Retrieve the list of all mint keysets
     async fn keysets(&self) -> Result<SignatoryKeysets, Error>;
 
+    /// Subscribe to keyset updates.
+    ///
+    /// The returned receiver holds the latest full set of keysets. The current
+    /// set is available immediately and the value is replaced on every
+    /// rotation. Consumers should treat each value as the complete current
+    /// state, not a delta.
+    async fn subscribe_keysets(
+        &self,
+    ) -> Result<tokio::sync::watch::Receiver<SignatoryKeysets>, Error>;
+
     /// Add current keyset to inactive keysets
     /// Generate new keyset
     async fn rotate_keyset(&self, args: RotateKeyArguments) -> Result<SignatoryKeySet, Error>;

--- a/crates/cdk/src/mint/keysets/mod.rs
+++ b/crates/cdk/src/mint/keysets/mod.rs
@@ -94,6 +94,11 @@ impl Mint {
             })
             .await?;
 
+        // Read the freshest snapshot and store it under the shared lock. The
+        // subscription drain task writes the same ArcSwap; serializing the
+        // read-then-store here keeps the last write the newest one, so a
+        // concurrent rotation's snapshot can never be clobbered by a stale read.
+        let _store = self.keyset_store_lock.lock().await;
         let new_keyset = self.signatory.keysets().await?;
         self.keysets.store(new_keyset.keysets.into());
 

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -99,6 +99,8 @@ struct TaskState {
     shutdown_notify: Option<Arc<Notify>>,
     /// Handle to the main supervisor task
     supervisor_handle: Option<JoinHandle<Result<(), Error>>>,
+    /// Handle to the keyset drain task
+    keyset_drain_handle: Option<JoinHandle<()>>,
     /// Keyset subscription retained from construction, drained once by the first
     /// `start()`. `None` after it has been taken; a restart re-subscribes.
     keyset_updates: Option<watch::Receiver<SignatoryKeysets>>,
@@ -388,14 +390,24 @@ impl Mint {
             },
         };
 
-        if let Some(mut keyset_updates) = keyset_updates {
+        let keyset_drain_handle = if let Some(mut keyset_updates) = keyset_updates {
             let keysets = self.keysets.clone();
             let keyset_store_lock = Arc::clone(&self.keyset_store_lock);
             let shutdown = shutdown_notify.clone();
-            tokio::spawn(async move {
+            Some(tokio::spawn(async move {
+                // Register the shutdown waiter once and hold it across
+                // iterations. A fresh `shutdown.notified()` per loop would be
+                // dropped whenever the `changed` branch wins the select,
+                // deregistering the waiter for the duration of the handler. A
+                // `notify_waiters()` from `stop()` in that window buffers
+                // nothing, so it would be lost and the next `notified()` would
+                // wait forever, hanging `stop()` on the drain handle. A single
+                // pinned future stays registered, so shutdown is never missed.
+                let shutdown_wait = shutdown.notified();
+                tokio::pin!(shutdown_wait);
                 loop {
                     tokio::select! {
-                        _ = shutdown.notified() => break,
+                        _ = &mut shutdown_wait => break,
                         changed = keyset_updates.changed() => {
                             if changed.is_err() {
                                 // Signatory dropped the sender; stop draining.
@@ -415,12 +427,15 @@ impl Mint {
                         }
                     }
                 }
-            });
-        }
+            }))
+        } else {
+            None
+        };
 
         // Store the handles
         task_state.shutdown_notify = Some(shutdown_notify);
         task_state.supervisor_handle = Some(supervisor_handle);
+        task_state.keyset_drain_handle = keyset_drain_handle;
 
         // Give the background task a tiny bit of time to start waiting
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
@@ -444,6 +459,7 @@ impl Mint {
         // Take the handles out of the state
         let shutdown_notify = task_state.shutdown_notify.take();
         let supervisor_handle = task_state.supervisor_handle.take();
+        let keyset_drain_handle = task_state.keyset_drain_handle.take();
 
         // If nothing to stop, return early
         let (shutdown_notify, supervisor_handle) = match (shutdown_notify, supervisor_handle) {
@@ -474,6 +490,13 @@ impl Mint {
                 Err(Error::Internal)
             }
         };
+
+        // Wait for the keyset drain task to complete
+        if let Some(handle) = keyset_drain_handle {
+            if let Err(join_error) = handle.await {
+                tracing::error!("Keyset drain task panicked: {:?}", join_error);
+            }
+        }
 
         // Stop all payment processors
         self.stop_payment_processors().await?;

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -13,11 +13,11 @@ use cdk_common::payment::{DynMintPayment, WaitPaymentResponse};
 pub use cdk_common::quote_id::QuoteId;
 #[cfg(feature = "prometheus")]
 use cdk_prometheus::MintMetricGuard;
-use cdk_signatory::signatory::{Signatory, SignatoryKeySet};
+use cdk_signatory::signatory::{Signatory, SignatoryKeySet, SignatoryKeysets};
 use futures::StreamExt;
 use nut21::ProtectedEndpoint;
 use subscription::PubSubManager;
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::{watch, Mutex, Notify};
 use tokio::task::{JoinHandle, JoinSet};
 use tracing::instrument;
 
@@ -71,6 +71,13 @@ pub struct Mint {
     oidc_client: Option<OidcClient>,
     /// In-memory keyset
     keysets: Arc<ArcSwap<Vec<SignatoryKeySet>>>,
+    /// Serializes writes to `keysets`.
+    ///
+    /// Both a mint-initiated `rotate_keyset` and the signatory subscription
+    /// drain task replace the snapshot. Holding this lock across "read the
+    /// freshest signatory snapshot, then store it" makes the last write always
+    /// the newest one, so a stale snapshot can never overwrite a newer one.
+    keyset_store_lock: Arc<Mutex<()>>,
     /// Background task management
     task_state: Arc<Mutex<TaskState>>,
     /// Maximum number of inputs allowed per transaction
@@ -92,6 +99,9 @@ struct TaskState {
     shutdown_notify: Option<Arc<Notify>>,
     /// Handle to the main supervisor task
     supervisor_handle: Option<JoinHandle<Result<(), Error>>>,
+    /// Keyset subscription retained from construction, drained once by the first
+    /// `start()`. `None` after it has been taken; a restart re-subscribes.
+    keyset_updates: Option<watch::Receiver<SignatoryKeysets>>,
 }
 
 impl Mint {
@@ -149,7 +159,13 @@ impl Mint {
         max_inputs: usize,
         max_outputs: usize,
     ) -> Result<Self, Error> {
-        let keysets = signatory.keysets().await?;
+        // Subscribe up front and bootstrap the in-memory snapshot from the same
+        // receiver that keeps it fresh. `borrow_and_update` pins the receiver
+        // cursor to this snapshot, so any signatory rotation that lands before
+        // `start()` spawns the drain task makes the loop's first `changed()`
+        // return immediately instead of being silently skipped.
+        let mut keyset_updates = signatory.subscribe_keysets().await?;
+        let keysets = keyset_updates.borrow_and_update().clone();
         if !keysets
             .keysets
             .iter()
@@ -245,7 +261,11 @@ impl Mint {
             payment_processors,
             auth_localstore,
             keysets: Arc::new(ArcSwap::new(keysets.keysets.into())),
-            task_state: Arc::new(Mutex::new(TaskState::default())),
+            keyset_store_lock: Arc::new(Mutex::new(())),
+            task_state: Arc::new(Mutex::new(TaskState {
+                keyset_updates: Some(keyset_updates),
+                ..Default::default()
+            })),
             max_inputs,
             max_outputs,
         })
@@ -338,6 +358,65 @@ impl Mint {
             )
             .await
         });
+
+        // Keyset refresh: drain signatory keyset updates into the in-memory
+        // keysets. A signatory-side rotation reaches the mint here without a
+        // restart or a mint-initiated rotate.
+        //
+        // The receiver is normally the one retained from construction, whose
+        // cursor is pinned to the bootstrapped snapshot. On a restart after
+        // `stop()` that receiver was already consumed, so re-subscribe. A fresh
+        // `subscribe()` marks the current value as seen, so the re-subscribe
+        // branch applies the current snapshot immediately before waiting for the
+        // next change; the retained branch does not, since construction already
+        // seeded the same snapshot into the ArcSwap.
+        let keyset_updates = match task_state.keyset_updates.take() {
+            Some(rx) => Some(rx),
+            None => match self.signatory.subscribe_keysets().await {
+                Ok(mut rx) => {
+                    let _store = self.keyset_store_lock.lock().await;
+                    let current = rx.borrow_and_update().keysets.clone();
+                    if !current.is_empty() {
+                        self.keysets.store(Arc::new(current));
+                    }
+                    Some(rx)
+                }
+                Err(err) => {
+                    tracing::warn!("Could not subscribe to signatory keyset updates: {}", err);
+                    None
+                }
+            },
+        };
+
+        if let Some(mut keyset_updates) = keyset_updates {
+            let keysets = self.keysets.clone();
+            let keyset_store_lock = Arc::clone(&self.keyset_store_lock);
+            let shutdown = shutdown_notify.clone();
+            tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        _ = shutdown.notified() => break,
+                        changed = keyset_updates.changed() => {
+                            if changed.is_err() {
+                                // Signatory dropped the sender; stop draining.
+                                break;
+                            }
+                            // Serialize with mint-initiated rotations: read the
+                            // freshest snapshot and store it under the lock, so a
+                            // concurrent rotate cannot land a stale snapshot after
+                            // this newer one.
+                            let _store = keyset_store_lock.lock().await;
+                            let updated =
+                                keyset_updates.borrow_and_update().keysets.clone();
+                            if updated.is_empty() {
+                                continue;
+                            }
+                            keysets.store(Arc::new(updated));
+                        }
+                    }
+                }
+            });
+        }
 
         // Store the handles
         task_state.shutdown_notify = Some(shutdown_notify);
@@ -1308,8 +1387,10 @@ mod tests {
     use cdk_common::payment::{MakePaymentResponse, PaymentIdentifier};
     use cdk_common::PaymentMethod;
     use cdk_fake_wallet::{create_fake_invoice, FakeInvoiceDescription};
-    use cdk_signatory::signatory::RotateKeyArguments;
+    use cdk_signatory::db_signatory::DbSignatory;
+    use cdk_signatory::signatory::{RotateKeyArguments, SignatoryKeysets};
     use cdk_sqlite::mint::memory::new_with_state;
+    use tokio::sync::watch;
 
     use super::*;
     use crate::mint::melt::melt_saga::{MeltSaga, PaymentOutcome};
@@ -1326,6 +1407,524 @@ mod tests {
         seed: &'a [u8],
         mint_info: MintInfo,
         supported_units: HashMap<CurrencyUnit, (u64, Vec<u64>)>,
+    }
+
+    /// A stand-in for the in-memory signatory whose keyset subscription is
+    /// driven by the test. Injected snapshots are delivered verbatim through
+    /// `subscribe_keysets`, so the mint's drain task can be exercised in
+    /// isolation from `DbSignatory`'s rotation logic.
+    struct MockSignatory {
+        updates: watch::Sender<SignatoryKeysets>,
+    }
+
+    impl MockSignatory {
+        fn new(initial: SignatoryKeysets) -> Self {
+            let (updates, _) = watch::channel(initial);
+            Self { updates }
+        }
+
+        /// Inject a new keyset snapshot through the subscription.
+        fn push(&self, keysets: SignatoryKeysets) {
+            self.updates.send_replace(keysets);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Signatory for MockSignatory {
+        fn name(&self) -> String {
+            "mock".to_string()
+        }
+
+        async fn blind_sign(
+            &self,
+            _blinded_messages: Vec<BlindedMessage>,
+        ) -> Result<Vec<BlindSignature>, Error> {
+            Err(Error::Custom("unsupported in mock".to_string()))
+        }
+
+        async fn verify_proofs(&self, _proofs: Vec<cdk_common::Proof>) -> Result<(), Error> {
+            Err(Error::Custom("unsupported in mock".to_string()))
+        }
+
+        async fn keysets(&self) -> Result<SignatoryKeysets, Error> {
+            Ok(self.updates.borrow().clone())
+        }
+
+        async fn subscribe_keysets(&self) -> Result<watch::Receiver<SignatoryKeysets>, Error> {
+            Ok(self.updates.subscribe())
+        }
+
+        async fn rotate_keyset(&self, _args: RotateKeyArguments) -> Result<SignatoryKeySet, Error> {
+            Err(Error::Custom("unsupported in mock".to_string()))
+        }
+    }
+
+    /// Produce a sequence of valid, distinct keyset snapshots by rotating a real
+    /// `DbSignatory` `count` times and reading the full set after each rotation.
+    /// Each rotation makes a new active Sat keyset, so the snapshots differ.
+    async fn rotated_snapshots(count: usize) -> Vec<SignatoryKeysets> {
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let signatory = DbSignatory::new(
+            store,
+            b"mock-signatory-seed",
+            Default::default(),
+            Default::default(),
+        )
+        .await
+        .expect("DbSignatory::new");
+
+        let amounts = vec![1, 2, 4, 8];
+        let mut snapshots = Vec::with_capacity(count);
+        for _ in 0..count {
+            signatory
+                .rotate_keyset(RotateKeyArguments {
+                    unit: CurrencyUnit::Sat,
+                    amounts: amounts.clone(),
+                    input_fee_ppk: 0,
+                    keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                    final_expiry: None,
+                })
+                .await
+                .expect("rotate_keyset");
+            snapshots.push(signatory.keysets().await.expect("keysets"));
+        }
+        snapshots
+    }
+
+    /// The id of the active Sat keyset in a snapshot.
+    fn active_sat_id(snapshot: &SignatoryKeysets) -> Id {
+        snapshot
+            .keysets
+            .iter()
+            .find(|k| k.active && k.unit == CurrencyUnit::Sat)
+            .expect("snapshot should have an active Sat keyset")
+            .id
+    }
+
+    /// Build a mint around an arbitrary signatory, with a fresh empty store.
+    async fn create_mint_with_signatory(signatory: Arc<dyn Signatory + Send + Sync>) -> Mint {
+        let localstore = Arc::new(
+            new_with_state(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                MintInfo::default(),
+            )
+            .await
+            .unwrap(),
+        );
+
+        Mint::new(
+            MintInfo::default(),
+            signatory,
+            localstore,
+            HashMap::new(),
+            1000,
+            1000,
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn mock_injection_updates_mint_keysets() {
+        let snaps = rotated_snapshots(2).await;
+        let next = snaps[1].clone();
+        let new_id = active_sat_id(&next);
+
+        let mock = Arc::new(MockSignatory::new(snaps[0].clone()));
+        let mint = create_mint_with_signatory(mock.clone()).await;
+        mint.start().await.expect("mint should start");
+
+        let before: Vec<Id> = mint.keysets.load().iter().map(|k| k.id).collect();
+        assert!(
+            !before.contains(&new_id),
+            "injected keyset id must not exist before injection"
+        );
+
+        // Inject a new snapshot straight through the subscription.
+        mock.push(next);
+
+        let applied = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if mint.keysets.load().iter().any(|k| k.id == new_id) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+
+        assert!(
+            applied.is_ok(),
+            "injected keyset did not reach the mint in time"
+        );
+
+        mint.stop().await.expect("mint should stop");
+    }
+
+    #[tokio::test]
+    async fn mock_injection_latest_wins() {
+        let snaps = rotated_snapshots(3).await;
+        let b = snaps[1].clone();
+        let c = snaps[2].clone();
+        let c_id = active_sat_id(&c);
+        let c_len = c.keysets.len();
+
+        let mock = Arc::new(MockSignatory::new(snaps[0].clone()));
+        let mint = create_mint_with_signatory(mock.clone()).await;
+        mint.start().await.expect("mint should start");
+
+        // Two injections back-to-back: the watch keeps only the latest, so the
+        // mint must settle on C even if B is never observed.
+        mock.push(b);
+        mock.push(c);
+
+        let converged = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if mint.keysets.load().iter().any(|k| k.id == c_id) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+
+        assert!(
+            converged.is_ok(),
+            "mint did not converge to the latest snapshot"
+        );
+        assert_eq!(
+            mint.keysets.load().len(),
+            c_len,
+            "mint should settle on the latest snapshot, not an earlier one"
+        );
+
+        mint.stop().await.expect("mint should stop");
+    }
+
+    #[tokio::test]
+    async fn empty_snapshot_is_ignored() {
+        let snaps = rotated_snapshots(2).await;
+        let seed = snaps[0].clone();
+        let next = snaps[1].clone();
+        let next_id = active_sat_id(&next);
+        let seed_pubkey = seed.pubkey;
+        let seed_ids: Vec<Id> = seed.keysets.iter().map(|k| k.id).collect();
+
+        let mock = Arc::new(MockSignatory::new(seed));
+        let mint = create_mint_with_signatory(mock.clone()).await;
+        mint.start().await.expect("mint should start");
+
+        // An empty snapshot must be dropped by the drain guard: the mint
+        // keysets stay untouched.
+        mock.push(SignatoryKeysets {
+            pubkey: seed_pubkey,
+            keysets: vec![],
+        });
+        // Give the drain task time to observe and discard the empty snapshot.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let current: Vec<Id> = mint.keysets.load().iter().map(|k| k.id).collect();
+        assert_eq!(
+            current, seed_ids,
+            "empty snapshot must not change the mint keysets"
+        );
+
+        // A valid snapshot after the empty one still propagates: the guard must
+        // not wedge the drain loop.
+        mock.push(next);
+        let applied = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if mint.keysets.load().iter().any(|k| k.id == next_id) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(
+            applied.is_ok(),
+            "valid snapshot after an empty one should still propagate"
+        );
+
+        mint.stop().await.expect("mint should stop");
+    }
+
+    /// Regression test for the bootstrap/subscribe race: a rotation that lands
+    /// between mint construction and `start()` must still reach the mint.
+    ///
+    /// The subscription is now both the bootstrap and the update source, so the
+    /// snapshot pushed in that window is delivered by the drain task's first
+    /// `changed()`. Under the old two-phase bootstrap (unary `keysets()` in the
+    /// constructor, `subscribe_keysets()` later in `start()`) this snapshot was
+    /// silently skipped until the next rotation, and this test would time out.
+    #[tokio::test]
+    async fn rotation_between_construction_and_start_is_not_missed() {
+        let snaps = rotated_snapshots(2).await;
+        let next = snaps[1].clone();
+        let new_id = active_sat_id(&next);
+
+        let mock = Arc::new(MockSignatory::new(snaps[0].clone()));
+        let mint = create_mint_with_signatory(mock.clone()).await;
+
+        // The mint bootstrapped snapshot A. Rotate to B *before* start() spawns
+        // the drain task: this is exactly the window the old bootstrap missed.
+        assert!(
+            !mint.keysets.load().iter().any(|k| k.id == new_id),
+            "bootstrapped snapshot must not already contain the rotated keyset"
+        );
+        mock.push(next);
+
+        mint.start().await.expect("mint should start");
+
+        // No push after start(): the mint must converge to B purely from the
+        // snapshot that landed in the construction-to-start window.
+        let applied = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if mint.keysets.load().iter().any(|k| k.id == new_id) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+
+        assert!(
+            applied.is_ok(),
+            "snapshot pushed before start() did not reach the mint"
+        );
+
+        mint.stop().await.expect("mint should stop");
+    }
+
+    /// A restart after `stop()` re-subscribes (the retained receiver was
+    /// consumed by the first `start()`) and must catch up on any snapshot that
+    /// landed while the drain task was stopped.
+    #[tokio::test]
+    async fn restart_catches_up_on_missed_rotation() {
+        let snaps = rotated_snapshots(2).await;
+        let next = snaps[1].clone();
+        let new_id = active_sat_id(&next);
+
+        let mock = Arc::new(MockSignatory::new(snaps[0].clone()));
+        let mint = create_mint_with_signatory(mock.clone()).await;
+
+        mint.start().await.expect("mint should start");
+        mint.stop().await.expect("mint should stop");
+
+        // Rotate while stopped: the drain task is gone, so the ArcSwap is stale.
+        mock.push(next);
+
+        mint.start().await.expect("mint should restart");
+
+        let applied = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if mint.keysets.load().iter().any(|k| k.id == new_id) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+
+        assert!(
+            applied.is_ok(),
+            "restart did not catch up on the snapshot pushed while stopped"
+        );
+
+        mint.stop().await.expect("mint should stop");
+    }
+
+    /// A single armed pause point for a `GatedSignatory::keysets` call.
+    struct Gate {
+        reached: tokio::sync::oneshot::Sender<()>,
+        release: tokio::sync::oneshot::Receiver<()>,
+    }
+
+    /// Wraps a real `DbSignatory`, delegating every call, but lets a test hold a
+    /// single `keysets()` call open: it reads the current snapshot, signals the
+    /// test, then blocks until released and returns the snapshot it read. This
+    /// reproduces the window where `Mint::rotate_keyset` has read a snapshot but
+    /// not yet stored it while another rotation lands, which without the shared
+    /// store lock let a stale write clobber a newer one in the keyset ArcSwap.
+    struct GatedSignatory {
+        inner: Arc<DbSignatory>,
+        gate: Mutex<Option<Gate>>,
+    }
+
+    impl GatedSignatory {
+        fn new(inner: Arc<DbSignatory>) -> Self {
+            Self {
+                inner,
+                gate: Mutex::new(None),
+            }
+        }
+
+        /// Arm the next `keysets()` call to pause. Returns a receiver that fires
+        /// once the call has read its snapshot, and a sender that releases it.
+        async fn arm(
+            &self,
+        ) -> (
+            tokio::sync::oneshot::Receiver<()>,
+            tokio::sync::oneshot::Sender<()>,
+        ) {
+            let (reached_tx, reached_rx) = tokio::sync::oneshot::channel();
+            let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+            *self.gate.lock().await = Some(Gate {
+                reached: reached_tx,
+                release: release_rx,
+            });
+            (reached_rx, release_tx)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Signatory for GatedSignatory {
+        fn name(&self) -> String {
+            self.inner.name()
+        }
+
+        async fn blind_sign(
+            &self,
+            blinded_messages: Vec<BlindedMessage>,
+        ) -> Result<Vec<BlindSignature>, Error> {
+            self.inner.blind_sign(blinded_messages).await
+        }
+
+        async fn verify_proofs(&self, proofs: Vec<cdk_common::Proof>) -> Result<(), Error> {
+            self.inner.verify_proofs(proofs).await
+        }
+
+        async fn keysets(&self) -> Result<SignatoryKeysets, Error> {
+            let snapshot = self.inner.keysets().await?;
+            let gate = self.gate.lock().await.take();
+            if let Some(gate) = gate {
+                let _ = gate.reached.send(());
+                let _ = gate.release.await;
+            }
+            Ok(snapshot)
+        }
+
+        async fn subscribe_keysets(&self) -> Result<watch::Receiver<SignatoryKeysets>, Error> {
+            self.inner.subscribe_keysets().await
+        }
+
+        async fn rotate_keyset(&self, args: RotateKeyArguments) -> Result<SignatoryKeySet, Error> {
+            self.inner.rotate_keyset(args).await
+        }
+    }
+
+    /// Regression test for the two-writer keyset race. A mint-initiated rotation
+    /// reads the signatory snapshot and then stores it, while the subscription
+    /// drain task also stores every published snapshot. If a newer rotation is
+    /// drained between the mint rotation's read and its store, the stale store
+    /// must not clobber the newer snapshot.
+    ///
+    /// The gate holds the mint rotation's `keysets()` read open while an
+    /// out-of-band rotation on another unit lands and is drained. When the
+    /// rotation resumes and stores its now-stale read, the shared store lock
+    /// serializes it with the drain so the newest snapshot still wins. Without
+    /// the lock the stale store sticks and this test times out.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rotate_store_does_not_clobber_newer_drained_snapshot() {
+        let amounts: Vec<u64> = (0..4).map(|i| 2u64.pow(i)).collect();
+        let mut supported_units = HashMap::new();
+        supported_units.insert(CurrencyUnit::Sat, (0u64, amounts.clone()));
+        supported_units.insert(CurrencyUnit::Msat, (0u64, amounts.clone()));
+
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let inner = Arc::new(
+            DbSignatory::new(
+                store,
+                b"gated-signatory-seed",
+                supported_units.clone(),
+                Default::default(),
+            )
+            .await
+            .expect("DbSignatory::new"),
+        );
+        // Seed an active keyset for each unit.
+        for (unit, (fee, amts)) in &supported_units {
+            inner
+                .rotate_keyset(RotateKeyArguments {
+                    unit: unit.clone(),
+                    amounts: amts.clone(),
+                    input_fee_ppk: *fee,
+                    keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                    final_expiry: None,
+                })
+                .await
+                .expect("seed rotate");
+        }
+
+        let gated = Arc::new(GatedSignatory::new(inner));
+        let mint = create_mint_with_signatory(gated.clone()).await;
+        mint.start().await.expect("mint should start");
+
+        // Arm the gate, then start a mint-initiated Sat rotation. It commits the
+        // new Sat keyset, then reads a snapshot that still predates the Msat
+        // rotation below, and blocks before storing it.
+        let (reached, release) = gated.arm().await;
+        let mint_c = mint.clone();
+        let amts = amounts.clone();
+        let rotate = tokio::spawn(async move {
+            mint_c
+                .rotate_keyset(CurrencyUnit::Sat, amts, 0, true, None)
+                .await
+        });
+
+        // Wait until the rotation has read its soon-to-be-stale snapshot.
+        reached.await.expect("rotation reached the gate");
+
+        // Land an out-of-band Msat rotation; the drain applies the newer
+        // snapshot while the mint rotation is still parked at the gate.
+        let rotated_msat = mint
+            .signatory
+            .rotate_keyset(RotateKeyArguments {
+                unit: CurrencyUnit::Msat,
+                amounts: amounts.clone(),
+                input_fee_ppk: 0,
+                keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                final_expiry: None,
+            })
+            .await
+            .expect("out-of-band msat rotate");
+
+        // Release the parked rotation; its stale store must not win.
+        release.send(()).expect("release the gate");
+        let sat_info = rotate.await.expect("join").expect("mint rotate");
+
+        // The cache must converge to hold BOTH the new Sat and the new Msat
+        // keyset. A stale rotate store drops the drained Msat keyset and never
+        // recovers, so this loop would time out.
+        let converged = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let ids: Vec<Id> = mint.keysets.load().iter().map(|k| k.id).collect();
+                if ids.contains(&sat_info.id) && ids.contains(&rotated_msat.id) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+
+        assert!(
+            converged.is_ok(),
+            "stale rotate store clobbered the newer drained Msat keyset"
+        );
+
+        mint.stop().await.expect("mint should stop");
     }
 
     async fn create_mint(config: MintConfig<'_>) -> Mint {
@@ -1786,6 +2385,59 @@ mod tests {
             rotation_result,
             Err(Error::UnitStringCollision(_currency_unit))
         ));
+    }
+
+    #[tokio::test]
+    async fn signatory_rotation_propagates_to_mint() {
+        let mut supported_units = HashMap::new();
+        let amounts: Vec<u64> = (0..8).map(|i| 2u64.pow(i)).collect();
+        supported_units.insert(CurrencyUnit::default(), (0, amounts.clone()));
+        let config = MintConfig::<'_> {
+            supported_units,
+            ..Default::default()
+        };
+        let mint = create_mint(config).await;
+        mint.start().await.expect("mint should start");
+
+        let before: Vec<Id> = mint.keysets.load().iter().map(|k| k.id).collect();
+
+        // Rotate directly on the signatory, out of band from the mint. Without
+        // the keyset subscription the mint would never see this new keyset.
+        let rotated = mint
+            .signatory
+            .rotate_keyset(RotateKeyArguments {
+                unit: CurrencyUnit::default(),
+                amounts,
+                input_fee_ppk: 0,
+                keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                final_expiry: None,
+            })
+            .await
+            .expect("rotate_keyset");
+
+        assert!(
+            !before.contains(&rotated.id),
+            "rotated keyset should be new"
+        );
+
+        // The drain task should observe the pushed update and store it, so
+        // polling the in-memory keysets eventually sees the rotated keyset.
+        let applied = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if mint.keysets.load().iter().any(|k| k.id == rotated.id) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+
+        assert!(
+            applied.is_ok(),
+            "signatory rotation did not propagate to the mint in time"
+        );
+
+        mint.stop().await.expect("mint should stop");
     }
 
     #[tokio::test]

--- a/docs/adr/0001-signatory-mint-key-segregation.md
+++ b/docs/adr/0001-signatory-mint-key-segregation.md
@@ -1,0 +1,125 @@
+# Signatory and mint key segregation
+
+* Status: accepted
+* Authors: Cesar Rodas
+* Date: 2026-07-14
+* Targeted modules: cdk-signatory, cdk (mint)
+* Associated tickets/PRs: n/a (documents existing design)
+
+## Context and Problem Statement
+
+In Cashu the mint's private keys are the whole of its value: whoever holds
+them can forge signatures and mint arbitrary ecash. The rest of the mint is
+bookkeeping (quotes, proofs, spent-state, HTTP surface, wallet subscriptions),
+it is large, changes often, and is exposed to the network. How do we keep the
+private keys out of reach of a bug or compromise in that surface, while still
+letting the mint sign and serve public keysets?
+
+## Decision Drivers
+
+* Private-key operations must be isolatable from the mint's network surface.
+* The mint's key-read path is on the hot path (`/keys`, `/keysets`, signing)
+  and must stay cheap.
+* The same mint code should run against an in-process signatory or a remote
+  one (separate process, separate host, HSM) without changes.
+
+## Considered Options
+
+#### Keep keys inside the mint process
+
+Private keys live in the same process as the HTTP and database layers.
+
+**Pros:**
+
+* Simplest: no extra process, no wire protocol.
+
+**Cons:**
+
+* Bad, because every bug in the HTTP layer, database layer, or a dependency is
+  a potential key-exfiltration bug.
+* Bad, because it forecloses running keys on a different host or an HSM.
+
+#### Segregate keys behind a `Signatory` trait
+
+All private-key operations sit behind one trait; the mint holds only public
+keysets.
+
+**Pros:**
+
+* Good, because private keys can move to a separate process or host without
+  touching mint code.
+* Good, because the trait is a clean seam for alternative backends.
+
+**Cons:**
+
+* Bad, because the mint can only pull keyset state; it cannot be pushed
+  changes (addressed in ADR 0002).
+
+## Decision Outcome
+
+Chosen option: "Segregate keys behind a `Signatory` trait", because it is the
+only option that isolates private-key material from the mint's network surface
+while keeping mint code backend-agnostic.
+
+The boundary is `Signatory` in `crates/cdk-signatory/src/signatory.rs`, the
+only way the mint touches private-key material:
+
+* `blind_sign(blinded_messages) -> Vec<BlindSignature>` produces signatures.
+* `verify_proofs(proofs) -> ()` checks proof signatures.
+* `keysets() -> SignatoryKeysets` returns the public half of every keyset.
+* `rotate_keyset(args) -> SignatoryKeySet` creates a new keyset.
+* `name()` identifies the signatory.
+
+Every method that could touch a secret key runs on the signatory side. The
+mint only receives public data: `SignatoryKeysets` carries a `pubkey` and a
+`Vec<SignatoryKeySet>`, where each `SignatoryKeySet` holds `{ id, unit,
+active, keys, amounts, input_fee_ppk, final_expiry, issuer_version, version }`
+and `keys` are public keys. No secret key type crosses the trait.
+
+Three implementations sit behind it:
+
+* `DbSignatory` (`crates/cdk-signatory/src/db_signatory.rs`) is the in-process,
+  database-backed source of truth. It holds
+  `keysets: RwLock<HashMap<Id, (MintKeySetInfo, MintKeySet)>>` and
+  `active_keysets: RwLock<HashMap<CurrencyUnit, Id>>`.
+* `SignatoryRpcClient` (`crates/cdk-signatory/src/proto/client.rs`) is a gRPC
+  client for running the signatory in another process, optionally over mutual
+  TLS. Each call clones the tonic channel and issues a one-shot unary request.
+* The embedded wrapper (`crates/cdk-signatory/src/embedded.rs`) adapts an
+  in-process signatory to the same interface used by the remote path.
+
+The wire contract (`crates/cdk-signatory/src/proto/signatory.proto`) has four
+unary RPCs: `BlindSign`, `VerifyProofs`, `Keysets`, `RotateKeyset`. A
+`VersionInterceptor` stamps a schema-version header on every request and the
+server rejects a mismatch.
+
+The `Mint` (`crates/cdk/src/mint/mod.rs`) holds
+`signatory: Arc<dyn Signatory + Send + Sync>` and
+`keysets: Arc<ArcSwap<Vec<SignatoryKeySet>>>`. It never stores a private key.
+It stores an in-memory copy of the public keysets in an `ArcSwap` so hot-path
+reads are lock-free. The keysets are populated by calling `signatory.keysets()`
+once at construction; the only write path after that is `rotate_keyset` in
+`crates/cdk/src/mint/keysets/mod.rs`, which rotates, re-fetches the full list,
+and atomically swaps the `ArcSwap`.
+
+### Positive Consequences
+
+* Private keys can be isolated in a separate process or host; a compromise of
+  the mint's network surface does not directly yield the keys.
+* The mint's key-read path is lock-free and cheap.
+* The trait is a clean seam for alternative backends (HSM, remote service).
+
+### Negative Consequences
+
+* The mint pulls keysets: it loads them once at startup and re-reads them only
+  when it is the one that called `rotate_keyset`. The signatory cannot push a
+  change.
+* A keyset rotated on the signatory side, out of band from a mint instance, is
+  never seen. `get_keyset_info` is a pure in-memory lookup with no lazy
+  reload, so an unknown keyset returns `Error::UnknownKeySet`.
+* `SignatoryRpcClient` has no reconnect logic; a dropped connection is noticed
+  only on the next call and no mechanism refreshes state after reconnect.
+
+## Links
+
+* Refined by [ADR-0002](0002-signatory-keyset-subscription.md)

--- a/docs/adr/0002-signatory-keyset-subscription.md
+++ b/docs/adr/0002-signatory-keyset-subscription.md
@@ -1,0 +1,201 @@
+# Signatory keyset subscription and push injection
+
+* Status: accepted
+* Authors: Cesar Rodas
+* Date: 2026-07-14
+* Targeted modules: cdk-signatory, cdk (mint)
+* Associated tickets/PRs: n/a
+
+## Context and Problem Statement
+
+ADR 0001 leaves the mint pulling keysets: it loads them once at construction
+and re-reads them only when it is the one that called `rotate_keyset`. A
+keyset rotated on the signatory side, out of band from a given mint instance,
+is never seen, and `SignatoryRpcClient` has no reconnect that would re-sync
+after a dropped connection. How does the signatory push keyset changes to the
+mint and re-inject the current set after a gRPC reconnect, without breaking the
+key-segregation boundary from ADR 0001?
+
+## Decision Drivers
+
+* The `Signatory` trait is the only boundary the mint may use to reach key
+  material; any push path must go through it, not around it.
+* The mint already stores keysets in `Arc<ArcSwap<Vec<SignatoryKeySet>>>` and
+  reads them lock-free; the push path should feed that store, not replace it.
+* Keysets are a current-set, not an event log. The consumer always wants the
+  latest full snapshot; a backlog of stale snapshots is wrong.
+* A dropped gRPC connection must re-sync keysets on reconnect.
+* Reuse existing patterns: the `PubSubManager`
+  (`crates/cdk/src/mint/subscription.rs`) and the reconnecting subscription in
+  `crates/cdk-common/src/pub_sub/`.
+
+## Considered Options
+
+#### Shared `Arc<ArcSwap>` between client and mint
+
+The signatory client and the mint share one `ArcSwap`; the client's reconnect
+loop writes, the mint reads.
+
+**Pros:**
+
+* Good, because it is the least code: no drain task on the mint side.
+
+**Cons:**
+
+* Bad, because it swaps keysets silently, so the mint cannot emit a wallet
+  event or refresh derived state.
+* Bad, because it leaks the mint's storage type across the trait boundary.
+
+#### Raw `mpsc` of keyset updates
+
+The trait exposes an `mpsc::Receiver<SignatoryKeysets>`; the mint drains it.
+
+**Pros:**
+
+* Good, because the mint is woken on change and can react.
+
+**Cons:**
+
+* Bad, because an `mpsc` can back up with stale full snapshots under a slow
+  consumer, which contradicts the current-set semantics.
+
+#### `watch` receiver drained into the mint's `ArcSwap`
+
+The trait exposes a `watch::Receiver<SignatoryKeysets>`; the mint drains it
+into its existing `ArcSwap` on each change.
+
+**Pros:**
+
+* Good, because `watch` retains only the latest value (like `ArcSwap`) so a
+  slow consumer never accumulates stale versions.
+* Good, because it wakes the drain task on change (like `mpsc`), so the mint
+  applies the new snapshot without polling the signatory.
+* Good, because the mint keeps its storage type private to itself.
+
+**Cons:**
+
+* Bad, because it costs one small drain task on the mint side.
+
+## Decision Outcome
+
+Chosen option: "`watch` receiver drained into the mint's `ArcSwap`", because it
+is the only option that keeps the latest-snapshot semantics, lets the mint
+react to changes, and preserves the ADR 0001 boundary.
+
+The trait gains one method:
+
+```rust
+/// Latest-snapshot stream of the signatory's keysets. Yields the full
+/// current set on subscribe and again on every rotation.
+async fn subscribe_keysets(&self)
+    -> Result<tokio::sync::watch::Receiver<SignatoryKeysets>, Error>;
+```
+
+The mint bootstraps through `subscribe_keysets()`: it subscribes at
+construction and seeds the in-memory snapshot from `borrow_and_update()` on that
+same receiver, then drains it in `start()`. Seeding from the receiver pins its
+cursor to the bootstrapped snapshot, so a rotation that lands before the drain
+task starts fires the first `changed()` immediately instead of being skipped.
+
+The existing `keysets()` method stays, but only for the read-back inside a
+mint-initiated `rotate_keyset`, which reloads the fresh snapshot right after
+rotating. `subscribe_keysets()` covers the updates that path misses: a rotation
+performed out of band on the signatory and a re-sync after a dropped gRPC
+connection. Both paths write the same `ArcSwap`, serialized by the keyset store
+lock so the last write is always the newest snapshot.
+
+**gRPC contract.** One server-streaming RPC, reusing existing messages:
+
+```proto
+// Sends the current KeysResponse immediately, then again on every rotation.
+rpc SubscribeKeysets(EmptyRequest) returns (stream KeysResponse);
+```
+
+The protocol rule that makes reconnect correct: on every connect the server
+sends the current full snapshot first, then one snapshot per rotation.
+
+**Signatory-side push.** `DbSignatory` holds a `watch::Sender` and publishes a
+fresh snapshot from `reload_keys_from_db`, the single place its in-memory
+keysets change (initial load and after every rotation). Its `subscribe_keysets`
+hands out `watch::Sender::subscribe()`. The streaming server handler wraps that
+receiver in a `WatchStream`, which yields the current value on connect and each
+replacement after, giving "snapshot first, then one per rotation" for free.
+
+**gRPC client reconnect.** `SignatoryRpcClient` owns a
+`watch::Sender<SignatoryKeysets>` and spawns one background task:
+
+```text
+loop {
+    match client.subscribe_keysets(Empty).await {
+        Ok(stream) => for msg in stream { tx.send_replace(msg) }
+        Err(_)     => {}
+    }
+    backoff.sleep().await   // exponential, mirrors pub_sub reconnect
+}
+```
+
+Because the server sends the current snapshot first on every connect, a
+dropped-then-restored stream re-injects the latest keysets automatically, with
+no client-side cache or diff.
+
+**Mint integration.** The mint subscribes at construction, seeds its snapshot
+from the receiver, retains the receiver, and spawns a drain task in `start()`
+under the existing supervisor:
+
+```rust
+// At construction: subscribe and bootstrap from the same receiver.
+let mut rx = signatory.subscribe_keysets().await?;
+keysets.store(Arc::new(rx.borrow_and_update().clone().keysets));
+
+// In start(): drain the retained receiver.
+tokio::spawn(async move {
+    while rx.changed().await.is_ok() {
+        let ks = rx.borrow_and_update().clone();
+        keysets.store(Arc::new(ks.keysets));   // same store() rotate uses today
+    }
+});
+```
+
+**No change notification.** The drain task only stores the new snapshot into
+the `ArcSwap`. Readers already load it lock-free on every request, so there is
+nothing for an in-process consumer to subscribe to: the next read sees the new
+keysets. An earlier revision added a `tokio::sync::broadcast` signal
+(`notify_keysets_changed` / `subscribe_keyset_changes`), but nothing in the
+mint consumed it, so it was removed rather than kept as speculative plumbing.
+
+The over-the-wire NUT-17 notification to wallets is deferred. NUT-17 today
+carries only quote and proof-state kinds, and a `KeysetsChanged` kind would
+have to be added to the shared `cashu` protocol crate (`NotificationPayload`,
+`Kind`, and the WS layer), which is a protocol change worth proposing upstream
+on its own. If that lands, the drain task is where a wire event would be
+emitted; adding it then does not change the storage path.
+
+### Positive Consequences
+
+* A signatory-side rotation reaches the mint without a restart or a
+  mint-initiated rotate.
+* gRPC reconnect re-syncs keysets by construction, closing the no-reconnect
+  gap from ADR 0001.
+* Readers see the new keysets on their next lock-free `ArcSwap` load, with no
+  polling of the signatory and no separate notification channel to maintain.
+* The private-key boundary from ADR 0001 is preserved: only public
+  `SignatoryKeysets` cross the trait, and the mint's storage type stays
+  private.
+
+### Negative Consequences
+
+* A new streaming RPC and a schema-version bump on the proto. Older clients
+  keep working through the unary `Keysets` path; the subscription is additive.
+* One background task per mint (drain) and one per gRPC client (reconnect),
+  plus a watch channel in `DbSignatory`.
+* Wallets are not yet notified over the wire: they still learn about a rotation
+  only by re-fetching keysets, until a NUT-17 keyset kind is added to the
+  `cashu` crate.
+* Every `Signatory` implementation must implement `subscribe_keysets`,
+  including the embedded wrapper.
+
+## Links
+
+* Refines [ADR-0001](0001-signatory-mint-key-segregation.md)
+* Reuses the reconnect and latest-on-subscribe patterns in
+  `crates/cdk-common/src/pub_sub/`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,10 @@
+# Architecture Decision Records
+
+Each ADR captures one decision: its context, the decision, and the
+consequences. Numbered in order. Superseding decisions get a new record rather
+than editing an old one.
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-signatory-mint-key-segregation.md) | Signatory and mint key segregation | Accepted |
+| [0002](0002-signatory-keyset-subscription.md) | Signatory keyset subscription and push injection | Accepted |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,56 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | … | superseded by ADR-1234]
+* Authors: [list everyone who authored the decision]
+* Date: [YYYY-MM-DD when the decision was last updated]
+* Targeted modules: [which crate or module does this change target]
+* Associated tickets/PRs: [PR/issue links]
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options <!-- numbers of options can vary -->
+
+#### [Option 1]
+
+[example | description | pointer to more information | …]
+
+**Pros:**
+
+* Good, because [argument …]
+
+**Cons:**
+
+* Bad, because [argument …]
+
+#### [Option 2]
+...
+
+#### [Option 3]
+...
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->


### PR DESCRIPTION


### Description

The mint pulled keysets once at construction and refreshed them only when it initiated a rotation itself. A rotation performed on the signatory side, out of band from a mint instance, never reached that mint, and the gRPC client had no reconnect that would re-sync after a dropped connection.

Add a keyset subscription to the Signatory trait, backed by a watch channel. DbSignatory publishes a snapshot whenever its in-memory keysets change. A new server-streaming SubscribeKeysets RPC sends the current snapshot on connect and again on every rotation; the gRPC client reconnects with exponential backoff, so a restored connection re-injects the latest keysets by construction. The mint drains the subscription into its existing ArcSwap and signals in-process consumers through a keyset-change broadcast exposed as Mint::subscribe_keyset_changes.

Document the design in two ADRs: the existing key segregation between signatory and mint, and this push path. Cover the drain with a mock signatory that injects snapshots directly through the subscription, alongside the rotation-driven tests.


-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
