### PR TITLE
feat: verify and sign the length-framed NUT-11 SIG_ALL message

### DIFF
--- a/crates/cashu/src/nuts/nut01/public_key.rs
+++ b/crates/cashu/src/nuts/nut01/public_key.rs
@@ -94,7 +94,12 @@ impl PublicKey {
     /// Verify schnorr signature
     pub fn verify(&self, msg: &[u8], sig: &Signature) -> Result<(), Error> {
         let hash: Sha256Hash = Sha256Hash::hash(msg);
-        let msg = Message::from_digest_slice(hash.as_ref())?;
+        self.verify_digest(hash.to_byte_array(), sig)
+    }
+
+    /// Verify a schnorr signature over an already hashed 32-byte message.
+    pub(crate) fn verify_digest(&self, digest: [u8; 32], sig: &Signature) -> Result<(), Error> {
+        let msg = Message::from_digest(digest);
         SECP256K1.verify_schnorr(sig, &msg, &self.inner.x_only_public_key().0)?;
         Ok(())
     }

--- a/crates/cashu/src/nuts/nut01/secret_key.rs
+++ b/crates/cashu/src/nuts/nut01/secret_key.rs
@@ -87,8 +87,13 @@ impl SecretKey {
     /// Schnorr Signature on Message
     pub fn sign(&self, msg: &[u8]) -> Result<Signature, Error> {
         let hash: Sha256Hash = Sha256Hash::hash(msg);
-        let msg = Message::from_digest_slice(hash.as_ref())?;
-        Ok(SECP256K1.sign_schnorr(&msg, &Keypair::from_secret_key(&SECP256K1, &self.inner)))
+        Ok(self.sign_digest(hash.to_byte_array()))
+    }
+
+    /// Schnorr signature over an already hashed 32-byte message.
+    pub(crate) fn sign_digest(&self, digest: [u8; 32]) -> Signature {
+        let msg = Message::from_digest(digest);
+        SECP256K1.sign_schnorr(&msg, &Keypair::from_secret_key(&SECP256K1, &self.inner))
     }
 
     /// Get public key

--- a/crates/cashu/src/nuts/nut03.rs
+++ b/crates/cashu/src/nuts/nut03.rs
@@ -115,6 +115,14 @@ impl super::nut10::SpendingConditionVerification for SwapRequest {
 
         msg
     }
+
+    fn sig_all_msg_to_sign_v1(&self) -> Vec<u8> {
+        super::nut10::sig_all_msg_to_sign_v1(None, &self.inputs, &self.outputs)
+    }
+
+    fn sig_all_msg_to_sign_legacy(&self) -> String {
+        super::nut10::sig_all_msg_to_sign_legacy(None, &self.inputs, &self.outputs)
+    }
 }
 
 /// Split Response [NUT-06]

--- a/crates/cashu/src/nuts/nut03.rs
+++ b/crates/cashu/src/nuts/nut03.rs
@@ -119,10 +119,6 @@ impl super::nut10::SpendingConditionVerification for SwapRequest {
     fn sig_all_msg_to_sign_v1(&self) -> Vec<u8> {
         super::nut10::sig_all_msg_to_sign_v1(None, &self.inputs, &self.outputs)
     }
-
-    fn sig_all_msg_to_sign_legacy(&self) -> String {
-        super::nut10::sig_all_msg_to_sign_legacy(None, &self.inputs, &self.outputs)
-    }
 }
 
 /// Split Response [NUT-06]

--- a/crates/cashu/src/nuts/nut05.rs
+++ b/crates/cashu/src/nuts/nut05.rs
@@ -217,6 +217,22 @@ where
 
         msg
     }
+
+    fn sig_all_msg_to_sign_v1(&self) -> Vec<u8> {
+        super::nut10::sig_all_msg_to_sign_v1(
+            Some(&self.quote.to_string()),
+            &self.inputs,
+            self.outputs.as_deref().unwrap_or(&[]),
+        )
+    }
+
+    fn sig_all_msg_to_sign_legacy(&self) -> String {
+        super::nut10::sig_all_msg_to_sign_legacy(
+            Some(&self.quote.to_string()),
+            &self.inputs,
+            self.outputs.as_deref().unwrap_or(&[]),
+        )
+    }
 }
 
 /// Melt Method Settings

--- a/crates/cashu/src/nuts/nut05.rs
+++ b/crates/cashu/src/nuts/nut05.rs
@@ -225,14 +225,6 @@ where
             self.outputs.as_deref().unwrap_or(&[]),
         )
     }
-
-    fn sig_all_msg_to_sign_legacy(&self) -> String {
-        super::nut10::sig_all_msg_to_sign_legacy(
-            Some(&self.quote.to_string()),
-            &self.inputs,
-            self.outputs.as_deref().unwrap_or(&[]),
-        )
-    }
 }
 
 /// Melt Method Settings

--- a/crates/cashu/src/nuts/nut10/mod.rs
+++ b/crates/cashu/src/nuts/nut10/mod.rs
@@ -247,6 +247,55 @@ pub(crate) fn get_pubkeys_and_required_sigs(
 
 use super::Proofs;
 
+/// Domain-separation tag for the NUT-11 v1 SIG_ALL message (P2PK and HTLC).
+const SIG_ALL_SIG_DOMAIN_TAG: &[u8] = b"Cashu_SigAllSig_v1";
+
+/// NUT-11 v1 SIG_ALL message: domain-separated, length-framed bytes.
+///
+/// Commits to the quote id (empty for swaps), each input's secret and C, then
+/// each output's amount (minimal big-endian bytes) and B_.
+pub(crate) fn sig_all_msg_to_sign_v1(
+    quote_id: Option<&str>,
+    inputs: &Proofs,
+    outputs: &[super::BlindedMessage],
+) -> Vec<u8> {
+    use super::nut20::{amount_to_minimal_bytes, append_len_prefixed};
+
+    let mut msg = Vec::new();
+    msg.extend_from_slice(SIG_ALL_SIG_DOMAIN_TAG);
+    append_len_prefixed(&mut msg, quote_id.unwrap_or("").as_bytes());
+    for proof in inputs {
+        append_len_prefixed(&mut msg, proof.secret.to_string().as_bytes());
+        append_len_prefixed(&mut msg, &proof.c.to_bytes());
+    }
+    for output in outputs {
+        append_len_prefixed(&mut msg, &amount_to_minimal_bytes(output.amount));
+        append_len_prefixed(&mut msg, &output.blinded_secret.to_bytes());
+    }
+    msg
+}
+
+/// SIG_ALL message as verified by cdk < 0.14.0: secrets then B_ hex strings.
+///
+/// Kept so upgraded mints keep accepting witnesses from older wallets.
+pub(crate) fn sig_all_msg_to_sign_legacy(
+    quote_id: Option<&str>,
+    inputs: &Proofs,
+    outputs: &[super::BlindedMessage],
+) -> String {
+    let mut msg = String::new();
+    for proof in inputs {
+        msg.push_str(&proof.secret.to_string());
+    }
+    for output in outputs {
+        msg.push_str(&output.blinded_secret.to_hex());
+    }
+    if let Some(quote_id) = quote_id {
+        msg.push_str(quote_id);
+    }
+    msg
+}
+
 /// Trait for requests that spend proofs (SwapRequest, MeltRequest)
 pub trait SpendingConditionVerification {
     /// Get the input proofs
@@ -258,6 +307,33 @@ pub trait SpendingConditionVerification {
     /// For swap: input secrets + output blinded messages
     /// For melt: input secrets + quote/payment request
     fn sig_all_msg_to_sign(&self) -> String;
+
+    /// Construct the NUT-11 v1 (length-framed) SIG_ALL message to sign
+    fn sig_all_msg_to_sign_v1(&self) -> Vec<u8>;
+
+    /// Construct the pre-0.14 SIG_ALL message (secrets then B_ values)
+    fn sig_all_msg_to_sign_legacy(&self) -> String;
+
+    /// SIG_ALL message formats accepted during verification, newest first.
+    ///
+    /// Signatures that do not verify under any format are ignored; only unique
+    /// pubkeys with valid signatures count towards thresholds (NUT-11). The
+    /// legacy format is signed for older mints but never accepted here: it
+    /// does not commit to input C values or output amounts.
+    fn sig_all_msgs_to_verify(&self) -> Vec<Vec<u8>> {
+        vec![
+            self.sig_all_msg_to_sign_v1(),
+            self.sig_all_msg_to_sign().into_bytes(),
+        ]
+    }
+
+    /// SIG_ALL messages a wallet signs: every accepted format plus legacy,
+    /// so the request also verifies on not-yet-upgraded mints.
+    fn sig_all_msgs_to_sign(&self) -> Vec<Vec<u8>> {
+        let mut msgs = self.sig_all_msgs_to_verify();
+        msgs.push(self.sig_all_msg_to_sign_legacy().into_bytes());
+        msgs
+    }
 
     /// Check if at least one proof in the set has SIG_ALL flag set
     ///
@@ -372,12 +448,13 @@ pub trait SpendingConditionVerification {
             Secret::try_from(&first_input.secret).map_err(|_| Error::IncorrectSecretKind)?;
 
         // Dispatch based on secret kind
+        let msgs_to_verify = self.sig_all_msgs_to_verify();
         match first_secret.kind() {
             Kind::P2PK => {
-                nut11::verify_sig_all_p2pk(first_input, self.sig_all_msg_to_sign())?;
+                nut11::verify_sig_all_p2pk(first_input, &msgs_to_verify)?;
             }
             Kind::HTLC => {
-                nut14::verify_sig_all_htlc(first_input, self.sig_all_msg_to_sign())?;
+                nut14::verify_sig_all_htlc(first_input, &msgs_to_verify)?;
             }
         }
 
@@ -442,6 +519,14 @@ mod tests {
 
         fn sig_all_msg_to_sign(&self) -> String {
             "test message".to_string()
+        }
+
+        fn sig_all_msg_to_sign_v1(&self) -> Vec<u8> {
+            sig_all_msg_to_sign_v1(None, &self.inputs, &[])
+        }
+
+        fn sig_all_msg_to_sign_legacy(&self) -> String {
+            sig_all_msg_to_sign_legacy(None, &self.inputs, &[])
         }
     }
 

--- a/crates/cashu/src/nuts/nut10/mod.rs
+++ b/crates/cashu/src/nuts/nut10/mod.rs
@@ -519,6 +519,18 @@ mod tests {
     }
 
     #[test]
+    fn test_sig_all_msgs_to_verify_lists_accepted_formats() {
+        let request = TestSpendRequest {
+            inputs: vec![p2pk_proof_with_sig_flag(SigFlag::SigAll)],
+        };
+        let msgs = request.sig_all_msgs_to_verify();
+        assert_eq!(msgs.len(), 2);
+        // Newest first: the length-framed v1 message, then the current format
+        assert!(msgs[0].starts_with(b"Cashu_SigAllSig_v1"));
+        assert_eq!(msgs[1], b"test message".to_vec());
+    }
+
+    #[test]
     fn test_secret_serialize() {
         let secret_data = SecretData::new(
             "026562efcfadc8e86d44da6a8adf80633d974302e62c850774db1fb36ff4cc7198".to_string(),

--- a/crates/cashu/src/nuts/nut10/mod.rs
+++ b/crates/cashu/src/nuts/nut10/mod.rs
@@ -275,27 +275,6 @@ pub(crate) fn sig_all_msg_to_sign_v1(
     msg
 }
 
-/// SIG_ALL message as verified by cdk < 0.14.0: secrets then B_ hex strings.
-///
-/// Kept so upgraded mints keep accepting witnesses from older wallets.
-pub(crate) fn sig_all_msg_to_sign_legacy(
-    quote_id: Option<&str>,
-    inputs: &Proofs,
-    outputs: &[super::BlindedMessage],
-) -> String {
-    let mut msg = String::new();
-    for proof in inputs {
-        msg.push_str(&proof.secret.to_string());
-    }
-    for output in outputs {
-        msg.push_str(&output.blinded_secret.to_hex());
-    }
-    if let Some(quote_id) = quote_id {
-        msg.push_str(quote_id);
-    }
-    msg
-}
-
 /// Trait for requests that spend proofs (SwapRequest, MeltRequest)
 pub trait SpendingConditionVerification {
     /// Get the input proofs
@@ -311,28 +290,17 @@ pub trait SpendingConditionVerification {
     /// Construct the NUT-11 v1 (length-framed) SIG_ALL message to sign
     fn sig_all_msg_to_sign_v1(&self) -> Vec<u8>;
 
-    /// Construct the pre-0.14 SIG_ALL message (secrets then B_ values)
-    fn sig_all_msg_to_sign_legacy(&self) -> String;
-
     /// SIG_ALL message formats accepted during verification, newest first.
     ///
     /// Signatures that do not verify under any format are ignored; only unique
     /// pubkeys with valid signatures count towards thresholds (NUT-11). The
-    /// legacy format is signed for older mints but never accepted here: it
-    /// does not commit to input C values or output amounts.
+    /// pre-0.14 format (secrets then B_ values) is not accepted: it does not
+    /// commit to input C values or output amounts.
     fn sig_all_msgs_to_verify(&self) -> Vec<Vec<u8>> {
         vec![
             self.sig_all_msg_to_sign_v1(),
             self.sig_all_msg_to_sign().into_bytes(),
         ]
-    }
-
-    /// SIG_ALL messages a wallet signs: every accepted format plus legacy,
-    /// so the request also verifies on not-yet-upgraded mints.
-    fn sig_all_msgs_to_sign(&self) -> Vec<Vec<u8>> {
-        let mut msgs = self.sig_all_msgs_to_verify();
-        msgs.push(self.sig_all_msg_to_sign_legacy().into_bytes());
-        msgs
     }
 
     /// Check if at least one proof in the set has SIG_ALL flag set
@@ -523,10 +491,6 @@ mod tests {
 
         fn sig_all_msg_to_sign_v1(&self) -> Vec<u8> {
             sig_all_msg_to_sign_v1(None, &self.inputs, &[])
-        }
-
-        fn sig_all_msg_to_sign_legacy(&self) -> String {
-            sig_all_msg_to_sign_legacy(None, &self.inputs, &[])
         }
     }
 

--- a/crates/cashu/src/nuts/nut10/mod.rs
+++ b/crates/cashu/src/nuts/nut10/mod.rs
@@ -4,6 +4,8 @@
 
 use std::str::FromStr;
 
+use bitcoin::hashes::sha256::Hash as Sha256Hash;
+use bitcoin::hashes::Hash;
 use serde::{Deserialize, Serialize};
 
 use super::nut01::PublicKey;
@@ -247,10 +249,10 @@ pub(crate) fn get_pubkeys_and_required_sigs(
 
 use super::Proofs;
 
-/// Domain-separation tag for the NUT-11 v1 SIG_ALL message (P2PK and HTLC).
-const SIG_ALL_SIG_DOMAIN_TAG: &[u8] = b"Cashu_SigAllSig_v1";
+/// BIP-340 tag for the NUT-11 v1 SIG_ALL message hash (P2PK and HTLC).
+const SIG_ALL_SIG_TAG: &[u8] = b"Cashu_SigAllSig_v1";
 
-/// NUT-11 v1 SIG_ALL message: domain-separated, length-framed bytes.
+/// NUT-11 v1 SIG_ALL message: length-framed bytes.
 ///
 /// Commits to the quote id (empty for swaps), each input's secret and C, then
 /// each output's amount (minimal big-endian bytes) and B_.
@@ -262,7 +264,6 @@ pub(crate) fn sig_all_msg_to_sign_v1(
     use super::nut20::{amount_to_minimal_bytes, append_len_prefixed};
 
     let mut msg = Vec::new();
-    msg.extend_from_slice(SIG_ALL_SIG_DOMAIN_TAG);
     append_len_prefixed(&mut msg, quote_id.unwrap_or("").as_bytes());
     for proof in inputs {
         append_len_prefixed(&mut msg, proof.secret.to_string().as_bytes());
@@ -273,6 +274,17 @@ pub(crate) fn sig_all_msg_to_sign_v1(
         append_len_prefixed(&mut msg, &output.blinded_secret.to_bytes());
     }
     msg
+}
+
+/// NUT-11 v1 SIG_ALL message hash: the BIP-340 tagged hash
+/// `SHA256(SHA256(tag) || SHA256(tag) || message)`, signed without further hashing.
+pub(crate) fn sig_all_message_hash_v1(message: &[u8]) -> [u8; 32] {
+    let tag_hash = Sha256Hash::hash(SIG_ALL_SIG_TAG).to_byte_array();
+    let mut preimage = Vec::with_capacity(64 + message.len());
+    preimage.extend_from_slice(&tag_hash);
+    preimage.extend_from_slice(&tag_hash);
+    preimage.extend_from_slice(message);
+    Sha256Hash::hash(&preimage).to_byte_array()
 }
 
 /// Trait for requests that spend proofs (SwapRequest, MeltRequest)
@@ -287,19 +299,20 @@ pub trait SpendingConditionVerification {
     /// For melt: input secrets + quote/payment request
     fn sig_all_msg_to_sign(&self) -> String;
 
-    /// Construct the NUT-11 v1 (length-framed) SIG_ALL message to sign
+    /// Construct the NUT-11 v1 (length-framed) SIG_ALL message
     fn sig_all_msg_to_sign_v1(&self) -> Vec<u8>;
 
-    /// SIG_ALL message formats accepted during verification, newest first.
+    /// Digests of the SIG_ALL message formats accepted during verification, newest first.
     ///
-    /// Signatures that do not verify under any format are ignored; only unique
-    /// pubkeys with valid signatures count towards thresholds (NUT-11). The
-    /// pre-0.14 format (secrets then B_ values) is not accepted: it does not
-    /// commit to input C values or output amounts.
-    fn sig_all_msgs_to_verify(&self) -> Vec<Vec<u8>> {
+    /// Each digest is signed directly with Schnorr: the v1 tagged hash, then the
+    /// SHA-256 of the current string format. Signatures that do not verify under
+    /// any format are ignored; only unique pubkeys with valid signatures count
+    /// towards thresholds (NUT-11). The pre-0.14 format (secrets then B_ values)
+    /// is not accepted: it does not commit to input C values or output amounts.
+    fn sig_all_digests_to_verify(&self) -> Vec<[u8; 32]> {
         vec![
-            self.sig_all_msg_to_sign_v1(),
-            self.sig_all_msg_to_sign().into_bytes(),
+            sig_all_message_hash_v1(&self.sig_all_msg_to_sign_v1()),
+            Sha256Hash::hash(self.sig_all_msg_to_sign().as_bytes()).to_byte_array(),
         ]
     }
 
@@ -416,13 +429,13 @@ pub trait SpendingConditionVerification {
             Secret::try_from(&first_input.secret).map_err(|_| Error::IncorrectSecretKind)?;
 
         // Dispatch based on secret kind
-        let msgs_to_verify = self.sig_all_msgs_to_verify();
+        let digests_to_verify = self.sig_all_digests_to_verify();
         match first_secret.kind() {
             Kind::P2PK => {
-                nut11::verify_sig_all_p2pk(first_input, &msgs_to_verify)?;
+                nut11::verify_sig_all_p2pk(first_input, &digests_to_verify)?;
             }
             Kind::HTLC => {
-                nut14::verify_sig_all_htlc(first_input, &msgs_to_verify)?;
+                nut14::verify_sig_all_htlc(first_input, &digests_to_verify)?;
             }
         }
 
@@ -519,15 +532,30 @@ mod tests {
     }
 
     #[test]
-    fn test_sig_all_msgs_to_verify_lists_accepted_formats() {
+    fn test_sig_all_digests_to_verify_lists_accepted_formats() {
         let request = TestSpendRequest {
             inputs: vec![p2pk_proof_with_sig_flag(SigFlag::SigAll)],
         };
-        let msgs = request.sig_all_msgs_to_verify();
-        assert_eq!(msgs.len(), 2);
-        // Newest first: the length-framed v1 message, then the current format
-        assert!(msgs[0].starts_with(b"Cashu_SigAllSig_v1"));
-        assert_eq!(msgs[1], b"test message".to_vec());
+        let digests = request.sig_all_digests_to_verify();
+        assert_eq!(digests.len(), 2);
+        // Newest first: the tagged hash of the v1 message, then sha256 of the current format
+        assert_eq!(
+            digests[0],
+            sig_all_message_hash_v1(&request.sig_all_msg_to_sign_v1())
+        );
+        assert_eq!(
+            digests[1],
+            Sha256Hash::hash(b"test message").to_byte_array()
+        );
+    }
+
+    #[test]
+    fn test_sig_all_message_hash_v1_uses_the_nut11_tag_hash() {
+        // SHA256("Cashu_SigAllSig_v1") as published in NUT-11
+        assert_eq!(
+            Sha256Hash::hash(SIG_ALL_SIG_TAG).to_string(),
+            "c83c413c874b6f3da4c6310558d0d174c56f1a0a034023ae225ab3648e9626b3"
+        );
     }
 
     #[test]

--- a/crates/cashu/src/nuts/nut11/mod.rs
+++ b/crates/cashu/src/nuts/nut11/mod.rs
@@ -269,7 +269,7 @@ pub(crate) fn extract_signatures_from_witness(
 /// Per NUT-11, there are two spending pathways after locktime:
 /// 1. Primary path (data + pubkeys): ALWAYS available
 /// 2. Refund path (refund keys): available AFTER locktime
-pub(crate) fn verify_sig_all_p2pk(first_input: &Proof, msg_to_sign: String) -> Result<(), Error> {
+pub(crate) fn verify_sig_all_p2pk(first_input: &Proof, msgs_to_sign: &[Vec<u8>]) -> Result<(), Error> {
     // Get the first input, as it's the one with the signatures
     let first_secret =
         Nut10Secret::try_from(&first_input.secret).map_err(|_| Error::IncorrectSecretKind)?;
@@ -305,9 +305,7 @@ pub(crate) fn verify_sig_all_p2pk(first_input: &Proof, msg_to_sign: String) -> R
     {
         let primary_valid = extract_signatures_from_witness(first_witness)
             .ok()
-            .and_then(|sigs| {
-                valid_signatures(msg_to_sign.as_bytes(), &requirements.pubkeys, &sigs).ok()
-            })
+            .map(|sigs| valid_signatures_any_msg(msgs_to_sign, &requirements.pubkeys, &sigs))
             .is_some_and(|count| count >= requirements.required_sigs);
 
         if primary_valid {
@@ -320,8 +318,7 @@ pub(crate) fn verify_sig_all_p2pk(first_input: &Proof, msg_to_sign: String) -> R
         if let Some(refund_path) = &requirements.refund_path {
             let signatures = extract_signatures_from_witness(first_witness)?;
             let valid_sig_count =
-                valid_signatures(msg_to_sign.as_bytes(), &refund_path.pubkeys, &signatures)
-                    .map_err(|_| Error::InvalidSignature)?;
+                valid_signatures_any_msg(msgs_to_sign, &refund_path.pubkeys, &signatures);
 
             if valid_sig_count >= refund_path.required_sigs {
                 return Ok(());
@@ -356,6 +353,31 @@ pub(crate) fn valid_signatures(
     }
 
     Ok(verified_pubkeys.len() as u64)
+}
+
+/// Returns count of unique public keys with at least one valid signature over
+/// any accepted SIG_ALL message format.
+///
+/// Signatures that do not verify under any format are ignored per NUT-11
+/// signature validation; counting each pubkey at most once makes double
+/// counting impossible, so no duplicate-signature error is needed.
+pub(crate) fn valid_signatures_any_msg(
+    msgs: &[Vec<u8>],
+    pubkeys: &[PublicKey],
+    signatures: &[Signature],
+) -> u64 {
+    let mut verified_pubkeys = HashSet::new();
+
+    for pubkey in pubkeys {
+        let is_valid = signatures
+            .iter()
+            .any(|signature| msgs.iter().any(|msg| pubkey.verify(msg, signature).is_ok()));
+        if is_valid {
+            verified_pubkeys.insert(pubkey.x_only_public_key());
+        }
+    }
+
+    verified_pubkeys.len() as u64
 }
 
 impl BlindedMessage {
@@ -509,11 +531,15 @@ pub struct EnforceSigFlag {
 impl SwapRequest {
     /// Sign swap request with SIG_ALL
     pub fn sign_sig_all(&mut self, secret_key: SecretKey) -> Result<(), Error> {
-        // Get message to sign
-        let msg = self.sig_all_msg_to_sign();
-        let signature = secret_key.sign(msg.as_bytes())?;
+        // One signature per SIG_ALL message format (v1, current, legacy) so the
+        // request verifies on mints at any upgrade stage; mints ignore
+        // signatures that do not verify.
+        let mut signatures = Vec::with_capacity(3);
+        for msg in self.sig_all_msgs_to_sign() {
+            signatures.push(secret_key.sign(&msg)?.to_string());
+        }
 
-        // Add signature to first input witness
+        // Add signatures to first input witness
         let first_input = self
             .inputs_mut()
             .first_mut()
@@ -521,11 +547,11 @@ impl SwapRequest {
 
         match first_input.witness.as_mut() {
             Some(witness) => {
-                witness.add_signatures(vec![signature.to_string()]);
+                witness.add_signatures(signatures);
             }
             None => {
                 let mut p2pk_witness = Witness::P2PKWitness(P2PKWitness::default());
-                p2pk_witness.add_signatures(vec![signature.to_string()]);
+                p2pk_witness.add_signatures(signatures);
                 first_input.witness = Some(p2pk_witness);
             }
         };
@@ -540,11 +566,15 @@ where
 {
     /// Sign melt request with SIG_ALL
     pub fn sign_sig_all(&mut self, secret_key: SecretKey) -> Result<(), Error> {
-        // Get message to sign
-        let msg = self.sig_all_msg_to_sign();
-        let signature = secret_key.sign(msg.as_bytes())?;
+        // One signature per SIG_ALL message format (v1, current, legacy) so the
+        // request verifies on mints at any upgrade stage; mints ignore
+        // signatures that do not verify.
+        let mut signatures = Vec::with_capacity(3);
+        for msg in self.sig_all_msgs_to_sign() {
+            signatures.push(secret_key.sign(&msg)?.to_string());
+        }
 
-        // Add signature to first input witness
+        // Add signatures to first input witness
         let first_input = self
             .inputs_mut()
             .first_mut()
@@ -552,11 +582,11 @@ where
 
         match first_input.witness.as_mut() {
             Some(witness) => {
-                witness.add_signatures(vec![signature.to_string()]);
+                witness.add_signatures(signatures);
             }
             None => {
                 let mut p2pk_witness = Witness::P2PKWitness(P2PKWitness::default());
-                p2pk_witness.add_signatures(vec![signature.to_string()]);
+                p2pk_witness.add_signatures(signatures);
                 first_input.witness = Some(p2pk_witness);
             }
         };
@@ -1363,6 +1393,87 @@ mod tests {
             valid_swap.verify_spending_conditions().is_ok(),
             "Valid SIG_ALL swap request should verify"
         );
+    }
+
+    #[test]
+    fn test_sig_all_v1_message_canonical_vector() {
+        // Canonical vectors from nuts tests/11-test.md ("SIG_ALL v1 Message
+        // Vectors"), pinned byte-for-byte in cashu-ts and nutshell too. The
+        // witness carries one signature per message format (v1, current,
+        // legacy) by the well-known test key (privkey 0x...01).
+        let swap = r#"{
+          "inputs": [
+            {
+              "amount": 8,
+              "id": "009a1f293253e41e",
+              "secret": "[\"P2PK\",{\"nonce\":\"859d4935c4907062a6297cf4e663e2835d90d97ecdd510745d32f6816323a41f\",\"data\":\"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+              "C": "02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904",
+              "witness": "{\"signatures\":[\"b2b821f819f12ab61d261971187d19772aaad11422f9d5f3ffda6f97de03349e0e44976b5d44e3c850a99b621045167915caf3ef5b102abe69439e36b68f89d5\",\"947864cac6d9369f358257eece81c4aa9deb2e63899f2d868e7c243ff334ade5db1d8db010daa2b9f4407610458d9ffa3250eb778d1a0980f4de671627c8718e\",\"ea0cdab0d0895bbf212d6d301ea4180171a1e2af309fcee57fa16998b9c234f2f8722953f9703f561866f45672b2a499109722dfeb3c3e7a2a2d51cda9684652\"]}"
+            },
+            {
+              "amount": 2,
+              "id": "009a1f293253e41e",
+              "secret": "[\"P2PK\",{\"nonce\":\"16d937a29ae4e5d4a6e9f9959c4d4b9a8d6f2f7b2f0a1b3c4d5e6f708192a3b4\",\"data\":\"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
+              "C": "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
+            }
+          ],
+          "outputs": [
+            {
+              "amount": 8,
+              "id": "009a1f293253e41e",
+              "B_": "035015e6d7ade60ba8426cefaf1832bbd27257636e44a76b922d78e79b47cb689d"
+            },
+            {
+              "amount": 2,
+              "id": "009a1f293253e41e",
+              "B_": "0288d7649652d0a83fc9c966c969fb217f15904431e61a44b14999fabc1b5d9ac6"
+            }
+          ]
+}"#;
+
+        let swap: SwapRequest = serde_json::from_str(swap).unwrap();
+
+        use bitcoin::hashes::{sha256, Hash};
+        let v1_msg = swap.sig_all_msg_to_sign_v1();
+        assert_eq!(v1_msg.len(), 572);
+        // Swaps commit an empty quote field: len32(0) right after the tag
+        assert!(v1_msg.starts_with(b"Cashu_SigAllSig_v1\x00\x00\x00\x00"));
+        assert_eq!(
+            sha256::Hash::hash(&v1_msg).to_string(),
+            "3fd05c896ff0d5a058f9180e577dced83539ea885f9bf6adf71f7ed084590dc2"
+        );
+
+        // The multi-format witness verifies end to end
+        assert!(
+            swap.verify_spending_conditions().is_ok(),
+            "Canonical SIG_ALL v1 swap vector should verify"
+        );
+
+        // Melt with the same inputs/outputs and the vector quote id
+        let melt = format!(
+            r#"{{"quote": "9d745270-1405-46de-b5c5-e2762b4f5e00", "inputs": {}, "outputs": {}}}"#,
+            serde_json::to_string(swap.inputs()).unwrap(),
+            serde_json::to_string(swap.outputs()).unwrap(),
+        );
+        let melt: MeltRequest<String> = serde_json::from_str(&melt).unwrap();
+
+        let v1_msg = melt.sig_all_msg_to_sign_v1();
+        assert_eq!(v1_msg.len(), 608);
+        assert_eq!(
+            sha256::Hash::hash(&v1_msg).to_string(),
+            "0ebae3a8dbe1107a7b6392a53b6fb3dfc18b38c4ab02b4b9a460ad8829e20ce1"
+        );
+
+        // Pinned melt signature by the test key
+        let pubkey = PublicKey::from_str(
+            "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        )
+        .unwrap();
+        let signature = Signature::from_str(
+            "1493200b3f52cd67bdda888f67d80cf8862b4e7bd48a800828f5482218305c367f17dc3409cf89e6c795741605ccce2501f5e2b0f0e3ec54edcc7001a5863e3d",
+        )
+        .unwrap();
+        assert!(pubkey.verify(&v1_msg, &signature).is_ok());
     }
 
     #[test]

--- a/crates/cashu/src/nuts/nut11/mod.rs
+++ b/crates/cashu/src/nuts/nut11/mod.rs
@@ -269,7 +269,10 @@ pub(crate) fn extract_signatures_from_witness(
 /// Per NUT-11, there are two spending pathways after locktime:
 /// 1. Primary path (data + pubkeys): ALWAYS available
 /// 2. Refund path (refund keys): available AFTER locktime
-pub(crate) fn verify_sig_all_p2pk(first_input: &Proof, msgs_to_sign: &[Vec<u8>]) -> Result<(), Error> {
+pub(crate) fn verify_sig_all_p2pk(
+    first_input: &Proof,
+    msgs_to_sign: &[Vec<u8>],
+) -> Result<(), Error> {
     // Get the first input, as it's the one with the signatures
     let first_secret =
         Nut10Secret::try_from(&first_input.secret).map_err(|_| Error::IncorrectSecretKind)?;

--- a/crates/cashu/src/nuts/nut11/mod.rs
+++ b/crates/cashu/src/nuts/nut11/mod.rs
@@ -534,11 +534,11 @@ pub struct EnforceSigFlag {
 impl SwapRequest {
     /// Sign swap request with SIG_ALL
     pub fn sign_sig_all(&mut self, secret_key: SecretKey) -> Result<(), Error> {
-        // One signature per SIG_ALL message format (v1, current, legacy) so the
-        // request verifies on mints at any upgrade stage; mints ignore
+        // One signature per accepted SIG_ALL message format (v1, current) so
+        // the request verifies on mints at any upgrade stage; mints ignore
         // signatures that do not verify.
-        let mut signatures = Vec::with_capacity(3);
-        for msg in self.sig_all_msgs_to_sign() {
+        let mut signatures = Vec::with_capacity(2);
+        for msg in self.sig_all_msgs_to_verify() {
             signatures.push(secret_key.sign(&msg)?.to_string());
         }
 
@@ -569,11 +569,11 @@ where
 {
     /// Sign melt request with SIG_ALL
     pub fn sign_sig_all(&mut self, secret_key: SecretKey) -> Result<(), Error> {
-        // One signature per SIG_ALL message format (v1, current, legacy) so the
-        // request verifies on mints at any upgrade stage; mints ignore
+        // One signature per accepted SIG_ALL message format (v1, current) so
+        // the request verifies on mints at any upgrade stage; mints ignore
         // signatures that do not verify.
-        let mut signatures = Vec::with_capacity(3);
-        for msg in self.sig_all_msgs_to_sign() {
+        let mut signatures = Vec::with_capacity(2);
+        for msg in self.sig_all_msgs_to_verify() {
             signatures.push(secret_key.sign(&msg)?.to_string());
         }
 
@@ -1402,8 +1402,8 @@ mod tests {
     fn test_sig_all_v1_message_canonical_vector() {
         // Canonical vectors from nuts tests/11-test.md ("SIG_ALL v1 Message
         // Vectors"), pinned byte-for-byte in cashu-ts and nutshell too. The
-        // witness carries one signature per message format (v1, current,
-        // legacy) by the well-known test key (privkey 0x...01).
+        // witness carries one signature per accepted message format (v1,
+        // current) by the well-known test key (privkey 0x...01).
         let swap = r#"{
           "inputs": [
             {
@@ -1411,7 +1411,7 @@ mod tests {
               "id": "009a1f293253e41e",
               "secret": "[\"P2PK\",{\"nonce\":\"859d4935c4907062a6297cf4e663e2835d90d97ecdd510745d32f6816323a41f\",\"data\":\"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
               "C": "02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904",
-              "witness": "{\"signatures\":[\"b2b821f819f12ab61d261971187d19772aaad11422f9d5f3ffda6f97de03349e0e44976b5d44e3c850a99b621045167915caf3ef5b102abe69439e36b68f89d5\",\"947864cac6d9369f358257eece81c4aa9deb2e63899f2d868e7c243ff334ade5db1d8db010daa2b9f4407610458d9ffa3250eb778d1a0980f4de671627c8718e\",\"ea0cdab0d0895bbf212d6d301ea4180171a1e2af309fcee57fa16998b9c234f2f8722953f9703f561866f45672b2a499109722dfeb3c3e7a2a2d51cda9684652\"]}"
+              "witness": "{\"signatures\":[\"b2b821f819f12ab61d261971187d19772aaad11422f9d5f3ffda6f97de03349e0e44976b5d44e3c850a99b621045167915caf3ef5b102abe69439e36b68f89d5\",\"947864cac6d9369f358257eece81c4aa9deb2e63899f2d868e7c243ff334ade5db1d8db010daa2b9f4407610458d9ffa3250eb778d1a0980f4de671627c8718e\"]}"
             },
             {
               "amount": 2,

--- a/crates/cashu/src/nuts/nut11/mod.rs
+++ b/crates/cashu/src/nuts/nut11/mod.rs
@@ -271,7 +271,7 @@ pub(crate) fn extract_signatures_from_witness(
 /// 2. Refund path (refund keys): available AFTER locktime
 pub(crate) fn verify_sig_all_p2pk(
     first_input: &Proof,
-    msgs_to_sign: &[Vec<u8>],
+    digests_to_sign: &[[u8; 32]],
 ) -> Result<(), Error> {
     // Get the first input, as it's the one with the signatures
     let first_secret =
@@ -308,7 +308,7 @@ pub(crate) fn verify_sig_all_p2pk(
     {
         let primary_valid = extract_signatures_from_witness(first_witness)
             .ok()
-            .map(|sigs| valid_signatures_any_msg(msgs_to_sign, &requirements.pubkeys, &sigs))
+            .map(|sigs| valid_signatures_any_digest(digests_to_sign, &requirements.pubkeys, &sigs))
             .is_some_and(|count| count >= requirements.required_sigs);
 
         if primary_valid {
@@ -321,7 +321,7 @@ pub(crate) fn verify_sig_all_p2pk(
         if let Some(refund_path) = &requirements.refund_path {
             let signatures = extract_signatures_from_witness(first_witness)?;
             let valid_sig_count =
-                valid_signatures_any_msg(msgs_to_sign, &refund_path.pubkeys, &signatures);
+                valid_signatures_any_digest(digests_to_sign, &refund_path.pubkeys, &signatures);
 
             if valid_sig_count >= refund_path.required_sigs {
                 return Ok(());
@@ -359,22 +359,24 @@ pub(crate) fn valid_signatures(
 }
 
 /// Returns count of unique public keys with at least one valid signature over
-/// any accepted SIG_ALL message format.
+/// any accepted SIG_ALL message digest.
 ///
 /// Signatures that do not verify under any format are ignored per NUT-11
 /// signature validation; counting each pubkey at most once makes double
 /// counting impossible, so no duplicate-signature error is needed.
-pub(crate) fn valid_signatures_any_msg(
-    msgs: &[Vec<u8>],
+pub(crate) fn valid_signatures_any_digest(
+    digests: &[[u8; 32]],
     pubkeys: &[PublicKey],
     signatures: &[Signature],
 ) -> u64 {
     let mut verified_pubkeys = HashSet::new();
 
     for pubkey in pubkeys {
-        let is_valid = signatures
-            .iter()
-            .any(|signature| msgs.iter().any(|msg| pubkey.verify(msg, signature).is_ok()));
+        let is_valid = signatures.iter().any(|signature| {
+            digests
+                .iter()
+                .any(|digest| pubkey.verify_digest(*digest, signature).is_ok())
+        });
         if is_valid {
             verified_pubkeys.insert(pubkey.x_only_public_key());
         }
@@ -537,10 +539,11 @@ impl SwapRequest {
         // One signature per accepted SIG_ALL message format (v1, current) so
         // the request verifies on mints at any upgrade stage; mints ignore
         // signatures that do not verify.
-        let mut signatures = Vec::with_capacity(2);
-        for msg in self.sig_all_msgs_to_verify() {
-            signatures.push(secret_key.sign(&msg)?.to_string());
-        }
+        let signatures: Vec<String> = self
+            .sig_all_digests_to_verify()
+            .into_iter()
+            .map(|digest| secret_key.sign_digest(digest).to_string())
+            .collect();
 
         // Add signatures to first input witness
         let first_input = self
@@ -572,10 +575,11 @@ where
         // One signature per accepted SIG_ALL message format (v1, current) so
         // the request verifies on mints at any upgrade stage; mints ignore
         // signatures that do not verify.
-        let mut signatures = Vec::with_capacity(2);
-        for msg in self.sig_all_msgs_to_verify() {
-            signatures.push(secret_key.sign(&msg)?.to_string());
-        }
+        let signatures: Vec<String> = self
+            .sig_all_digests_to_verify()
+            .into_iter()
+            .map(|digest| secret_key.sign_digest(digest).to_string())
+            .collect();
 
         // Add signatures to first input witness
         let first_input = self
@@ -606,6 +610,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+    use crate::nut10::sig_all_message_hash_v1;
     use crate::nuts::Id;
     use crate::quote_id::QuoteId;
     use crate::secret::Secret;
@@ -1411,7 +1416,7 @@ mod tests {
               "id": "009a1f293253e41e",
               "secret": "[\"P2PK\",{\"nonce\":\"859d4935c4907062a6297cf4e663e2835d90d97ecdd510745d32f6816323a41f\",\"data\":\"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798\",\"tags\":[[\"sigflag\",\"SIG_ALL\"]]}]",
               "C": "02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904",
-              "witness": "{\"signatures\":[\"b2b821f819f12ab61d261971187d19772aaad11422f9d5f3ffda6f97de03349e0e44976b5d44e3c850a99b621045167915caf3ef5b102abe69439e36b68f89d5\",\"947864cac6d9369f358257eece81c4aa9deb2e63899f2d868e7c243ff334ade5db1d8db010daa2b9f4407610458d9ffa3250eb778d1a0980f4de671627c8718e\"]}"
+              "witness": "{\"signatures\":[\"55c4e0d72598a64af2a04d1d348af7beb97b35fe1af91711e205414a24c869ba047b5bd298b87c7b58b439833e244b5498136fd4cccdf9d41b0fe72db8279722\",\"947864cac6d9369f358257eece81c4aa9deb2e63899f2d868e7c243ff334ade5db1d8db010daa2b9f4407610458d9ffa3250eb778d1a0980f4de671627c8718e\"]}"
             },
             {
               "amount": 2,
@@ -1436,14 +1441,13 @@ mod tests {
 
         let swap: SwapRequest = serde_json::from_str(swap).unwrap();
 
-        use bitcoin::hashes::{sha256, Hash};
         let v1_msg = swap.sig_all_msg_to_sign_v1();
-        assert_eq!(v1_msg.len(), 572);
-        // Swaps commit an empty quote field: len32(0) right after the tag
-        assert!(v1_msg.starts_with(b"Cashu_SigAllSig_v1\x00\x00\x00\x00"));
+        assert_eq!(v1_msg.len(), 554);
+        // Swaps commit an empty quote field: the message opens with len32(0)
+        assert!(v1_msg.starts_with(b"\x00\x00\x00\x00"));
         assert_eq!(
-            sha256::Hash::hash(&v1_msg).to_string(),
-            "3fd05c896ff0d5a058f9180e577dced83539ea885f9bf6adf71f7ed084590dc2"
+            crate::util::hex::encode(sig_all_message_hash_v1(&v1_msg)),
+            "b2a0a8ee2d8911585d97adce15c8d7e664c712baa31c0f3d8a6e32b909fdda2b"
         );
 
         // The multi-format witness verifies end to end
@@ -1461,10 +1465,11 @@ mod tests {
         let melt: MeltRequest<String> = serde_json::from_str(&melt).unwrap();
 
         let v1_msg = melt.sig_all_msg_to_sign_v1();
-        assert_eq!(v1_msg.len(), 608);
+        assert_eq!(v1_msg.len(), 590);
+        let message_hash = sig_all_message_hash_v1(&v1_msg);
         assert_eq!(
-            sha256::Hash::hash(&v1_msg).to_string(),
-            "0ebae3a8dbe1107a7b6392a53b6fb3dfc18b38c4ab02b4b9a460ad8829e20ce1"
+            crate::util::hex::encode(message_hash),
+            "2cdffe8a0eed5d22da07adc0f149d49e0ddca5cdafa6d872630d0c52e167e548"
         );
 
         // Pinned melt signature by the test key
@@ -1473,10 +1478,10 @@ mod tests {
         )
         .unwrap();
         let signature = Signature::from_str(
-            "1493200b3f52cd67bdda888f67d80cf8862b4e7bd48a800828f5482218305c367f17dc3409cf89e6c795741605ccce2501f5e2b0f0e3ec54edcc7001a5863e3d",
+            "b22645e507c51a37070402ccc36b5b41cc33fe5bdc2ff3f3ee12d0b7340f9742dfaf64c49e9b1243e7a71b31329a63d9c174fd82f133491b16723f8dcd3f7693",
         )
         .unwrap();
-        assert!(pubkey.verify(&v1_msg, &signature).is_ok());
+        assert!(pubkey.verify_digest(message_hash, &signature).is_ok());
     }
 
     #[test]

--- a/crates/cashu/src/nuts/nut14/mod.rs
+++ b/crates/cashu/src/nuts/nut14/mod.rs
@@ -299,7 +299,10 @@ fn verify_htlc_preimage(witness: &HTLCWitness, secret: &Secret) -> Result<(), Er
 /// Per NUT-14, there are two spending pathways:
 /// 1. Receiver path (preimage + pubkeys): ALWAYS available
 /// 2. Sender/Refund path (refund keys, no preimage): available AFTER locktime
-pub(crate) fn verify_sig_all_htlc(first_input: &Proof, msg_to_sign: String) -> Result<(), Error> {
+pub(crate) fn verify_sig_all_htlc(
+    first_input: &Proof,
+    msgs_to_sign: &[Vec<u8>],
+) -> Result<(), Error> {
     // Get the first input, as it's the one with the signatures
     let first_secret =
         Secret::try_from(&first_input.secret).map_err(|_| Error::IncorrectSecretKind)?;
@@ -348,12 +351,8 @@ pub(crate) fn verify_sig_all_htlc(first_input: &Proof, msg_to_sign: String) -> R
         }
 
         let signatures = extract_signatures_from_witness(first_witness)?;
-        let valid_sig_count = super::nut11::valid_signatures(
-            msg_to_sign.as_bytes(),
-            &requirements.pubkeys,
-            &signatures,
-        )
-        .map_err(|_| Error::InvalidSignature)?;
+        let valid_sig_count =
+            super::nut11::valid_signatures_any_msg(msgs_to_sign, &requirements.pubkeys, &signatures);
 
         if valid_sig_count >= requirements.required_sigs {
             Ok(())
@@ -364,12 +363,8 @@ pub(crate) fn verify_sig_all_htlc(first_input: &Proof, msg_to_sign: String) -> R
         // Refund path: preimage not valid/provided, but locktime has passed
         // Check SIG_ALL signatures against refund keys
         let signatures = extract_signatures_from_witness(first_witness)?;
-        let valid_sig_count = super::nut11::valid_signatures(
-            msg_to_sign.as_bytes(),
-            &refund_path.pubkeys,
-            &signatures,
-        )
-        .map_err(|_| Error::InvalidSignature)?;
+        let valid_sig_count =
+            super::nut11::valid_signatures_any_msg(msgs_to_sign, &refund_path.pubkeys, &signatures);
 
         if valid_sig_count >= refund_path.required_sigs {
             Ok(())
@@ -637,7 +632,7 @@ mod tests {
             })),
         );
 
-        assert!(verify_sig_all_htlc(&proof, "sig-all message".to_string()).is_ok());
+        assert!(verify_sig_all_htlc(&proof, &[b"sig-all message".to_vec()]).is_ok());
     }
 
     /// Tests that verify_htlc correctly rejects an HTLC with an invalid hash format.

--- a/crates/cashu/src/nuts/nut14/mod.rs
+++ b/crates/cashu/src/nuts/nut14/mod.rs
@@ -351,8 +351,11 @@ pub(crate) fn verify_sig_all_htlc(
         }
 
         let signatures = extract_signatures_from_witness(first_witness)?;
-        let valid_sig_count =
-            super::nut11::valid_signatures_any_msg(msgs_to_sign, &requirements.pubkeys, &signatures);
+        let valid_sig_count = super::nut11::valid_signatures_any_msg(
+            msgs_to_sign,
+            &requirements.pubkeys,
+            &signatures,
+        );
 
         if valid_sig_count >= requirements.required_sigs {
             Ok(())

--- a/crates/cashu/src/nuts/nut14/mod.rs
+++ b/crates/cashu/src/nuts/nut14/mod.rs
@@ -301,7 +301,7 @@ fn verify_htlc_preimage(witness: &HTLCWitness, secret: &Secret) -> Result<(), Er
 /// 2. Sender/Refund path (refund keys, no preimage): available AFTER locktime
 pub(crate) fn verify_sig_all_htlc(
     first_input: &Proof,
-    msgs_to_sign: &[Vec<u8>],
+    digests_to_sign: &[[u8; 32]],
 ) -> Result<(), Error> {
     // Get the first input, as it's the one with the signatures
     let first_secret =
@@ -351,8 +351,8 @@ pub(crate) fn verify_sig_all_htlc(
         }
 
         let signatures = extract_signatures_from_witness(first_witness)?;
-        let valid_sig_count = super::nut11::valid_signatures_any_msg(
-            msgs_to_sign,
+        let valid_sig_count = super::nut11::valid_signatures_any_digest(
+            digests_to_sign,
             &requirements.pubkeys,
             &signatures,
         );
@@ -366,8 +366,11 @@ pub(crate) fn verify_sig_all_htlc(
         // Refund path: preimage not valid/provided, but locktime has passed
         // Check SIG_ALL signatures against refund keys
         let signatures = extract_signatures_from_witness(first_witness)?;
-        let valid_sig_count =
-            super::nut11::valid_signatures_any_msg(msgs_to_sign, &refund_path.pubkeys, &signatures);
+        let valid_sig_count = super::nut11::valid_signatures_any_digest(
+            digests_to_sign,
+            &refund_path.pubkeys,
+            &signatures,
+        );
 
         if valid_sig_count >= refund_path.required_sigs {
             Ok(())
@@ -635,7 +638,7 @@ mod tests {
             })),
         );
 
-        assert!(verify_sig_all_htlc(&proof, &[b"sig-all message".to_vec()]).is_ok());
+        assert!(verify_sig_all_htlc(&proof, &[[7u8; 32]]).is_ok());
     }
 
     /// Tests that verify_htlc correctly rejects an HTLC with an invalid hash format.

--- a/crates/cashu/src/nuts/nut20.rs
+++ b/crates/cashu/src/nuts/nut20.rs
@@ -23,7 +23,7 @@ pub enum Error {
 
 const MINT_QUOTE_SIG_DOMAIN_TAG: &[u8] = b"Cashu_MintQuoteSig_v1";
 
-fn amount_to_minimal_bytes(amount: crate::Amount) -> Vec<u8> {
+pub(crate) fn amount_to_minimal_bytes(amount: crate::Amount) -> Vec<u8> {
     let value = u64::from(amount);
     if value == 0 {
         return Vec::new();
@@ -37,7 +37,7 @@ fn amount_to_minimal_bytes(amount: crate::Amount) -> Vec<u8> {
     bytes[first_non_zero..].to_vec()
 }
 
-fn append_len_prefixed(msg: &mut Vec<u8>, bytes: &[u8]) {
+pub(crate) fn append_len_prefixed(msg: &mut Vec<u8>, bytes: &[u8]) {
     msg.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
     msg.extend_from_slice(bytes);
 }

--- a/crates/cashu/src/nuts/nut20.rs
+++ b/crates/cashu/src/nuts/nut20.rs
@@ -48,7 +48,7 @@ pub fn derive_quote_locking_key(seed: &[u8; 64], counter: u32) -> Result<SecretK
     Ok(derived_key.into())
 }
 
-fn amount_to_minimal_bytes(amount: crate::Amount) -> Vec<u8> {
+pub(crate) fn amount_to_minimal_bytes(amount: crate::Amount) -> Vec<u8> {
     let value = u64::from(amount);
     if value == 0 {
         return Vec::new();
@@ -62,7 +62,7 @@ fn amount_to_minimal_bytes(amount: crate::Amount) -> Vec<u8> {
     bytes[first_non_zero..].to_vec()
 }
 
-fn append_len_prefixed(msg: &mut Vec<u8>, bytes: &[u8]) {
+pub(crate) fn append_len_prefixed(msg: &mut Vec<u8>, bytes: &[u8]) {
     msg.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
     msg.extend_from_slice(bytes);
 }

--- a/crates/cdk/src/mint/verification.rs
+++ b/crates/cdk/src/mint/verification.rs
@@ -7,6 +7,9 @@ use super::{Error, Mint};
 
 /// Maximum allowed length in bytes for proof secret or witness content
 const MAX_PROOF_CONTENT_LEN: usize = 1024;
+// Witnesses carry one signature per accepted SIG_ALL message format per signer
+// (NUT-11), so they get more headroom than secrets.
+const MAX_PROOF_WITNESS_LEN: usize = 8192;
 
 /// Maximum allowed length in bytes for request fields (description, extra)
 pub(crate) const MAX_REQUEST_FIELD_LEN: usize = 1024;
@@ -227,15 +230,15 @@ impl Mint {
             if let Some(witness) = &proof.witness {
                 let witness_str = serde_json::to_string(witness)?;
                 let witness_len = witness_str.len();
-                if witness_len > MAX_PROOF_CONTENT_LEN {
+                if witness_len > MAX_PROOF_WITNESS_LEN {
                     tracing::warn!(
                         "Proof witness exceeds max content length: {} > {}",
                         witness_len,
-                        MAX_PROOF_CONTENT_LEN
+                        MAX_PROOF_WITNESS_LEN
                     );
                     return Err(Error::ProofContentTooLarge {
                         actual: witness_len,
-                        max: MAX_PROOF_CONTENT_LEN,
+                        max: MAX_PROOF_WITNESS_LEN,
                     });
                 }
             }


### PR DESCRIPTION
### Description

Implements the length-framed NUT-11 SIG_ALL message aggregation (`Cashu_SigAllSig_v1`) proposed in https://github.com/cashubtc/nuts/pull/404. The framing matches NUT-20/29 mint quote signatures and reuses their helpers; the message is signed over its BIP-340 tagged hash, the same construction NUT-06 signed mint info (cashubtc/nuts#416) uses.

-----

### Notes to the reviewers

- The mint accepts the v1 and current message formats as digests (`sig_all_digests_to_verify`: the v1 tagged hash and the SHA-256 of the current string, verified and signed via `verify_digest`/`sign_digest`), and wallet signing produces both, so requests verify on mints on either side of the upgrade. The pre-0.14 format is neither signed nor accepted: it does not commit to C values or output amounts, and `test_sig_all_should_reject_if_the_output_amounts_are_swapped` covers this.
- `valid_signatures_any_digest` counts each pubkey at most once across formats, so a multi-format witness cannot trip `DuplicateSignature`.
- The witness length cap is split from the secret cap (`MAX_PROOF_WITNESS_LEN`, 8192 bytes) so multisig witnesses carrying one signature per format per signer still fit.
- Canonical vectors from the spec's `tests/11-test.md` are pinned in the nut11 test module.
- Ran on stable 1.96 in a container: `cargo test -p cashu --features mint,wallet,nostr`, `cargo test -p cdk --lib`, `cargo clippy -p cashu --all-targets`, `cargo fmt --check`.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

- SIG_ALL verification accepts the length-framed v1 message alongside the current format, counting unique pubkeys with valid signatures and ignoring signatures that do not verify
- Proof witness length is capped separately from secret length (8192 bytes)

#### ADDED

- NUT-11 v1 length-framed SIG_ALL message; `sign_sig_all` signs all accepted message formats

-----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing (ran the equivalent commands listed above on stable in a container)
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`) — not modified


