### PR TITLE
feat: implement NUT-342 dynamic gap recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,10 +1116,12 @@ dependencies = [
 name = "cashu"
 version = "0.17.0"
 dependencies = [
+ "aes-gcm",
  "bip39",
  "bitcoin 0.32.101",
  "cbor-diag",
  "ciborium",
+ "hkdf",
  "lightning",
  "lightning-invoice",
  "nostr-sdk",
@@ -1127,6 +1129,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sha2 0.10.9",
  "strum 0.27.2",
  "strum_macros 0.27.2",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ readme = "README.md"
 [workspace.dependencies]
 anyhow = "1"
 async-trait = "0.1"
+aes-gcm = "0.10"
 axum = { version = "0.8.1", features = ["ws"] }
 bitcoin = { version = "0.32.2", features = ["base64", "serde", "rand", "rand-std"] }
 bip39 = { version = "2.0", features = ["rand"] }
@@ -117,6 +118,8 @@ web-time = "1.1.0"
 rand = "0.9.1"
 regex = "1"
 home = "0.5.5"
+hkdf = "0.12"
+sha2 = "0.10"
 tonic = { version = "0.14.2", default-features = false }
 tonic-prost = "0.14.2"
 tonic-prost-build = "0.14.2"

--- a/crates/cashu/Cargo.toml
+++ b/crates/cashu/Cargo.toml
@@ -18,6 +18,7 @@ nostr = ["dep:nostr-sdk"]
 bench = []
 
 [dependencies]
+aes-gcm.workspace = true
 uuid.workspace = true
 bitcoin.workspace = true
 cbor-diag.workspace = true
@@ -37,6 +38,8 @@ nostr-sdk = { workspace = true, optional = true }
 zeroize = "1"
 web-time.workspace = true
 unicode-normalization = "0.1.25"
+hkdf.workspace = true
+sha2.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { workspace = true, features = ["js"], optional = true }

--- a/crates/cashu/src/dhke.rs
+++ b/crates/cashu/src/dhke.rs
@@ -471,6 +471,7 @@ mod tests {
             c: SecretKey::generate().public_key(),
             keyset_id: Id::from_str("00deadbeef123456").unwrap(),
             dleq: None,
+            metadata: None,
         };
         let promises = vec![promise];
         let rs = vec![SecretKey::generate(), SecretKey::generate()]; // Different length
@@ -513,6 +514,7 @@ mod tests {
             c: signature,
             keyset_id: Id::from_str("00deadbeef123456").unwrap(),
             dleq: None,
+            metadata: None,
         };
 
         let promises = vec![promise.clone(), promise.clone()];

--- a/crates/cashu/src/nuts/mod.rs
+++ b/crates/cashu/src/nuts/mod.rs
@@ -32,6 +32,7 @@ pub mod nut27;
 pub mod nut28;
 pub mod nut29;
 pub mod nut30;
+pub mod nut342;
 
 mod auth;
 
@@ -93,3 +94,4 @@ pub use nut30::{
     MeltOnchainRequest, MeltQuoteOnchainRequest, MeltQuoteOnchainResponse, MintQuoteOnchainRequest,
     MintQuoteOnchainResponse,
 };
+pub use nut342::{decrypt_d_gap, encrypt_d_gap, Metadata, Settings as Nut342Settings};

--- a/crates/cashu/src/nuts/nut00/mod.rs
+++ b/crates/cashu/src/nuts/nut00/mod.rs
@@ -241,6 +241,9 @@ pub struct BlindedMessage {
     /// <https://github.com/cashubtc/nuts/blob/main/11.md>
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub witness: Option<Witness>,
+    /// Optional NUT-keyed metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<super::nut342::Metadata>,
 }
 
 impl BlindedMessage {
@@ -252,6 +255,7 @@ impl BlindedMessage {
             keyset_id,
             blinded_secret,
             witness: None,
+            metadata: None,
         }
     }
 
@@ -284,6 +288,9 @@ pub struct BlindSignature {
     /// <https://github.com/cashubtc/nuts/blob/main/12.md>
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dleq: Option<BlindSignatureDleq>,
+    /// Metadata accepted with the corresponding blinded message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<super::nut342::Metadata>,
 }
 
 impl Ord for BlindSignature {
@@ -942,6 +949,9 @@ pub struct PreMint {
     pub r: SecretKey,
     /// Amount
     pub amount: Amount,
+    /// NUT-13 derivation index for deterministic secrets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub derivation_index: Option<u32>,
 }
 
 #[cfg(feature = "wallet")]
@@ -1000,6 +1010,7 @@ impl PreMintSecrets {
                 blinded_message,
                 r,
                 amount,
+                derivation_index: None,
             });
         }
 
@@ -1027,6 +1038,7 @@ impl PreMintSecrets {
                 blinded_message,
                 r,
                 amount,
+                derivation_index: None,
             });
         }
 
@@ -1053,6 +1065,7 @@ impl PreMintSecrets {
                 blinded_message,
                 r,
                 amount: Amount::ZERO,
+                derivation_index: None,
             })
         }
 
@@ -1138,6 +1151,7 @@ impl PreMintSecrets {
                 blinded_message,
                 r: rs,
                 amount,
+                derivation_index: None,
             });
         }
 
@@ -1172,6 +1186,7 @@ impl PreMintSecrets {
                 blinded_message,
                 r,
                 amount,
+                derivation_index: None,
             });
         }
 
@@ -2077,6 +2092,7 @@ mod tests {
             )
             .unwrap(),
             dleq: None,
+            metadata: None,
         };
         let sig2 = BlindSignature {
             amount: Amount::from(20),
@@ -2086,6 +2102,7 @@ mod tests {
             )
             .unwrap(),
             dleq: None,
+            metadata: None,
         };
         let sig3 = BlindSignature {
             amount: Amount::from(10),
@@ -2095,6 +2112,7 @@ mod tests {
             )
             .unwrap(),
             dleq: None,
+            metadata: None,
         };
 
         // Test partial_cmp

--- a/crates/cashu/src/nuts/nut06.rs
+++ b/crates/cashu/src/nuts/nut06.rs
@@ -337,6 +337,10 @@ pub struct Nuts {
     #[serde(rename = "29")]
     #[serde(skip_serializing_if = "nut29::Settings::is_empty")]
     pub nut29: nut29::Settings,
+    /// NUT342 Settings
+    #[serde(default)]
+    #[serde(rename = "342")]
+    pub nut342: super::nut342::Settings,
 }
 
 impl Nuts {
@@ -458,6 +462,14 @@ impl Nuts {
     pub fn nut29(self, settings: nut29::Settings) -> Self {
         Self {
             nut29: settings,
+            ..self
+        }
+    }
+
+    /// Nut342 settings
+    pub fn nut342(self, supported: bool) -> Self {
+        Self {
+            nut342: super::nut342::Settings { supported },
             ..self
         }
     }

--- a/crates/cashu/src/nuts/nut08.rs
+++ b/crates/cashu/src/nuts/nut08.rs
@@ -60,6 +60,7 @@ mod tests {
             )
             .unwrap(),
             dleq: None,
+            metadata: None,
         }
     }
 

--- a/crates/cashu/src/nuts/nut11/mod.rs
+++ b/crates/cashu/src/nuts/nut11/mod.rs
@@ -778,6 +778,7 @@ mod tests {
             blinded_secret: pubkey,
             keyset_id: Id::from_str("009a1f293253e41e").unwrap(),
             witness: None,
+            metadata: None,
         };
 
         // Sign once
@@ -808,6 +809,7 @@ mod tests {
             blinded_secret: pubkey,
             keyset_id: Id::from_str("009a1f293253e41e").unwrap(),
             witness: None,
+            metadata: None,
         };
 
         blinded_message.sign_p2pk(secret_key).unwrap();
@@ -830,6 +832,7 @@ mod tests {
             blinded_secret: pubkey,
             keyset_id: Id::from_str("009a1f293253e41e").unwrap(),
             witness: None,
+            metadata: None,
         };
 
         // Sign once
@@ -1049,6 +1052,7 @@ mod tests {
             blinded_secret: pubkey,
             keyset_id: Id::from_str("009a1f293253e41e").unwrap(),
             witness: None,
+            metadata: None,
         }
     }
 

--- a/crates/cashu/src/nuts/nut12.rs
+++ b/crates/cashu/src/nuts/nut12.rs
@@ -213,6 +213,7 @@ impl BlindSignature {
                 blinded_message,
                 mint_secretkey,
             )?),
+            metadata: None,
         })
     }
 
@@ -466,6 +467,7 @@ mod tests {
             keyset_id: Id::from_str("00882760bfa2eb41").unwrap(),
             c: blinded_signature,
             dleq: None,
+            metadata: None,
         };
 
         // Initially, DLEQ should be None

--- a/crates/cashu/src/nuts/nut13.rs
+++ b/crates/cashu/src/nuts/nut13.rs
@@ -118,6 +118,28 @@ impl SecretKey {
 }
 
 impl PreMintSecrets {
+    /// Attach encrypted NUT-342 dynamic-gap hints to deterministic outputs.
+    pub fn add_nut342_metadata(
+        &mut self,
+        start_counter: u32,
+        first_active: Option<u32>,
+    ) -> Result<(), super::nut342::Error> {
+        let first_active = first_active.or(Some(start_counter));
+        for (offset, pre_mint) in self.secrets.iter_mut().enumerate() {
+            let current_index = start_counter.saturating_add(offset as u32);
+            let d_gap = first_active
+                .map(|first| current_index.saturating_sub(first))
+                .unwrap_or(0);
+            let value = super::nut342::encrypt_d_gap(d_gap, &pre_mint.r)?;
+            pre_mint
+                .blinded_message
+                .metadata
+                .get_or_insert_default()
+                .insert("342".to_owned(), value);
+        }
+        Ok(())
+    }
+
     /// Generate blinded messages from predetermined secrets and blindings
     /// factor
     #[instrument(skip(seed))]
@@ -146,6 +168,7 @@ impl PreMintSecrets {
                 secret: secret.clone(),
                 r,
                 amount,
+                derivation_index: Some(counter),
             };
 
             pre_mint_secrets.secrets.push(pre_mint);
@@ -182,6 +205,7 @@ impl PreMintSecrets {
                 secret: secret.clone(),
                 r,
                 amount,
+                derivation_index: Some(counter),
             };
 
             pre_mint_secrets.secrets.push(pre_mint);
@@ -213,6 +237,7 @@ impl PreMintSecrets {
                 secret: secret.clone(),
                 r,
                 amount: Amount::ZERO,
+                derivation_index: Some(i),
             };
 
             pre_mint_secrets.secrets.push(pre_mint);
@@ -565,6 +590,28 @@ mod tests {
             let counter = start_count + i as u32;
             let expected_secret = Secret::from_seed(&seed, keyset_id, counter).unwrap();
             assert_eq!(pre_mint.secret, expected_secret);
+        }
+    }
+
+    #[test]
+    fn nut342_metadata_covers_existing_and_new_outputs() {
+        let seed = [7_u8; 64];
+        let keyset_id = Id::from_str("009a1f293253e41e").unwrap();
+        let mut secrets = PreMintSecrets::restore_batch(keyset_id, &seed, 10, 13).unwrap();
+        secrets.add_nut342_metadata(10, Some(4)).unwrap();
+
+        for (offset, pre_mint) in secrets.secrets.iter().enumerate() {
+            let encrypted = pre_mint
+                .blinded_message
+                .metadata
+                .as_ref()
+                .unwrap()
+                .get("342")
+                .unwrap();
+            assert_eq!(
+                crate::nuts::nut342::decrypt_d_gap(encrypted, &pre_mint.r).unwrap(),
+                6 + offset as u32
+            );
         }
     }
 }

--- a/crates/cashu/src/nuts/nut29.rs
+++ b/crates/cashu/src/nuts/nut29.rs
@@ -153,6 +153,7 @@ mod tests {
             keyset_id: Id::from_str("009a1f293253e41e").unwrap(),
             blinded_secret: secret_key.public_key(),
             witness: None,
+            metadata: None,
         }
     }
 
@@ -162,6 +163,7 @@ mod tests {
             keyset_id: Id::from_str("009a1f293253e41e").expect("valid keyset id"),
             blinded_secret: PublicKey::from_hex(blinded_secret).expect("valid blinded secret"),
             witness: None,
+            metadata: None,
         }
     }
 

--- a/crates/cashu/src/nuts/nut342.rs
+++ b/crates/cashu/src/nuts/nut342.rs
@@ -1,0 +1,124 @@
+//! NUT-342: Efficient wallet recovery with dynamic gap backup.
+
+use std::collections::BTreeMap;
+
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes128Gcm, Nonce};
+use hkdf::Hkdf;
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use thiserror::Error;
+
+use super::nut01::SecretKey;
+use crate::util::hex;
+
+/// Metadata carried by blinded messages and their signatures.
+pub type Metadata = BTreeMap<String, String>;
+
+/// NUT-342 mint settings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub struct Settings {
+    /// Whether dynamic-gap metadata is supported.
+    pub supported: bool,
+}
+
+/// NUT-342 error.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Metadata is not the required lowercase 40-character hexadecimal value.
+    #[error("invalid NUT-342 metadata")]
+    InvalidMetadata,
+    /// HKDF output expansion failed.
+    #[error("could not derive NUT-342 encryption material")]
+    KeyDerivation,
+    /// AES-GCM encryption or authentication failed.
+    #[error("NUT-342 encryption or authentication failed")]
+    Encryption,
+}
+
+const KEY_INFO: &[u8] = b"cashu:nut-342:d-gap:key:v1";
+const NONCE_INFO: &[u8] = b"cashu:nut-342:d-gap:nonce:v1";
+
+fn key_and_nonce(r: &SecretKey) -> Result<([u8; 16], [u8; 12]), Error> {
+    let hkdf = Hkdf::<Sha256>::new(Some(&[]), &r.to_secret_bytes());
+    let mut key = [0_u8; 16];
+    let mut nonce = [0_u8; 12];
+    hkdf.expand(KEY_INFO, &mut key)
+        .map_err(|_| Error::KeyDerivation)?;
+    hkdf.expand(NONCE_INFO, &mut nonce)
+        .map_err(|_| Error::KeyDerivation)?;
+    Ok((key, nonce))
+}
+
+/// Encrypt a dynamic gap with the output's private blinding factor.
+pub fn encrypt_d_gap(d_gap: u32, r: &SecretKey) -> Result<String, Error> {
+    let (key, nonce) = key_and_nonce(r)?;
+    let cipher = Aes128Gcm::new_from_slice(&key).map_err(|_| Error::Encryption)?;
+    let encrypted = cipher
+        .encrypt(Nonce::from_slice(&nonce), d_gap.to_be_bytes().as_ref())
+        .map_err(|_| Error::Encryption)?;
+    Ok(hex::encode(encrypted))
+}
+
+/// Decrypt a dynamic gap with the output's private blinding factor.
+pub fn decrypt_d_gap(value: &str, r: &SecretKey) -> Result<u32, Error> {
+    validate_metadata(value)?;
+    let encrypted = hex::decode(value).map_err(|_| Error::InvalidMetadata)?;
+    let (key, nonce) = key_and_nonce(r)?;
+    let cipher = Aes128Gcm::new_from_slice(&key).map_err(|_| Error::Encryption)?;
+    let plaintext = cipher
+        .decrypt(Nonce::from_slice(&nonce), encrypted.as_ref())
+        .map_err(|_| Error::Encryption)?;
+    let bytes: [u8; 4] = plaintext.try_into().map_err(|_| Error::Encryption)?;
+    Ok(u32::from_be_bytes(bytes))
+}
+
+/// Validate the wire encoding of metadata key `342`.
+pub fn validate_metadata(value: &str) -> Result<(), Error> {
+    if value.len() != 40
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(Error::InvalidMetadata);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn d_gap_roundtrip_and_validation() {
+        let r = SecretKey::generate();
+        let encrypted = encrypt_d_gap(42, &r).unwrap();
+        assert_eq!(encrypted.len(), 40);
+        assert_eq!(decrypt_d_gap(&encrypted, &r).unwrap(), 42);
+        assert!(validate_metadata(&encrypted.to_uppercase()).is_err());
+    }
+
+    #[test]
+    fn encryption_is_deterministic_for_an_output() {
+        let r = SecretKey::generate();
+        assert_eq!(encrypt_d_gap(7, &r).unwrap(), encrypt_d_gap(7, &r).unwrap());
+    }
+
+    #[test]
+    fn authentication_rejects_tampering_and_wrong_blinding_factor() {
+        let r = SecretKey::generate();
+        let encrypted = encrypt_d_gap(7, &r).unwrap();
+        assert!(decrypt_d_gap(&encrypted, &SecretKey::generate()).is_err());
+
+        let mut tampered = encrypted.into_bytes();
+        tampered[0] = if tampered[0] == b'0' { b'1' } else { b'0' };
+        let tampered = String::from_utf8(tampered).unwrap();
+        assert!(decrypt_d_gap(&tampered, &r).is_err());
+    }
+
+    #[test]
+    fn validation_rejects_wrong_length_and_non_hex() {
+        assert!(validate_metadata("00").is_err());
+        assert!(validate_metadata("gggggggggggggggggggggggggggggggggggggggg").is_err());
+    }
+}

--- a/crates/cdk-common/src/database/mint/test/mint.rs
+++ b/crates/cdk-common/src/database/mint/test/mint.rs
@@ -504,6 +504,7 @@ where
         keyset_id,
         amount: Amount::from(100u64),
         witness: None,
+        metadata: None,
     };
     let blinded_messages = vec![blinded_message];
 
@@ -557,6 +558,7 @@ where
         keyset_id,
         amount: Amount::from(100u64),
         witness: None,
+        metadata: None,
     };
     let blinded_messages = vec![blinded_message.clone()];
 
@@ -568,6 +570,7 @@ where
         keyset_id,
         c,
         dleq: None,
+        metadata: None,
     };
     let blinded_secrets = vec![blinded_message.blinded_secret];
     tx.add_blind_signatures(&blinded_secrets, &[blind_sig], Some(quote_id1))
@@ -613,6 +616,7 @@ where
         keyset_id,
         amount: Amount::from(100u64),
         witness: None,
+        metadata: None,
     };
     let blinded_messages = vec![blinded_message];
 
@@ -676,6 +680,7 @@ where
         keyset_id,
         amount: Amount::from(100u64),
         witness: None,
+        metadata: None,
     };
     let blinded_messages = vec![blinded_message];
 
@@ -1094,6 +1099,7 @@ where
         keyset_id,
         amount: Amount::from(100u64),
         witness: None,
+        metadata: None,
     };
 
     let blinded_message2 = cashu::BlindedMessage {
@@ -1101,6 +1107,7 @@ where
         keyset_id,
         amount: Amount::from(200u64),
         witness: None,
+        metadata: None,
     };
 
     let blinded_messages = vec![blinded_message1.clone(), blinded_message2.clone()];
@@ -1518,6 +1525,7 @@ where
         keyset_id,
         c: SecretKey::generate().public_key(),
         dleq: None,
+        metadata: None,
     };
 
     // Add blind signature

--- a/crates/cdk-common/src/database/mint/test/signatures.rs
+++ b/crates/cdk-common/src/database/mint/test/signatures.rs
@@ -1,5 +1,6 @@
 //! Blind signature tests
 
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use cashu::{Amount, BlindSignature, Id, SecretKey};
@@ -25,6 +26,10 @@ where
         keyset_id,
         c: SecretKey::generate().public_key(),
         dleq: None,
+        metadata: Some(BTreeMap::from([(
+            "342".to_owned(),
+            "0000000000000000000000000000000000000000".to_owned(),
+        )])),
     };
 
     let sig2 = BlindSignature {
@@ -32,6 +37,7 @@ where
         keyset_id,
         c: SecretKey::generate().public_key(),
         dleq: None,
+        metadata: None,
     };
 
     let signatures = vec![sig1.clone(), sig2.clone()];
@@ -53,6 +59,7 @@ where
     let retrieved_sig2 = retrieved[1].as_ref().unwrap();
     assert_eq!(retrieved_sig1.amount, sig1.amount);
     assert_eq!(retrieved_sig1.c, sig1.c);
+    assert_eq!(retrieved_sig1.metadata, sig1.metadata);
     assert_eq!(retrieved_sig2.amount, sig2.amount);
     assert_eq!(retrieved_sig2.c, sig2.c);
 }
@@ -72,6 +79,7 @@ where
         keyset_id: keyset_id1,
         c: SecretKey::generate().public_key(),
         dleq: None,
+        metadata: None,
     };
 
     // Create signatures for keyset 2
@@ -81,6 +89,7 @@ where
         keyset_id: keyset_id2,
         c: SecretKey::generate().public_key(),
         dleq: None,
+        metadata: None,
     };
 
     // Add both signatures
@@ -126,6 +135,7 @@ where
         keyset_id,
         c: SecretKey::generate().public_key(),
         dleq: None,
+        metadata: None,
     };
 
     let sig2 = BlindSignature {
@@ -133,6 +143,7 @@ where
         keyset_id,
         c: SecretKey::generate().public_key(),
         dleq: None,
+        metadata: None,
     };
 
     // Create signature for quote 2
@@ -142,6 +153,7 @@ where
         keyset_id,
         c: SecretKey::generate().public_key(),
         dleq: None,
+        metadata: None,
     };
 
     // Add signatures with different quote ids
@@ -194,6 +206,7 @@ where
         keyset_id,
         c: SecretKey::generate().public_key(),
         dleq: None,
+        metadata: None,
     };
 
     let sig2 = BlindSignature {
@@ -201,6 +214,7 @@ where
         keyset_id,
         c: SecretKey::generate().public_key(),
         dleq: None,
+        metadata: None,
     };
 
     let sig3 = BlindSignature {
@@ -208,6 +222,7 @@ where
         keyset_id,
         c: SecretKey::generate().public_key(),
         dleq: None,
+        metadata: None,
     };
 
     // Add signatures
@@ -257,6 +272,7 @@ where
         keyset_id,
         c: SecretKey::generate().public_key(),
         dleq: None,
+        metadata: None,
     };
 
     // Add signature first time

--- a/crates/cdk-common/src/database/wallet/test/mod.rs
+++ b/crates/cdk-common/src/database/wallet/test/mod.rs
@@ -591,7 +591,8 @@ where
 {
     let mint_url = test_mint_url();
     let keyset_id = test_keyset_id();
-    let proof_info = test_proof_info(keyset_id, 100, mint_url.clone());
+    let mut proof_info = test_proof_info(keyset_id, 100, mint_url.clone());
+    proof_info.derivation_index = Some(42);
 
     // Add proof
     db.update_proofs(vec![proof_info.clone()], vec![])
@@ -613,6 +614,7 @@ where
     let ys = vec![proof_info.y];
     let proofs = db.get_proofs_by_ys(ys).await.unwrap();
     assert!(!proofs.is_empty());
+    assert_eq!(proofs[0].derivation_index, Some(42));
 }
 
 /// Test getting proofs in transaction

--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -57,6 +57,9 @@ pub enum Error {
     /// Witness missing or invalid
     #[error("Signature missing or invalid")]
     SignatureMissingOrInvalid,
+    /// Output metadata is malformed or belongs to an unsupported NUT
+    #[error("Invalid or unsupported output metadata")]
+    InvalidOutputMetadata,
     /// Amountless Invoice Not supported
     #[error("Amount Less Invoice is not allowed")]
     AmountLessNotAllowed,
@@ -645,6 +648,23 @@ mod tests {
         ));
         assert!(max_outputs.is_definitive_failure());
     }
+
+    #[test]
+    fn test_invalid_output_metadata_error_roundtrip() {
+        assert_eq!(ErrorCode::InvalidOutputMetadata.to_code(), 11018);
+        assert_eq!(
+            ErrorCode::from_code(11018),
+            ErrorCode::InvalidOutputMetadata
+        );
+
+        let response = ErrorResponse::from(Error::InvalidOutputMetadata);
+        assert_eq!(response.code, ErrorCode::InvalidOutputMetadata);
+        assert_eq!(response.detail, "Invalid or unsupported output metadata");
+
+        let error = Error::from(response);
+        assert!(matches!(error, Error::InvalidOutputMetadata));
+        assert!(error.is_definitive_failure());
+    }
 }
 
 impl Error {
@@ -667,6 +687,7 @@ impl Error {
             | Self::AmountOverflow
             | Self::OverIssue
             | Self::SignatureMissingOrInvalid
+            | Self::InvalidOutputMetadata
             | Self::AmountLessNotAllowed
             | Self::InternalMultiPartMeltQuote
             | Self::MppUnitMethodNotSupported(_, _)
@@ -1053,6 +1074,10 @@ impl From<Error> for ErrorResponse {
                 code: ErrorCode::WitnessMissingOrInvalid,
                 detail: err.to_string(),
             },
+            Error::InvalidOutputMetadata => ErrorResponse {
+                code: ErrorCode::InvalidOutputMetadata,
+                detail: err.to_string(),
+            },
             Error::SigAllUsedInMelt => ErrorResponse {
                 code: ErrorCode::WitnessMissingOrInvalid,
                 detail: err.to_string(),
@@ -1211,6 +1236,7 @@ impl From<ErrorResponse> for Error {
             }
             ErrorCode::DuplicateQuoteIds => Self::DuplicateQuoteIds,
             ErrorCode::BatchSizeExceeded => Self::BatchSizeExceeded { actual: 0, max: 0 },
+            ErrorCode::InvalidOutputMetadata => Self::InvalidOutputMetadata,
             ErrorCode::MultipleUnits => Self::MultipleUnits,
             ErrorCode::UnitMismatch => Self::UnitMismatch,
             ErrorCode::AmountlessInvoiceNotSupported => Self::AmountLessNotAllowed,
@@ -1297,6 +1323,8 @@ pub enum ErrorCode {
     DuplicateQuoteIds,
     /// Batch size exceeds mint limit (11017)
     BatchSizeExceeded,
+    /// Output metadata is malformed or belongs to an unsupported NUT (11018)
+    InvalidOutputMetadata,
     // 12xxx - Keyset errors
     /// Keyset is not known (12001)
     KeysetNotFound,
@@ -1372,6 +1400,7 @@ impl ErrorCode {
             11015 => Self::MaxOutputsExceeded,
             11016 => Self::DuplicateQuoteIds,
             11017 => Self::BatchSizeExceeded,
+            11018 => Self::InvalidOutputMetadata,
             // 12xxx - Keyset errors
             12001 => Self::KeysetNotFound,
             12002 => Self::KeysetInactive,
@@ -1421,6 +1450,7 @@ impl ErrorCode {
             Self::MaxOutputsExceeded => 11015,
             Self::DuplicateQuoteIds => 11016,
             Self::BatchSizeExceeded => 11017,
+            Self::InvalidOutputMetadata => 11018,
             // 12xxx - Keyset errors
             Self::KeysetNotFound => 12001,
             Self::KeysetInactive => 12002,

--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -68,6 +68,9 @@ pub struct ProofInfo {
     pub spending_condition: Option<SpendingConditions>,
     /// Unit
     pub unit: CurrencyUnit,
+    /// NUT-13 derivation index for deterministic proofs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub derivation_index: Option<u32>,
     /// Operation ID that is using/spending this proof
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub used_by_operation: Option<Uuid>,
@@ -95,6 +98,7 @@ impl ProofInfo {
             state,
             spending_condition,
             unit,
+            derivation_index: None,
             used_by_operation: None,
             created_by_operation: None,
         })
@@ -120,9 +124,16 @@ impl ProofInfo {
             state,
             spending_condition,
             unit,
+            derivation_index: None,
             used_by_operation,
             created_by_operation,
         })
+    }
+
+    /// Set the NUT-13 derivation index for this proof.
+    pub fn with_derivation_index(mut self, derivation_index: u32) -> Self {
+        self.derivation_index = Some(derivation_index);
+        self
     }
 
     /// Check if [`Proof`] matches conditions

--- a/crates/cdk-ffi/src/database.rs
+++ b/crates/cdk-ffi/src/database.rs
@@ -550,6 +550,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
                             cdk::cdk_database::Error::Database(e.to_string().into())
                         })?,
                     unit: info.unit.into(),
+                    derivation_index: info.derivation_index,
                     used_by_operation: info
                         .used_by_operation
                         .map(|id| uuid::Uuid::parse_str(&id))
@@ -602,6 +603,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
                             cdk::cdk_database::Error::Database(e.to_string().into())
                         })?,
                     unit: info.unit.into(),
+                    derivation_index: info.derivation_index,
                     used_by_operation: info
                         .used_by_operation
                         .map(|id| uuid::Uuid::parse_str(&id))
@@ -1025,6 +1027,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
                             cdk::cdk_database::Error::Database(e.to_string().into())
                         })?,
                     unit: info.unit.into(),
+                    derivation_index: info.derivation_index,
                     used_by_operation: info
                         .used_by_operation
                         .map(|id| uuid::Uuid::parse_str(&id))
@@ -1493,6 +1496,7 @@ where
                         .map(|sc| sc.try_into())
                         .transpose()?,
                     unit: info.unit.into(),
+                    derivation_index: info.derivation_index,
                     used_by_operation: info
                         .used_by_operation
                         .map(|id| uuid::Uuid::parse_str(&id))

--- a/crates/cdk-ffi/src/types/mint.rs
+++ b/crates/cdk-ffi/src/types/mint.rs
@@ -511,6 +511,9 @@ pub struct Nuts {
     pub nut22: Option<BlindAuthSettings>,
     /// NUT29 Settings - Batch minting
     pub nut29: Nut29Settings,
+    /// NUT342 Settings - Dynamic-gap recovery
+    #[serde(default)]
+    pub nut342_supported: bool,
     /// Supported currency units for minting
     pub mint_units: Vec<CurrencyUnit>,
     /// Supported currency units for melting
@@ -544,6 +547,7 @@ impl From<cdk::nuts::Nuts> for Nuts {
             nut21: nuts.nut21.map(Into::into),
             nut22: nuts.nut22.map(Into::into),
             nut29: nuts.nut29.into(),
+            nut342_supported: nuts.nut342.supported,
             mint_units,
             melt_units,
         }
@@ -587,6 +591,9 @@ impl TryFrom<Nuts> for cdk::nuts::Nuts {
             nut21: n.nut21.map(|s| s.try_into()).transpose()?,
             nut22: n.nut22.map(|s| s.try_into()).transpose()?,
             nut29: n.nut29.into(),
+            nut342: cdk::nuts::nut342::Settings {
+                supported: n.nut342_supported,
+            },
         })
     }
 }
@@ -764,6 +771,7 @@ mod tests {
                 )],
             }),
             nut29: Default::default(),
+            nut342: cdk::nuts::nut342::Settings { supported: true },
         }
     }
 
@@ -904,6 +912,7 @@ mod tests {
             nut21: None,
             nut22: None,
             nut29: Default::default(),
+            nut342: Default::default(),
         };
 
         let ffi_nuts: Nuts = cdk_nuts.into();
@@ -936,6 +945,7 @@ mod tests {
             nut21: None,
             nut22: None,
             nut29: Default::default(),
+            nut342_supported: false,
             mint_units: vec![],
             melt_units: vec![],
         };
@@ -1099,6 +1109,7 @@ mod tests {
                     }],
                 }),
                 nut29: Nut29Settings::default(),
+                nut342_supported: false,
                 mint_units: vec![],
                 melt_units: vec![],
             },

--- a/crates/cdk-ffi/src/types/proof.rs
+++ b/crates/cdk-ffi/src/types/proof.rs
@@ -489,6 +489,8 @@ pub struct ProofInfo {
     pub spending_condition: Option<SpendingConditions>,
     /// Currency unit
     pub unit: CurrencyUnit,
+    /// NUT-13 derivation index for deterministic proofs
+    pub derivation_index: Option<u32>,
     /// Operation ID that is using/spending this proof
     pub used_by_operation: Option<String>,
     /// Operation ID that created this proof
@@ -504,6 +506,7 @@ impl From<cdk::types::ProofInfo> for ProofInfo {
             state: info.state.into(),
             spending_condition: info.spending_condition.map(Into::into),
             unit: info.unit.into(),
+            derivation_index: info.derivation_index,
             used_by_operation: info.used_by_operation.map(|u| u.to_string()),
             created_by_operation: info.created_by_operation.map(|u| u.to_string()),
         }
@@ -529,6 +532,7 @@ pub fn encode_proof_info(info: ProofInfo) -> Result<String, FfiError> {
         state: info.state.into(),
         spending_condition: info.spending_condition.map(TryInto::try_into).transpose()?,
         unit: info.unit.into(),
+        derivation_index: info.derivation_index,
         used_by_operation: info
             .used_by_operation
             .map(|id| uuid::Uuid::from_str(&id))

--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::{env, fs};
 
@@ -32,6 +33,18 @@ use uuid::Uuid;
 pub struct DirectMintConnection {
     pub mint: Mint,
     auth_wallet: Arc<RwLock<Option<AuthWallet>>>,
+    advertise_nut342: bool,
+    restore_requests: AtomicU64,
+    restore_blinded_messages: AtomicU64,
+}
+
+/// Counters collected from restore requests made through a direct mint connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RestoreMetrics {
+    /// Number of NUT-09 restore requests.
+    pub requests: u64,
+    /// Total blinded messages sent across all restore requests.
+    pub blinded_messages: u64,
 }
 
 impl DirectMintConnection {
@@ -39,6 +52,23 @@ impl DirectMintConnection {
         Self {
             mint,
             auth_wallet: Arc::new(RwLock::new(None)),
+            advertise_nut342: true,
+            restore_requests: AtomicU64::new(0),
+            restore_blinded_messages: AtomicU64::new(0),
+        }
+    }
+
+    /// Override whether this connection advertises NUT-342 to its wallet.
+    pub fn with_nut342_advertisement(mut self, supported: bool) -> Self {
+        self.advertise_nut342 = supported;
+        self
+    }
+
+    /// Return restore request counters collected by this connection.
+    pub fn restore_metrics(&self) -> RestoreMetrics {
+        RestoreMetrics {
+            requests: self.restore_requests.load(Ordering::Relaxed),
+            blinded_messages: self.restore_blinded_messages.load(Ordering::Relaxed),
         }
     }
 }
@@ -352,7 +382,9 @@ impl MintConnector for DirectMintConnection {
     }
 
     async fn get_mint_info(&self) -> Result<MintInfo, Error> {
-        Ok(self.mint.mint_info().await?.clone().time(unix_time()))
+        let mut mint_info = self.mint.mint_info().await?.clone().time(unix_time());
+        mint_info.nuts.nut342.supported = self.advertise_nut342;
+        Ok(mint_info)
     }
 
     async fn post_check_state(
@@ -363,6 +395,9 @@ impl MintConnector for DirectMintConnection {
     }
 
     async fn post_restore(&self, request: RestoreRequest) -> Result<RestoreResponse, Error> {
+        self.restore_requests.fetch_add(1, Ordering::Relaxed);
+        self.restore_blinded_messages
+            .fetch_add(request.outputs.len() as u64, Ordering::Relaxed);
         self.mint.restore(request).await
     }
 
@@ -582,7 +617,22 @@ pub async fn create_test_wallet_for_mint(mint: Mint) -> Result<Wallet> {
 ///
 /// Useful for restore tests where two wallets must share the same seed.
 pub async fn create_test_wallet_for_mint_with_seed(mint: Mint, seed: [u8; 64]) -> Result<Wallet> {
-    let connector = DirectMintConnection::new(mint.clone());
+    Ok(
+        create_instrumented_test_wallet_for_mint_with_seed(mint, seed, true)
+            .await?
+            .0,
+    )
+}
+
+/// Create a test wallet and return its instrumented direct mint connection.
+pub async fn create_instrumented_test_wallet_for_mint_with_seed(
+    mint: Mint,
+    seed: [u8; 64],
+    advertise_nut342: bool,
+) -> Result<(Wallet, Arc<DirectMintConnection>)> {
+    let connector = Arc::new(
+        DirectMintConnection::new(mint.clone()).with_nut342_advertisement(advertise_nut342),
+    );
 
     let mint_info = mint.mint_info().await?;
     let mint_url = mint_info
@@ -630,10 +680,10 @@ pub async fn create_test_wallet_for_mint_with_seed(mint: Mint, seed: [u8; 64]) -
         .unit(unit)
         .localstore(localstore)
         .seed(seed)
-        .client(connector)
+        .shared_client(connector.clone())
         .build()?;
 
-    Ok(wallet)
+    Ok((wallet, connector))
 }
 
 /// Creates a mint quote for the given amount and checks its state in a loop. Returns when

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -15,7 +15,7 @@ use std::hash::RandomState;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use bip39::Mnemonic;
 use cashu::amount::SplitTarget;
@@ -2386,6 +2386,104 @@ async fn test_nut342_dynamic_gap_wallet_recovery() {
         .unwrap()
         .iter()
         .all(|proof| proof.derivation_index.is_some()));
+}
+
+/// Compares legacy NUT-13 scanning with NUT-342 bisected recovery over the same histories.
+#[tokio::test]
+#[ignore = "long-horizon NUT-342 recovery benchmark"]
+async fn benchmark_legacy_vs_bisected_recovery() {
+    let mut target_indices = std::env::var("CDK_RECOVERY_BENCH_TARGET_INDICES")
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .filter_map(|value| value.trim().parse().ok())
+                .collect::<Vec<u32>>()
+        })
+        .filter(|values| !values.is_empty())
+        .unwrap_or_else(|| vec![1_000, 5_000, 10_000]);
+    target_indices.sort_unstable();
+    target_indices.dedup();
+
+    let mint = create_and_start_test_mint()
+        .await
+        .expect("Failed to create benchmark mint");
+    let seed = Mnemonic::generate(12).unwrap().to_seed_normalized("");
+    let source = create_test_wallet_for_mint_with_seed(mint.clone(), seed)
+        .await
+        .expect("Failed to create benchmark source wallet");
+
+    fund_wallet(source.clone(), 8_191, None)
+        .await
+        .expect("Failed to fund benchmark wallet");
+    let keyset_id = source.active_keyset().await.unwrap().id;
+    let mut derived = source
+        .localstore
+        .increment_keyset_counter(&keyset_id, 0)
+        .await
+        .unwrap();
+
+    for target_index in target_indices {
+        while derived < target_index {
+            let proofs = source.get_unspent_proofs().await.unwrap();
+            source
+                .swap(None, SplitTarget::default(), proofs, None, false, false)
+                .await
+                .expect("Failed to extend benchmark history");
+            derived = source
+                .localstore
+                .increment_keyset_counter(&keyset_id, 0)
+                .await
+                .unwrap();
+        }
+
+        let expected_balance = source.total_balance().await.unwrap();
+        let expected_proof_count = source.get_unspent_proofs().await.unwrap().len();
+
+        let (legacy_wallet, legacy_connection) =
+            create_instrumented_test_wallet_for_mint_with_seed(mint.clone(), seed, false)
+                .await
+                .expect("Failed to create legacy recovery wallet");
+        let legacy_started = Instant::now();
+        let legacy_restored = legacy_wallet
+            .restore()
+            .await
+            .expect("Legacy restore failed");
+        let legacy_elapsed = legacy_started.elapsed();
+        let legacy_metrics = legacy_connection.restore_metrics();
+        let legacy_proofs = legacy_wallet.get_unspent_proofs().await.unwrap().len();
+
+        let (bisected_wallet, bisected_connection) =
+            create_instrumented_test_wallet_for_mint_with_seed(mint.clone(), seed, true)
+                .await
+                .expect("Failed to create bisected recovery wallet");
+        let bisected_started = Instant::now();
+        let bisected_restored = bisected_wallet
+            .restore()
+            .await
+            .expect("Bisected restore failed");
+        let bisected_elapsed = bisected_started.elapsed();
+        let bisected_metrics = bisected_connection.restore_metrics();
+        let bisected_proofs = bisected_wallet.get_unspent_proofs().await.unwrap().len();
+
+        assert_eq!(legacy_restored.unspent, expected_balance);
+        assert_eq!(bisected_restored.unspent, expected_balance);
+        assert_eq!(legacy_proofs, expected_proof_count);
+        assert_eq!(bisected_proofs, expected_proof_count);
+
+        println!(
+            "derived={derived} strategy=legacy requests={} blinded_messages={} elapsed_us={} proofs_recovered={legacy_proofs}",
+            legacy_metrics.requests,
+            legacy_metrics.blinded_messages,
+            legacy_elapsed.as_micros()
+        );
+        println!(
+            "derived={derived} strategy=bisected requests={} blinded_messages={} elapsed_us={} proofs_recovered={bisected_proofs}",
+            bisected_metrics.requests,
+            bisected_metrics.blinded_messages,
+            bisected_elapsed.as_micros()
+        );
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -2314,6 +2314,80 @@ async fn test_restore_after_keyset_rotation() {
     );
 }
 
+/// Exercises NUT-342 recovery across mint, swap, send, receive, and proof-state checks.
+#[tokio::test]
+async fn test_nut342_dynamic_gap_wallet_recovery() {
+    setup_tracing();
+    let mint = create_and_start_test_mint()
+        .await
+        .expect("Failed to create test mint");
+    let seed = Mnemonic::generate(12).unwrap().to_seed_normalized("");
+    let wallet = create_test_wallet_for_mint_with_seed(mint.clone(), seed)
+        .await
+        .expect("Failed to create source wallet");
+    let recipient = create_test_wallet_for_mint(mint.clone())
+        .await
+        .expect("Failed to create recipient wallet");
+
+    assert!(wallet.load_mint_info().await.unwrap().nuts.nut342.supported);
+    fund_wallet(wallet.clone(), 64, None)
+        .await
+        .expect("Failed to fund source wallet");
+    assert!(wallet
+        .localstore
+        .get_proofs(
+            Some(wallet.mint_url.clone()),
+            Some(wallet.unit.clone()),
+            Some(vec![State::Unspent]),
+            None,
+        )
+        .await
+        .unwrap()
+        .iter()
+        .all(|proof| proof.derivation_index.is_some()));
+
+    let prepared = wallet
+        .prepare_send(Amount::from(40), SendOptions::default())
+        .await
+        .expect("Failed to prepare send");
+    let token = prepared
+        .confirm(None)
+        .await
+        .expect("Failed to confirm send");
+    recipient
+        .receive(&token.to_string(), ReceiveOptions::default())
+        .await
+        .expect("Failed to spend sent proofs at recipient");
+    assert_eq!(wallet.total_balance().await.unwrap(), Amount::from(24));
+
+    let restored_wallet = create_test_wallet_for_mint_with_seed(mint, seed)
+        .await
+        .expect("Failed to create restored wallet");
+    let restored = restored_wallet
+        .restore()
+        .await
+        .expect("NUT-342 restore failed");
+
+    assert_eq!(restored.unspent, Amount::from(24));
+    assert_eq!(
+        restored_wallet.total_balance().await.unwrap(),
+        Amount::from(24)
+    );
+    assert!(restored.spent > Amount::ZERO);
+    assert!(restored_wallet
+        .localstore
+        .get_proofs(
+            Some(restored_wallet.mint_url.clone()),
+            Some(restored_wallet.unit.clone()),
+            Some(vec![State::Unspent, State::Pending]),
+            None,
+        )
+        .await
+        .unwrap()
+        .iter()
+        .all(|proof| proof.derivation_index.is_some()));
+}
+
 #[derive(Debug, Default)]
 struct CustomPaymentProcessor {
     /// Captures the quote_id seen by `get_payment_quote` so tests can assert

--- a/crates/cdk-integration-tests/tests/test_blind_signature_order.rs
+++ b/crates/cdk-integration-tests/tests/test_blind_signature_order.rs
@@ -20,12 +20,14 @@ async fn test_blind_signature_order_in_db() -> Result<()> {
         keyset_id: Id::from_str("001711afb1de20cb").unwrap(),
         amount: Amount::from(10),
         witness: None,
+        metadata: None,
     };
     let msg2 = BlindedMessage {
         blinded_secret: SecretKey::generate().public_key(),
         keyset_id: Id::from_str("001711afb1de20cb").unwrap(),
         amount: Amount::from(20),
         witness: None,
+        metadata: None,
     };
 
     let messages = vec![msg1.clone(), msg2.clone()];

--- a/crates/cdk-signatory/src/proto/convert.rs
+++ b/crates/cdk-signatory/src/proto/convert.rs
@@ -211,6 +211,7 @@ impl TryInto<cdk_common::BlindSignature> for BlindSignature {
             c: cdk_common::PublicKey::from_slice(&self.blinded_secret)?,
             keyset_id: Id::from_bytes(&self.keyset_id)?,
             dleq: self.dleq.map(|dleq| dleq.try_into()).transpose()?,
+            metadata: None,
         })
     }
 }
@@ -235,6 +236,7 @@ impl TryInto<cdk_common::BlindedMessage> for BlindedMessage {
             blinded_secret: cdk_common::PublicKey::from_slice(&self.blinded_secret)
                 .map_err(|e| Status::from_error(Box::new(e)))?,
             witness: None,
+            metadata: None,
         })
     }
 }

--- a/crates/cdk-sql-common/src/mint/migrations/postgres/20260716000000_add_nut342_metadata.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/postgres/20260716000000_add_nut342_metadata.sql
@@ -1,0 +1,1 @@
+ALTER TABLE blind_signature ADD COLUMN metadata TEXT;

--- a/crates/cdk-sql-common/src/mint/migrations/sqlite/20260716000000_add_nut342_metadata.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/sqlite/20260716000000_add_nut342_metadata.sql
@@ -1,0 +1,1 @@
+ALTER TABLE blind_signature ADD COLUMN metadata TEXT;

--- a/crates/cdk-sql-common/src/mint/quotes.rs
+++ b/crates/cdk-sql-common/src/mint/quotes.rs
@@ -805,6 +805,7 @@ where
                         keyset_id,
                         amount: Amount::from(amount),
                         witness: None, // Not storing witness in database currently
+                        metadata: None,
                     })
                 })
                 .collect();

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -18,7 +18,7 @@ use crate::{column_as_nullable_string, column_as_number, column_as_string, unpac
 pub(crate) fn sql_row_to_blind_signature(row: Vec<Column>) -> Result<BlindSignature, Error> {
     unpack_into!(
         let (
-            keyset_id, amount, c, dleq_e, dleq_s
+            keyset_id, amount, c, dleq_e, dleq_s, metadata
         ) = row
     );
 
@@ -34,12 +34,17 @@ pub(crate) fn sql_row_to_blind_signature(row: Vec<Column>) -> Result<BlindSignat
     };
 
     let amount: u64 = column_as_number!(amount);
+    let metadata = column_as_nullable_string!(metadata)
+        .map(|value| serde_json::from_str(&value))
+        .transpose()
+        .map_err(|err| Error::Internal(err.to_string()))?;
 
     Ok(BlindSignature {
         amount: Amount::from(amount),
         keyset_id: column_as_string!(keyset_id, Id::from_str, Id::from_bytes),
         c: column_as_string!(c, PublicKey::from_hex, PublicKey::from_slice),
         dleq,
+        metadata,
     })
 }
 
@@ -99,9 +104,9 @@ where
                     query(
                         r#"
                         INSERT INTO blind_signature
-                        (blinded_message, amount, keyset_id, c, quote_id, dleq_e, dleq_s, created_time, signed_time, order_index)
+                        (blinded_message, amount, keyset_id, c, quote_id, dleq_e, dleq_s, metadata, created_time, signed_time, order_index)
                         VALUES
-                        (:blinded_message, :amount, :keyset_id, :c, :quote_id, :dleq_e, :dleq_s, :created_time, :signed_time, :order_index)
+                        (:blinded_message, :amount, :keyset_id, :c, :quote_id, :dleq_e, :dleq_s, :metadata, :created_time, :signed_time, :order_index)
                         "#,
                     )?
                     .bind("blinded_message", message.to_bytes().to_vec())
@@ -116,6 +121,15 @@ where
                     .bind(
                         "dleq_s",
                         signature.dleq.as_ref().map(|dleq| dleq.s.to_secret_hex()),
+                    )
+                    .bind(
+                        "metadata",
+                        signature
+                            .metadata
+                            .as_ref()
+                            .map(serde_json::to_string)
+                            .transpose()
+                            .map_err(|err| Error::Internal(err.to_string()))?,
                     )
                     .bind("created_time", current_time as i64)
                     .bind("signed_time", current_time as i64)
@@ -144,7 +158,7 @@ where
                             query(
                                 r#"
                                 UPDATE blind_signature
-                                SET c = :c, dleq_e = :dleq_e, dleq_s = :dleq_s, signed_time = :signed_time, amount = :amount
+                                SET c = :c, dleq_e = :dleq_e, dleq_s = :dleq_s, metadata = :metadata, signed_time = :signed_time, amount = :amount
                                 WHERE blinded_message = :blinded_message
                                 "#,
                             )?
@@ -156,6 +170,15 @@ where
                             .bind(
                                 "dleq_s",
                                 signature.dleq.as_ref().map(|dleq| dleq.s.to_secret_hex()),
+                            )
+                            .bind(
+                                "metadata",
+                                signature
+                                    .metadata
+                                    .as_ref()
+                                    .map(serde_json::to_string)
+                                    .transpose()
+                                    .map_err(|err| Error::Internal(err.to_string()))?,
                             )
                             .bind("blinded_message", message.to_bytes().to_vec())
                             .bind("signed_time", current_time as i64)
@@ -217,6 +240,7 @@ where
                 c,
                 dleq_e,
                 dleq_s,
+                metadata,
                 blinded_message
             FROM
                 blind_signature
@@ -274,6 +298,7 @@ where
                 c,
                 dleq_e,
                 dleq_s,
+                metadata,
                 blinded_message
             FROM
                 blind_signature
@@ -323,7 +348,8 @@ where
                 amount,
                 c,
                 dleq_e,
-                dleq_s
+                dleq_s,
+                metadata
             FROM
                 blind_signature
             WHERE
@@ -355,7 +381,8 @@ where
                 amount,
                 c,
                 dleq_e,
-                dleq_s
+                dleq_s,
+                metadata
             FROM
                 blind_signature
             WHERE

--- a/crates/cdk-sql-common/src/wallet/migrations/postgres/20260716000000_add_proof_derivation_index.sql
+++ b/crates/cdk-sql-common/src/wallet/migrations/postgres/20260716000000_add_proof_derivation_index.sql
@@ -1,0 +1,4 @@
+ALTER TABLE proof ADD COLUMN IF NOT EXISTS derivation_index INTEGER;
+
+CREATE INDEX IF NOT EXISTS proof_keyset_state_derivation_index
+ON proof(keyset_id, state, derivation_index);

--- a/crates/cdk-sql-common/src/wallet/migrations/sqlite/20260716000000_add_proof_derivation_index.sql
+++ b/crates/cdk-sql-common/src/wallet/migrations/sqlite/20260716000000_add_proof_derivation_index.sql
@@ -1,0 +1,4 @@
+ALTER TABLE proof ADD COLUMN derivation_index INTEGER;
+
+CREATE INDEX proof_keyset_state_derivation_index
+ON proof(keyset_id, state, derivation_index);

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -536,6 +536,7 @@ where
                 spending_condition,
                 used_by_operation,
                 created_by_operation,
+                derivation_index,
                 p2pk_e
             FROM proof
             "#,
@@ -583,6 +584,7 @@ where
                 spending_condition,
                 used_by_operation,
                 created_by_operation,
+                derivation_index,
                 p2pk_e
             FROM proof
             WHERE y IN (:ys)
@@ -769,9 +771,9 @@ where
             query(
                 r#"
     INSERT INTO proof
-    (y, mint_url, state, spending_condition, unit, amount, keyset_id, secret, c, witness, dleq_e, dleq_s, dleq_r, used_by_operation, created_by_operation, p2pk_e)
+    (y, mint_url, state, spending_condition, unit, amount, keyset_id, secret, c, witness, dleq_e, dleq_s, dleq_r, used_by_operation, created_by_operation, derivation_index, p2pk_e)
     VALUES
-    (:y, :mint_url, :state, :spending_condition, :unit, :amount, :keyset_id, :secret, :c, :witness, :dleq_e, :dleq_s, :dleq_r, :used_by_operation, :created_by_operation, :p2pk_e)
+    (:y, :mint_url, :state, :spending_condition, :unit, :amount, :keyset_id, :secret, :c, :witness, :dleq_e, :dleq_s, :dleq_r, :used_by_operation, :created_by_operation, :derivation_index, :p2pk_e)
     ON CONFLICT(y) DO UPDATE SET
         mint_url = excluded.mint_url,
         state = excluded.state,
@@ -787,6 +789,7 @@ where
         dleq_r = excluded.dleq_r,
         used_by_operation = excluded.used_by_operation,
         created_by_operation = excluded.created_by_operation,
+        derivation_index = excluded.derivation_index,
         p2pk_e = excluded.p2pk_e
     ;
             "#,
@@ -826,6 +829,7 @@ where
             )
             .bind("used_by_operation", proof.used_by_operation.map(|id| id.to_string()))
             .bind("created_by_operation", proof.created_by_operation.map(|id| id.to_string()))
+            .bind("derivation_index", proof.derivation_index.map(i64::from))
             .bind(
                 "p2pk_e",
                 proof
@@ -1643,6 +1647,7 @@ where
                 spending_condition,
                 used_by_operation,
                 created_by_operation,
+                derivation_index,
                 p2pk_e
             FROM proof
             WHERE used_by_operation = :operation_id
@@ -2108,6 +2113,7 @@ fn sql_row_to_proof_info(row: Vec<Column>) -> Result<ProofInfo, Error> {
             spending_condition,
             used_by_operation,
             created_by_operation,
+            derivation_index,
             p2pk_e
         ) = row
     );
@@ -2146,6 +2152,7 @@ fn sql_row_to_proof_info(row: Vec<Column>) -> Result<ProofInfo, Error> {
         column_as_nullable_string!(used_by_operation).and_then(|id| Uuid::from_str(&id).ok());
     let created_by_operation =
         column_as_nullable_string!(created_by_operation).and_then(|id| Uuid::from_str(&id).ok());
+    let derivation_index = column_as_nullable_number!(derivation_index);
 
     Ok(ProofInfo {
         proof,
@@ -2160,6 +2167,7 @@ fn sql_row_to_proof_info(row: Vec<Column>) -> Result<ProofInfo, Error> {
         unit: column_as_string!(unit, CurrencyUnit::from_str),
         used_by_operation,
         created_by_operation,
+        derivation_index,
     })
 }
 

--- a/crates/cdk-supabase/migrations/supabase/migrations/20260716000000_add_proof_derivation_index.sql
+++ b/crates/cdk-supabase/migrations/supabase/migrations/20260716000000_add_proof_derivation_index.sql
@@ -1,0 +1,4 @@
+ALTER TABLE proof ADD COLUMN IF NOT EXISTS derivation_index INTEGER;
+
+CREATE INDEX IF NOT EXISTS proof_keyset_state_derivation_index
+ON proof(keyset_id, state, derivation_index);

--- a/crates/cdk-supabase/src/wallet.rs
+++ b/crates/cdk-supabase/src/wallet.rs
@@ -2728,6 +2728,8 @@ struct ProofTable {
     state: String,
     spending_condition: Option<String>,
     unit: String,
+    #[serde(default)]
+    derivation_index: Option<i64>,
     amount: i64,
     keyset_id: String,
     secret: String,
@@ -2767,6 +2769,7 @@ impl TryInto<ProofInfo> for ProofTable {
                 .transpose()?,
             unit: CurrencyUnit::from_str(&self.unit)
                 .map_err(|_| DatabaseError::Internal("Invalid unit".into()))?,
+            derivation_index: self.derivation_index.map(|index| index as u32),
             proof: cdk_common::Proof {
                 amount: cdk_common::Amount::from(self.amount as u64),
                 keyset_id: Id::from_str(&self.keyset_id)
@@ -2822,6 +2825,7 @@ impl TryFrom<ProofInfo> for ProofTable {
                 .map(|s| serde_json::to_string(&s))
                 .transpose()?,
             unit: p.unit.to_string(),
+            derivation_index: p.derivation_index.map(i64::from),
             amount: p.proof.amount.to_u64() as i64,
             keyset_id: p.proof.keyset_id.to_string(),
             secret: p.proof.secret.to_string(),

--- a/crates/cdk/src/mint/builder.rs
+++ b/crates/cdk/src/mint/builder.rs
@@ -99,6 +99,7 @@ impl MintBuilder {
                 .nut12(true)
                 .nut14(true)
                 .nut20(true)
+                .nut342(true)
                 .nut29(cdk_common::nut29::Settings::default()),
             ..Default::default()
         };

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1127,7 +1127,7 @@ impl Mint {
                         || !supports_nut342
                         || cdk_common::nuts::nut342::validate_metadata(value).is_err()
                     {
-                        return Err(Error::SignatureMissingOrInvalid);
+                        return Err(Error::InvalidOutputMetadata);
                     }
                 }
             }

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1119,7 +1119,34 @@ impl Mint {
         #[cfg(feature = "prometheus")]
         let metrics = MintMetricGuard::new("blind_sign");
 
-        let result = self.signatory.blind_sign(blinded_message).await;
+        let supports_nut342 = self.mint_info().await?.nuts.nut342.supported;
+        for output in &blinded_message {
+            if let Some(metadata) = &output.metadata {
+                for (nut, value) in metadata {
+                    if nut != "342"
+                        || !supports_nut342
+                        || cdk_common::nuts::nut342::validate_metadata(value).is_err()
+                    {
+                        return Err(Error::SignatureMissingOrInvalid);
+                    }
+                }
+            }
+        }
+
+        let metadata: Vec<_> = blinded_message
+            .iter()
+            .map(|output| output.metadata.clone())
+            .collect();
+        let result = self
+            .signatory
+            .blind_sign(blinded_message)
+            .await
+            .map(|mut signatures| {
+                for (signature, metadata) in signatures.iter_mut().zip(metadata) {
+                    signature.metadata = metadata;
+                }
+                signatures
+            });
 
         #[cfg(feature = "prometheus")]
         {

--- a/crates/cdk/src/wallet/auth/auth_wallet.rs
+++ b/crates/cdk/src/wallet/auth/auth_wallet.rs
@@ -645,6 +645,7 @@ mod tests {
                     },
                     c: output.blinded_secret,
                     dleq: None,
+                    metadata: None,
                 })
                 .collect();
 

--- a/crates/cdk/src/wallet/issue/saga/mod.rs
+++ b/crates/cdk/src/wallet/issue/saga/mod.rs
@@ -381,14 +381,18 @@ impl<'a> MintSaga<'a, Initial> {
 
                 let count = new_counter - num_secrets;
 
-                PreMintSecrets::from_seed(
+                let mut premint_secrets = PreMintSecrets::from_seed(
                     active_keyset_id,
                     count,
                     &self.wallet.seed,
                     amount,
                     &split_target,
                     fee_and_amounts,
-                )?
+                )?;
+                self.wallet
+                    .add_nut342_metadata(active_keyset_id, count, &mut premint_secrets)
+                    .await?;
+                premint_secrets
             }
         };
 
@@ -673,14 +677,18 @@ impl<'a> MintSaga<'a, Initial> {
 
                 let count = new_counter - num_secrets;
 
-                PreMintSecrets::from_seed(
+                let mut premint_secrets = PreMintSecrets::from_seed(
                     active_keyset_id,
                     count,
                     &self.wallet.seed,
                     total_amount,
                     &split_target,
                     &fee_and_amounts,
-                )?
+                )?;
+                self.wallet
+                    .add_nut342_metadata(active_keyset_id, count, &mut premint_secrets)
+                    .await?;
+                premint_secrets
             }
         };
 
@@ -907,13 +915,18 @@ impl<'a> MintSaga<'a, Prepared> {
 
             let proof_infos = proofs
                 .iter()
-                .map(|proof| {
-                    ProofInfo::new(
+                .zip(&premint_secrets.secrets)
+                .map(|(proof, premint)| {
+                    let proof_info = ProofInfo::new(
                         proof.clone(),
                         wallet.mint_url.clone(),
                         State::Unspent,
                         wallet.unit.clone(),
-                    )
+                    )?;
+                    Ok::<_, Error>(match premint.derivation_index {
+                        Some(index) => proof_info.with_derivation_index(index),
+                        None => proof_info,
+                    })
                 })
                 .collect::<Result<Vec<ProofInfo>, _>>()?;
 
@@ -1236,6 +1249,7 @@ mod tests {
                 keyset_id: blinded_message.keyset_id,
                 c: blinded_message.blinded_secret,
                 dleq: None,
+                metadata: None,
             })
             .collect();
 

--- a/crates/cdk/src/wallet/issue/saga/resume.rs
+++ b/crates/cdk/src/wallet/issue/saga/resume.rs
@@ -406,8 +406,18 @@ impl Wallet {
 
             let proof_infos: Vec<ProofInfo> = proofs
                 .into_iter()
-                .map(|p| {
-                    ProofInfo::new(p, self.mint_url.clone(), State::Unspent, self.unit.clone())
+                .zip(&premint_secrets.secrets)
+                .map(|(p, premint)| {
+                    let proof_info = ProofInfo::new(
+                        p,
+                        self.mint_url.clone(),
+                        State::Unspent,
+                        self.unit.clone(),
+                    )?;
+                    Ok::<_, Error>(match premint.derivation_index {
+                        Some(index) => proof_info.with_derivation_index(index),
+                        None => proof_info,
+                    })
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
@@ -536,7 +546,15 @@ impl Wallet {
 
         let proof_infos: Vec<ProofInfo> = proofs
             .into_iter()
-            .map(|p| ProofInfo::new(p, self.mint_url.clone(), State::Unspent, self.unit.clone()))
+            .zip(&premint_secrets.secrets)
+            .map(|(p, premint)| {
+                let proof_info =
+                    ProofInfo::new(p, self.mint_url.clone(), State::Unspent, self.unit.clone())?;
+                Ok::<_, Error>(match premint.derivation_index {
+                    Some(index) => proof_info.with_derivation_index(index),
+                    None => proof_info,
+                })
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Some(proof_infos))

--- a/crates/cdk/src/wallet/melt/saga/mod.rs
+++ b/crates/cdk/src/wallet/melt/saga/mod.rs
@@ -158,13 +158,18 @@ async fn finalize_melt_common<'a>(
     let change_proof_infos = match change_proofs.clone() {
         Some(change_proofs) => change_proofs
             .into_iter()
-            .map(|proof| {
-                ProofInfo::new(
+            .zip(&premint_secrets.secrets)
+            .map(|(proof, premint)| {
+                let proof_info = ProofInfo::new(
                     proof,
                     wallet.mint_url.clone(),
                     State::Unspent,
                     quote_info.unit.clone(),
-                )
+                )?;
+                Ok::<_, Error>(match premint.derivation_index {
+                    Some(index) => proof_info.with_derivation_index(index),
+                    None => proof_info,
+                })
             })
             .collect::<Result<Vec<ProofInfo>, _>>()?,
         None => Vec::new(),
@@ -528,7 +533,12 @@ impl<'a> MeltSaga<'a, Initial> {
 
         // Since proofs may be external (not in our database), add them first
         // while preserving the operation link needed for recovery.
-        let proofs_info = proofs
+        let existing_proofs = self
+            .wallet
+            .localstore
+            .get_proofs_by_ys(proof_ys.clone())
+            .await?;
+        let mut proofs_info = proofs
             .clone()
             .into_iter()
             .map(|p| {
@@ -542,6 +552,12 @@ impl<'a> MeltSaga<'a, Initial> {
                 )
             })
             .collect::<Result<Vec<ProofInfo>, _>>()?;
+        for proof_info in &mut proofs_info {
+            proof_info.derivation_index = existing_proofs
+                .iter()
+                .find(|existing| existing.y == proof_info.y)
+                .and_then(|existing| existing.derivation_index);
+        }
 
         self.wallet
             .localstore
@@ -766,7 +782,13 @@ impl<'a> MeltSaga<'a, Prepared> {
         }
 
         // Set proofs to Pending state before making melt request
-        let proofs_info = final_proofs
+        let final_proof_ys = final_proofs.ys()?;
+        let existing_proofs = self
+            .wallet
+            .localstore
+            .get_proofs_by_ys(final_proof_ys)
+            .await?;
+        let mut proofs_info = final_proofs
             .clone()
             .into_iter()
             .map(|p| {
@@ -780,6 +802,12 @@ impl<'a> MeltSaga<'a, Prepared> {
                 )
             })
             .collect::<Result<Vec<ProofInfo>, _>>()?;
+        for proof_info in &mut proofs_info {
+            proof_info.derivation_index = existing_proofs
+                .iter()
+                .find(|existing| existing.y == proof_info.y)
+                .and_then(|existing| existing.derivation_index);
+        }
 
         self.wallet
             .localstore
@@ -800,7 +828,7 @@ impl<'a> MeltSaga<'a, Prepared> {
         // Calculate change accounting for input fees
         let change_amount = proofs_total - quote_info.amount - actual_input_fee;
 
-        let premint_secrets = if change_amount <= Amount::ZERO {
+        let mut premint_secrets = if change_amount <= Amount::ZERO {
             PreMintSecrets::new(active_keyset_id)
         } else {
             let num_secrets =
@@ -829,6 +857,9 @@ impl<'a> MeltSaga<'a, Prepared> {
             .increment_keyset_counter(&active_keyset_id, 0)
             .await?;
         let counter_start = counter_end.saturating_sub(premint_secrets.secrets.len() as u32);
+        self.wallet
+            .add_nut342_metadata(active_keyset_id, counter_start, &mut premint_secrets)
+            .await?;
 
         let change_blinded_messages = if change_amount > Amount::ZERO {
             Some(premint_secrets.blinded_messages())
@@ -1743,6 +1774,7 @@ mod tests {
             keyset_id,
             c: premint_secrets.blinded_messages()[0].blinded_secret,
             dleq: None,
+            metadata: None,
         }];
 
         let result = finalize_melt_common(
@@ -1780,6 +1812,7 @@ mod tests {
             keyset_id,
             c: premint_secrets.blinded_messages()[0].blinded_secret,
             dleq: None,
+            metadata: None,
         }];
 
         let result = finalize_melt_common(

--- a/crates/cdk/src/wallet/melt/saga/mod.rs
+++ b/crates/cdk/src/wallet/melt/saga/mod.rs
@@ -328,13 +328,15 @@ impl<'a> MeltSaga<'a, Initial> {
             .await?;
 
         let available_proofs = self.wallet.get_unspent_proofs().await?;
+        let derivation_indices = self.wallet.unspent_proof_derivation_indices().await?;
 
-        let exact_input_proofs = Wallet::select_proofs(
+        let exact_input_proofs = Wallet::select_proofs_with_derivation_indices(
             inputs_needed_amount,
             available_proofs.clone(),
             &active_keyset_ids,
             &keyset_fees_and_amounts,
             true,
+            &derivation_indices,
         )?;
         let proofs_total = exact_input_proofs.total_amount()?;
 
@@ -421,12 +423,13 @@ impl<'a> MeltSaga<'a, Initial> {
             .checked_add(estimated_melt_fee)
             .ok_or(Error::AmountOverflow)?;
 
-        let input_proofs = Wallet::select_proofs(
+        let input_proofs = Wallet::select_proofs_with_derivation_indices(
             selection_amount,
             available_proofs,
             &active_keyset_ids,
             &keyset_fees_and_amounts,
             true,
+            &derivation_indices,
         )?;
 
         let input_fee = estimated_melt_fee;

--- a/crates/cdk/src/wallet/melt/saga/resume.rs
+++ b/crates/cdk/src/wallet/melt/saga/resume.rs
@@ -456,6 +456,7 @@ mod tests {
                 keyset_id: message.keyset_id,
                 c: message.blinded_secret,
                 dleq: None,
+                metadata: None,
             })
             .collect();
 

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -236,6 +236,120 @@ impl From<WalletSubscription> for WalletParams {
 pub use cdk_common::wallet::Restored;
 
 impl Wallet {
+    async fn nut342_recovery_window(&self, keyset_id: Id) -> Result<Option<(u32, u32)>, Error> {
+        if !self.load_mint_info().await?.nuts.nut342.supported {
+            return Ok(None);
+        }
+
+        let has_signature = |counter: u32| async move {
+            let premint = PreMintSecrets::restore_batch(
+                keyset_id,
+                &self.seed,
+                counter,
+                counter.saturating_add(1),
+            )?;
+            let response = self
+                .client
+                .post_restore(RestoreRequest {
+                    outputs: premint.blinded_messages(),
+                })
+                .await?;
+            Ok::<_, Error>((!response.signatures.is_empty(), premint, response))
+        };
+
+        if !has_signature(0).await?.0 {
+            return Ok(None);
+        }
+
+        let mut low = 0_u32;
+        let mut high = u32::MAX;
+        while low < high {
+            let midpoint = low + (high - low) / 2 + 1;
+            if has_signature(midpoint).await?.0 {
+                low = midpoint;
+            } else {
+                high = midpoint - 1;
+            }
+        }
+
+        let (_, premint, response) = has_signature(low).await?;
+        let Some(encrypted_gap) = response
+            .signatures
+            .first()
+            .and_then(|signature| signature.metadata.as_ref())
+            .and_then(|metadata| metadata.get("342"))
+        else {
+            return Ok(None);
+        };
+        let r = &premint
+            .secrets
+            .first()
+            .ok_or_else(|| Error::InvalidMintResponse("missing recovery secret".to_owned()))?
+            .r;
+        let d_gap = crate::nuts::nut342::decrypt_d_gap(encrypted_gap, r)
+            .map_err(|err| Error::InvalidMintResponse(err.to_string()))?;
+        Ok(Some((low.saturating_sub(d_gap), low.saturating_add(1))))
+    }
+
+    async fn add_nut342_metadata(
+        &self,
+        keyset_id: Id,
+        start_counter: u32,
+        premint_secrets: &mut PreMintSecrets,
+    ) -> Result<(), Error> {
+        if premint_secrets.is_empty() || !self.load_mint_info().await?.nuts.nut342.supported {
+            return Ok(());
+        }
+
+        let mut active_proofs = self
+            .localstore
+            .get_proofs(
+                Some(self.mint_url.clone()),
+                Some(self.unit.clone()),
+                Some(vec![
+                    State::Unspent,
+                    State::Pending,
+                    State::Reserved,
+                    State::PendingSpent,
+                ]),
+                None,
+            )
+            .await?
+            .into_iter()
+            .filter(|proof| proof.proof.keyset_id == keyset_id)
+            .collect::<Vec<_>>();
+
+        if active_proofs
+            .iter()
+            .any(|proof| proof.derivation_index.is_none())
+        {
+            let mut changed = false;
+            for counter in 0..start_counter {
+                let secret = cdk_common::secret::Secret::from_seed(&self.seed, keyset_id, counter)?;
+                for proof in active_proofs.iter_mut().filter(|proof| {
+                    proof.derivation_index.is_none() && proof.proof.secret == secret
+                }) {
+                    proof.derivation_index = Some(counter);
+                    changed = true;
+                }
+            }
+            if changed {
+                self.localstore
+                    .update_proofs(active_proofs.clone(), vec![])
+                    .await?;
+            }
+        }
+
+        let first_active = active_proofs
+            .iter()
+            .filter_map(|proof| proof.derivation_index)
+            .min();
+
+        premint_secrets
+            .add_nut342_metadata(start_counter, first_active)
+            .map_err(|err| Error::Custom(err.to_string()))
+    }
+
     /// Create new [`Wallet`] using the builder pattern
     /// # Synopsis
     /// ```rust
@@ -583,8 +697,8 @@ impl Wallet {
     #[instrument(skip(self))]
     pub async fn restore_with_opts(&self, opts: NUT13Options) -> Result<Restored, Error> {
         let opts = NUT13Options::new(opts.batch_size, opts.max_gap)?;
-        let batch_size = opts.batch_size;
-        let max_gap = opts.max_gap;
+        let default_batch_size = opts.batch_size;
+        let default_max_gap = opts.max_gap;
 
         // Check that mint is in store of mints
         if self
@@ -602,8 +716,12 @@ impl Wallet {
 
         for keyset in keysets {
             let keys = self.keyset(keyset.id).await?.keys;
+            let recovery_window = self.nut342_recovery_window(keyset.id).await?;
+            let (mut start_counter, batch_size, max_gap) = match recovery_window {
+                Some((start, end)) => (start, end.saturating_sub(start).max(1), 1),
+                None => (0, default_batch_size, default_max_gap),
+            };
             let mut empty_batch: u32 = 0;
-            let mut start_counter: u32 = 0;
             // Track the highest counter value that had a signature
             let mut highest_counter: Option<u32> = None;
 
@@ -696,9 +814,15 @@ impl Wallet {
                 let (unspent_proofs, updated_restored) = proofs
                     .into_iter()
                     .zip(states)
-                    .filter_map(|(p, state)| {
+                    .enumerate()
+                    .filter_map(|(index, (p, state))| {
                         ProofInfo::new(p, self.mint_url.clone(), state.state, keyset.unit.clone())
                             .ok()
+                            .map(|proof_info| {
+                                proof_info.with_derivation_index(
+                                    start_counter + matched_secrets[index].0 as u32,
+                                )
+                            })
                     })
                     .try_fold(
                         (Vec::new(), restored_result),
@@ -1135,18 +1259,21 @@ mod tests {
             secret: secret1.clone(),
             r: r1.clone(),
             amount: Amount::from(1),
+            derivation_index: None,
         };
         let premint2 = PreMint {
             blinded_message: BlindedMessage::new(Amount::from(2), keyset_id, blinded2),
             secret: secret2.clone(),
             r: r2.clone(),
             amount: Amount::from(2),
+            derivation_index: None,
         };
         let premint3 = PreMint {
             blinded_message: BlindedMessage::new(Amount::from(4), keyset_id, blinded3),
             secret: secret3.clone(),
             r: r3.clone(),
             amount: Amount::from(4),
+            derivation_index: None,
         };
 
         let premint_secrets = PreMintSecrets {
@@ -1160,18 +1287,21 @@ mod tests {
             keyset_id,
             c: blinded1, // Using blinded as placeholder for signature
             dleq: None,
+            metadata: None,
         };
         let sig2 = BlindSignature {
             amount: Amount::from(2),
             keyset_id,
             c: blinded2,
             dleq: None,
+            metadata: None,
         };
         let sig3 = BlindSignature {
             amount: Amount::from(4),
             keyset_id,
             c: blinded3,
             dleq: None,
+            metadata: None,
         };
 
         // Response in same order as request
@@ -1233,18 +1363,21 @@ mod tests {
             secret: secret1.clone(),
             r: r1.clone(),
             amount: Amount::from(1),
+            derivation_index: None,
         };
         let premint2 = PreMint {
             blinded_message: BlindedMessage::new(Amount::from(2), keyset_id, blinded2),
             secret: secret2.clone(),
             r: r2.clone(),
             amount: Amount::from(2),
+            derivation_index: None,
         };
         let premint3 = PreMint {
             blinded_message: BlindedMessage::new(Amount::from(4), keyset_id, blinded3),
             secret: secret3.clone(),
             r: r3.clone(),
             amount: Amount::from(4),
+            derivation_index: None,
         };
 
         let premint_secrets = PreMintSecrets {
@@ -1257,18 +1390,21 @@ mod tests {
             keyset_id,
             c: blinded1,
             dleq: None,
+            metadata: None,
         };
         let sig2 = BlindSignature {
             amount: Amount::from(2),
             keyset_id,
             c: blinded2,
             dleq: None,
+            metadata: None,
         };
         let sig3 = BlindSignature {
             amount: Amount::from(4),
             keyset_id,
             c: blinded3,
             dleq: None,
+            metadata: None,
         };
 
         // Response in REVERSED order (simulating out-of-order response from mint)
@@ -1331,18 +1467,21 @@ mod tests {
             secret: secret1.clone(),
             r: r1.clone(),
             amount: Amount::from(1),
+            derivation_index: None,
         };
         let premint2 = PreMint {
             blinded_message: BlindedMessage::new(Amount::from(2), keyset_id, blinded2),
             secret: secret2.clone(),
             r: r2.clone(),
             amount: Amount::from(2),
+            derivation_index: None,
         };
         let premint3 = PreMint {
             blinded_message: BlindedMessage::new(Amount::from(4), keyset_id, blinded3),
             secret: secret3.clone(),
             r: r3.clone(),
             amount: Amount::from(4),
+            derivation_index: None,
         };
 
         let premint_secrets = PreMintSecrets {
@@ -1355,12 +1494,14 @@ mod tests {
             keyset_id,
             c: blinded1,
             dleq: None,
+            metadata: None,
         };
         let sig3 = BlindSignature {
             amount: Amount::from(4),
             keyset_id,
             c: blinded3,
             dleq: None,
+            metadata: None,
         };
 
         // Response only has signatures for premint1 and premint3 (gap at premint2)

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -591,6 +591,11 @@ impl Wallet {
         proofs: &mut Proofs,
         derivation_indices: &HashMap<Proof, u32>,
     ) {
+        if derivation_indices.is_empty() {
+            // Preserve the selector's legacy ordering when no recovery metadata is available.
+            proofs.sort_by(|a, b| a.cmp(b).reverse());
+            return;
+        }
         proofs.sort_by(|a, b| {
             b.amount.cmp(&a.amount).then_with(|| {
                 derivation_indices
@@ -607,6 +612,9 @@ impl Wallet {
         right: &Proofs,
         derivation_indices: &HashMap<Proof, u32>,
     ) -> bool {
+        if derivation_indices.is_empty() {
+            return false;
+        }
         let mut left_indices = left
             .iter()
             .map(|proof| derivation_indices.get(proof).copied().unwrap_or(u32::MAX))
@@ -687,6 +695,23 @@ mod tests {
     }
 
     #[test]
+    fn test_select_proofs_without_indices_preserves_legacy_order() {
+        let proofs = vec![proof(8), proof(8), proof(8)];
+        let expected = proofs[0].clone();
+
+        let selected = Wallet::select_proofs(
+            Amount::from(8),
+            proofs,
+            &vec![id()],
+            &fee_and_amounts(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(selected, vec![expected]);
+    }
+
+    #[test]
     fn test_select_proofs_keeps_exact_amount_priority_over_age() {
         let old = indexed_proof(16, 4);
         let young = indexed_proof(8, 400);
@@ -713,11 +738,15 @@ mod tests {
         average_gap: u64,
     }
 
-    fn run_gap_simulation(prefer_oldest: bool, target_index: u32) -> GapSimulationResult {
+    fn run_gap_simulation(
+        prefer_oldest: bool,
+        target_index: u32,
+        run_nonce: u64,
+    ) -> GapSimulationResult {
         let mut proofs = Vec::new();
         let mut indices = HashMap::new();
         let mut next_index = 0_u32;
-        let mut rng = 0x4d595df4d0f33173_u64;
+        let mut rng = run_nonce;
         let mut previous_gap = 0_u32;
         let mut maximum_gap = 0_u32;
         let mut shrink_events = 0_u32;
@@ -734,7 +763,15 @@ mod tests {
                 if amount & denomination == 0 {
                     continue;
                 }
-                let proof = indexed_proof(denomination, *next_index);
+                let proof = Proof::new(
+                    Amount::from(denomination),
+                    id(),
+                    Secret::new(format!("simulation-{run_nonce:016x}-{next_index:08}")),
+                    PublicKey::from_hex(
+                        "03deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                    )
+                    .unwrap(),
+                );
                 if retain {
                     indices.insert(proof.clone(), *next_index);
                     proofs.push(proof);
@@ -753,19 +790,14 @@ mod tests {
 
             rng = rng.wrapping_mul(6364136223846793005).wrapping_add(1);
             let spend = 1 + (rng >> 32) % 4_096;
-            let ranking = indices
-                .iter()
-                .map(|(proof, index)| {
-                    (
-                        proof.clone(),
-                        if prefer_oldest {
-                            *index
-                        } else {
-                            u32::MAX - *index
-                        },
-                    )
-                })
-                .collect();
+            let ranking = if prefer_oldest {
+                indices
+                    .iter()
+                    .map(|(proof, index)| (proof.clone(), *index))
+                    .collect()
+            } else {
+                HashMap::new()
+            };
             let selected = Wallet::select_proofs_with_derivation_indices(
                 Amount::from(spend),
                 proofs.clone(),
@@ -814,31 +846,40 @@ mod tests {
 
     #[test]
     #[ignore = "long-horizon NUT-342 diagnostic simulation"]
-    fn simulate_oldest_first_dynamic_gap() {
-        let newest_first = run_gap_simulation(false, 50_000);
-        let oldest_first = run_gap_simulation(true, 50_000);
+    fn benchmark_legacy_vs_oldest_first_dynamic_gap() {
+        let target_index = std::env::var("CDK_GAP_SIM_TARGET_INDEX")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(50_000);
+        let trials = std::env::var("CDK_GAP_SIM_TRIALS")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(1);
 
-        println!(
-            "newest-first: final={}, max={}, shrinks={}, samples={}, average={}",
-            newest_first.final_gap,
-            newest_first.maximum_gap,
-            newest_first.shrink_events,
-            newest_first.samples,
-            newest_first.average_gap
-        );
-        println!(
-            "oldest-first: final={}, max={}, shrinks={}, samples={}, average={}",
-            oldest_first.final_gap,
-            oldest_first.maximum_gap,
-            oldest_first.shrink_events,
-            oldest_first.samples,
-            oldest_first.average_gap
-        );
-        assert!(oldest_first.final_gap < newest_first.final_gap);
-        assert!(oldest_first.maximum_gap < newest_first.maximum_gap);
-        assert!(oldest_first.average_gap < newest_first.average_gap);
-        assert!(oldest_first.shrink_events > newest_first.shrink_events);
-        assert_eq!(oldest_first.samples, newest_first.samples);
+        for trial in 1..=trials {
+            let run_nonce = rand::random::<u64>();
+            let legacy = run_gap_simulation(false, target_index, run_nonce);
+            let oldest_first = run_gap_simulation(true, target_index, run_nonce);
+
+            println!("trial={trial} nonce={run_nonce:016x} target_index={target_index}");
+            println!(
+                "legacy: final={}, max={}, shrinks={}, swaps={}, average={}",
+                legacy.final_gap,
+                legacy.maximum_gap,
+                legacy.shrink_events,
+                legacy.samples,
+                legacy.average_gap
+            );
+            println!(
+                "oldest-first: final={}, max={}, shrinks={}, swaps={}, average={}",
+                oldest_first.final_gap,
+                oldest_first.maximum_gap,
+                oldest_first.shrink_events,
+                oldest_first.samples,
+                oldest_first.average_gap
+            );
+            assert_eq!(oldest_first.samples, legacy.samples);
+        }
     }
 
     #[test]

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -732,26 +732,22 @@ mod tests {
 
     struct GapSimulationResult {
         final_gap: u32,
+        minimum_gap: u32,
+        median_gap: u32,
         maximum_gap: u32,
         shrink_events: u32,
         samples: u32,
-        average_gap: u64,
     }
 
-    fn run_gap_simulation(
-        prefer_oldest: bool,
-        target_index: u32,
-        run_nonce: u64,
-    ) -> GapSimulationResult {
+    fn run_gap_simulation(target_index: u32, run_nonce: u64) -> GapSimulationResult {
         let mut proofs = Vec::new();
         let mut indices = HashMap::new();
         let mut next_index = 0_u32;
         let mut rng = run_nonce;
         let mut previous_gap = 0_u32;
-        let mut maximum_gap = 0_u32;
         let mut shrink_events = 0_u32;
         let mut samples = 0_u32;
-        let mut gap_sum = 0_u64;
+        let mut gaps = Vec::new();
 
         let add_outputs = |amount: u64,
                            retain: bool,
@@ -790,14 +786,10 @@ mod tests {
 
             rng = rng.wrapping_mul(6364136223846793005).wrapping_add(1);
             let spend = 1 + (rng >> 32) % 4_096;
-            let ranking = if prefer_oldest {
-                indices
-                    .iter()
-                    .map(|(proof, index)| (proof.clone(), *index))
-                    .collect()
-            } else {
-                HashMap::new()
-            };
+            let ranking = indices
+                .iter()
+                .map(|(proof, index)| (proof.clone(), *index))
+                .collect();
             let selected = Wallet::select_proofs_with_derivation_indices(
                 Amount::from(spend),
                 proofs.clone(),
@@ -830,55 +822,66 @@ mod tests {
                 shrink_events += 1;
             }
             previous_gap = gap;
-            maximum_gap = maximum_gap.max(gap);
-            gap_sum += u64::from(gap);
+            gaps.push(gap);
             samples += 1;
         }
 
+        gaps.sort_unstable();
+        let minimum_gap = gaps.first().copied().unwrap_or_default();
+        let median_gap = match gaps.len() {
+            0 => 0,
+            len if len % 2 == 0 => {
+                let upper = u64::from(gaps[len / 2]);
+                let lower = u64::from(gaps[len / 2 - 1]);
+                ((lower + upper) / 2) as u32
+            }
+            len => gaps[len / 2],
+        };
+        let maximum_gap = gaps.last().copied().unwrap_or_default();
+
         GapSimulationResult {
             final_gap: previous_gap,
+            minimum_gap,
+            median_gap,
             maximum_gap,
             shrink_events,
             samples,
-            average_gap: gap_sum / u64::from(samples),
         }
     }
 
     #[test]
     #[ignore = "long-horizon NUT-342 diagnostic simulation"]
-    fn benchmark_legacy_vs_oldest_first_dynamic_gap() {
-        let target_index = std::env::var("CDK_GAP_SIM_TARGET_INDEX")
+    fn benchmark_oldest_first_dynamic_gap_across_lengths() {
+        let target_indices = std::env::var("CDK_GAP_SIM_TARGET_INDICES")
             .ok()
-            .and_then(|value| value.parse().ok())
-            .unwrap_or(50_000);
+            .map(|value| {
+                value
+                    .split(',')
+                    .filter_map(|value| value.trim().parse().ok())
+                    .collect::<Vec<u32>>()
+            })
+            .filter(|values| !values.is_empty())
+            .unwrap_or_else(|| vec![10_000, 50_000, 100_000]);
         let trials = std::env::var("CDK_GAP_SIM_TRIALS")
             .ok()
             .and_then(|value| value.parse().ok())
             .unwrap_or(1);
 
-        for trial in 1..=trials {
-            let run_nonce = rand::random::<u64>();
-            let legacy = run_gap_simulation(false, target_index, run_nonce);
-            let oldest_first = run_gap_simulation(true, target_index, run_nonce);
+        for target_index in target_indices {
+            for trial in 1..=trials {
+                let run_nonce = rand::random::<u64>();
+                let result = run_gap_simulation(target_index, run_nonce);
 
-            println!("trial={trial} nonce={run_nonce:016x} target_index={target_index}");
-            println!(
-                "legacy: final={}, max={}, shrinks={}, swaps={}, average={}",
-                legacy.final_gap,
-                legacy.maximum_gap,
-                legacy.shrink_events,
-                legacy.samples,
-                legacy.average_gap
-            );
-            println!(
-                "oldest-first: final={}, max={}, shrinks={}, swaps={}, average={}",
-                oldest_first.final_gap,
-                oldest_first.maximum_gap,
-                oldest_first.shrink_events,
-                oldest_first.samples,
-                oldest_first.average_gap
-            );
-            assert_eq!(oldest_first.samples, legacy.samples);
+                println!(
+                    "target_index={target_index} trial={trial} nonce={run_nonce:016x} swaps={} min={} median={} max={} final={} shrinks={}",
+                    result.samples,
+                    result.minimum_gap,
+                    result.median_gap,
+                    result.maximum_gap,
+                    result.final_gap,
+                    result.shrink_events
+                );
+            }
         }
     }
 

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -13,6 +13,23 @@ use crate::nuts::{
 use crate::{ensure_cdk, Amount, Error, Wallet};
 
 impl Wallet {
+    pub(crate) async fn unspent_proof_derivation_indices(
+        &self,
+    ) -> Result<HashMap<Proof, u32>, Error> {
+        Ok(self
+            .localstore
+            .get_proofs(
+                Some(self.mint_url.clone()),
+                Some(self.unit.clone()),
+                Some(vec![State::Unspent]),
+                None,
+            )
+            .await?
+            .into_iter()
+            .filter_map(|proof| proof.derivation_index.map(|index| (proof.proof, index)))
+            .collect())
+    }
+
     /// Get unspent proofs for mint
     #[instrument(skip(self))]
     pub async fn get_unspent_proofs(&self) -> Result<Proofs, Error> {
@@ -253,6 +270,25 @@ impl Wallet {
         fees_and_keyset_amounts: &KeysetFeeAndAmounts,
         include_fees: bool,
     ) -> Result<Proofs, Error> {
+        Self::select_proofs_with_derivation_indices(
+            amount,
+            proofs,
+            active_keyset_ids,
+            fees_and_keyset_amounts,
+            include_fees,
+            &HashMap::new(),
+        )
+    }
+
+    /// Select proofs, preferring older deterministic proofs when choices are otherwise equivalent.
+    pub(crate) fn select_proofs_with_derivation_indices(
+        amount: Amount,
+        proofs: Proofs,
+        active_keyset_ids: &Vec<Id>,
+        fees_and_keyset_amounts: &KeysetFeeAndAmounts,
+        include_fees: bool,
+        derivation_indices: &HashMap<Proof, u32>,
+    ) -> Result<Proofs, Error> {
         if amount == Amount::ZERO {
             return Ok(vec![]);
         }
@@ -260,7 +296,7 @@ impl Wallet {
 
         // Sort proofs in descending order
         let mut proofs = proofs;
-        proofs.sort_by(|a, b| a.cmp(b).reverse());
+        Self::sort_proofs_by_amount_and_age(&mut proofs, derivation_indices);
 
         // Track selected proofs and remaining amounts (include all inactive proofs first)
         let inactive_proofs: Proofs = proofs
@@ -273,8 +309,8 @@ impl Wallet {
             tracing::debug!("All inactive proofs are sufficient");
             // Still need to filter to minimum set, not return all of them
             let mut inactive_selected = selected_proofs.into_iter().collect::<Vec<_>>();
-            inactive_selected.sort_by(|a, b| a.cmp(b).reverse());
-            return Self::select_least_amount_over(inactive_selected, amount);
+            Self::sort_proofs_by_amount_and_age(&mut inactive_selected, derivation_indices);
+            return Self::select_least_amount_over(inactive_selected, amount, derivation_indices);
         }
         let mut remaining_amounts: Vec<Amount> = Vec::new();
 
@@ -333,6 +369,7 @@ impl Wallet {
                     result,
                     active_keyset_ids,
                     fees_and_keyset_amounts,
+                    derivation_indices,
                 );
             } else {
                 return Ok(result);
@@ -384,8 +421,9 @@ impl Wallet {
         let mut selected_proofs = selected_proofs.into_iter().collect::<Vec<_>>();
         let total_amount = selected_proofs.total_amount()?;
         if total_amount != amount && selected_proofs.len() > 1 {
-            selected_proofs.sort_by(|a, b| a.cmp(b).reverse());
-            selected_proofs = Self::select_least_amount_over(selected_proofs, amount)?;
+            Self::sort_proofs_by_amount_and_age(&mut selected_proofs, derivation_indices);
+            selected_proofs =
+                Self::select_least_amount_over(selected_proofs, amount, derivation_indices)?;
         }
 
         if include_fees {
@@ -395,13 +433,18 @@ impl Wallet {
                 selected_proofs,
                 active_keyset_ids,
                 fees_and_keyset_amounts,
+                derivation_indices,
             );
         }
 
         Ok(selected_proofs)
     }
 
-    fn select_least_amount_over(proofs: Proofs, amount: Amount) -> Result<Vec<Proof>, Error> {
+    fn select_least_amount_over(
+        proofs: Proofs,
+        amount: Amount,
+        derivation_indices: &HashMap<Proof, u32>,
+    ) -> Result<Vec<Proof>, Error> {
         let total_amount = proofs.total_amount()?;
         if total_amount < amount {
             return Err(Error::InsufficientFunds);
@@ -419,13 +462,20 @@ impl Wallet {
 
             if left_amount >= amount && right_amount >= amount {
                 match (
-                    Self::select_least_amount_over(left, amount),
-                    Self::select_least_amount_over(right, amount),
+                    Self::select_least_amount_over(left, amount, derivation_indices),
+                    Self::select_least_amount_over(right, amount, derivation_indices),
                 ) {
                     (Ok(left_proofs), Ok(right_proofs)) => {
                         let left_total_amount = left_proofs.total_amount()?;
                         let right_total_amount = right_proofs.total_amount()?;
-                        if left_total_amount < right_total_amount {
+                        if left_total_amount < right_total_amount
+                            || (left_total_amount == right_total_amount
+                                && Self::is_older_selection(
+                                    &left_proofs,
+                                    &right_proofs,
+                                    derivation_indices,
+                                ))
+                        {
                             return Ok(left_proofs);
                         } else {
                             return Ok(right_proofs);
@@ -436,9 +486,9 @@ impl Wallet {
                     (Err(_), Err(_)) => return Err(Error::InsufficientFunds),
                 }
             } else if left_amount >= amount {
-                return Self::select_least_amount_over(left, amount);
+                return Self::select_least_amount_over(left, amount, derivation_indices);
             } else if right_amount >= amount {
-                return Self::select_least_amount_over(right, amount);
+                return Self::select_least_amount_over(right, amount, derivation_indices);
             }
         }
 
@@ -451,6 +501,7 @@ impl Wallet {
         mut selected_proofs: Proofs,
         active_keyset_ids: &Vec<Id>,
         fees_and_keyset_amounts: &KeysetFeeAndAmounts,
+        derivation_indices: &HashMap<Proof, u32>,
     ) -> Result<Proofs, Error> {
         tracing::debug!("Including fees");
         let fee_breakdown = calculate_fee(
@@ -518,12 +569,13 @@ impl Wallet {
             let shortfall = amount - net_amount;
             tracing::debug!("Net amount is less than required, shortfall={}", shortfall);
 
-            let additional = Wallet::select_proofs(
+            let additional = Wallet::select_proofs_with_derivation_indices(
                 shortfall,
                 remaining_proofs.clone(),
                 active_keyset_ids,
                 fees_and_keyset_amounts,
                 false,
+                derivation_indices,
             )?;
 
             if additional.is_empty() {
@@ -534,14 +586,48 @@ impl Wallet {
             selected_proofs.extend(additional);
         }
     }
+
+    fn sort_proofs_by_amount_and_age(
+        proofs: &mut Proofs,
+        derivation_indices: &HashMap<Proof, u32>,
+    ) {
+        proofs.sort_by(|a, b| {
+            b.amount.cmp(&a.amount).then_with(|| {
+                derivation_indices
+                    .get(a)
+                    .copied()
+                    .unwrap_or(u32::MAX)
+                    .cmp(&derivation_indices.get(b).copied().unwrap_or(u32::MAX))
+            })
+        });
+    }
+
+    fn is_older_selection(
+        left: &Proofs,
+        right: &Proofs,
+        derivation_indices: &HashMap<Proof, u32>,
+    ) -> bool {
+        let mut left_indices = left
+            .iter()
+            .map(|proof| derivation_indices.get(proof).copied().unwrap_or(u32::MAX))
+            .collect::<Vec<_>>();
+        let mut right_indices = right
+            .iter()
+            .map(|proof| derivation_indices.get(proof).copied().unwrap_or(u32::MAX))
+            .collect::<Vec<_>>();
+        left_indices.sort_unstable();
+        right_indices.sort_unstable();
+        left_indices < right_indices
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
+    use cdk_common::amount::KeysetFeeAndAmounts;
     use cdk_common::secret::Secret;
-    use cdk_common::{Amount, Id, Proof, PublicKey};
+    use cdk_common::{Amount, Id, Proof, Proofs, ProofsMethods, PublicKey};
 
     use crate::Wallet;
 
@@ -559,6 +645,200 @@ mod tests {
             )
             .unwrap(),
         )
+    }
+
+    fn indexed_proof(amount: u64, index: u32) -> Proof {
+        Proof::new(
+            Amount::from(amount),
+            id(),
+            Secret::new(format!("proof-{index:08}")),
+            PublicKey::from_hex(
+                "03deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            )
+            .unwrap(),
+        )
+    }
+
+    fn fee_and_amounts() -> KeysetFeeAndAmounts {
+        HashMap::from([(
+            id(),
+            (0, (0..32).map(|x| 2u64.pow(x)).collect::<Vec<_>>()).into(),
+        )])
+    }
+
+    #[test]
+    fn test_select_proofs_prefers_oldest_equal_amount() {
+        let old = indexed_proof(8, 4);
+        let middle = indexed_proof(8, 40);
+        let young = indexed_proof(8, 400);
+        let indices = HashMap::from([(old.clone(), 4), (middle.clone(), 40), (young.clone(), 400)]);
+
+        let selected = Wallet::select_proofs_with_derivation_indices(
+            Amount::from(8),
+            vec![young, middle, old.clone()],
+            &vec![id()],
+            &fee_and_amounts(),
+            false,
+            &indices,
+        )
+        .unwrap();
+
+        assert_eq!(selected, vec![old]);
+    }
+
+    #[test]
+    fn test_select_proofs_keeps_exact_amount_priority_over_age() {
+        let old = indexed_proof(16, 4);
+        let young = indexed_proof(8, 400);
+        let indices = HashMap::from([(old.clone(), 4), (young.clone(), 400)]);
+
+        let selected = Wallet::select_proofs_with_derivation_indices(
+            Amount::from(8),
+            vec![old, young.clone()],
+            &vec![id()],
+            &fee_and_amounts(),
+            false,
+            &indices,
+        )
+        .unwrap();
+
+        assert_eq!(selected, vec![young]);
+    }
+
+    struct GapSimulationResult {
+        final_gap: u32,
+        maximum_gap: u32,
+        shrink_events: u32,
+        samples: u32,
+        average_gap: u64,
+    }
+
+    fn run_gap_simulation(prefer_oldest: bool, target_index: u32) -> GapSimulationResult {
+        let mut proofs = Vec::new();
+        let mut indices = HashMap::new();
+        let mut next_index = 0_u32;
+        let mut rng = 0x4d595df4d0f33173_u64;
+        let mut previous_gap = 0_u32;
+        let mut maximum_gap = 0_u32;
+        let mut shrink_events = 0_u32;
+        let mut samples = 0_u32;
+        let mut gap_sum = 0_u64;
+
+        let add_outputs = |amount: u64,
+                           retain: bool,
+                           proofs: &mut Proofs,
+                           indices: &mut HashMap<Proof, u32>,
+                           next_index: &mut u32| {
+            for bit in 0..64 {
+                let denomination = 1_u64 << bit;
+                if amount & denomination == 0 {
+                    continue;
+                }
+                let proof = indexed_proof(denomination, *next_index);
+                if retain {
+                    indices.insert(proof.clone(), *next_index);
+                    proofs.push(proof);
+                }
+                *next_index = next_index.saturating_add(1);
+            }
+        };
+
+        add_outputs(65_535, true, &mut proofs, &mut indices, &mut next_index);
+
+        while next_index < target_index {
+            let balance: u64 = proofs.total_amount().unwrap().into();
+            if balance < 32_768_u64 {
+                add_outputs(32_768, true, &mut proofs, &mut indices, &mut next_index);
+            }
+
+            rng = rng.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let spend = 1 + (rng >> 32) % 4_096;
+            let ranking = indices
+                .iter()
+                .map(|(proof, index)| {
+                    (
+                        proof.clone(),
+                        if prefer_oldest {
+                            *index
+                        } else {
+                            u32::MAX - *index
+                        },
+                    )
+                })
+                .collect();
+            let selected = Wallet::select_proofs_with_derivation_indices(
+                Amount::from(spend),
+                proofs.clone(),
+                &vec![id()],
+                &fee_and_amounts(),
+                false,
+                &ranking,
+            )
+            .unwrap();
+            let selected_total: u64 = selected.total_amount().unwrap().into();
+            proofs.retain(|proof| !selected.contains(proof));
+            for proof in &selected {
+                indices.remove(proof);
+            }
+
+            // A normal online send derives both the outgoing proofs and change. The outgoing
+            // proofs are considered claimed immediately; retained change remains active.
+            add_outputs(spend, false, &mut proofs, &mut indices, &mut next_index);
+            add_outputs(
+                selected_total - spend,
+                true,
+                &mut proofs,
+                &mut indices,
+                &mut next_index,
+            );
+
+            let first_active = indices.values().copied().min().unwrap_or(next_index);
+            let gap = next_index.saturating_sub(first_active);
+            if samples > 0 && gap < previous_gap {
+                shrink_events += 1;
+            }
+            previous_gap = gap;
+            maximum_gap = maximum_gap.max(gap);
+            gap_sum += u64::from(gap);
+            samples += 1;
+        }
+
+        GapSimulationResult {
+            final_gap: previous_gap,
+            maximum_gap,
+            shrink_events,
+            samples,
+            average_gap: gap_sum / u64::from(samples),
+        }
+    }
+
+    #[test]
+    #[ignore = "long-horizon NUT-342 diagnostic simulation"]
+    fn simulate_oldest_first_dynamic_gap() {
+        let newest_first = run_gap_simulation(false, 50_000);
+        let oldest_first = run_gap_simulation(true, 50_000);
+
+        println!(
+            "newest-first: final={}, max={}, shrinks={}, samples={}, average={}",
+            newest_first.final_gap,
+            newest_first.maximum_gap,
+            newest_first.shrink_events,
+            newest_first.samples,
+            newest_first.average_gap
+        );
+        println!(
+            "oldest-first: final={}, max={}, shrinks={}, samples={}, average={}",
+            oldest_first.final_gap,
+            oldest_first.maximum_gap,
+            oldest_first.shrink_events,
+            oldest_first.samples,
+            oldest_first.average_gap
+        );
+        assert!(oldest_first.final_gap < newest_first.final_gap);
+        assert!(oldest_first.maximum_gap < newest_first.maximum_gap);
+        assert!(oldest_first.average_gap < newest_first.average_gap);
+        assert!(oldest_first.shrink_events > newest_first.shrink_events);
+        assert_eq!(oldest_first.samples, newest_first.samples);
     }
 
     #[test]

--- a/crates/cdk/src/wallet/receive/saga/mod.rs
+++ b/crates/cdk/src/wallet/receive/saga/mod.rs
@@ -415,13 +415,18 @@ impl<'a> ReceiveSaga<'a, Prepared> {
 
         let recv_proof_infos = recv_proofs
             .into_iter()
-            .map(|proof| {
-                ProofInfo::new(
+            .zip(&pre_swap.pre_mint_secrets.secrets)
+            .map(|(proof, premint)| {
+                let proof_info = ProofInfo::new(
                     proof,
                     self.wallet.mint_url.clone(),
                     State::Unspent,
                     self.wallet.unit.clone(),
-                )
+                )?;
+                Ok::<_, Error>(match premint.derivation_index {
+                    Some(index) => proof_info.with_derivation_index(index),
+                    None => proof_info,
+                })
             })
             .collect::<Result<Vec<ProofInfo>, _>>()?;
 

--- a/crates/cdk/src/wallet/recovery.rs
+++ b/crates/cdk/src/wallet/recovery.rs
@@ -293,7 +293,15 @@ impl RecoveryHelpers for Wallet {
         // Convert to ProofInfo
         let proof_infos: Vec<ProofInfo> = proofs
             .into_iter()
-            .map(|p| ProofInfo::new(p, self.mint_url.clone(), State::Unspent, self.unit.clone()))
+            .zip(&premint_secrets.secrets)
+            .map(|(p, premint)| {
+                let proof_info =
+                    ProofInfo::new(p, self.mint_url.clone(), State::Unspent, self.unit.clone())?;
+                Ok::<_, Error>(match premint.derivation_index {
+                    Some(index) => proof_info.with_derivation_index(index),
+                    None => proof_info,
+                })
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Some(proof_infos))
@@ -552,7 +560,15 @@ impl Wallet {
         // Convert to ProofInfo
         let proof_infos: Vec<ProofInfo> = proofs
             .into_iter()
-            .map(|p| ProofInfo::new(p, self.mint_url.clone(), State::Unspent, self.unit.clone()))
+            .zip(matched)
+            .map(|(p, (premint, _))| {
+                let proof_info =
+                    ProofInfo::new(p, self.mint_url.clone(), State::Unspent, self.unit.clone())?;
+                Ok::<_, Error>(match premint.derivation_index {
+                    Some(index) => proof_info.with_derivation_index(index),
+                    None => proof_info,
+                })
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(OutputRecoveryResult::Restored(proof_infos))

--- a/crates/cdk/src/wallet/send/saga/mod.rs
+++ b/crates/cdk/src/wallet/send/saga/mod.rs
@@ -79,7 +79,7 @@ use crate::amount::SplitTarget;
 use crate::fees::calculate_fee;
 use crate::nuts::nut00::ProofsMethods;
 use crate::nuts::nut11::{enforce_sig_flag, SigFlag};
-use crate::nuts::{Proofs, State, Token};
+use crate::nuts::{Proof, Proofs, State, Token};
 use crate::wallet::saga::{
     add_compensation, execute_compensations, new_compensations, Compensations,
     RevertProofReservation,
@@ -184,6 +184,7 @@ struct InputFeeCoverageContext<'a> {
     send_amounts: &'a [Amount],
     force_swap: bool,
     is_exact_or_offline: bool,
+    derivation_indices: &'a HashMap<Proof, u32>,
 }
 
 fn ensure_selected_proofs_cover_input_fees(
@@ -225,12 +226,13 @@ fn ensure_selected_proofs_cover_input_fees(
         let shortfall = (context.amount + context.send_fee)
             .checked_sub(selected_net)
             .unwrap_or(Amount::ZERO);
-        let additional = Wallet::select_proofs(
+        let additional = Wallet::select_proofs_with_derivation_indices(
             shortfall,
             remaining_proofs.clone(),
             context.active_keyset_ids,
             context.keyset_fees,
             false,
+            context.derivation_indices,
         )?;
 
         if additional.is_empty() {
@@ -525,12 +527,14 @@ impl<'a> SendSaga<'a, Initial> {
                 .any(crate::wallet::util::is_p2pk_locked);
 
         let proof_pool = available_proofs.clone();
-        let mut selected_proofs = Wallet::select_proofs(
+        let derivation_indices = self.wallet.unspent_proof_derivation_indices().await?;
+        let mut selected_proofs = Wallet::select_proofs_with_derivation_indices(
             selection_amount,
             available_proofs,
             &active_keyset_ids,
             &keyset_fees,
             opts.include_fee || force_swap,
+            &derivation_indices,
         )?;
 
         let send_fee = if opts.include_fee {
@@ -554,6 +558,7 @@ impl<'a> SendSaga<'a, Initial> {
                     send_amounts: &send_amounts.0,
                     force_swap,
                     is_exact_or_offline,
+                    derivation_indices: &derivation_indices,
                 },
             )?;
         }
@@ -1175,6 +1180,7 @@ impl std::fmt::Debug for SendSaga<'_, Prepared> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use cdk_common::amount::KeysetFeeAndAmounts;
@@ -1620,6 +1626,7 @@ mod tests {
                 send_amounts: &send_amounts,
                 force_swap: true,
                 is_exact_or_offline: false,
+                derivation_indices: &HashMap::new(),
             },
         )
         .unwrap();
@@ -1654,6 +1661,7 @@ mod tests {
                 send_amounts: &send_amounts,
                 force_swap: true,
                 is_exact_or_offline: false,
+                derivation_indices: &HashMap::new(),
             },
         )
         .expect_err("selected proofs cannot cover input fees without extra proofs");
@@ -1684,6 +1692,7 @@ mod tests {
                 send_amounts: &send_amounts,
                 force_swap: false,
                 is_exact_or_offline: false,
+                derivation_indices: &HashMap::new(),
             },
         )
         .unwrap();

--- a/crates/cdk/src/wallet/swap/mod.rs
+++ b/crates/cdk/src/wallet/swap/mod.rs
@@ -230,8 +230,9 @@ impl Wallet {
 
         let mut count = starting_counter;
 
+        let has_spending_conditions = spending_conditions.is_some();
         let mut p2bk_ephemeral_key = None;
-        let (mut desired_messages, change_messages) = match spending_conditions {
+        let (mut desired_messages, mut change_messages) = match spending_conditions {
             Some(conditions) => {
                 let change_premint_secrets = PreMintSecrets::from_seed(
                     active_keyset_id,
@@ -313,6 +314,20 @@ impl Wallet {
                 (premint_secrets, change_premint_secrets)
             }
         };
+
+        if has_spending_conditions {
+            self.add_nut342_metadata(active_keyset_id, starting_counter, &mut change_messages)
+                .await?;
+        } else {
+            self.add_nut342_metadata(active_keyset_id, starting_counter, &mut desired_messages)
+                .await?;
+            self.add_nut342_metadata(
+                active_keyset_id,
+                starting_counter.saturating_add(desired_messages.len() as u32),
+                &mut change_messages,
+            )
+            .await?;
+        }
 
         // Combine the BlindedMessages totaling the desired amount with change
         desired_messages.combine(change_messages);

--- a/crates/cdk/src/wallet/swap/saga/mod.rs
+++ b/crates/cdk/src/wallet/swap/saga/mod.rs
@@ -344,6 +344,16 @@ impl<'a> SwapSaga<'a, Prepared> {
             .map(|proof| ProofInfo::new(proof, mint_url.clone(), State::Unspent, unit.clone()))
             .collect::<Result<Vec<ProofInfo>, _>>()?;
         added_proofs.extend(keep_proofs);
+        for proof_info in &mut added_proofs {
+            proof_info.derivation_index = self
+                .state_data
+                .pre_swap
+                .pre_mint_secrets
+                .secrets
+                .iter()
+                .find(|premint| premint.secret == proof_info.proof.secret)
+                .and_then(|premint| premint.derivation_index);
+        }
 
         // Add new proofs and mark input proofs as Spent (don't delete them)
         self.wallet
@@ -603,6 +613,7 @@ mod tests {
                 keyset_id: blinded_message.keyset_id,
                 c: Nut01SecretKey::generate().public_key(),
                 dleq: None,
+                metadata: None,
             })
             .collect();
 


### PR DESCRIPTION
### Description

Implements the recovery strategy and protocol changes proposed in [cashubtc/nuts#342](https://github.com/cashubtc/nuts/pull/342).

This adds:

- NUT-342 mint capability advertisement and metadata validation/echoing
- authenticated encryption and decryption of dynamic-gap metadata
- binary-search wallet recovery using the encrypted gap hint
- derivation-index persistence on wallet proofs across SQL, Supabase, Redb serialization, and FFI
- active-proof gap calculation scoped to one mint, unit, and keyset, including unspent, pending, reserved, and pending-spent proofs
- derivation-index propagation through issue, swap, melt, receive, restore, and saga recovery paths
- age-aware proof selection as an economic tie-breaker for send and melt flows
- a dedicated InvalidOutputMetadata error and input/output error code 11018
- unit, database, integration, and long-horizon randomized simulation coverage

-----

### Notes to the reviewers

The long-horizon simulation exercises only the implemented oldest-first selector. It runs non-deterministic swap-style workloads at configurable derivation horizons and reports minimum, median, maximum, and final dynamic gap values plus shrink events. It does not attempt to present the previous selector as a control.

The live regtest environment was not available in this checkout. The pure integration test uses the in-process mint and wallet stack.

`just quick-check` could not complete because `nixpkgs-fmt` is unavailable in the current environment. Rust formatting and full workspace Clippy passed independently.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

- Wallet coin selection uses persisted derivation indices to prefer older economically equivalent proofs.

#### ADDED

- NUT-342 dynamic-gap recovery metadata and wallet recovery support.
- Persistent derivation indices for deterministic wallet proofs.
- A dedicated error response for invalid or unsupported output metadata.

#### REMOVED

#### FIXED

----

### Validation

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p cashu nut342`
- `cargo test -p cdk test_select_proofs_`
- `CDK_TEST_DB_TYPE=memory cargo test -p cdk-integration-tests --test integration_tests_pure test_nut342_dynamic_gap_wallet_recovery -- --test-threads 1`
- SQLite and Redb wallet proof persistence tests
- randomized oldest-first simulations at 10,000, 50,000, and 100,000 derivation indices

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing (blocked at Nix formatting because `nixpkgs-fmt` is unavailable)
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)