### PR TITLE
test: use UUIDv7 for database fixture IDs

### DIFF
--- a/crates/cdk-common/src/database/mint/test/mint.rs
+++ b/crates/cdk-common/src/database/mint/test/mint.rs
@@ -7,11 +7,14 @@ use cashu::nut00::KnownMethod;
 use cashu::quote_id::QuoteId;
 use cashu::{Amount, BlindSignature, CurrencyUnit, Id, SecretKey};
 
-use crate::database::mint::test::unique_string;
 use crate::database::mint::{Database, Error, KeysDatabase};
 use crate::database::MintSignaturesDatabase;
 use crate::mint::{MeltPaymentRequest, MeltQuote, MintQuote, Operation};
 use crate::payment::PaymentIdentifier;
+
+fn unique_string() -> String {
+    uuid::Uuid::now_v7().to_string()
+}
 
 /// Add a mint quote
 pub async fn add_mint_quote<DB>(db: DB)
@@ -892,8 +895,6 @@ pub async fn get_all_mint_quotes<DB>(db: DB)
 where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
-    use crate::database::mint::test::unique_string;
-
     let quote1 = MintQuote::new(
         None,
         unique_string(),
@@ -1002,8 +1003,6 @@ pub async fn get_mint_quote_by_request<DB>(db: DB)
 where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
-    use crate::database::mint::test::unique_string;
-
     let request = unique_string();
     let mint_quote = MintQuote::new(
         None,
@@ -1041,8 +1040,6 @@ pub async fn get_mint_quote_by_request_lookup_id<DB>(db: DB)
 where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
-    use crate::database::mint::test::unique_string;
-
     let lookup_id = PaymentIdentifier::CustomId(unique_string());
     let mint_quote = MintQuote::new(
         None,
@@ -1158,8 +1155,6 @@ pub async fn increment_mint_quote_amount_paid<DB>(db: DB)
 where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
-    use crate::database::mint::test::unique_string;
-
     let mint_quote = MintQuote::new(
         None,
         unique_string(),
@@ -1260,8 +1255,6 @@ pub async fn increment_mint_quote_amount_issued<DB>(db: DB)
 where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
-    use crate::database::mint::test::unique_string;
-
     let mint_quote = MintQuote::new(
         None,
         unique_string(),
@@ -1346,8 +1339,6 @@ pub async fn get_mint_quote_in_transaction<DB>(db: DB)
 where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
-    use crate::database::mint::test::unique_string;
-
     let mint_quote = MintQuote::new(
         None,
         unique_string(),
@@ -1423,8 +1414,6 @@ pub async fn get_mint_quote_by_request_in_transaction<DB>(db: DB)
 where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
-    use crate::database::mint::test::unique_string;
-
     let request = unique_string();
     let mint_quote = MintQuote::new(
         None,
@@ -1464,8 +1453,6 @@ pub async fn get_mint_quote_by_request_lookup_id_in_transaction<DB>(db: DB)
 where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
-    use crate::database::mint::test::unique_string;
-
     let lookup_id = PaymentIdentifier::CustomId(unique_string());
     let mint_quote = MintQuote::new(
         None,
@@ -1542,8 +1529,6 @@ pub async fn get_melt_quotes_by_request_lookup_id<DB>(db: DB)
 where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
-    use crate::database::mint::test::unique_string;
-
     let lookup_id = PaymentIdentifier::CustomId(unique_string());
 
     let quote1 = MeltQuote::new(
@@ -1611,8 +1596,6 @@ pub async fn lock_melt_quote_and_related<DB>(db: DB)
 where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
-    use crate::database::mint::test::unique_string;
-
     let lookup_id = PaymentIdentifier::CustomId(unique_string());
 
     let quote1 = MeltQuote::new(
@@ -1690,8 +1673,6 @@ pub async fn reject_duplicate_payment_ids<DB>(db: DB)
 where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
-    use crate::database::mint::test::unique_string;
-
     let mint_quote = MintQuote::new(
         None,
         unique_string(),
@@ -1787,8 +1768,6 @@ pub async fn modify_mint_quote_after_loading_succeeds<DB>(db: DB)
 where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
-    use crate::database::mint::test::unique_string;
-
     let mint_quote = MintQuote::new(
         None,
         unique_string(),
@@ -1849,8 +1828,6 @@ pub async fn get_mint_quotes_by_ids<DB>(db: DB)
 where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
-    use crate::database::mint::test::unique_string;
-
     let quote1 = MintQuote::new(
         None,
         unique_string(),

--- a/crates/cdk-common/src/database/mint/test/mod.rs
+++ b/crates/cdk-common/src/database/mint/test/mod.rs
@@ -4,12 +4,10 @@
 //! implementation
 #![allow(clippy::unwrap_used, clippy::missing_panics_doc)]
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 // For derivation path parsing
 use bitcoin::bip32::DerivationPath;
 use cashu::CurrencyUnit;
-use web_time::{SystemTime, UNIX_EPOCH};
 
 use super::*;
 use crate::common::IssuerVersion;
@@ -142,45 +140,6 @@ where
         let keys = db.kv_list("test_namespace", "sub_namespace").await.unwrap();
         assert_eq!(keys, vec!["key1"]);
     }
-}
-
-static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// Returns a unique, random-looking Base62 string (no external crates).
-/// Not cryptographically secure, but great for ids, keys, temp names, etc.
-fn unique_string() -> String {
-    // 1) high-res timestamp (nanos since epoch)
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-
-    // 2) per-process monotonic counter to avoid collisions in the same instant
-    let n = COUNTER.fetch_add(1, Ordering::Relaxed) as u128;
-
-    // 3) process id to reduce collision chance across processes
-    let pid = std::process::id() as u128;
-
-    // Mix the components (simple XOR/shift mix; good enough for "random-looking")
-    let mixed = now ^ (pid << 64) ^ (n << 32);
-
-    base62_encode(mixed)
-}
-
-fn base62_encode(mut x: u128) -> String {
-    const ALPHABET: &[u8; 62] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-    if x == 0 {
-        return "0".to_string();
-    }
-    let mut buf = [0u8; 26]; // enough for base62(u128)
-    let mut i = buf.len();
-    while x > 0 {
-        let rem = (x % 62) as usize;
-        x /= 62;
-        i -= 1;
-        buf[i] = ALPHABET[rem];
-    }
-    String::from_utf8_lossy(&buf[i..]).into_owned()
 }
 
 /// Unit test that is expected to be passed for a correct database implementation

--- a/crates/cdk-common/src/database/wallet/test/mod.rs
+++ b/crates/cdk-common/src/database/wallet/test/mod.rs
@@ -7,13 +7,11 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use bitcoin::bip32::DerivationPath;
 use cashu::nut00::KnownMethod;
 use cashu::secret::Secret;
 use cashu::{Amount, CurrencyUnit, MeltQuoteState, MintQuoteState, SecretKey};
-use web_time::{SystemTime, UNIX_EPOCH};
 
 use super::*;
 use crate::mint_url::MintUrl;
@@ -23,16 +21,9 @@ use crate::wallet::{
     TransactionDirection, WalletSaga, WalletSagaState,
 };
 
-static COUNTER: AtomicU64 = AtomicU64::new(0);
-
 /// Generate a unique test ID
 fn unique_id() -> String {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("test_{}_{}", now, n)
+    format!("test-{}", uuid::Uuid::now_v7())
 }
 
 /// Generate valid test keys and return both the keys and the matching keyset ID.


### PR DESCRIPTION
Replace timestamp and counter based test ID generation with UUIDv7 values.

- fixes https://github.com/cashubtc/cdk/issues/2257
- alternative to https://github.com/cashubtc/cdk/pull/2258

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
