### PR TITLE
Extract a reusable stream supervisor for long-lived subscriptions

### DIFF
--- a/crates/cdk-common/Cargo.toml
+++ b/crates/cdk-common/Cargo.toml
@@ -51,7 +51,7 @@ tonic = { workspace = true, optional = true }
 cdk-http-client = { workspace = true, default-features = false, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1", default-features = false, features = ["rt", "rt-multi-thread", "macros", "test-util", "sync"] }
+tokio = { version = "1", default-features = false, features = ["rt", "rt-multi-thread", "macros", "test-util", "sync", "time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { workspace = true, features = ["js"], optional = true }

--- a/crates/cdk-common/src/lib.rs
+++ b/crates/cdk-common/src/lib.rs
@@ -36,6 +36,7 @@ pub mod payment;
 pub mod pub_sub;
 #[cfg(feature = "mint")]
 pub mod state;
+pub mod stream;
 pub mod subscription;
 #[cfg(feature = "wallet")]
 pub mod wallet;

--- a/crates/cdk-common/src/stream.rs
+++ b/crates/cdk-common/src/stream.rs
@@ -1,0 +1,452 @@
+//! Supervision for long-lived streaming subscriptions.
+//!
+//! [`SupervisedStream`] owns the reconnect, backoff, and shutdown loop that
+//! every consumer of a long-lived stream (a gRPC server-stream, a payment
+//! backend's event stream) would otherwise hand-roll. It is transport-agnostic:
+//! the implementor supplies how to open a fresh stream and how to handle each
+//! item, holding its connection state as fields rather than cloning it into
+//! per-call closures.
+
+use std::fmt;
+use std::future::Future;
+
+use futures::{pin_mut, Stream, StreamExt};
+
+/// Capped exponential backoff for [`SupervisedStream`] reconnect attempts.
+///
+/// Only consecutive connect failures grow the delay; a successful connect resets
+/// it. So an endpoint that keeps refusing is backed off exponentially, while one
+/// that recovers is not held to a delay earned by earlier failures.
+#[derive(Debug, Clone, Copy)]
+pub struct BackoffPolicy {
+    /// Delay before the first reconnect, and the floor a successful connect
+    /// resets the growing backoff to. Must be non-zero, else the doubling
+    /// (`0 * 2 == 0`) never grows and reconnects busy-loop.
+    pub initial_connect_backoff: std::time::Duration,
+    /// Cap on the delay while backing off. Must be at least `initial`.
+    pub max_connect_backoff: std::time::Duration,
+}
+
+/// A supervised, self-reconnecting streaming subscription.
+///
+/// Implementors own the connection state (clients, channels, publishers) as
+/// fields, so the reconnect/backoff/shutdown loop can hand each item to
+/// [`on_message`](Self::on_message) without the per-item state-cloning a
+/// closure-based supervisor forces. The provided [`supervise`](Self::supervise)
+/// method owns that loop; an implementor supplies only how to connect, how to
+/// handle an item, and (optionally) how to tear down.
+#[async_trait::async_trait]
+pub trait SupervisedStream: Send {
+    /// Item the stream yields and [`on_message`](Self::on_message) consumes.
+    type Item: Send;
+    /// Error a failed connect attempt yields. Logged, then retried.
+    type ConnectError: fmt::Display + Send;
+    /// Error the stream may yield per item. Logged, then reconnected.
+    type StreamError: fmt::Display + Send;
+    /// The stream a successful [`connect`](Self::connect) opens.
+    type Stream: Stream<Item = Result<Self::Item, Self::StreamError>> + Send;
+
+    /// Names this subscription in the supervisor's reconnect/close logs.
+    fn name(&self) -> &str;
+
+    /// Backoff policy for reconnect attempts.
+    fn backoff_policy(&self) -> BackoffPolicy;
+
+    /// Open a fresh stream of items.
+    async fn connect(&mut self) -> Result<Self::Stream, Self::ConnectError>;
+
+    /// Handle one delivered item. Awaited to completion, so a slow handler
+    /// holds the read loop; offload work that must not block it.
+    async fn on_message(&mut self, item: Self::Item);
+
+    /// Teardown run once before [`supervise`](Self::supervise) returns, on every
+    /// exit path. Cancel tokens or release resources here.
+    async fn on_shutdown(&mut self) {}
+
+    /// Keep the subscription alive across reconnects until `shutdown` resolves.
+    ///
+    /// Every item [`connect`](Self::connect) yields is handed to
+    /// [`on_message`](Self::on_message). Reconnect timing follows
+    /// [`BackoffPolicy`]: an opened stream that later closes or errors reconnects
+    /// at the floor, since the connection itself was healthy.
+    ///
+    /// `shutdown` stops the supervisor promptly whenever it is waiting: to
+    /// connect, for the next item, or during a backoff. It does not interrupt an
+    /// in-flight `on_message`. [`on_shutdown`](Self::on_shutdown) runs on every
+    /// exit path.
+    async fn supervise<S>(&mut self, shutdown: S)
+    where
+        S: Future<Output = ()> + Send,
+    {
+        // Clamp a degenerate policy rather than trusting the implementor: a
+        // zero `initial` would busy-loop (`0 * 2 == 0`) and a `max` below
+        // `initial` would clamp below the floor.
+        let policy = self.backoff_policy();
+        let initial = policy
+            .initial_connect_backoff
+            .max(std::time::Duration::from_millis(1));
+        let max = policy.max_connect_backoff.max(initial);
+
+        pin_mut!(shutdown);
+        let mut backoff = initial;
+
+        'outer: loop {
+            let connect_result = tokio::select! {
+                biased;
+                _ = &mut shutdown => break 'outer,
+                result = self.connect() => result,
+            };
+
+            let wait = match connect_result {
+                Ok(stream) => {
+                    // Reset on a healthy connection, not per message, so an
+                    // idle-but-open stream that later drops still reconnects at
+                    // the floor.
+                    backoff = initial;
+                    pin_mut!(stream);
+                    loop {
+                        let next = tokio::select! {
+                            biased;
+                            _ = &mut shutdown => break 'outer,
+                            next = stream.next() => next,
+                        };
+
+                        match next {
+                            Some(Ok(item)) => self.on_message(item).await,
+                            Some(Err(err)) => {
+                                tracing::warn!(name = self.name(), "Stream error: {err}");
+                                break;
+                            }
+                            None => {
+                                tracing::debug!(name = self.name(), "Stream closed by the server");
+                                break;
+                            }
+                        }
+                    }
+                    // An opened stream closed or errored. Wait the floor, not
+                    // the growing backoff: the connection was working.
+                    initial
+                }
+                Err(err) => {
+                    tracing::warn!(name = self.name(), "Could not open stream: {err}");
+                    // Wait the current backoff, then grow it. Saturating so a
+                    // large `initial` cannot overflow; `max` clamps it back down.
+                    let wait = backoff;
+                    backoff = backoff.saturating_mul(2).min(max);
+                    wait
+                }
+            };
+
+            // Shutdown during the wait ends the loop immediately.
+            tokio::select! {
+                biased;
+                _ = &mut shutdown => break 'outer,
+                _ = tokio::time::sleep(wait) => {}
+            }
+        }
+
+        self.on_shutdown().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use futures::stream;
+    use tokio::sync::Notify;
+    use tokio::time::Instant;
+
+    use super::*;
+
+    /// Stream error type used across the tests. `&'static str` is `Display`.
+    type TestErr = &'static str;
+    /// Concrete stream type each `connect` returns, so the `Ok` and `Err` arms
+    /// share one type without boxing.
+    type ItemStream = stream::Iter<std::vec::IntoIter<Result<u32, TestErr>>>;
+    /// One scripted connect outcome: a failed connect, or a stream of items.
+    type ConnectStep = Result<Vec<Result<u32, TestErr>>, TestErr>;
+
+    /// A scripted [`SupervisedStream`] implementor. Each connect consumes the
+    /// next `steps` entry (the last entry repeats), and the stop conditions fire
+    /// `shutdown` from `connect` or `on_message` so a test drives the loop to a
+    /// deterministic end.
+    struct Harness {
+        policy: BackoffPolicy,
+        steps: Vec<ConnectStep>,
+        shutdown: Arc<Notify>,
+        connects: Arc<AtomicUsize>,
+        received: Arc<Mutex<Vec<u32>>>,
+        shutdown_ran: Arc<AtomicBool>,
+        /// Fire shutdown from `connect` once this many attempts have started.
+        stop_after_connects: Option<usize>,
+        /// Fire shutdown from `on_message` when this item arrives.
+        stop_on_item: Option<u32>,
+        /// Fire shutdown from `on_message` once this many items are received.
+        stop_at_len: Option<usize>,
+    }
+
+    impl Harness {
+        fn new(policy: BackoffPolicy, steps: Vec<ConnectStep>) -> Self {
+            Self {
+                policy,
+                steps,
+                shutdown: Arc::new(Notify::new()),
+                connects: Arc::new(AtomicUsize::new(0)),
+                received: Arc::new(Mutex::new(Vec::new())),
+                shutdown_ran: Arc::new(AtomicBool::new(false)),
+                stop_after_connects: None,
+                stop_on_item: None,
+                stop_at_len: None,
+            }
+        }
+    }
+
+    // The connect counter is bumped inside `connect`'s body, not in the loop.
+    // `tokio::select!` evaluates the `self.connect()` branch expression eagerly
+    // every iteration, even on the pass where `shutdown` wins, so only the poll
+    // of the future (running the body) marks a real connection attempt.
+    #[async_trait::async_trait]
+    impl SupervisedStream for Harness {
+        type Item = u32;
+        type ConnectError = TestErr;
+        type StreamError = TestErr;
+        type Stream = ItemStream;
+
+        fn name(&self) -> &str {
+            "test"
+        }
+
+        fn backoff_policy(&self) -> BackoffPolicy {
+            self.policy
+        }
+
+        async fn connect(&mut self) -> Result<Self::Stream, TestErr> {
+            let n = self.connects.fetch_add(1, Ordering::SeqCst);
+            if let Some(k) = self.stop_after_connects {
+                if n + 1 >= k {
+                    self.shutdown.notify_one();
+                }
+            }
+            let idx = n.min(self.steps.len() - 1);
+            self.steps[idx].clone().map(stream::iter)
+        }
+
+        async fn on_message(&mut self, item: u32) {
+            let mut v = self.received.lock().expect("lock");
+            v.push(item);
+            if self.stop_on_item == Some(item) {
+                self.shutdown.notify_one();
+            }
+            if self.stop_at_len.is_some_and(|l| v.len() >= l) {
+                self.shutdown.notify_one();
+            }
+        }
+
+        async fn on_shutdown(&mut self) {
+            self.shutdown_ran.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_before_first_connect_never_connects() {
+        let mut h = Harness::new(
+            BackoffPolicy {
+                initial_connect_backoff: Duration::from_millis(10),
+                max_connect_backoff: Duration::from_secs(1),
+            },
+            vec![Ok(vec![])],
+        );
+        // Already signalled: the very first select must pick shutdown.
+        h.shutdown.notify_one();
+        let connects = Arc::clone(&h.connects);
+        let shutdown = Arc::clone(&h.shutdown);
+
+        h.supervise(async move { shutdown.notified().await }).await;
+
+        assert_eq!(connects.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn forwards_items_and_reconnects_until_shutdown() {
+        // Each connection yields two items, so reaching four proves a reconnect.
+        let mut h = Harness::new(
+            BackoffPolicy {
+                initial_connect_backoff: Duration::from_millis(10),
+                max_connect_backoff: Duration::from_secs(1),
+            },
+            vec![Ok(vec![Ok(0), Ok(1)]), Ok(vec![Ok(2), Ok(3)])],
+        );
+        h.stop_at_len = Some(4);
+        let connects = Arc::clone(&h.connects);
+        let received = Arc::clone(&h.received);
+        let shutdown = Arc::clone(&h.shutdown);
+
+        h.supervise(async move { shutdown.notified().await }).await;
+
+        assert_eq!(*received.lock().expect("lock"), vec![0, 1, 2, 3]);
+        assert_eq!(connects.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn item_error_reconnects_and_skips_rest_of_stream() {
+        // The error breaks the first stream before `11` is reached.
+        let mut h = Harness::new(
+            BackoffPolicy {
+                initial_connect_backoff: Duration::from_millis(10),
+                max_connect_backoff: Duration::from_secs(1),
+            },
+            vec![
+                Ok(vec![Ok(10), Err("mid-stream"), Ok(11)]),
+                Ok(vec![Ok(20)]),
+            ],
+        );
+        h.stop_on_item = Some(20);
+        let received = Arc::clone(&h.received);
+        let shutdown = Arc::clone(&h.shutdown);
+
+        h.supervise(async move { shutdown.notified().await }).await;
+
+        // `11` is never delivered: the error terminated that stream first.
+        assert_eq!(*received.lock().expect("lock"), vec![10, 20]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn opened_stream_error_waits_floor_not_grown_backoff() {
+        // Two connect failures grow the backoff, then a stream opens and
+        // immediately errors. The successful connect resets the backoff, so the
+        // wait after the stream error is the fixed floor, not the grown delay:
+        // only connect failures back off, an opened stream that errors does not.
+        let mut h = Harness::new(
+            BackoffPolicy {
+                initial_connect_backoff: Duration::from_millis(100),
+                max_connect_backoff: Duration::from_secs(10),
+            },
+            vec![
+                // Fails: sleep 100ms floor, backoff doubles to 200ms.
+                Err("connect refused"),
+                // Fails: sleep 200ms, backoff doubles to 400ms.
+                Err("connect refused"),
+                // Opens then errors: reset to the floor, then wait the fixed
+                // 100ms, not the 400ms the failures had reached.
+                Ok(vec![Err("mid-stream")]),
+            ],
+        );
+        h.stop_after_connects = Some(4);
+        let attempts = Arc::clone(&h.connects);
+        let shutdown = Arc::clone(&h.shutdown);
+        let start = Instant::now();
+
+        h.supervise(async move { shutdown.notified().await }).await;
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 4);
+        // 100 (fail) + 200 (fail) + 100 (floor after the stream error) = 400ms.
+        // If a stream error grew the backoff, the third wait would have been
+        // 400ms, for 700ms total.
+        assert_eq!(start.elapsed(), Duration::from_millis(400));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn connect_failures_back_off_exponentially() {
+        let mut h = Harness::new(
+            BackoffPolicy {
+                initial_connect_backoff: Duration::from_millis(100),
+                max_connect_backoff: Duration::from_millis(400),
+            },
+            vec![Err("connect refused")],
+        );
+        // Stop after the fourth failed attempt.
+        h.stop_after_connects = Some(4);
+        let attempts = Arc::clone(&h.connects);
+        let shutdown = Arc::clone(&h.shutdown);
+        let start = Instant::now();
+
+        h.supervise(async move { shutdown.notified().await }).await;
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 4);
+        // Backoff sleeps precede each doubling, so the delays between the four
+        // attempts are 100 + 200 + 400 (capped) = 700ms. The paused clock only
+        // advances for the elapsed sleeps.
+        assert_eq!(start.elapsed(), Duration::from_millis(700));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn successful_connect_resets_backoff_even_without_messages() {
+        // Two connect failures grow the backoff, then a stream opens but never
+        // delivers a message before closing. The reset happens on the successful
+        // connect, not on a delivery, so the disconnect waits the 100ms floor
+        // rather than the elevated backoff.
+        let mut h = Harness::new(
+            BackoffPolicy {
+                initial_connect_backoff: Duration::from_millis(100),
+                max_connect_backoff: Duration::from_secs(10),
+            },
+            vec![
+                // Fails: sleep 100ms floor, backoff doubles to 200ms.
+                Err("connect refused"),
+                // Fails: sleep 200ms, backoff doubles to 400ms.
+                Err("connect refused"),
+                // Opens but yields nothing and closes: reset to the floor, then
+                // wait the fixed 100ms, not the 400ms the failures had reached.
+                Ok(vec![]),
+            ],
+        );
+        h.stop_after_connects = Some(4);
+        let attempts = Arc::clone(&h.connects);
+        let shutdown = Arc::clone(&h.shutdown);
+        let start = Instant::now();
+
+        h.supervise(async move { shutdown.notified().await }).await;
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 4);
+        // 100 (fail) + 200 (fail) + 100 (floor after the empty stream) = 400ms.
+        // Under a per-failure backoff that ignored the successful connect, the
+        // third wait would have been 400ms, for 700ms total.
+        assert_eq!(start.elapsed(), Duration::from_millis(400));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn max_below_initial_is_clamped_to_the_floor() {
+        // `max` below `initial` is a caller mistake; the supervisor clamps it up
+        // to `initial` so the delay never drops below the floor.
+        let mut h = Harness::new(
+            BackoffPolicy {
+                initial_connect_backoff: Duration::from_millis(200),
+                max_connect_backoff: Duration::from_millis(100),
+            },
+            vec![Err("connect refused")],
+        );
+        // Stop after the third failed attempt, so two backoff sleeps elapse.
+        h.stop_after_connects = Some(3);
+        let attempts = Arc::clone(&h.connects);
+        let shutdown = Arc::clone(&h.shutdown);
+        let start = Instant::now();
+
+        h.supervise(async move { shutdown.notified().await }).await;
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        // Both sleeps are the 200ms floor: without the clamp the second would be
+        // `min(400, 100) = 100ms`, giving 300ms total instead of 400ms.
+        assert_eq!(start.elapsed(), Duration::from_millis(400));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn on_shutdown_runs_after_supervise_returns() {
+        let mut h = Harness::new(
+            BackoffPolicy {
+                initial_connect_backoff: Duration::from_millis(10),
+                max_connect_backoff: Duration::from_secs(1),
+            },
+            vec![Ok(vec![])],
+        );
+        h.shutdown.notify_one();
+        let shutdown_ran = Arc::clone(&h.shutdown_ran);
+        let shutdown = Arc::clone(&h.shutdown);
+
+        h.supervise(async move { shutdown.notified().await }).await;
+
+        assert!(shutdown_ran.load(Ordering::SeqCst));
+    }
+}

--- a/crates/cdk-signatory/src/proto/client.rs
+++ b/crates/cdk-signatory/src/proto/client.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use cdk_common::error::Error;
 use cdk_common::grpc::{VersionInterceptor, VERSION_SIGNATORY_HEADER};
+use cdk_common::stream::{BackoffPolicy, SupervisedStream};
 use cdk_common::{BlindSignature, BlindedMessage, Proof};
 use tokio::sync::watch;
 use tonic::codegen::InterceptedService;
@@ -89,10 +91,25 @@ impl SignatoryRpcClient {
         let initial = fetch_keysets(&mut client).await?;
         let (keyset_updates_tx, keyset_updates) = watch::channel(initial);
 
-        // Keep the keyset watch fresh in the background. On every (re)connect the
-        // server sends the current snapshot first, so a dropped connection
-        // re-injects the latest keysets on reconnect.
-        tokio::spawn(keyset_subscription_loop(client.clone(), keyset_updates_tx));
+        // Keep the keyset watch fresh in the background. `SupervisedStream` owns
+        // the reconnect/backoff/shutdown machinery; the task stops once every
+        // watch receiver is dropped, which `closed()` observes. On every
+        // (re)connect the server sends the current snapshot first, so a dropped
+        // connection re-injects the latest keysets.
+        //
+        // One `Arc` handle publishes from inside the subscription; a second
+        // drives the shutdown future. `Sender::closed` keys on receiver drop
+        // (senders do not matter), so both handles observe the same shutdown.
+        let keyset_updates_tx = Arc::new(keyset_updates_tx);
+        let shutdown_tx = Arc::clone(&keyset_updates_tx);
+        let subscription_client = client.clone();
+        tokio::spawn(async move {
+            let mut subscription = KeysetSubscription {
+                client: subscription_client,
+                keyset_updates_tx,
+            };
+            subscription.supervise(shutdown_tx.closed()).await;
+        });
 
         Ok(Self {
             client,
@@ -135,60 +152,46 @@ fn keys_response_into_keysets(
         .try_into()
 }
 
-/// Subscribe to the signatory keyset stream, forwarding every snapshot into the
-/// watch channel and reconnecting with exponential backoff on failure.
-///
-/// The loop exits once every receiver has been dropped (the mint is gone).
-async fn keyset_subscription_loop(
-    mut client: InnerClient,
-    updates: watch::Sender<SignatoryKeysets>,
-) {
-    let mut backoff = Duration::from_secs(1);
+/// Background subscription that keeps the keyset watch fresh from the signatory.
+struct KeysetSubscription {
+    client: InnerClient,
+    keyset_updates_tx: Arc<watch::Sender<SignatoryKeysets>>,
+}
 
-    loop {
-        if updates.is_closed() {
-            break;
+#[async_trait::async_trait]
+impl SupervisedStream for KeysetSubscription {
+    type Item = super::KeysResponse;
+    type ConnectError = tonic::Status;
+    type StreamError = tonic::Status;
+    type Stream = tonic::Streaming<super::KeysResponse>;
+
+    fn name(&self) -> &str {
+        "signatory keysets"
+    }
+
+    fn backoff_policy(&self) -> BackoffPolicy {
+        BackoffPolicy {
+            initial_connect_backoff: Duration::from_secs(1),
+            max_connect_backoff: KEYSET_RECONNECT_MAX_BACKOFF,
         }
+    }
 
-        match client
+    async fn connect(&mut self) -> Result<Self::Stream, tonic::Status> {
+        self.client
             .subscribe_keysets(tonic::Request::new(super::EmptyRequest {}))
             .await
-        {
-            Ok(response) => {
-                backoff = Duration::from_secs(1);
-                let mut stream = response.into_inner();
-                loop {
-                    match stream.message().await {
-                        Ok(Some(message)) => match keys_response_into_keysets(message) {
-                            Ok(keysets) => {
-                                updates.send_replace(keysets);
-                            }
-                            Err(err) => {
-                                tracing::warn!("Invalid keyset update from signatory: {err}");
-                            }
-                        },
-                        Ok(None) => {
-                            tracing::debug!("Signatory closed the keyset stream");
-                            break;
-                        }
-                        Err(status) => {
-                            tracing::warn!("Keyset stream error: {status}");
-                            break;
-                        }
-                    }
-                }
+            .map(tonic::Response::into_inner)
+    }
+
+    async fn on_message(&mut self, message: super::KeysResponse) {
+        match keys_response_into_keysets(message) {
+            Ok(keysets) => {
+                self.keyset_updates_tx.send_replace(keysets);
             }
-            Err(status) => {
-                tracing::warn!("Could not subscribe to signatory keysets: {status}");
+            Err(err) => {
+                tracing::warn!("Invalid keyset update from signatory: {err}");
             }
         }
-
-        if updates.is_closed() {
-            break;
-        }
-
-        tokio::time::sleep(backoff).await;
-        backoff = (backoff * 2).min(KEYSET_RECONNECT_MAX_BACKOFF);
     }
 }
 

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1,6 +1,7 @@
 //! Cashu Mint
 
 use std::collections::HashMap;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -11,10 +12,11 @@ use cdk_common::database::{self, DynMintAuthDatabase, DynMintDatabase};
 use cdk_common::nuts::{BlindSignature, BlindedMessage, CurrencyUnit, Id};
 use cdk_common::payment::{DynMintPayment, WaitPaymentResponse};
 pub use cdk_common::quote_id::QuoteId;
+use cdk_common::stream::{BackoffPolicy, SupervisedStream};
 #[cfg(feature = "prometheus")]
 use cdk_prometheus::MintMetricGuard;
 use cdk_signatory::signatory::{Signatory, SignatoryKeySet, SignatoryKeysets};
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use nut21::ProtectedEndpoint;
 use subscription::PubSubManager;
 use tokio::sync::{watch, Mutex, Notify};
@@ -104,6 +106,113 @@ struct TaskState {
     /// Keyset subscription retained from construction, drained once by the first
     /// `start()`. `None` after it has been taken; a restart re-subscribes.
     keyset_updates: Option<watch::Receiver<SignatoryKeysets>>,
+}
+
+/// Supervised subscription to a single payment processor's event stream.
+///
+/// Holds the state the handlers need as fields, so `on_message` reads
+/// `&self.field` instead of the closure-based supervisor's per-item cloning.
+struct PaymentWaiter {
+    /// Identifies the processor in the supervisor's logs (unit and method).
+    name: String,
+    mint: Arc<Mint>,
+    processor: DynMintPayment,
+    localstore: DynMintDatabase,
+    pubsub_manager: Arc<PubSubManager>,
+}
+
+#[async_trait::async_trait]
+impl SupervisedStream for PaymentWaiter {
+    type Item = cdk_common::payment::Event;
+    // `DynMintPayment::wait_payment_event` fails with `Error`; its stream is
+    // already decoded and never yields a stream-level error, so wrap items in
+    // `Ok` with an `Infallible` error to satisfy the `Result` item contract.
+    type ConnectError = Error;
+    type StreamError = std::convert::Infallible;
+    type Stream = Pin<Box<dyn Stream<Item = Result<Self::Item, Self::StreamError>> + Send>>;
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn backoff_policy(&self) -> BackoffPolicy {
+        // Keep `initial` short so payment-detection latency stays low when a
+        // healthy backend cycles its stream (that fixed floor is the wait after
+        // every close); the cap only throttles a backend that keeps refusing
+        // connections. See `BackoffPolicy` for the full semantics.
+        BackoffPolicy {
+            initial_connect_backoff: Duration::from_millis(250),
+            max_connect_backoff: Duration::from_secs(30),
+        }
+    }
+
+    async fn connect(&mut self) -> Result<Self::Stream, Error> {
+        let stream = self.processor.wait_payment_event().await?;
+        Ok(Box::pin(stream.map(Ok::<_, std::convert::Infallible>)))
+    }
+
+    async fn on_message(&mut self, event: Self::Item) {
+        match event {
+            cdk_common::payment::Event::PaymentReceived(wait_payment_response) => {
+                if let Err(e) = Mint::handle_payment_notification(
+                    &self.localstore,
+                    &self.pubsub_manager,
+                    wait_payment_response,
+                )
+                .await
+                {
+                    tracing::warn!("Payment notification error: {:?}", e);
+                }
+            }
+            cdk_common::payment::Event::PaymentSuccessful { quote_id, details } => {
+                tracing::info!(
+                    "Outgoing payment confirmed for quote {}: status {}",
+                    quote_id,
+                    details.status,
+                );
+
+                if let Err(e) = Mint::handle_successful_melt_payment_event(
+                    &self.mint,
+                    &self.localstore,
+                    &self.pubsub_manager,
+                    &quote_id,
+                    details,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        "Failed to process successful payment event for quote {}: {}",
+                        quote_id,
+                        e
+                    );
+                }
+            }
+            cdk_common::payment::Event::PaymentFailed { quote_id, reason } => {
+                tracing::warn!("Outgoing payment failed for quote {}: {}", quote_id, reason,);
+
+                if let Err(e) = Mint::handle_failed_melt_payment_event(
+                    &self.mint,
+                    &self.localstore,
+                    &self.pubsub_manager,
+                    &quote_id,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        "Failed to process failed payment event for quote {}: {}",
+                        quote_id,
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    async fn on_shutdown(&mut self) {
+        // The loop stopped because shutdown fired; run the teardown the old
+        // inner and outer shutdown arms performed.
+        self.processor.cancel_payment_event_stream();
+    }
 }
 
 impl Mint {
@@ -751,6 +860,7 @@ impl Mint {
             tracing::info!("Starting payment wait task for {:?}", key);
 
             // Clone for the spawned task
+            let name = format!("payment processor {:?} {:?}", key.method, key.unit);
             let mint = Arc::clone(&mint);
             let processor = Arc::clone(processor);
             let localstore = Arc::clone(&localstore);
@@ -759,6 +869,7 @@ impl Mint {
 
             join_set.spawn(async move {
                 let result = Self::wait_for_processor_payments(
+                    name,
                     mint,
                     processor,
                     localstore,
@@ -803,104 +914,23 @@ impl Mint {
     /// Handles payment waiting for a single processor
     #[instrument(skip_all)]
     async fn wait_for_processor_payments(
+        name: String,
         mint: Arc<Mint>,
         processor: DynMintPayment,
         localstore: DynMintDatabase,
         pubsub_manager: Arc<PubSubManager>,
         shutdown: Arc<Notify>,
     ) -> Result<(), Error> {
-        let shutdown_future = shutdown.notified();
-        tokio::pin!(shutdown_future);
-
-        loop {
-            tokio::select! {
-                _ = &mut shutdown_future => {
-                    processor.cancel_payment_event_stream();
-                    break;
-                }
-                result = processor.wait_payment_event() => {
-                    match result {
-                        Ok(mut stream) => {
-                            loop {
-                                tokio::select! {
-                                    _ = &mut shutdown_future => {
-                                        processor.cancel_payment_event_stream();
-                                        return Ok(());
-                                    }
-                                    maybe_event = stream.next() => {
-                                        let Some(event) = maybe_event else {
-                                            break;
-                                        };
-
-                                        match event {
-                                            cdk_common::payment::Event::PaymentReceived(wait_payment_response) => {
-                                                if let Err(e) = Self::handle_payment_notification(
-                                                    &localstore,
-                                                    &pubsub_manager,
-                                                    wait_payment_response,
-                                                ).await {
-                                                    tracing::warn!("Payment notification error: {:?}", e);
-                                                }
-                                            }
-                                            cdk_common::payment::Event::PaymentSuccessful { quote_id, details } => {
-                                                tracing::info!(
-                                                    "Outgoing payment confirmed for quote {}: status {}",
-                                                    quote_id,
-                                                    details.status,
-                                                );
-
-                                                if let Err(e) = Self::handle_successful_melt_payment_event(
-                                                    &mint,
-                                                    &localstore,
-                                                    &pubsub_manager,
-                                                    &quote_id,
-                                                    details,
-                                                )
-                                                .await
-                                                {
-                                                    tracing::warn!(
-                                                        "Failed to process successful payment event for quote {}: {}",
-                                                        quote_id,
-                                                        e
-                                                    );
-                                                }
-                                            }
-                                            cdk_common::payment::Event::PaymentFailed { quote_id, reason } => {
-                                                tracing::warn!(
-                                                    "Outgoing payment failed for quote {}: {}",
-                                                    quote_id,
-                                                    reason,
-                                                );
-
-                                                if let Err(e) = Self::handle_failed_melt_payment_event(
-                                                    &mint,
-                                                    &localstore,
-                                                    &pubsub_manager,
-                                                    &quote_id,
-                                                )
-                                                .await
-                                                {
-                                                    tracing::warn!(
-                                                        "Failed to process failed payment event for quote {}: {}",
-                                                        quote_id,
-                                                        e
-                                                    );
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        Err(e) => {
-                            tracing::warn!("Failed to get payment stream: {}", e);
-                            tokio::time::sleep(Duration::from_secs(5)).await;
-                        }
-                    }
-                }
-            }
-        }
+        let mut waiter = PaymentWaiter {
+            name,
+            mint,
+            processor,
+            localstore,
+            pubsub_manager,
+        };
+        // `supervise` owns the reconnect/backoff/shutdown loop and runs
+        // `on_shutdown` (which cancels the backend stream) on the way out.
+        waiter.supervise(shutdown.notified()).await;
         Ok(())
     }
 


### PR DESCRIPTION
This is a follow-up for #2225

Two consumers of long-lived streams, the signatory keyset subscription and the mint payment-event stream, each carried their own reconnect, backoff, and shutdown loop. The copies had already drifted: one used capped exponential backoff, the other a flat sleep; one keyed shutdown off a dropped watch receiver, the other off a Notify token. That duplication is where the transport supervision should be factored out from the per-payload decoding.

Add cdk_common::stream::supervise_stream, which owns only the reconnect, backoff, and shutdown machinery and is transport-agnostic: the caller supplies a connect closure that opens a fresh stream and an async handler run for each item. It selects the shutdown signal against the connect step, the pending item, and the backoff sleep, so a dead consumer stops the loop promptly instead of lingering on an open stream.  The backoff is capped exponential and resets once a message is delivered, so a healthy connection that later drops reconnects quickly while a failing endpoint is not hammered. BackoffPolicy is clamped defensively (initial forced non-zero, max raised to at least initial) so a degenerate policy cannot busy-loop or invert the cap in any build.

Migrate both callers onto it. The signatory adapter supplies the policy, uses the watch sender's closed() as the shutdown signal, opens the subscription, and republishes each decoded snapshot into the watch. The mint payment loop supplies its Notify-based shutdown, wraps its already-decoded event stream, dispatches each payment event, and runs its stream teardown on the line after the supervisor returns.

One behavior change falls out of the mint migration: the payment loop now waits a short initial delay before every reconnect, including a clean close, where it previously reconnected immediately. The floor stops a backend that accepts, delivers, and instantly drops from spinning in a hot reconnect loop, and it is kept short so payment-detection latency stays low.

Enable tokio's time feature on cdk-common, since the supervisor sleeps between reconnects, and cover the supervisor with tests: shutdown at each await point, item forwarding across reconnects, mid-stream error handling, backoff growth and reset on delivery, and policy clamping.


### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
