### PR TITLE
fix(wallet): allow LNURL-pay description hash mismatches

### DIFF
--- a/crates/cdk/src/lightning_address.rs
+++ b/crates/cdk/src/lightning_address.rs
@@ -59,9 +59,6 @@ pub enum Error {
         "Returned invoice amount {actual} msat does not match requested amount {expected} msat"
     )]
     IncorrectInvoiceAmount { actual: u64, expected: u64 },
-    /// Returned invoice description hash does not match LNURL metadata
-    #[error("Returned invoice description hash does not match LNURL metadata")]
-    IncorrectInvoiceDescriptionHash,
 }
 
 /// Lightning address - represents a user@domain.com address
@@ -163,10 +160,14 @@ impl LightningAddress {
         }
 
         let expected_description_hash = Sha256Hash::hash(pay_data.metadata.as_bytes());
-        match invoice.description() {
+        if !matches!(
+            invoice.description(),
             lightning_invoice::Bolt11InvoiceDescriptionRef::Hash(hash)
-                if hash.0.as_byte_array() == expected_description_hash.as_byte_array() => {}
-            _ => return Err(Error::IncorrectInvoiceDescriptionHash),
+                if hash.0.as_byte_array() == expected_description_hash.as_byte_array()
+        ) {
+            tracing::warn!(
+                "LNURL-pay invoice description hash does not match metadata; continuing payment"
+            );
         }
 
         Ok(invoice)
@@ -489,7 +490,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_request_invoice_rejects_invoice_when_metadata_does_not_hash() {
+    async fn test_request_invoice_accepts_invoice_when_metadata_does_not_hash() {
         let connector = Arc::new(MockMintConnector::new());
         connector.set_lnurl_pay_request_response(Ok(LnurlPayResponse {
             callback: "https://example.com/callback".to_string(),
@@ -507,17 +508,15 @@ mod tests {
         }));
 
         let address = LightningAddress::from_str("alice@example.com").expect("valid address");
-        let result = address
+        let invoice = address
             .request_invoice(
                 &(connector as Arc<dyn crate::wallet::MintConnector + Send + Sync>),
                 Amount::from(100_000_u64),
             )
-            .await;
+            .await
+            .expect("metadata hash mismatch should not prevent payment");
 
-        assert!(matches!(
-            result,
-            Err(Error::IncorrectInvoiceDescriptionHash)
-        ));
+        assert_eq!(invoice.amount_milli_satoshis(), Some(100_000));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Warn when an invoice does not commit to LNURL metadata instead of rejecting it. Keep invoice amount validation strict as required by LUD-06.

Fixes #2235

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

closes: https://github.com/cashubtc/cdk/issues/2235

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
