### PR TITLE
feat(http-client): support custom and preconfigured transports

### DIFF
--- a/crates/cdk-http-client/src/transport/mod.rs
+++ b/crates/cdk-http-client/src/transport/mod.rs
@@ -12,10 +12,14 @@ use url::Url;
 use crate::{HttpClient, HttpClientBuilder};
 use crate::{HttpError, RawResponse};
 
-/// Expected HTTP transport
+/// Expected HTTP transport.
+///
+/// Callers that construct a transport implicitly may add a [`Default`] bound,
+/// while configured transports can be supplied directly without implementing
+/// a meaningless default configuration.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait Transport: Default + Send + Sync + Debug + Clone {
+pub trait Transport: Send + Sync + Debug + Clone {
     /// Connect to a WebSocket endpoint using this transport.
     async fn ws_connect(
         &self,

--- a/crates/cdk-http-client/src/transport/mod.rs
+++ b/crates/cdk-http-client/src/transport/mod.rs
@@ -41,9 +41,16 @@ pub trait Transport: Send + Sync + Debug + Clone {
         accept_invalid_certs: bool,
     ) -> Result<(), HttpError>;
 
-    #[cfg(all(feature = "bip353", not(target_arch = "wasm32")))]
     /// DNS resolver to get TXT records from a domain name.
-    async fn resolve_dns_txt(&self, domain: &str) -> Result<Vec<String>, HttpError>;
+    ///
+    /// Transports that support DNS resolution should override this method. The
+    /// default implementation keeps the trait API stable when the `bip353`
+    /// feature is disabled.
+    async fn resolve_dns_txt(&self, _domain: &str) -> Result<Vec<String>, HttpError> {
+        Err(HttpError::Other(
+            "DNS TXT resolution is not enabled for this transport".to_owned(),
+        ))
+    }
 
     /// HTTP GET request.
     async fn http_get<R>(&self, url: Url, auth: Option<AuthToken>) -> Result<R, HttpError>

--- a/crates/cdk-http-client/src/ws/mod.rs
+++ b/crates/cdk-http-client/src/ws/mod.rs
@@ -13,6 +13,6 @@ pub use error::WsError;
 #[cfg(all(feature = "tor", not(target_arch = "wasm32")))]
 pub(crate) use native::connect_tor;
 #[cfg(not(target_arch = "wasm32"))]
-pub use native::{connect, WsReceiver, WsSender};
+pub use native::{connect, from_websocket_stream, WsReceiver, WsSender};
 #[cfg(target_arch = "wasm32")]
 pub use wasm::{connect, WsReceiver, WsSender};

--- a/crates/cdk-http-client/src/ws/native.rs
+++ b/crates/cdk-http-client/src/ws/native.rs
@@ -3,6 +3,7 @@
 use futures::{SinkExt, StreamExt};
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::WebSocketStream;
 
 use super::WsError;
 
@@ -67,6 +68,31 @@ impl WsReceiver {
     }
 }
 
+/// Adapt an established WebSocket stream to CDK's sender and receiver types.
+///
+/// This is useful for transports that perform the HTTP upgrade themselves,
+/// such as an encrypted tunnel, and then construct a WebSocket stream over the
+/// resulting bidirectional byte stream.
+pub fn from_websocket_stream<S>(ws_stream: WebSocketStream<S>) -> (WsSender, WsReceiver)
+where
+    WebSocketStream<S>: futures::Sink<Message, Error = tokio_tungstenite::tungstenite::Error>
+        + futures::Stream<Item = Result<Message, tokio_tungstenite::tungstenite::Error>>
+        + Unpin
+        + Send
+        + 'static,
+{
+    let (sink, stream) = ws_stream.split();
+
+    (
+        WsSender {
+            inner: Box::new(sink),
+        },
+        WsReceiver {
+            inner: Box::new(stream),
+        },
+    )
+}
+
 /// Connect to a WebSocket endpoint with optional headers.
 ///
 /// `headers` is a slice of `(name, value)` pairs to include in the upgrade request.
@@ -91,16 +117,7 @@ pub async fn connect(
         .await
         .map_err(|e| WsError::Connection(e.to_string()))?;
 
-    let (sink, stream) = ws_stream.split();
-
-    Ok((
-        WsSender {
-            inner: Box::new(sink),
-        },
-        WsReceiver {
-            inner: Box::new(stream),
-        },
-    ))
+    Ok(from_websocket_stream(ws_stream))
 }
 
 /// Connect to a WebSocket endpoint through an Arti Tor client.
@@ -143,14 +160,5 @@ pub(crate) async fn connect_tor(
             .await
             .map_err(|e| WsError::Connection(e.to_string()))?;
 
-    let (sink, stream) = ws_stream.split();
-
-    Ok((
-        WsSender {
-            inner: Box::new(sink),
-        },
-        WsReceiver {
-            inner: Box::new(stream),
-        },
-    ))
+    Ok(from_websocket_stream(ws_stream))
 }

--- a/crates/cdk/src/wallet/mint_connector/http_client.rs
+++ b/crates/cdk/src/wallet/mint_connector/http_client.rs
@@ -185,7 +185,10 @@ where
     }
 
     /// Create new [`HttpClient`]
-    pub fn new(mint_url: MintUrl, auth_wallet: Option<AuthWallet>) -> Self {
+    pub fn new(mint_url: MintUrl, auth_wallet: Option<AuthWallet>) -> Self
+    where
+        T: Default,
+    {
         Self {
             transport: T::default().into(),
             mint_url,
@@ -219,7 +222,10 @@ where
         proxy: Url,
         host_matcher: Option<&str>,
         accept_invalid_certs: bool,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, Error>
+    where
+        T: Default,
+    {
         let mut transport = T::default();
         transport
             .with_proxy(proxy, host_matcher, accept_invalid_certs)
@@ -977,7 +983,10 @@ where
     }
 
     /// Create new [`AuthHttpClient`]
-    pub fn new(mint_url: MintUrl, cat: Option<AuthToken>) -> Self {
+    pub fn new(mint_url: MintUrl, cat: Option<AuthToken>) -> Self
+    where
+        T: Default,
+    {
         Self {
             transport: T::default().into(),
             mint_url,
@@ -1006,7 +1015,10 @@ where
         host_matcher: Option<&str>,
         accept_invalid_certs: bool,
         cat: Option<AuthToken>,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, Error>
+    where
+        T: Default,
+    {
         let mut transport = T::default();
         transport
             .with_proxy(proxy, host_matcher, accept_invalid_certs)


### PR DESCRIPTION
needed for https://github.com/cashubtc/cdk/pull/2231

----

Improve `cdk-http-client` extensibility for transports that maintain their own state or establish connections outside the standard HTTP/WebSocket flow.

This PR:

- Removes the global `Default` requirement from the `Transport` trait. Constructors that instantiate a transport still require `T: Default`, while callers can provide preconfigured transports that do not have a meaningful default configuration.
- Adds `from_websocket_stream`, allowing an already-established `WebSocketStream` to be adapted into CDK’s `WsSender` and `WsReceiver` types. Existing direct and Tor connections now reuse this adapter.
- Makes `resolve_dns_txt` an unconditional trait method with a default unsupported implementation. Feature flags therefore no longer change the trait’s required methods or cause compilation failures through Cargo feature unification.

Together, these changes enable stateful transports, encrypted tunnels, and transports that perform their own WebSocket upgrade without complicating the standard client path.

-----

### Notes to the reviewers

The public API changes are additive or relax existing constraints:

- Existing transports implementing `Default` continue to work unchanged.
- `Default` is required only where CDK constructs the transport itself.
- DNS-capable transports can override `resolve_dns_txt`; other transports receive a clear runtime error if it is called.
- The WebSocket adapter accepts any compatible, established `WebSocketStream`.