### PR TITLE
feat(cdk-mint-rpc): add KeysetService alongside legacy CdkMint

### DIFF
--- a/crates/cdk-mint-rpc/build.rs
+++ b/crates/cdk-mint-rpc/build.rs
@@ -3,17 +3,20 @@
 #![allow(clippy::unwrap_used)]
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("cargo:rerun-if-changed=src/proto/cdk-mint-rpc.proto");
+    println!("cargo:rerun-if-changed=src/proto");
 
     // Tell cargo to tell rustc to allow missing docs in generated code
     println!("cargo:rustc-env=RUSTDOC_ARGS=--allow-missing-docs");
 
-    // Configure tonic build to generate code with documentation
+    // Compiles the legacy monolithic proto alongside the per-domain protos
     tonic_prost_build::configure()
         .protoc_arg("--experimental_allow_proto3_optional")
         .type_attribute(".", "#[allow(missing_docs)]")
         .field_attribute(".", "#[allow(missing_docs)]")
-        .compile_protos(&["src/proto/cdk-mint-rpc.proto"], &["src/proto"])?;
+        .compile_protos(
+            &["src/proto/cdk-mint-rpc.proto", "src/proto/keyset.proto"],
+            &["src/proto"],
+        )?;
 
     Ok(())
 }

--- a/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
+++ b/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use anyhow::{anyhow, Result};
 use cdk_common::grpc::{VersionInterceptor, VERSION_HEADER};
 use cdk_mint_rpc::cdk_mint_client::CdkMintClient;
+use cdk_mint_rpc::keyset::keyset_service_client::KeysetServiceClient;
 use cdk_mint_rpc::mint_rpc_cli::subcommands;
 use cdk_mint_rpc::GetInfoRequest;
 use clap::{Parser, Subcommand};
@@ -153,10 +154,10 @@ async fn main() -> Result<()> {
             .await?
     };
 
-    // Create client with version header interceptor
+    // Shared version header interceptor
     let interceptor =
         VersionInterceptor::new(VERSION_HEADER, cdk_common::MINT_RPC_PROTOCOL_VERSION);
-    let mut client = CdkMintClient::with_interceptor(channel, interceptor);
+    let mut client = CdkMintClient::with_interceptor(channel.clone(), interceptor.clone());
 
     match cli.command {
         Commands::GetInfo => {
@@ -238,7 +239,8 @@ async fn main() -> Result<()> {
             subcommands::update_nut04_quote_state(&mut client, &sub_command_args).await?;
         }
         Commands::RotateNextKeyset(sub_command_args) => {
-            subcommands::rotate_next_keyset(&mut client, &sub_command_args).await?;
+            let mut keyset_client = KeysetServiceClient::with_interceptor(channel, interceptor);
+            subcommands::rotate_next_keyset(&mut keyset_client, &sub_command_args).await?;
         }
     }
 

--- a/crates/cdk-mint-rpc/src/lib.rs
+++ b/crates/cdk-mint-rpc/src/lib.rs
@@ -16,3 +16,11 @@ pub type InterceptedCdkMintClient = cdk_mint_client::CdkMintClient<
         cdk_common::grpc::VersionInterceptor,
     >,
 >;
+
+/// Type alias for KeysetServiceClient with the version header interceptor over a Channel
+pub type InterceptedKeysetServiceClient = keyset::keyset_service_client::KeysetServiceClient<
+    tonic::codegen::InterceptedService<
+        tonic::transport::Channel,
+        cdk_common::grpc::VersionInterceptor,
+    >,
+>;

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/rotate_next_keyset.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/rotate_next_keyset.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use clap::Args;
 use tonic::Request;
 
-use crate::{InterceptedCdkMintClient, RotateNextKeysetRequest};
+use crate::keyset::RotateNextKeysetRequest;
+use crate::InterceptedKeysetServiceClient;
 
 /// Command to rotate to the next keyset for the mint
 ///
@@ -37,7 +38,7 @@ pub struct RotateNextKeysetCommand {
 /// * `client` - The RPC client used to communicate with the mint
 /// * `sub_command_args` - The arguments specifying how the new keyset should be configured
 pub async fn rotate_next_keyset(
-    client: &mut InterceptedCdkMintClient,
+    client: &mut InterceptedKeysetServiceClient,
     sub_command_args: &RotateNextKeysetCommand,
 ) -> Result<()> {
     let amounts = if let Some(amounts_str) = &sub_command_args.amounts {

--- a/crates/cdk-mint-rpc/src/proto/keyset.proto
+++ b/crates/cdk-mint-rpc/src/proto/keyset.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package cdk_mint_keyset_v1;
+
+// Keyset administration for a mint.
+service KeysetService {
+    // Rotates to the next keyset for the specified currency unit.
+    rpc RotateNextKeyset(RotateNextKeysetRequest) returns (RotateNextKeysetResponse) {}
+}
+
+message RotateNextKeysetRequest {
+    string unit = 1;
+    repeated uint64 amounts = 2;
+    optional uint64 input_fee_ppk = 3;
+    optional bool use_keyset_v2 = 4;
+    optional uint64 final_expiry = 5;
+}
+
+message RotateNextKeysetResponse {
+    string id = 1;
+    string unit = 2;
+    repeated uint64 amounts = 3;
+    uint64 input_fee_ppk = 4;
+}

--- a/crates/cdk-mint-rpc/src/proto/keyset.proto
+++ b/crates/cdk-mint-rpc/src/proto/keyset.proto
@@ -9,16 +9,36 @@ service KeysetService {
 }
 
 message RotateNextKeysetRequest {
+    // Currency unit the new keyset signs, e.g. "sat". Matched case-
+    // insensitively. A unit the mint cannot derive a keyset for fails with
+    // gRPC status INVALID_ARGUMENT.
     string unit = 1;
+    // Token denominations the keyset can sign, e.g. [1, 2, 4, 8, 16]. If
+    // empty, the amounts of the currently active keyset for this unit are
+    // reused; rotating a unit that has no active keyset requires a non-empty
+    // list.
     repeated uint64 amounts = 2;
+    // Input fee charged per input, in parts per thousand. Defaults to 0 when
+    // omitted.
     optional uint64 input_fee_ppk = 3;
+    // When true (the default), emit a NUT-02 Version01 keyset; when false,
+    // a Version00 keyset. Defaults to true if omitted.
     optional bool use_keyset_v2 = 4;
+    // Absolute expiry as seconds since the UNIX epoch. Omit for a keyset
+    // that never expires.
     optional uint64 final_expiry = 5;
 }
 
+// Describes the keyset the mint activated. On failure a gRPC error status is
+// returned instead.
 message RotateNextKeysetResponse {
+    // Hex-encoded ID of the new active keyset.
     string id = 1;
+    // Currency unit the keyset signs, normalized to lowercase (e.g. a
+    // request of "SAT" returns "sat").
     string unit = 2;
+    // Token denominations the new keyset can sign.
     repeated uint64 amounts = 3;
+    // Input fee per input, in parts per thousand, applied to this keyset.
     uint64 input_fee_ppk = 4;
 }

--- a/crates/cdk-mint-rpc/src/proto/keyset.proto
+++ b/crates/cdk-mint-rpc/src/proto/keyset.proto
@@ -9,9 +9,10 @@ service KeysetService {
 }
 
 message RotateNextKeysetRequest {
-    // Currency unit the new keyset signs, e.g. "sat". Matched case-
-    // insensitively. A unit the mint cannot derive a keyset for fails with
-    // gRPC status INVALID_ARGUMENT.
+    // Currency unit the new keyset signs, e.g. "sat". Known units are
+    // matched case-insensitively; custom units are used as provided
+    // (whitespace-trimmed). A unit the mint cannot derive a keyset for
+    // fails with gRPC status INVALID_ARGUMENT.
     string unit = 1;
     // Token denominations the keyset can sign, e.g. [1, 2, 4, 8, 16]. If
     // empty, the amounts of the currently active keyset for this unit are

--- a/crates/cdk-mint-rpc/src/proto/mod.rs
+++ b/crates/cdk-mint-rpc/src/proto/mod.rs
@@ -2,6 +2,11 @@
 
 tonic::include_proto!("cdk_mint_management_v1");
 
+/// Keyset administration service
+pub mod keyset {
+    tonic::include_proto!("cdk_mint_keyset_v1");
+}
+
 mod server;
 
 /// Protocol version for gRPC Mint RPC communication

--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use cdk::mint::{Mint, MintQuote};
+use cdk::mint::{Mint, MintKeySetInfo, MintQuote};
 use cdk::nuts::nut04::MintMethodSettings;
 use cdk::nuts::nut05::MeltMethodSettings;
 use cdk::nuts::{CurrencyUnit, MintQuoteState, PaymentMethod};
@@ -19,6 +19,7 @@ use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
 use tonic::{Request, Response, Status};
 
 use crate::cdk_mint_server::{CdkMint, CdkMintServer};
+use crate::keyset::keyset_service_server::{KeysetService, KeysetServiceServer};
 use crate::{
     ContactInfo, GetInfoRequest, GetInfoResponse, GetQuoteTtlRequest, GetQuoteTtlResponse,
     RotateNextKeysetRequest, RotateNextKeysetResponse, UpdateContactRequest,
@@ -136,25 +137,40 @@ impl MintRPCServer {
                     .identity(server_identity)
                     .client_ca_root(client_ca_cert);
 
-                Server::builder().tls_config(tls_config)?.add_service(
-                    CdkMintServer::with_interceptor(
+                Server::builder()
+                    .tls_config(tls_config)?
+                    .add_service(CdkMintServer::with_interceptor(
                         self.clone(),
                         create_version_check_interceptor(
                             cdk_common::grpc::VERSION_HEADER,
                             cdk_common::MINT_RPC_PROTOCOL_VERSION,
                         ),
-                    ),
-                )
+                    ))
+                    .add_service(KeysetServiceServer::with_interceptor(
+                        self.clone(),
+                        create_version_check_interceptor(
+                            cdk_common::grpc::VERSION_HEADER,
+                            cdk_common::MINT_RPC_PROTOCOL_VERSION,
+                        ),
+                    ))
             }
             None => {
                 tracing::warn!("No valid TLS configuration found, starting insecure server");
-                Server::builder().add_service(CdkMintServer::with_interceptor(
-                    self.clone(),
-                    create_version_check_interceptor(
-                        cdk_common::grpc::VERSION_HEADER,
-                        cdk_common::MINT_RPC_PROTOCOL_VERSION,
-                    ),
-                ))
+                Server::builder()
+                    .add_service(CdkMintServer::with_interceptor(
+                        self.clone(),
+                        create_version_check_interceptor(
+                            cdk_common::grpc::VERSION_HEADER,
+                            cdk_common::MINT_RPC_PROTOCOL_VERSION,
+                        ),
+                    ))
+                    .add_service(KeysetServiceServer::with_interceptor(
+                        self.clone(),
+                        create_version_check_interceptor(
+                            cdk_common::grpc::VERSION_HEADER,
+                            cdk_common::MINT_RPC_PROTOCOL_VERSION,
+                        ),
+                    ))
             }
         };
 
@@ -185,6 +201,30 @@ impl MintRPCServer {
 
         tracing::info!("Mint rpc server stopped");
         Ok(())
+    }
+
+    /// Rotates to the next keyset for the given unit
+    ///
+    /// Shared by the legacy [`CdkMint`] service and [`KeysetService`] while
+    /// both are served.
+    async fn rotate_keyset(
+        &self,
+        unit: CurrencyUnit,
+        amounts: Vec<u64>,
+        input_fee_ppk: Option<u64>,
+        use_keyset_v2: Option<bool>,
+        final_expiry: Option<u64>,
+    ) -> Result<MintKeySetInfo, Status> {
+        self.mint
+            .rotate_keyset(
+                unit,
+                amounts,
+                input_fee_ppk.unwrap_or(0),
+                use_keyset_v2.unwrap_or(true),
+                final_expiry,
+            )
+            .await
+            .map_err(|_| Status::invalid_argument("Could not rotate keyset".to_string()))
     }
 }
 
@@ -802,21 +842,48 @@ impl CdkMint for MintRPCServer {
         let unit = CurrencyUnit::from_str(&request.unit)
             .map_err(|_| Status::invalid_argument("Invalid unit".to_string()))?;
 
-        let amounts = request.amounts;
-
         let keyset_info = self
-            .mint
             .rotate_keyset(
                 unit,
-                amounts,
-                request.input_fee_ppk.unwrap_or(0),
-                request.use_keyset_v2.unwrap_or(true),
+                request.amounts,
+                request.input_fee_ppk,
+                request.use_keyset_v2,
                 request.final_expiry,
             )
-            .await
-            .map_err(|_| Status::invalid_argument("Could not rotate keyset".to_string()))?;
+            .await?;
 
         Ok(Response::new(RotateNextKeysetResponse {
+            id: keyset_info.id.to_string(),
+            unit: keyset_info.unit.to_string(),
+            amounts: keyset_info.amounts,
+            input_fee_ppk: keyset_info.input_fee_ppk,
+        }))
+    }
+}
+
+#[tonic::async_trait]
+impl KeysetService for MintRPCServer {
+    /// Rotates to the next keyset for the specified currency unit
+    async fn rotate_next_keyset(
+        &self,
+        request: Request<crate::keyset::RotateNextKeysetRequest>,
+    ) -> Result<Response<crate::keyset::RotateNextKeysetResponse>, Status> {
+        let request = request.into_inner();
+
+        let unit = CurrencyUnit::from_str(&request.unit)
+            .map_err(|_| Status::invalid_argument("Invalid unit".to_string()))?;
+
+        let keyset_info = self
+            .rotate_keyset(
+                unit,
+                request.amounts,
+                request.input_fee_ppk,
+                request.use_keyset_v2,
+                request.final_expiry,
+            )
+            .await?;
+
+        Ok(Response::new(crate::keyset::RotateNextKeysetResponse {
             id: keyset_info.id.to_string(),
             unit: keyset_info.unit.to_string(),
             amounts: keyset_info.amounts,
@@ -922,6 +989,30 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.into_inner().tos_url.unwrap(), tos);
+    }
+
+    #[tokio::test]
+    async fn test_keyset_service_rotate_next_keyset() {
+        let server = create_test_rpc_server().await;
+
+        let response = KeysetService::rotate_next_keyset(
+            &server,
+            Request::new(crate::keyset::RotateNextKeysetRequest {
+                unit: "sat".to_string(),
+                amounts: vec![1, 2, 4, 8],
+                input_fee_ppk: Some(1),
+                use_keyset_v2: Some(true),
+                final_expiry: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let response = response.into_inner();
+        assert!(!response.id.is_empty());
+        assert_eq!(response.unit, "sat");
+        assert_eq!(response.amounts, vec![1, 2, 4, 8]);
+        assert_eq!(response.input_fee_ppk, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Description

This PR begins splitting the monolithic `CdkMint` mint-management gRPC service into focused, per-domain services. It introduces the first one, `KeysetService` (package `cdk_mint_keyset_v1`), which exposes `RotateNextKeyset`.

The new service is registered **alongside** the existing `CdkMint` service on the same endpoint (additive dual-serve), so existing RPC clients are unaffected and the mint RPC protocol version is unchanged (`1.0.0`). The `cdk-mint-cli rotate-next-keyset` command now targets the new service.

-----

### Notes to the reviewers

- **First of a planned per-service split.** Follow-up PRs move the remaining domains (quotes, payment methods, mint info) onto their own services the same way. Doing it additively means every intermediate release keeps the legacy `CdkMint` service working; a later PR removes the legacy service and bumps the protocol version — this PR is not a breaking change.
- **No behavior change to the legacy path.** The rotation logic was extracted into an inherent `MintRPCServer::rotate_keyset` method that both the legacy `CdkMint` impl and the new `KeysetService` impl delegate to.
- **Naming/layout follows existing house style.** Package `cdk_mint_keyset_v1` mirrors the existing `cdk_mint_management_v1`, and the new proto lives beside the legacy one in `src/proto/`. Proto lint / breaking-change CI (buf) is intentionally deferred to a follow-up PR to keep this one focused.
- The version-check interceptor is applied to the new service as well.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

- `cdk-mint-cli rotate-next-keyset` now calls the new `KeysetService` instead of `CdkMint`.

#### ADDED

- `KeysetService` gRPC service (`cdk_mint_keyset_v1`, `RotateNextKeyset`), served alongside the existing `CdkMint` management service as the first step of a per-domain split.

#### REMOVED

- None.

#### FIXED

- None.

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`) — N/A, no Wallet API change