### PR TITLE
fix: use atomic usize for better target compatblity

### DIFF
--- a/crates/cdk-common/src/database/mint/test/mod.rs
+++ b/crates/cdk-common/src/database/mint/test/mod.rs
@@ -4,7 +4,7 @@
 //! implementation
 #![allow(clippy::unwrap_used, clippy::missing_panics_doc)]
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 // For derivation path parsing
 use bitcoin::bip32::DerivationPath;
@@ -144,7 +144,7 @@ where
     }
 }
 
-static COUNTER: AtomicU64 = AtomicU64::new(0);
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 /// Returns a unique, random-looking Base62 string (no external crates).
 /// Not cryptographically secure, but great for ids, keys, temp names, etc.

--- a/crates/cdk-common/src/database/wallet/test/mod.rs
+++ b/crates/cdk-common/src/database/wallet/test/mod.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use bitcoin::bip32::DerivationPath;
 use cashu::nut00::KnownMethod;
@@ -23,7 +23,7 @@ use crate::wallet::{
     TransactionDirection, WalletSaga, WalletSagaState,
 };
 
-static COUNTER: AtomicU64 = AtomicU64::new(0);
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 /// Generate a unique test ID
 fn unique_id() -> String {


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

closes: https://github.com/cashubtc/cdk/issues/2257

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
