### PR TITLE
fix(signatory): reject non-future keyset expiries

### DIFF
--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -268,6 +268,16 @@ pub enum Error {
     /// Keyset has expired
     #[error("Keyset has expired")]
     ExpiredKeyset,
+    /// Keyset expiry is not in the future
+    #[error(
+        "Invalid keyset expiry: `{expiry}` must be greater than current time `{current_time}`"
+    )]
+    InvalidKeysetExpiry {
+        /// Requested keyset expiry
+        expiry: u64,
+        /// Current unix time when the expiry was validated
+        current_time: u64,
+    },
     /// Transaction unbalanced
     #[error("Inputs: `{0}`, Outputs: `{1}`, Expected Fee: `{2}`")]
     TransactionUnbalanced(u64, u64, u64),
@@ -688,6 +698,7 @@ impl Error {
             | Self::BlindedMessageAlreadySigned
             | Self::InactiveKeyset
             | Self::ExpiredKeyset
+            | Self::InvalidKeysetExpiry { .. }
             | Self::TransactionUnbalanced(_, _, _)
             | Self::DuplicateInputs
             | Self::DuplicateOutputs

--- a/crates/cdk-integration-tests/src/bin/start_fake_mint.rs
+++ b/crates/cdk-integration-tests/src/bin/start_fake_mint.rs
@@ -87,19 +87,16 @@ async fn start_fake_mint(
                 unit: CurrencyUnit::Sat,
                 input_fee_ppk: 0,
                 version: "v1".into(),
-                expired: true,
             },
             cdk_mintd::config::FakeWalletKeysetRotation {
                 unit: CurrencyUnit::Sat,
                 input_fee_ppk: 0,
                 version: "v2".into(),
-                expired: false,
             },
             cdk_mintd::config::FakeWalletKeysetRotation {
                 unit: CurrencyUnit::Usd,
                 input_fee_ppk: 0,
                 version: "v1".into(),
-                expired: false,
             },
         ],
     });

--- a/crates/cdk-integration-tests/tests/mint.rs
+++ b/crates/cdk-integration-tests/tests/mint.rs
@@ -297,7 +297,7 @@ async fn test_concurrent_duplicate_payment_handling() {
     );
 }
 
-/// Test that rotating a keyset with a final_expiry sets the expiry on the old keyset
+/// Test that rotating a keyset with a final_expiry sets the expiry on the new keyset
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_rotate_keyset_with_expiry() {
     let mnemonic = Mnemonic::generate(12).unwrap();
@@ -349,17 +349,19 @@ async fn test_rotate_keyset_with_expiry() {
     let initial_keyset = mint.get_keyset_info(active_id).expect("There is keyset");
     assert!(initial_keyset.active);
 
-    // Rotate with a past expiry timestamp
-    let past_expiry = cdk::util::unix_time().saturating_sub(3600);
-    mint.rotate_keyset(
-        CurrencyUnit::Sat,
-        cdk_integration_tests::standard_keyset_amounts(32),
-        0,
-        true,
-        Some(past_expiry),
-    )
-    .await
-    .unwrap();
+    // Rotate with a future expiry timestamp
+    let future_expiry = unix_time() + 1_000_000;
+    let rotated_keyset = mint
+        .rotate_keyset(
+            CurrencyUnit::Sat,
+            cdk_integration_tests::standard_keyset_amounts(32),
+            0,
+            true,
+            Some(future_expiry),
+        )
+        .await
+        .unwrap();
+    assert_eq!(rotated_keyset.final_expiry, Some(future_expiry));
 
     // The old keyset should now be inactive
     let old_keyset = mint
@@ -372,6 +374,7 @@ async fn test_rotate_keyset_with_expiry() {
     let new_active_id = active
         .get(&CurrencyUnit::Sat)
         .expect("There is an active keyset");
+    assert_eq!(*new_active_id, rotated_keyset.id);
     assert_ne!(
         *new_active_id, initial_keyset.id,
         "New active keyset should differ from old"

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -316,24 +316,21 @@ custom_payment_methods = [
 min_delay_time = 1
 max_delay_time = 3
 
-# Optional keyset rotations to create inactive/expired test keysets
+# Optional keyset rotations to create inactive test keysets
 # Each rotation creates a keyset that gets rotated out during mint build
 # unit: currency unit (e.g. "sat", "usd")
 # version: "v1" (Version00) or "v2" (Version01)
 # input_fee_ppk: input fee in parts per thousand (default: 0)
-# expired: if true, keyset is created with a past expiry timestamp (default: false)
 #
 # [[fake_wallet.keyset_rotations]]
 # unit = "sat"
 # version = "v1"
 # input_fee_ppk = 0
-# expired = true
 #
 # [[fake_wallet.keyset_rotations]]
 # unit = "sat"
 # version = "v2"
 # input_fee_ppk = 0
-# expired = false
 
 # [grpc_processor]
 # gRPC Payment Processor configuration

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -793,9 +793,6 @@ pub struct FakeWalletKeysetRotation {
     /// Keyset version: "v1" (Version00) or "v2" (Version01)
     #[serde(default = "default_keyset_version")]
     pub version: String,
-    /// If true, the keyset will be created with a past expiry (expired)
-    #[serde(default)]
-    pub expired: bool,
 }
 
 #[cfg(feature = "fakewallet")]

--- a/crates/cdk-mintd/src/env_vars/fake_wallet.rs
+++ b/crates/cdk-mintd/src/env_vars/fake_wallet.rs
@@ -15,7 +15,7 @@ pub const ENV_FAKE_WALLET_CUSTOM_PAYMENT_METHODS: &str =
 pub const ENV_FAKE_WALLET_MIN_DELAY: &str = "CDK_MINTD_FAKE_WALLET_MIN_DELAY";
 pub const ENV_FAKE_WALLET_MAX_DELAY: &str = "CDK_MINTD_FAKE_WALLET_MAX_DELAY";
 /// JSON array of keyset rotations, e.g.:
-/// `[{"unit":"sat","version":"v1","input_fee_ppk":0,"expired":true}]`
+/// `[{"unit":"sat","version":"v1","input_fee_ppk":0}]`
 pub const ENV_FAKE_WALLET_KEYSET_ROTATIONS: &str = "CDK_MINTD_FAKE_WALLET_KEYSET_ROTATIONS";
 
 impl FakeWallet {

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -1103,18 +1103,13 @@ fn configure_fake_wallet_keyset_rotations_once(
         use cdk::mint::KeysetRotation;
 
         let amounts = cdk::mint::UnitConfig::default().amounts;
-        let final_expiry = if rotation_cfg.expired {
-            Some(cdk::util::unix_time().saturating_sub(3600))
-        } else {
-            None
-        };
 
         mint_builder = mint_builder.with_keyset_rotation(KeysetRotation {
             unit: rotation_cfg.unit.clone(),
             amounts,
             input_fee_ppk: rotation_cfg.input_fee_ppk,
             use_keyset_v2: rotation_cfg.version == "v2",
-            final_expiry,
+            final_expiry: None,
         });
     }
 

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -251,7 +251,7 @@ impl Signatory for DbSignatory {
             args.unit.clone(),
             &amounts,
             args.input_fee_ppk,
-            args.final_expiry,
+            args.final_expiry.map(|expiry| expiry.to_u64()),
             args.keyset_id_type,
         );
 
@@ -276,11 +276,13 @@ mod test {
 
     use bitcoin::key::Secp256k1;
     use bitcoin::Network;
+    use cdk_common::database::MintKeysDatabase;
     use cdk_common::nuts::SecretKey;
     use cdk_common::util::{hex, unix_time};
     use cdk_common::{Amount, MintKeySet, PublicKey};
 
     use super::*;
+    use crate::signatory::KeysetExpiry;
 
     #[tokio::test]
     async fn blind_sign_rejects_expired_keyset() {
@@ -290,7 +292,7 @@ mod test {
                 .expect("in-memory db"),
         );
         let signatory = DbSignatory::new(
-            store,
+            store.clone(),
             b"test-seed-for-unit-tests",
             Default::default(),
             Default::default(),
@@ -304,10 +306,27 @@ mod test {
                 amounts: vec![1, 2, 4, 8],
                 input_fee_ppk: 0,
                 keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
-                final_expiry: Some(unix_time() - 1),
+                final_expiry: Some(KeysetExpiry::new(unix_time() + 60).expect("future expiry")),
             })
             .await
             .expect("rotate_keyset");
+
+        // Simulate a keyset that expired after it was created.
+        let mut keyset_info = store
+            .get_keyset_info(&expired_keyset.id)
+            .await
+            .expect("get keyset info")
+            .expect("stored keyset info");
+        keyset_info.final_expiry = Some(unix_time() - 1);
+        let mut tx = store.begin_transaction().await.expect("begin transaction");
+        tx.add_keyset_info(keyset_info)
+            .await
+            .expect("update keyset info");
+        tx.commit().await.expect("commit keyset update");
+        signatory
+            .reload_keys_from_db()
+            .await
+            .expect("reload keysets");
 
         // Expiry check runs before crypto, so an unsigned blinded secret is fine here.
         let blinded_secret = SecretKey::generate().public_key();

--- a/crates/cdk-signatory/src/proto/convert.rs
+++ b/crates/cdk-signatory/src/proto/convert.rs
@@ -349,7 +349,7 @@ impl From<crate::signatory::RotateKeyArguments> for RotationRequest {
             amounts: value.amounts,
             input_fee_ppk: value.input_fee_ppk,
             keyset_id_type: value.keyset_id_type.to_proto_i32(),
-            final_expiry: value.final_expiry,
+            final_expiry: value.final_expiry.map(|expiry| expiry.to_u64()),
         }
     }
 }
@@ -365,7 +365,11 @@ impl TryInto<crate::signatory::RotateKeyArguments> for RotationRequest {
                 .try_into()?,
             amounts: self.amounts,
             input_fee_ppk: self.input_fee_ppk,
-            final_expiry: self.final_expiry,
+            final_expiry: self
+                .final_expiry
+                .map(crate::signatory::KeysetExpiry::new)
+                .transpose()
+                .map_err(|err| Status::invalid_argument(err.to_string()))?,
             keyset_id_type: KeySetVersion::from_proto_i32(self.keyset_id_type)
                 .map_err(|err| Status::invalid_argument(err.to_string()))?,
         })

--- a/crates/cdk-signatory/src/signatory.rs
+++ b/crates/cdk-signatory/src/signatory.rs
@@ -50,8 +50,32 @@ pub struct RotateKeyArguments {
     pub input_fee_ppk: u64,
     /// KeySet Version
     pub keyset_id_type: KeySetVersion,
-    /// FinalExpiry
-    pub final_expiry: Option<u64>,
+    /// Final expiry, which must be in the future when set
+    pub final_expiry: Option<KeysetExpiry>,
+}
+
+/// A validated keyset expiry timestamp.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct KeysetExpiry(u64);
+
+impl KeysetExpiry {
+    /// Create a future keyset expiry.
+    pub fn new(expiry: u64) -> Result<Self, Error> {
+        let current_time = cdk_common::util::unix_time();
+
+        match expiry <= current_time {
+            true => Err(Error::InvalidKeysetExpiry {
+                expiry,
+                current_time,
+            }),
+            false => Ok(Self(expiry)),
+        }
+    }
+
+    /// Return the unix timestamp.
+    pub fn to_u64(self) -> u64 {
+        self.0
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/cdk/src/mint/builder.rs
+++ b/crates/cdk/src/mint/builder.rs
@@ -11,7 +11,7 @@ use cdk_common::nut04::MintMethodOptions;
 use cdk_common::nut05::MeltMethodOptions;
 use cdk_common::payment::DynMintPayment;
 use cdk_common::{nut21, nut22};
-use cdk_signatory::signatory::{RotateKeyArguments, Signatory};
+use cdk_signatory::signatory::{KeysetExpiry, RotateKeyArguments, Signatory};
 
 use super::nut17::SupportedMethods;
 use super::nut19::{self, CachedEndpoint};
@@ -44,7 +44,7 @@ impl Default for UnitConfig {
 }
 
 /// Describes an extra keyset rotation to perform during mint build.
-/// Used to create inactive/expired keysets for testing.
+/// Used to create inactive or expiring keysets for testing.
 #[derive(Debug, Clone)]
 pub struct KeysetRotation {
     /// Currency unit for this rotation
@@ -128,7 +128,7 @@ impl MintBuilder {
     }
 
     /// Add a keyset rotation to execute during build.
-    /// Used to create inactive/expired keysets for testing.
+    /// Used to create inactive or expiring keysets for testing.
     pub fn with_keyset_rotation(mut self, rotation: KeysetRotation) -> Self {
         self.keyset_rotations.push(rotation);
         self
@@ -673,7 +673,7 @@ impl MintBuilder {
                     } else {
                         cdk_common::nut02::KeySetVersion::Version00
                     },
-                    final_expiry: rotation.final_expiry,
+                    final_expiry: rotation.final_expiry.map(KeysetExpiry::new).transpose()?,
                 })
                 .await?;
         }

--- a/crates/cdk/src/mint/keysets/mod.rs
+++ b/crates/cdk/src/mint/keysets/mod.rs
@@ -1,4 +1,4 @@
-use cdk_signatory::signatory::RotateKeyArguments;
+use cdk_signatory::signatory::{KeysetExpiry, RotateKeyArguments};
 use tracing::instrument;
 
 use super::{
@@ -79,20 +79,18 @@ impl Mint {
         use_keyset_v2: bool,
         final_expiry: Option<u64>,
     ) -> Result<MintKeySetInfo, Error> {
-        let result = self
-            .signatory
-            .rotate_keyset(RotateKeyArguments {
-                unit,
-                amounts,
-                input_fee_ppk,
-                keyset_id_type: if use_keyset_v2 {
-                    cdk_common::nut02::KeySetVersion::Version01
-                } else {
-                    cdk_common::nut02::KeySetVersion::Version00
-                },
-                final_expiry,
-            })
-            .await?;
+        let args = RotateKeyArguments {
+            unit,
+            amounts,
+            input_fee_ppk,
+            keyset_id_type: if use_keyset_v2 {
+                cdk_common::nut02::KeySetVersion::Version01
+            } else {
+                cdk_common::nut02::KeySetVersion::Version00
+            },
+            final_expiry: final_expiry.map(KeysetExpiry::new).transpose()?,
+        };
+        let result = self.signatory.rotate_keyset(args).await?;
 
         // Read the freshest snapshot and store it under the shared lock. The
         // subscription drain task writes the same ArcSwap; serializing the

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1438,6 +1438,7 @@ mod tests {
     use cdk_common::nut00::KnownMethod;
     use cdk_common::nuts::MeltQuoteBolt11Request;
     use cdk_common::payment::{MakePaymentResponse, PaymentIdentifier};
+    use cdk_common::util::unix_time;
     use cdk_common::PaymentMethod;
     use cdk_fake_wallet::{create_fake_invoice, FakeInvoiceDescription};
     use cdk_signatory::db_signatory::DbSignatory;
@@ -2105,7 +2106,7 @@ mod tests {
         };
         let mint = create_mint(config).await;
 
-        let expiry: u64 = 1_000_000;
+        let expiry = unix_time() + 1_000_000;
         let keyset_info = mint
             .rotate_keyset(CurrencyUnit::default(), vec![1], 0, true, Some(expiry))
             .await
@@ -2122,6 +2123,42 @@ mod tests {
             .get_keyset_info(&keyset_info.id)
             .expect("keyset should be found");
         assert_eq!(stored.final_expiry, Some(expiry));
+    }
+
+    #[tokio::test]
+    async fn mint_mod_rotate_keyset_rejects_non_future_expiry() {
+        let mut supported_units = HashMap::new();
+        let amounts: Vec<u64> = (0..32).map(|i| 2u64.pow(i)).collect();
+        supported_units.insert(CurrencyUnit::default(), (0, amounts));
+
+        let config = MintConfig::<'_> {
+            supported_units,
+            ..Default::default()
+        };
+        let mint = create_mint(config).await;
+        let keysets_before = mint.keysets();
+        let expiry = unix_time();
+
+        let result = mint
+            .rotate_keyset(CurrencyUnit::default(), vec![1], 0, true, Some(expiry))
+            .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(Error::InvalidKeysetExpiry {
+                    expiry: invalid_expiry,
+                    current_time,
+                }) if invalid_expiry == expiry && current_time >= expiry
+            ),
+            "expected InvalidKeysetExpiry error, got: {:?}",
+            result
+        );
+        assert_eq!(
+            mint.keysets().keysets,
+            keysets_before.keysets,
+            "invalid rotation must not change the mint keysets"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Validate keyset rotation requests before they reach storage or cross embedded and RPC signatory boundaries. Return a structured error for expiries at or before the current time and cover mint and signatory paths with regression tests.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

closes https://github.com/cashubtc/cdk/issues/1945#issuecomment-5093754155

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
