### PR TITLE
Fix: Remove DLEQ's storing redundant

### DIFF
--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -499,6 +499,12 @@ pub trait SignaturesDatabase {
         quote_id: &QuoteId,
     ) -> Result<Vec<BlindSignature>, Self::Err>;
 
+    /// Get [`BlindSignature`]s and [`BlindedMessage`] for quote
+    async fn get_blind_signatures_and_secret_for_quote(
+        &self,
+        quote_id: &QuoteId,
+    ) -> Result<Vec<(BlindSignature, PublicKey)>, Self::Err>;
+
     /// Get total amount issued by keyset id
     async fn get_total_issued(&self) -> Result<HashMap<Id, Amount>, Self::Err>;
 

--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -557,6 +557,12 @@ pub trait SignaturesDatabase {
         quote_id: &QuoteId,
     ) -> Result<Vec<BlindSignature>, Self::Err>;
 
+    /// Get [`BlindSignature`]s and [`BlindedMessage`] for quote
+    async fn get_blind_signatures_and_secret_for_quote(
+        &self,
+        quote_id: &QuoteId,
+    ) -> Result<Vec<(BlindSignature, PublicKey)>, Self::Err>;
+
     /// Get total amount issued by keyset id
     async fn get_total_issued(&self) -> Result<HashMap<Id, Amount>, Self::Err>;
 

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -16,7 +16,9 @@ use tracing::instrument;
 use crate::common::{
     check_unit_string_collision, create_new_keyset, derivation_path_from_unit, init_keysets,
 };
-use crate::signatory::{RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets};
+use crate::signatory::{
+    ReconstructDleqArguments, RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets,
+};
 
 /// In-memory Signatory
 ///
@@ -267,6 +269,27 @@ impl Signatory for DbSignatory {
         self.reload_keys_from_db().await?;
 
         Ok((&(info, keyset)).into())
+    }
+
+    async fn reconstruct_dleq(
+        &self,
+        args: ReconstructDleqArguments,
+    ) -> Result<BlindSignature, Error> {
+        let (mut blind_signature, blind_secret) = (args.blind_signature, args.blind_secret);
+
+        let keysets = self.keysets.read().await;
+        let (_, key) = keysets
+            .get(&blind_signature.keyset_id)
+            .ok_or(Error::UnknownKeySet)?;
+
+        let key_pair = key
+            .keys
+            .get(&blind_signature.amount)
+            .ok_or(Error::UnknownKeySet)?;
+
+        blind_signature.add_dleq_proof(&blind_secret, &key_pair.secret_key)?;
+
+        Ok(blind_signature)
     }
 }
 

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -27,7 +27,9 @@ use tracing::instrument;
 use crate::common::{
     check_unit_string_collision, create_new_keyset, derivation_path_from_unit, init_keysets,
 };
-use crate::signatory::{RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets};
+use crate::signatory::{
+    ReconstructDleqArguments, RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets,
+};
 
 /// Immutable in-memory view of the keysets, swapped atomically on every change.
 ///
@@ -496,6 +498,28 @@ impl Signatory for DbSignatory {
         self.load_keys_from_db().await?;
 
         Ok(signatory_keyset)
+    }
+
+    async fn reconstruct_dleq(
+        &self,
+        args: ReconstructDleqArguments,
+    ) -> Result<BlindSignature, Error> {
+        let (mut blind_signature, blind_secret) = (args.blind_signature, args.blind_secret);
+
+        let keysets = self.keysets.load();
+        let (_, key) = keysets
+            .by_id
+            .get(&blind_signature.keyset_id)
+            .ok_or(Error::UnknownKeySet)?;
+
+        let key_pair = key
+            .keys
+            .get(&blind_signature.amount)
+            .ok_or(Error::UnknownKeySet)?;
+
+        blind_signature.add_dleq_proof(&blind_secret, &key_pair.secret_key)?;
+
+        Ok(blind_signature)
     }
 }
 

--- a/crates/cdk-signatory/src/embedded.rs
+++ b/crates/cdk-signatory/src/embedded.rs
@@ -6,8 +6,11 @@ use cdk_common::{BlindSignature, BlindedMessage, Error, Proof};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 
-use crate::signatory::{RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets};
+use crate::signatory::{
+    ReconstructDleqArguments, RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets,
+};
 
+#[allow(clippy::large_enum_variant)]
 enum Request {
     BlindSign(
         (
@@ -22,6 +25,12 @@ enum Request {
         (
             RotateKeyArguments,
             oneshot::Sender<Result<SignatoryKeySet, Error>>,
+        ),
+    ),
+    ReconstructDleq(
+        (
+            ReconstructDleqArguments,
+            oneshot::Sender<Result<BlindSignature, Error>>,
         ),
     ),
 }
@@ -95,6 +104,12 @@ impl Service {
                         tracing::error!("Error sending response: {:?}", err);
                     }
                 }
+                Request::ReconstructDleq((args, response)) => {
+                    let output = handler.reconstruct_dleq(args).await;
+                    if let Err(err) = response.send(output) {
+                        tracing::error!("Error sending response: {:?}", err);
+                    }
+                }
             }
         }
     }
@@ -158,6 +173,21 @@ impl Signatory for Service {
         let (tx, rx) = oneshot::channel();
         self.pipeline
             .send(Request::RotateKeyset((args, tx)))
+            .await
+            .map_err(|e| Error::SendError(e.to_string()))?;
+
+        rx.await.map_err(|e| Error::RecvError(e.to_string()))?
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn reconstruct_dleq(
+        &self,
+        args: ReconstructDleqArguments,
+    ) -> Result<BlindSignature, Error> {
+        let (tx, rx) = oneshot::channel();
+
+        self.pipeline
+            .send(Request::ReconstructDleq((args, tx)))
             .await
             .map_err(|e| Error::SendError(e.to_string()))?;
 

--- a/crates/cdk-signatory/src/embedded.rs
+++ b/crates/cdk-signatory/src/embedded.rs
@@ -6,8 +6,11 @@ use cdk_common::{BlindSignature, BlindedMessage, Error, Proof};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 
-use crate::signatory::{RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets};
+use crate::signatory::{
+    ReconstructDleqArguments, RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets,
+};
 
+#[allow(clippy::large_enum_variant)]
 enum Request {
     BlindSign(
         (
@@ -22,6 +25,12 @@ enum Request {
         (
             RotateKeyArguments,
             oneshot::Sender<Result<SignatoryKeySet, Error>>,
+        ),
+    ),
+    ReconstructDleq(
+        (
+            ReconstructDleqArguments,
+            oneshot::Sender<Result<BlindSignature, Error>>,
         ),
     ),
 }
@@ -97,6 +106,12 @@ impl Service {
                         tracing::error!("Error sending keyset-rotation response: receiver dropped");
                     }
                 }
+                Request::ReconstructDleq((args, response)) => {
+                    let output = handler.reconstruct_dleq(args).await;
+                    if let Err(err) = response.send(output) {
+                        tracing::error!("Error sending response: {:?}", err);
+                    }
+                }
             }
         }
     }
@@ -160,6 +175,21 @@ impl Signatory for Service {
         let (tx, rx) = oneshot::channel();
         self.pipeline
             .send(Request::RotateKeyset((args, tx)))
+            .await
+            .map_err(|e| Error::SendError(e.to_string()))?;
+
+        rx.await.map_err(|e| Error::RecvError(e.to_string()))?
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn reconstruct_dleq(
+        &self,
+        args: ReconstructDleqArguments,
+    ) -> Result<BlindSignature, Error> {
+        let (tx, rx) = oneshot::channel();
+
+        self.pipeline
+            .send(Request::ReconstructDleq((args, tx)))
             .await
             .map_err(|e| Error::SendError(e.to_string()))?;
 

--- a/crates/cdk-signatory/src/proto/client.rs
+++ b/crates/cdk-signatory/src/proto/client.rs
@@ -12,7 +12,9 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
 
 use crate::proto;
 use crate::proto::signatory_client::SignatoryClient;
-use crate::signatory::{RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets};
+use crate::signatory::{
+    ReconstructDleqArguments, RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets,
+};
 
 /// Largest delay between keyset subscription reconnect attempts.
 const KEYSET_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(30);
@@ -285,6 +287,20 @@ impl Signatory for SignatoryRpcClient {
             .rotate_keyset(tonic::Request::new(req))
             .await
             .map(|response| handle_error!(response, keyset).try_into())
+            .map_err(|e| Error::Custom(e.to_string()))?
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn reconstruct_dleq(
+        &self,
+        args: ReconstructDleqArguments,
+    ) -> Result<BlindSignature, Error> {
+        let req: super::ReconstructDleqRequest = args.into();
+        self.client
+            .clone()
+            .reconstruct_dleq(tonic::Request::new(req))
+            .await
+            .map(|response| handle_error!(response, blind_signature).try_into())
             .map_err(|e| Error::Custom(e.to_string()))?
     }
 }

--- a/crates/cdk-signatory/src/proto/convert.rs
+++ b/crates/cdk-signatory/src/proto/convert.rs
@@ -405,6 +405,34 @@ impl TryInto<cdk_common::KeySetInfo> for KeySet {
     }
 }
 
+impl From<crate::signatory::ReconstructDleqArguments> for ReconstructDleqRequest {
+    fn from(value: crate::signatory::ReconstructDleqArguments) -> Self {
+        Self {
+            blind_signature: Some(value.blind_signature.into()),
+            blind_secret: value.blind_secret.to_bytes().to_vec(),
+        }
+    }
+}
+
+impl TryInto<crate::signatory::ReconstructDleqArguments> for ReconstructDleqRequest {
+    type Error = Status;
+
+    fn try_into(self) -> Result<crate::signatory::ReconstructDleqArguments, Self::Error> {
+        Ok(crate::signatory::ReconstructDleqArguments {
+            blind_signature: self
+                .blind_signature
+                .ok_or(Status::invalid_argument("blind_signature not set"))?
+                .try_into()
+                .map_err(|err: cdk_common::error::Error| {
+                    Status::invalid_argument(err.to_string())
+                })?,
+            blind_secret: PublicKey::from_slice(&self.blind_secret).map_err(
+                |err: cdk_common::nut01::Error| Status::invalid_argument(err.to_string()),
+            )?,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cdk-signatory/src/proto/server.rs
+++ b/crates/cdk-signatory/src/proto/server.rs
@@ -187,6 +187,30 @@ where
 
         Ok(Response::new(mint_keyset_info))
     }
+
+    async fn reconstruct_dleq(
+        &self,
+        request: Request<proto::ReconstructDleqRequest>,
+    ) -> Result<Response<proto::ReconstructDleqResponse>, Status> {
+        let metadata = request.metadata();
+        let signatory = self.load_signatory(metadata).await?;
+
+        let result = match signatory
+            .reconstruct_dleq(request.into_inner().try_into()?)
+            .await
+        {
+            Ok(result) => proto::ReconstructDleqResponse {
+                blind_signature: Some(result.into()),
+                ..Default::default()
+            },
+            Err(err) => proto::ReconstructDleqResponse {
+                error: Some(err.into()),
+                ..Default::default()
+            },
+        };
+
+        Ok(Response::new(result))
+    }
 }
 
 /// Trait for loading a signatory instance from gRPC metadata

--- a/crates/cdk-signatory/src/proto/signatory.proto
+++ b/crates/cdk-signatory/src/proto/signatory.proto
@@ -12,6 +12,8 @@ service Signatory {
   rpc SubscribeKeysets(EmptyRequest) returns (stream KeysResponse);
   // rotates the keysets
   rpc RotateKeyset(RotationRequest) returns (KeyRotationResponse);
+  // reconstruct DLEQ proof
+  rpc ReconstructDleq(ReconstructDleqRequest) returns (ReconstructDleqResponse);
 }
 
 enum Constants {
@@ -125,6 +127,16 @@ message BlindSignature {
 message BlindSignatureDLEQ {
   bytes e = 1;
   bytes s = 2;
+}
+
+message ReconstructDleqRequest {
+    BlindSignature blind_signature = 1;
+    bytes blind_secret = 2;
+}
+
+message ReconstructDleqResponse {
+  Error error = 1;
+  BlindSignature blind_signature = 2;
 }
 
 enum ErrorCode {

--- a/crates/cdk-signatory/src/proto/signatory.proto
+++ b/crates/cdk-signatory/src/proto/signatory.proto
@@ -19,7 +19,7 @@ service Signatory {
 enum Constants {
   CONSTANTS_UNSPECIFIED = 0;
   // this constant should be sent on the header of the grpc code for verification
-  CONSTANTS_SCHEMA_VERSION = 2;
+  CONSTANTS_SCHEMA_VERSION = 3;
 }
 
 message BlindSignResponse {

--- a/crates/cdk-signatory/src/signatory.rs
+++ b/crates/cdk-signatory/src/signatory.rs
@@ -54,6 +54,17 @@ pub struct RotateKeyArguments {
     pub final_expiry: Option<u64>,
 }
 
+/// RestoreDleqArguments
+///
+/// This struct is used to pass the arguments to the restore_dleq function
+#[derive(Debug, Clone)]
+pub struct ReconstructDleqArguments {
+    /// Blind Signature
+    pub blind_signature: BlindSignature,
+    /// Blinded Message
+    pub blind_secret: PublicKey,
+}
+
 #[derive(Debug, Clone)]
 /// Signatory keysets
 pub struct SignatoryKeysets {
@@ -189,6 +200,12 @@ pub trait Signatory {
     /// Add current keyset to inactive keysets
     /// Generate new keyset
     async fn rotate_keyset(&self, args: RotateKeyArguments) -> Result<SignatoryKeySet, Error>;
+
+    /// Reconstruct DLEQ proof
+    async fn reconstruct_dleq(
+        &self,
+        args: ReconstructDleqArguments,
+    ) -> Result<BlindSignature, Error>;
 }
 
 #[cfg(test)]

--- a/crates/cdk-signatory/src/signatory.rs
+++ b/crates/cdk-signatory/src/signatory.rs
@@ -31,6 +31,17 @@ pub struct RotateKeyArguments {
     pub final_expiry: Option<u64>,
 }
 
+/// ReconstructDleqArguments
+///
+/// This struct is used to pass the arguments to the reconstruct_dleq function
+#[derive(Debug, Clone)]
+pub struct ReconstructDleqArguments {
+    /// Blind Signature
+    pub blind_signature: BlindSignature,
+    /// Blinded Message
+    pub blind_secret: PublicKey,
+}
+
 #[derive(Debug, Clone)]
 /// Signatory keysets
 pub struct SignatoryKeysets {
@@ -169,6 +180,12 @@ pub trait Signatory {
     /// Add current keyset to inactive keysets
     /// Generate new keyset
     async fn rotate_keyset(&self, args: RotateKeyArguments) -> Result<SignatoryKeySet, Error>;
+
+    /// Reconstruct DLEQ proof
+    async fn reconstruct_dleq(
+        &self,
+        args: ReconstructDleqArguments,
+    ) -> Result<BlindSignature, Error>;
 }
 
 #[cfg(test)]

--- a/crates/cdk-sql-common/src/mint/auth/mod.rs
+++ b/crates/cdk-sql-common/src/mint/auth/mod.rs
@@ -375,8 +375,6 @@ where
                 keyset_id,
                 amount,
                 c,
-                dleq_e,
-                dleq_s,
                 blinded_message,
             FROM
                 blind_signature

--- a/crates/cdk-sql-common/src/mint/auth/mod.rs
+++ b/crates/cdk-sql-common/src/mint/auth/mod.rs
@@ -378,8 +378,6 @@ where
                 keyset_id,
                 amount,
                 c,
-                dleq_e,
-                dleq_s,
                 blinded_message,
             FROM
                 blind_signature

--- a/crates/cdk-sql-common/src/mint/migrations/postgres/20260629082800_removes_mint_dleq_proofs_from_blind_signature.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/postgres/20260629082800_removes_mint_dleq_proofs_from_blind_signature.sql
@@ -1,0 +1,2 @@
+ALTER TABLE blind_signature DROP COLUMN dleq_e;
+ALTER TABLE blind_signature DROP COLUMN dleq_s;

--- a/crates/cdk-sql-common/src/mint/migrations/sqlite/20260629082800_removes_mint_dleq_proofs_from_blind_signature.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/sqlite/20260629082800_removes_mint_dleq_proofs_from_blind_signature.sql
@@ -1,0 +1,2 @@
+ALTER TABLE blind_signature DROP COLUMN dleq_e;
+ALTER TABLE blind_signature DROP COLUMN dleq_s;

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -32,6 +32,28 @@ pub(crate) fn sql_row_to_blind_signature(row: Vec<Column>) -> Result<BlindSignat
     })
 }
 
+pub(crate) fn sql_row_to_blind_signature_and_secret(
+    row: Vec<Column>,
+) -> Result<(BlindSignature, PublicKey), Error> {
+    unpack_into!(
+        let (
+            blinded_message, keyset_id, amount, c
+        ) = row
+    );
+
+    let amount: u64 = column_as_number!(amount);
+
+    Ok((
+        BlindSignature {
+            amount: Amount::from(amount),
+            keyset_id: column_as_string!(keyset_id, Id::from_str, Id::from_bytes),
+            c: column_as_string!(c, PublicKey::from_hex, PublicKey::from_slice),
+            dleq: None,
+        },
+        column_as_string!(blinded_message, PublicKey::from_hex, PublicKey::from_slice),
+    ))
+}
+
 #[async_trait]
 impl<RM> MintSignatureTransaction for SQLTransaction<RM>
 where
@@ -334,6 +356,38 @@ where
         .into_iter()
         .map(sql_row_to_blind_signature)
         .collect::<Result<Vec<BlindSignature>, _>>()?)
+    }
+
+    /// Get [`BlindSignature`]s and blinded secret as [`PublicKey`] for quote
+    async fn get_blind_signatures_and_secret_for_quote(
+        &self,
+        quote_id: &QuoteId,
+    ) -> Result<Vec<(BlindSignature, PublicKey)>, Self::Err> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
+        Ok(query(
+            r#"
+            SELECT
+                blinded_message,
+                keyset_id,
+                amount,
+                c
+            FROM
+                blind_signature
+            WHERE
+                quote_id=:quote_id AND c IS NOT NULL
+            ORDER BY order_index ASC
+            "#,
+        )?
+        .bind("quote_id", quote_id.to_string())
+        .fetch_all(&*conn)
+        .await?
+        .into_iter()
+        .map(sql_row_to_blind_signature_and_secret)
+        .collect::<Result<Vec<(BlindSignature, PublicKey)>, _>>()?)
     }
 
     /// Get total proofs redeemed by keyset id

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -7,31 +7,20 @@ use async_trait::async_trait;
 use cdk_common::database::{self, Error, MintSignatureTransaction, MintSignaturesDatabase};
 use cdk_common::quote_id::QuoteId;
 use cdk_common::util::unix_time;
-use cdk_common::{Amount, BlindSignature, BlindSignatureDleq, Id, PublicKey, SecretKey};
+use cdk_common::{Amount, BlindSignature, Id, PublicKey};
 
 use super::proofs::sql_row_to_hashmap_amount;
 use super::{SQLMintDatabase, SQLTransaction};
 use crate::pool::DatabasePool;
 use crate::stmt::{query, Column};
-use crate::{column_as_nullable_string, column_as_number, column_as_string, unpack_into};
+use crate::{column_as_number, column_as_string, unpack_into};
 
 pub(crate) fn sql_row_to_blind_signature(row: Vec<Column>) -> Result<BlindSignature, Error> {
     unpack_into!(
         let (
-            keyset_id, amount, c, dleq_e, dleq_s
+            keyset_id, amount, c
         ) = row
     );
-
-    let dleq = match (
-        column_as_nullable_string!(dleq_e),
-        column_as_nullable_string!(dleq_s),
-    ) {
-        (Some(e), Some(s)) => Some(BlindSignatureDleq {
-            e: SecretKey::from_hex(e)?,
-            s: SecretKey::from_hex(s)?,
-        }),
-        _ => None,
-    };
 
     let amount: u64 = column_as_number!(amount);
 
@@ -39,7 +28,7 @@ pub(crate) fn sql_row_to_blind_signature(row: Vec<Column>) -> Result<BlindSignat
         amount: Amount::from(amount),
         keyset_id: column_as_string!(keyset_id, Id::from_str, Id::from_bytes),
         c: column_as_string!(c, PublicKey::from_hex, PublicKey::from_slice),
-        dleq,
+        dleq: None,
     })
 }
 
@@ -67,7 +56,7 @@ where
         // Select all existing rows for the given blinded messages at once
         let mut existing_rows = query(
             r#"
-            SELECT blinded_message, c, dleq_e, dleq_s
+            SELECT blinded_message, c
             FROM blind_signature
             WHERE blinded_message IN (:blinded_messages)
             FOR UPDATE
@@ -86,7 +75,7 @@ where
         .map(|mut row| {
             Ok((
                 column_as_string!(&row.remove(0), PublicKey::from_hex, PublicKey::from_slice),
-                (row[0].clone(), row[1].clone(), row[2].clone()),
+                (row[0].clone()),
             ))
         })
         .collect::<Result<HashMap<_, _>, Error>>()?;
@@ -99,9 +88,9 @@ where
                     query(
                         r#"
                         INSERT INTO blind_signature
-                        (blinded_message, amount, keyset_id, c, quote_id, dleq_e, dleq_s, created_time, signed_time, order_index)
+                        (blinded_message, amount, keyset_id, c, quote_id, created_time, signed_time, order_index)
                         VALUES
-                        (:blinded_message, :amount, :keyset_id, :c, :quote_id, :dleq_e, :dleq_s, :created_time, :signed_time, :order_index)
+                        (:blinded_message, :amount, :keyset_id, :c, :quote_id, :created_time, :signed_time, :order_index)
                         "#,
                     )?
                     .bind("blinded_message", message.to_bytes().to_vec())
@@ -109,14 +98,6 @@ where
                     .bind("keyset_id", signature.keyset_id.to_string())
                     .bind("c", signature.c.to_bytes().to_vec())
                     .bind("quote_id", quote_id.as_ref().map(|q| q.to_string()))
-                    .bind(
-                        "dleq_e",
-                        signature.dleq.as_ref().map(|dleq| dleq.e.to_secret_hex()),
-                    )
-                    .bind(
-                        "dleq_s",
-                        signature.dleq.as_ref().map(|dleq| dleq.s.to_secret_hex()),
-                    )
                     .bind("created_time", current_time as i64)
                     .bind("signed_time", current_time as i64)
                     .bind("order_index", i as i64)
@@ -136,27 +117,19 @@ where
                     .execute(&self.inner)
                     .await?;
                 }
-                Some((c, _dleq_e, _dleq_s)) => {
+                Some(c) => {
                     // Blind message exists: check if c is NULL
                     match c {
                         Column::Null => {
-                            // Blind message with no c: Update with missing columns c, dleq_e, dleq_s
+                            // Blind message with no c: Update with missing columns c
                             query(
                                 r#"
                                 UPDATE blind_signature
-                                SET c = :c, dleq_e = :dleq_e, dleq_s = :dleq_s, signed_time = :signed_time, amount = :amount
+                                SET c = :c, signed_time = :signed_time, amount = :amount
                                 WHERE blinded_message = :blinded_message
                                 "#,
                             )?
                             .bind("c", signature.c.to_bytes().to_vec())
-                            .bind(
-                                "dleq_e",
-                                signature.dleq.as_ref().map(|dleq| dleq.e.to_secret_hex()),
-                            )
-                            .bind(
-                                "dleq_s",
-                                signature.dleq.as_ref().map(|dleq| dleq.s.to_secret_hex()),
-                            )
                             .bind("blinded_message", message.to_bytes().to_vec())
                             .bind("signed_time", current_time as i64)
                             .bind("amount", u64::from(signature.amount) as i64)
@@ -215,8 +188,6 @@ where
                 keyset_id,
                 amount,
                 c,
-                dleq_e,
-                dleq_s,
                 blinded_message
             FROM
                 blind_signature
@@ -272,8 +243,6 @@ where
                 keyset_id,
                 amount,
                 c,
-                dleq_e,
-                dleq_s,
                 blinded_message
             FROM
                 blind_signature
@@ -321,9 +290,7 @@ where
             SELECT
                 keyset_id,
                 amount,
-                c,
-                dleq_e,
-                dleq_s
+                c
             FROM
                 blind_signature
             WHERE
@@ -353,9 +320,7 @@ where
             SELECT
                 keyset_id,
                 amount,
-                c,
-                dleq_e,
-                dleq_s
+                c
             FROM
                 blind_signature
             WHERE

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -32,6 +32,28 @@ pub(crate) fn sql_row_to_blind_signature(row: Vec<Column>) -> Result<BlindSignat
     })
 }
 
+pub(crate) fn sql_row_to_blind_signature_and_secret(
+    row: Vec<Column>,
+) -> Result<(BlindSignature, PublicKey), Error> {
+    unpack_into!(
+        let (
+            blinded_message, keyset_id, amount, c
+        ) = row
+    );
+
+    let amount: u64 = column_as_number!(amount);
+
+    Ok((
+        BlindSignature {
+            amount: Amount::from(amount),
+            keyset_id: column_as_string!(keyset_id, Id::from_str, Id::from_bytes),
+            c: column_as_string!(c, PublicKey::from_hex, PublicKey::from_slice),
+            dleq: None,
+        },
+        column_as_string!(blinded_message, PublicKey::from_hex, PublicKey::from_slice),
+    ))
+}
+
 #[async_trait]
 impl<RM> MintSignatureTransaction for SQLTransaction<RM>
 where
@@ -344,6 +366,38 @@ where
         .into_iter()
         .map(sql_row_to_blind_signature)
         .collect::<Result<Vec<BlindSignature>, _>>()?)
+    }
+
+    /// Get [`BlindSignature`]s and blinded secret as [`PublicKey`] for quote
+    async fn get_blind_signatures_and_secret_for_quote(
+        &self,
+        quote_id: &QuoteId,
+    ) -> Result<Vec<(BlindSignature, PublicKey)>, Self::Err> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
+        Ok(query(
+            r#"
+            SELECT
+                blinded_message,
+                keyset_id,
+                amount,
+                c
+            FROM
+                blind_signature
+            WHERE
+                quote_id=:quote_id AND c IS NOT NULL
+            ORDER BY order_index ASC
+            "#,
+        )?
+        .bind("quote_id", quote_id.to_string())
+        .fetch_all(&*conn)
+        .await?
+        .into_iter()
+        .map(sql_row_to_blind_signature_and_secret)
+        .collect::<Result<Vec<(BlindSignature, PublicKey)>, _>>()?)
     }
 
     /// Get total proofs redeemed by keyset id

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -7,31 +7,20 @@ use async_trait::async_trait;
 use cdk_common::database::{self, Error, MintSignatureTransaction, MintSignaturesDatabase};
 use cdk_common::quote_id::QuoteId;
 use cdk_common::util::unix_time;
-use cdk_common::{Amount, BlindSignature, BlindSignatureDleq, Id, PublicKey, SecretKey};
+use cdk_common::{Amount, BlindSignature, Id, PublicKey};
 
 use super::proofs::sql_row_to_hashmap_amount;
 use super::{SQLMintDatabase, SQLTransaction};
 use crate::pool::DatabasePool;
 use crate::stmt::{query, Column};
-use crate::{column_as_nullable_string, column_as_number, column_as_string, unpack_into};
+use crate::{column_as_number, column_as_string, unpack_into};
 
 pub(crate) fn sql_row_to_blind_signature(row: Vec<Column>) -> Result<BlindSignature, Error> {
     unpack_into!(
         let (
-            keyset_id, amount, c, dleq_e, dleq_s
+            keyset_id, amount, c
         ) = row
     );
-
-    let dleq = match (
-        column_as_nullable_string!(dleq_e),
-        column_as_nullable_string!(dleq_s),
-    ) {
-        (Some(e), Some(s)) => Some(BlindSignatureDleq {
-            e: SecretKey::from_hex(e)?,
-            s: SecretKey::from_hex(s)?,
-        }),
-        _ => None,
-    };
 
     let amount: u64 = column_as_number!(amount);
 
@@ -39,7 +28,7 @@ pub(crate) fn sql_row_to_blind_signature(row: Vec<Column>) -> Result<BlindSignat
         amount: Amount::from(amount),
         keyset_id: column_as_string!(keyset_id, Id::from_str, Id::from_bytes),
         c: column_as_string!(c, PublicKey::from_hex, PublicKey::from_slice),
-        dleq,
+        dleq: None,
     })
 }
 
@@ -67,7 +56,7 @@ where
         // Select all existing rows for the given blinded messages at once
         let mut existing_rows = query(
             r#"
-            SELECT blinded_message, c, dleq_e, dleq_s
+            SELECT blinded_message, c
             FROM blind_signature
             WHERE blinded_message IN (:blinded_messages)
             ORDER BY blinded_message
@@ -87,7 +76,7 @@ where
         .map(|mut row| {
             Ok((
                 column_as_string!(&row.remove(0), PublicKey::from_hex, PublicKey::from_slice),
-                (row[0].clone(), row[1].clone(), row[2].clone()),
+                (row[0].clone()),
             ))
         })
         .collect::<Result<HashMap<_, _>, Error>>()?;
@@ -109,9 +98,9 @@ where
                     query(
                         r#"
                         INSERT INTO blind_signature
-                        (blinded_message, amount, keyset_id, c, quote_id, dleq_e, dleq_s, created_time, signed_time, order_index)
+                        (blinded_message, amount, keyset_id, c, quote_id, created_time, signed_time, order_index)
                         VALUES
-                        (:blinded_message, :amount, :keyset_id, :c, :quote_id, :dleq_e, :dleq_s, :created_time, :signed_time, :order_index)
+                        (:blinded_message, :amount, :keyset_id, :c, :quote_id, :created_time, :signed_time, :order_index)
                         "#,
                     )?
                     .bind("blinded_message", message.to_bytes().to_vec())
@@ -119,14 +108,6 @@ where
                     .bind("keyset_id", signature.keyset_id.to_string())
                     .bind("c", signature.c.to_bytes().to_vec())
                     .bind("quote_id", quote_id.as_ref().map(|q| q.to_string()))
-                    .bind(
-                        "dleq_e",
-                        signature.dleq.as_ref().map(|dleq| dleq.e.to_secret_hex()),
-                    )
-                    .bind(
-                        "dleq_s",
-                        signature.dleq.as_ref().map(|dleq| dleq.s.to_secret_hex()),
-                    )
                     .bind("created_time", current_time as i64)
                     .bind("signed_time", current_time as i64)
                     .bind("order_index", i as i64)
@@ -146,27 +127,19 @@ where
                     .execute(&self.inner)
                     .await?;
                 }
-                Some((c, _dleq_e, _dleq_s)) => {
+                Some(c) => {
                     // Blind message exists: check if c is NULL
                     match c {
                         Column::Null => {
-                            // Blind message with no c: Update with missing columns c, dleq_e, dleq_s
+                            // Blind message with no c: Update with missing columns c
                             query(
                                 r#"
                                 UPDATE blind_signature
-                                SET c = :c, dleq_e = :dleq_e, dleq_s = :dleq_s, signed_time = :signed_time, amount = :amount
+                                SET c = :c, signed_time = :signed_time, amount = :amount
                                 WHERE blinded_message = :blinded_message
                                 "#,
                             )?
                             .bind("c", signature.c.to_bytes().to_vec())
-                            .bind(
-                                "dleq_e",
-                                signature.dleq.as_ref().map(|dleq| dleq.e.to_secret_hex()),
-                            )
-                            .bind(
-                                "dleq_s",
-                                signature.dleq.as_ref().map(|dleq| dleq.s.to_secret_hex()),
-                            )
                             .bind("blinded_message", message.to_bytes().to_vec())
                             .bind("signed_time", current_time as i64)
                             .bind("amount", u64::from(signature.amount) as i64)
@@ -225,8 +198,6 @@ where
                 keyset_id,
                 amount,
                 c,
-                dleq_e,
-                dleq_s,
                 blinded_message
             FROM
                 blind_signature
@@ -282,8 +253,6 @@ where
                 keyset_id,
                 amount,
                 c,
-                dleq_e,
-                dleq_s,
                 blinded_message
             FROM
                 blind_signature
@@ -331,9 +300,7 @@ where
             SELECT
                 keyset_id,
                 amount,
-                c,
-                dleq_e,
-                dleq_s
+                c
             FROM
                 blind_signature
             WHERE
@@ -363,9 +330,7 @@ where
             SELECT
                 keyset_id,
                 amount,
-                c,
-                dleq_e,
-                dleq_s
+                c
             FROM
                 blind_signature
             WHERE

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -215,6 +215,10 @@ where
         &mut self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
+        if blinded_messages.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let mut blinded_signatures = query(
             r#"SELECT
                 keyset_id,
@@ -265,6 +269,10 @@ where
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
+        if blinded_messages.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let conn = self
             .pool
             .get()

--- a/crates/cdk/src/mint/melt/mod.rs
+++ b/crates/cdk/src/mint/melt/mod.rs
@@ -17,9 +17,11 @@ use cdk_common::payment::{
 use cdk_common::quote_id::QuoteId;
 use cdk_common::subscription::Params;
 use cdk_common::{
-    MeltOptions, MeltQuoteBolt12Request, MeltQuoteCreateResponse, MeltQuoteCustomRequest,
-    MeltQuoteCustomResponse, MeltQuoteOnchainRequest, MeltQuoteOnchainResponse, MeltQuoteResponse,
+    BlindSignature, MeltOptions, MeltQuoteBolt12Request, MeltQuoteCreateResponse,
+    MeltQuoteCustomRequest, MeltQuoteCustomResponse, MeltQuoteOnchainRequest,
+    MeltQuoteOnchainResponse, MeltQuoteResponse,
 };
+use cdk_signatory::signatory::ReconstructDleqArguments;
 use lightning::offers::offer::Offer;
 use tracing::instrument;
 
@@ -822,9 +824,9 @@ impl Mint {
 
             self.handle_pending_melt_quote(&mut quote).await?;
 
-            let blind_signatures = self
+            let signatures_and_secrets = self
                 .localstore
-                .get_blind_signatures_for_quote(quote_id)
+                .get_blind_signatures_and_secret_for_quote(quote_id)
                 .await?;
 
             let mut blind_signatures: Vec<BlindSignature> =

--- a/crates/cdk/src/mint/melt/mod.rs
+++ b/crates/cdk/src/mint/melt/mod.rs
@@ -827,6 +827,20 @@ impl Mint {
                 .get_blind_signatures_for_quote(quote_id)
                 .await?;
 
+            let mut blind_signatures: Vec<BlindSignature> =
+                Vec::with_capacity(signatures_and_secrets.len());
+
+            for (blind_signature, blind_secret) in signatures_and_secrets.iter() {
+                let dleq = self
+                    .signatory
+                    .reconstruct_dleq(ReconstructDleqArguments {
+                        blind_signature: blind_signature.clone(),
+                        blind_secret: *blind_secret,
+                    })
+                    .await?;
+                blind_signatures.push(dleq);
+            }
+
             let change = (!blind_signatures.is_empty()).then_some(blind_signatures);
 
             let response = match quote.payment_method {

--- a/crates/cdk/src/mint/melt/mod.rs
+++ b/crates/cdk/src/mint/melt/mod.rs
@@ -17,9 +17,11 @@ use cdk_common::payment::{
 use cdk_common::quote_id::QuoteId;
 use cdk_common::subscription::Params;
 use cdk_common::{
-    MeltOptions, MeltQuoteBolt12Request, MeltQuoteCreateResponse, MeltQuoteCustomRequest,
-    MeltQuoteCustomResponse, MeltQuoteOnchainRequest, MeltQuoteOnchainResponse, MeltQuoteResponse,
+    BlindSignature, MeltOptions, MeltQuoteBolt12Request, MeltQuoteCreateResponse,
+    MeltQuoteCustomRequest, MeltQuoteCustomResponse, MeltQuoteOnchainRequest,
+    MeltQuoteOnchainResponse, MeltQuoteResponse,
 };
+use cdk_signatory::signatory::ReconstructDleqArguments;
 use lightning::offers::offer::Offer;
 use tracing::instrument;
 
@@ -794,9 +796,9 @@ impl Mint {
 
             self.handle_pending_melt_quote(&mut quote).await?;
 
-            let blind_signatures = self
+            let signatures_and_secrets = self
                 .localstore
-                .get_blind_signatures_for_quote(quote_id)
+                .get_blind_signatures_and_secret_for_quote(quote_id)
                 .await?;
 
             let mut blind_signatures: Vec<BlindSignature> =

--- a/crates/cdk/src/mint/melt/mod.rs
+++ b/crates/cdk/src/mint/melt/mod.rs
@@ -799,6 +799,20 @@ impl Mint {
                 .get_blind_signatures_for_quote(quote_id)
                 .await?;
 
+            let mut blind_signatures: Vec<BlindSignature> =
+                Vec::with_capacity(signatures_and_secrets.len());
+
+            for (blind_signature, blind_secret) in signatures_and_secrets.iter() {
+                let dleq = self
+                    .signatory
+                    .reconstruct_dleq(ReconstructDleqArguments {
+                        blind_signature: blind_signature.clone(),
+                        blind_secret: *blind_secret,
+                    })
+                    .await?;
+                blind_signatures.push(dleq);
+            }
+
             let change = (!blind_signatures.is_empty()).then_some(blind_signatures);
 
             let response = match quote.payment_method {

--- a/crates/cdk/src/mint/melt/shared.rs
+++ b/crates/cdk/src/mint/melt/shared.rs
@@ -14,7 +14,7 @@ use cdk_common::nuts::{BlindSignature, BlindedMessage, MeltQuoteState, Proofs, S
 use cdk_common::{Amount, CurrencyUnit, Error, PublicKey, QuoteId};
 #[cfg(feature = "prometheus")]
 use cdk_prometheus::METRICS;
-use cdk_signatory::signatory::SignatoryKeySet;
+use cdk_signatory::signatory::{ReconstructDleqArguments, SignatoryKeySet};
 
 use crate::mint::subscription::PubSubManager;
 use crate::mint::MeltQuote;
@@ -678,8 +678,28 @@ pub async fn finalize_melt_quote(
                 tx.rollback().await?;
             }
 
-            let sigs = db.get_blind_signatures_for_quote(&quote.id).await?;
-            return Ok(if sigs.is_empty() { None } else { Some(sigs) });
+            let sigs_and_secrets = db
+                .get_blind_signatures_and_secret_for_quote(&quote.id)
+                .await?;
+
+            if sigs_and_secrets.is_empty() {
+                return Ok(None);
+            }
+
+            let mut sigs: Vec<BlindSignature> = Vec::with_capacity(sigs_and_secrets.len());
+
+            for (blind_signature, blind_secret) in sigs_and_secrets.iter() {
+                let dleq = mint
+                    .signatory
+                    .reconstruct_dleq(ReconstructDleqArguments {
+                        blind_signature: blind_signature.clone(),
+                        blind_secret: *blind_secret,
+                    })
+                    .await?;
+                sigs.push(dleq);
+            }
+
+            return Ok(Some(sigs));
         }
     };
 

--- a/crates/cdk/src/mint/melt/shared.rs
+++ b/crates/cdk/src/mint/melt/shared.rs
@@ -14,7 +14,7 @@ use cdk_common::nuts::{BlindSignature, BlindedMessage, MeltQuoteState, Proofs, S
 use cdk_common::{Amount, CurrencyUnit, Error, PublicKey, QuoteId};
 #[cfg(feature = "prometheus")]
 use cdk_prometheus::METRICS;
-use cdk_signatory::signatory::SignatoryKeySet;
+use cdk_signatory::signatory::{ReconstructDleqArguments, SignatoryKeySet};
 
 use crate::mint::subscription::PubSubManager;
 use crate::mint::MeltQuote;
@@ -910,8 +910,28 @@ pub async fn finalize_melt_quote(
                 tx.rollback().await?;
             }
 
-            let sigs = db.get_blind_signatures_for_quote(&quote.id).await?;
-            return Ok(if sigs.is_empty() { None } else { Some(sigs) });
+            let sigs_and_secrets = db
+                .get_blind_signatures_and_secret_for_quote(&quote.id)
+                .await?;
+
+            if sigs_and_secrets.is_empty() {
+                return Ok(None);
+            }
+
+            let mut sigs: Vec<BlindSignature> = Vec::with_capacity(sigs_and_secrets.len());
+
+            for (blind_signature, blind_secret) in sigs_and_secrets.iter() {
+                let dleq = mint
+                    .signatory
+                    .reconstruct_dleq(ReconstructDleqArguments {
+                        blind_signature: blind_signature.clone(),
+                        blind_secret: *blind_secret,
+                    })
+                    .await?;
+                sigs.push(dleq);
+            }
+
+            return Ok(Some(sigs));
         }
     };
 

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1288,7 +1288,16 @@ impl Mint {
         let metrics = MintMetricGuard::new("restore");
 
         let result = async {
-            let output_len = request.outputs.len();
+            let blinded_messages: Vec<BlindedMessage> = request
+                .outputs
+                .into_iter()
+                .filter(|bm| {
+                    self.get_keyset_info(&bm.keyset_id)
+                        .is_some_and(|keyset_info| !keyset_info.is_expired())
+                })
+                .collect();
+
+            let output_len = blinded_messages.len();
 
             // Check max outputs limit
             if output_len > self.max_outputs {
@@ -1307,19 +1316,18 @@ impl Mint {
             let mut signatures = Vec::with_capacity(output_len);
 
             // Build a position map to track original request order for verification
-            let position_map: HashMap<PublicKey, usize> = request
-                .outputs
+            let position_map: HashMap<PublicKey, usize> = blinded_messages
                 .iter()
                 .enumerate()
                 .map(|(idx, output)| (output.blinded_secret, idx))
                 .collect();
 
-            let blinded_message: Vec<PublicKey> =
-                request.outputs.iter().map(|b| b.blinded_secret).collect();
+            let blinded_secrets: Vec<PublicKey> =
+                blinded_messages.iter().map(|b| b.blinded_secret).collect();
 
             let blinded_signatures = self
                 .localstore
-                .get_blind_signatures(&blinded_message)
+                .get_blind_signatures(&blinded_secrets)
                 .await?;
 
             if blinded_signatures.len() != output_len {
@@ -1327,7 +1335,7 @@ impl Mint {
             }
 
             for (blinded_message, blinded_signature) in
-                request.outputs.into_iter().zip(blinded_signatures)
+                blinded_messages.into_iter().zip(blinded_signatures)
             {
                 if let Some(mut blinded_signature) = blinded_signature {
                     blinded_signature = self
@@ -1338,15 +1346,6 @@ impl Mint {
                         })
                         .await?;
 
-                    if let Some(keyset_info) = self.get_keyset_info(&blinded_signature.keyset_id) {
-                        if keyset_info.is_expired() {
-                            tracing::debug!(
-                                "Skipping restore for expired keyset {}",
-                                blinded_signature.keyset_id
-                            );
-                            continue;
-                        }
-                    }
                     outputs.push(blinded_message);
                     signatures.push(blinded_signature);
                 }

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1327,7 +1327,15 @@ impl Mint {
             for (blinded_message, blinded_signature) in
                 request.outputs.into_iter().zip(blinded_signatures)
             {
-                if let Some(blinded_signature) = blinded_signature {
+                if let Some(mut blinded_signature) = blinded_signature {
+                    blinded_signature = self
+                        .signatory
+                        .reconstruct_dleq(ReconstructDleqArguments {
+                            blind_signature: blinded_signature.clone(),
+                            blind_secret: blinded_message.blinded_secret,
+                        })
+                        .await?;
+
                     if let Some(keyset_info) = self.get_keyset_info(&blinded_signature.keyset_id) {
                         if keyset_info.is_expired() {
                             tracing::debug!(
@@ -1508,6 +1516,13 @@ mod tests {
         }
 
         async fn rotate_keyset(&self, _args: RotateKeyArguments) -> Result<SignatoryKeySet, Error> {
+            Err(Error::Custom("unsupported in mock".to_string()))
+        }
+
+        async fn reconstruct_dleq(
+            &self,
+            _args: ReconstructDleqArguments,
+        ) -> Result<BlindSignature, Error> {
             Err(Error::Custom("unsupported in mock".to_string()))
         }
     }
@@ -1871,6 +1886,13 @@ mod tests {
 
         async fn rotate_keyset(&self, args: RotateKeyArguments) -> Result<SignatoryKeySet, Error> {
             self.inner.rotate_keyset(args).await
+        }
+
+        async fn reconstruct_dleq(
+            &self,
+            args: ReconstructDleqArguments,
+        ) -> Result<BlindSignature, Error> {
+            self.inner.reconstruct_dleq(args).await
         }
     }
 

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -15,7 +15,9 @@ pub use cdk_common::quote_id::QuoteId;
 use cdk_common::stream::{BackoffPolicy, SupervisedStream};
 #[cfg(feature = "prometheus")]
 use cdk_prometheus::MintMetricGuard;
-use cdk_signatory::signatory::{Signatory, SignatoryKeySet, SignatoryKeysets};
+use cdk_signatory::signatory::{
+    ReconstructDleqArguments, Signatory, SignatoryKeySet, SignatoryKeysets,
+};
 use futures::{Stream, StreamExt};
 use nut21::ProtectedEndpoint;
 use subscription::PubSubManager;

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1408,7 +1408,15 @@ impl Mint {
             for (blinded_message, blinded_signature) in
                 request.outputs.into_iter().zip(blinded_signatures)
             {
-                if let Some(blinded_signature) = blinded_signature {
+                if let Some(mut blinded_signature) = blinded_signature {
+                    blinded_signature = self
+                        .signatory
+                        .reconstruct_dleq(ReconstructDleqArguments {
+                            blind_signature: blinded_signature.clone(),
+                            blind_secret: blinded_message.blinded_secret,
+                        })
+                        .await?;
+
                     if let Some(keyset_info) = self.get_keyset_info(&blinded_signature.keyset_id) {
                         if keyset_info.is_expired() {
                             tracing::debug!(
@@ -1589,6 +1597,13 @@ mod tests {
         }
 
         async fn rotate_keyset(&self, _args: RotateKeyArguments) -> Result<SignatoryKeySet, Error> {
+            Err(Error::Custom("unsupported in mock".to_string()))
+        }
+
+        async fn reconstruct_dleq(
+            &self,
+            _args: ReconstructDleqArguments,
+        ) -> Result<BlindSignature, Error> {
             Err(Error::Custom("unsupported in mock".to_string()))
         }
     }
@@ -2003,6 +2018,13 @@ mod tests {
 
         async fn rotate_keyset(&self, args: RotateKeyArguments) -> Result<SignatoryKeySet, Error> {
             self.inner.rotate_keyset(args).await
+        }
+
+        async fn reconstruct_dleq(
+            &self,
+            args: ReconstructDleqArguments,
+        ) -> Result<BlindSignature, Error> {
+            self.inner.reconstruct_dleq(args).await
         }
     }
 

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -15,7 +15,9 @@ pub use cdk_common::quote_id::QuoteId;
 use cdk_common::stream::{BackoffPolicy, SupervisedStream};
 #[cfg(feature = "prometheus")]
 use cdk_prometheus::MintMetricGuard;
-use cdk_signatory::signatory::{Signatory, SignatoryKeySet, SignatoryKeysets};
+use cdk_signatory::signatory::{
+    ReconstructDleqArguments, Signatory, SignatoryKeySet, SignatoryKeysets,
+};
 use futures::{Stream, StreamExt};
 use nut21::ProtectedEndpoint;
 use subscription::PubSubManager;
@@ -1367,7 +1369,16 @@ impl Mint {
         let metrics = MintMetricGuard::new("restore");
 
         let result = async {
-            let output_len = request.outputs.len();
+            let blinded_messages: Vec<BlindedMessage> = request
+                .outputs
+                .into_iter()
+                .filter(|bm| {
+                    self.get_keyset_info(&bm.keyset_id)
+                        .is_some_and(|keyset_info| !keyset_info.is_expired())
+                })
+                .collect();
+
+            let output_len = blinded_messages.len();
 
             // Check max outputs limit
             if output_len > self.max_outputs {
@@ -1386,19 +1397,18 @@ impl Mint {
             let mut signatures = Vec::with_capacity(output_len);
 
             // Build a position map to track original request order for verification
-            let position_map: HashMap<PublicKey, usize> = request
-                .outputs
+            let position_map: HashMap<PublicKey, usize> = blinded_messages
                 .iter()
                 .enumerate()
                 .map(|(idx, output)| (output.blinded_secret, idx))
                 .collect();
 
-            let blinded_message: Vec<PublicKey> =
-                request.outputs.iter().map(|b| b.blinded_secret).collect();
+            let blinded_secrets: Vec<PublicKey> =
+                blinded_messages.iter().map(|b| b.blinded_secret).collect();
 
             let blinded_signatures = self
                 .localstore
-                .get_blind_signatures(&blinded_message)
+                .get_blind_signatures(&blinded_secrets)
                 .await?;
 
             if blinded_signatures.len() != output_len {
@@ -1406,7 +1416,7 @@ impl Mint {
             }
 
             for (blinded_message, blinded_signature) in
-                request.outputs.into_iter().zip(blinded_signatures)
+                blinded_messages.into_iter().zip(blinded_signatures)
             {
                 if let Some(mut blinded_signature) = blinded_signature {
                     blinded_signature = self
@@ -1417,15 +1427,6 @@ impl Mint {
                         })
                         .await?;
 
-                    if let Some(keyset_info) = self.get_keyset_info(&blinded_signature.keyset_id) {
-                        if keyset_info.is_expired() {
-                            tracing::debug!(
-                                "Skipping restore for expired keyset {}",
-                                blinded_signature.keyset_id
-                            );
-                            continue;
-                        }
-                    }
                     outputs.push(blinded_message);
                     signatures.push(blinded_signature);
                 }


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

While DLEQ proofs can be derived deterministically, we don't need to store on DB.

- Closes https://github.com/cashubtc/cdk/issues/2129

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

- a43a595873647de3242a02126793dc340223cbd8 removes DLEQ proofs from database
- 9ca2562151aa8a136dd0f16e7dca47c6cb690085 removes previous DLEQ queries
- f251395a9c52814f3e54871a9e3e95ef601e6200 adds `reconstruct_dleq` function to `Signatory`
- 5c3b663471a0a002db5105bf238e8b1c3234714d reconstruct DLEQ proofs in Mint `restore` function

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
