### PR TITLE
fix: normalize custom currency units to lowercase

### DIFF
--- a/crates/cashu/src/amount.rs
+++ b/crates/cashu/src/amount.rs
@@ -428,7 +428,7 @@ impl Amount<CurrencyUnit> {
     /// ```
     /// # use cashu::{Amount, nuts::CurrencyUnit};
     /// let sat_amount = Amount::new(1000, CurrencyUnit::Sat);
-    /// let custom = Amount::new(50, CurrencyUnit::Custom("BTC".into()));
+    /// let custom = Amount::new(50, CurrencyUnit::custom("BTC"));
     /// ```
     pub fn new(value: u64, unit: CurrencyUnit) -> Self {
         Self { value, unit }

--- a/crates/cashu/src/nuts/nut00/mod.rs
+++ b/crates/cashu/src/nuts/nut00/mod.rs
@@ -611,6 +611,13 @@ pub enum CurrencyUnit {
     Custom(String),
 }
 
+impl CurrencyUnit {
+    /// Construct a custom unit, normalizing to lowercase and trimming whitespace.
+    pub fn custom<S: AsRef<str>>(value: S) -> Self {
+        Self::Custom(normalize_custom_unit(value.as_ref()))
+    }
+}
+
 #[cfg(feature = "mint")]
 impl CurrencyUnit {
     /// Derivation index mint will use for unit
@@ -629,11 +636,6 @@ impl CurrencyUnit {
         }
     }
 
-    /// Construct a custom unit, normalizing to uppercase and trimming whitespace.
-    pub fn custom<S: AsRef<str>>(value: S) -> Self {
-        Self::Custom(normalize_custom_unit(value.as_ref()).to_uppercase())
-    }
-
     ///  Big endian encoded integer of the first 4 bytes of the sha256 hash of the unit string.
     pub fn hashed_derivation_index(&self) -> u32 {
         use bitcoin::hashes::sha256;
@@ -649,7 +651,11 @@ impl CurrencyUnit {
 
 fn normalize_custom_unit(value: &str) -> String {
     let trimmed = value.trim_matches(|c: char| matches!(c, ' ' | '\t' | '\r' | '\n'));
-    trimmed.nfc().collect::<String>()
+    trimmed
+        .chars()
+        .flat_map(char::to_lowercase)
+        .nfc()
+        .collect::<String>()
 }
 
 impl FromStr for CurrencyUnit {
@@ -662,14 +668,13 @@ impl FromStr for CurrencyUnit {
             "USD" => Ok(Self::Usd),
             "EUR" => Ok(Self::Eur),
             "AUTH" => Ok(Self::Auth),
-            _ => Ok(Self::Custom(normalize_custom_unit(value))),
+            _ => Ok(Self::custom(value)),
         }
     }
 }
 
 impl fmt::Display for CurrencyUnit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // let binding = normalize_custom_unit(&self).clone();
         let s = match self {
             CurrencyUnit::Sat => "SAT",
             CurrencyUnit::Msat => "MSAT",
@@ -680,14 +685,9 @@ impl fmt::Display for CurrencyUnit {
         };
 
         if let Some(width) = f.width() {
-            write!(
-                f,
-                "{:width$}",
-                normalize_custom_unit(s).to_lowercase(),
-                width = width
-            )
+            write!(f, "{:width$}", normalize_custom_unit(s), width = width)
         } else {
-            write!(f, "{}", normalize_custom_unit(s).to_lowercase())
+            write!(f, "{}", normalize_custom_unit(s))
         }
     }
 }
@@ -697,7 +697,7 @@ impl Serialize for CurrencyUnit {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_string().to_lowercase())
+        serializer.serialize_str(&self.to_string())
     }
 }
 
@@ -1411,18 +1411,25 @@ mod tests {
 
     #[test]
     fn custom_unit_ser_der() {
-        let unit = CurrencyUnit::Custom(String::from("test"));
+        let unit = CurrencyUnit::from_str("BADCOIN").unwrap();
         let serialized = serde_json::to_string(&unit).unwrap();
         let deserialized: CurrencyUnit = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(unit, deserialized)
+        let deserialized_uppercase: CurrencyUnit = serde_json::from_str(r#""BADCOIN""#).unwrap();
+
+        assert_eq!(unit, CurrencyUnit::Custom("badcoin".to_string()));
+        assert_eq!(unit, CurrencyUnit::from_str("badcoin").unwrap());
+        assert_eq!(unit, CurrencyUnit::custom("BADCOIN"));
+        assert_eq!(unit.to_string(), "badcoin");
+        assert_eq!(serialized, r#""badcoin""#);
+        assert_eq!(unit, deserialized);
+        assert_eq!(unit, deserialized_uppercase);
     }
 
     #[test]
-    #[cfg(feature = "mint")]
     fn test_currency_unit_custom_normalizes_and_stays_custom() {
         let unit = CurrencyUnit::custom(" usd\n");
 
-        assert_eq!(unit, CurrencyUnit::Custom("USD".to_string()));
+        assert_eq!(unit, CurrencyUnit::Custom("usd".to_string()));
         assert_ne!(unit, CurrencyUnit::default());
         assert_eq!(unit.to_string(), "usd");
     }
@@ -1443,6 +1450,10 @@ mod tests {
         // Custom
         assert_eq!(
             CurrencyUnit::from_str("custom").unwrap(),
+            CurrencyUnit::Custom("custom".to_string())
+        );
+        assert_eq!(
+            CurrencyUnit::from_str("CuStOm").unwrap(),
             CurrencyUnit::Custom("custom".to_string())
         );
     }

--- a/crates/cashu/src/nuts/nut26/encoding.rs
+++ b/crates/cashu/src/nuts/nut26/encoding.rs
@@ -33,7 +33,7 @@ impl From<CurrencyUnit> for TlvUnit {
             CurrencyUnit::Msat => TlvUnit::Custom("msat".to_string()),
             CurrencyUnit::Usd => TlvUnit::Custom("usd".to_string()),
             CurrencyUnit::Eur => TlvUnit::Custom("eur".to_string()),
-            CurrencyUnit::Custom(c) => TlvUnit::Custom(c),
+            CurrencyUnit::Custom(c) => TlvUnit::Custom(CurrencyUnit::custom(c).to_string()),
             CurrencyUnit::Auth => TlvUnit::Custom("auth".to_string()),
         }
     }
@@ -48,7 +48,7 @@ impl From<TlvUnit> for CurrencyUnit {
                 "usd" => CurrencyUnit::Usd,
                 "eur" => CurrencyUnit::Eur,
                 "auth" => CurrencyUnit::Auth,
-                _ => CurrencyUnit::Custom(s), // preserve unknown units
+                _ => CurrencyUnit::custom(s),
             },
         }
     }
@@ -881,6 +881,14 @@ mod tests {
         assert_eq!(
             CurrencyUnit::from(TlvUnit::from(CurrencyUnit::Auth)),
             CurrencyUnit::Auth
+        );
+        assert_eq!(
+            TlvUnit::from(CurrencyUnit::Custom("BADCOIN".to_string())),
+            TlvUnit::Custom("badcoin".to_string())
+        );
+        assert_eq!(
+            CurrencyUnit::from(TlvUnit::Custom("BADCOIN".to_string())),
+            CurrencyUnit::Custom("badcoin".to_string())
         );
     }
 

--- a/crates/cdk-cli/src/main.rs
+++ b/crates/cdk-cli/src/main.rs
@@ -226,7 +226,7 @@ async fn main() -> Result<()> {
     let currency_unit = match args.unit {
         Some(unit) => match unit.to_lowercase().as_str() {
             "" => bail!("Currency unit cannot be empty. Omit the flag to use the default 'sat'."),
-            _ => Some(CurrencyUnit::from_str(&unit).unwrap_or(CurrencyUnit::Custom(unit))),
+            _ => Some(CurrencyUnit::from_str(&unit)?),
         },
         None => None,
     };

--- a/crates/cdk-ffi/src/types/amount.rs
+++ b/crates/cdk-ffi/src/types/amount.rs
@@ -127,7 +127,9 @@ impl From<CdkCurrencyUnit> for CurrencyUnit {
             CdkCurrencyUnit::Usd => CurrencyUnit::Usd,
             CdkCurrencyUnit::Eur => CurrencyUnit::Eur,
             CdkCurrencyUnit::Auth => CurrencyUnit::Auth,
-            CdkCurrencyUnit::Custom(s) => CurrencyUnit::Custom { unit: s },
+            CdkCurrencyUnit::Custom(s) => CurrencyUnit::Custom {
+                unit: CdkCurrencyUnit::custom(s).to_string(),
+            },
             _ => CurrencyUnit::Sat, // Default for unknown units
         }
     }
@@ -141,7 +143,7 @@ impl From<CurrencyUnit> for CdkCurrencyUnit {
             CurrencyUnit::Usd => CdkCurrencyUnit::Usd,
             CurrencyUnit::Eur => CdkCurrencyUnit::Eur,
             CurrencyUnit::Auth => CdkCurrencyUnit::Auth,
-            CurrencyUnit::Custom { unit } => CdkCurrencyUnit::Custom(unit),
+            CurrencyUnit::Custom { unit } => CdkCurrencyUnit::custom(unit),
         }
     }
 }
@@ -180,5 +182,26 @@ impl From<cdk::amount::SplitTarget> for SplitTarget {
                 amounts: amounts.into_iter().map(Into::into).collect(),
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_currency_unit_is_lowercase_across_ffi_boundary() {
+        let ffi = CurrencyUnit::from(CdkCurrencyUnit::Custom("BADCOIN".to_string()));
+        assert_eq!(
+            ffi,
+            CurrencyUnit::Custom {
+                unit: "badcoin".to_string()
+            }
+        );
+
+        let cdk = CdkCurrencyUnit::from(CurrencyUnit::Custom {
+            unit: "BADCOIN".to_string(),
+        });
+        assert_eq!(cdk, CdkCurrencyUnit::Custom("badcoin".to_string()));
     }
 }

--- a/crates/cdk-mint-rpc/src/proto/keyset.proto
+++ b/crates/cdk-mint-rpc/src/proto/keyset.proto
@@ -10,8 +10,8 @@ service KeysetService {
 
 message RotateNextKeysetRequest {
     // Currency unit the new keyset signs, e.g. "sat". Known units are
-    // matched case-insensitively; custom units are used as provided
-    // (whitespace-trimmed). A unit the mint cannot derive a keyset for
+    // matched case-insensitively; custom units are whitespace-trimmed and
+    // normalized to lowercase. A unit the mint cannot derive a keyset for
     // fails with gRPC status INVALID_ARGUMENT.
     string unit = 1;
     // Token denominations the keyset can sign, e.g. [1, 2, 4, 8, 16]. If

--- a/crates/cdk-signatory/src/proto/convert.rs
+++ b/crates/cdk-signatory/src/proto/convert.rs
@@ -282,7 +282,9 @@ impl From<cdk_common::CurrencyUnit> for CurrencyUnit {
                 )),
             },
             cdk_common::CurrencyUnit::Custom(name) => CurrencyUnit {
-                currency_unit: Some(currency_unit::CurrencyUnit::CustomUnit(name)),
+                currency_unit: Some(currency_unit::CurrencyUnit::CustomUnit(
+                    cdk_common::CurrencyUnit::custom(name).to_string(),
+                )),
             },
             _ => unreachable!(),
         }
@@ -308,7 +310,7 @@ impl TryInto<cdk_common::CurrencyUnit> for CurrencyUnit {
                 }
             },
             Some(currency_unit::CurrencyUnit::CustomUnit(name)) => {
-                Ok(cdk_common::CurrencyUnit::Custom(name))
+                Ok(cdk_common::CurrencyUnit::custom(name))
             }
             None => Err(Status::invalid_argument("Currency unit not set")),
         }
@@ -400,5 +402,35 @@ impl TryInto<cdk_common::KeySetInfo> for KeySet {
             input_fee_ppk: self.input_fee_ppk,
             final_expiry: self.final_expiry,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_currency_unit_is_lowercase_across_proto_boundary() {
+        let proto: CurrencyUnit = cdk_common::CurrencyUnit::Custom("BADCOIN".to_string()).into();
+
+        assert_eq!(
+            proto.currency_unit,
+            Some(currency_unit::CurrencyUnit::CustomUnit(
+                "badcoin".to_string()
+            ))
+        );
+
+        let common: cdk_common::CurrencyUnit = CurrencyUnit {
+            currency_unit: Some(currency_unit::CurrencyUnit::CustomUnit(
+                "BADCOIN".to_string(),
+            )),
+        }
+        .try_into()
+        .unwrap();
+
+        assert_eq!(
+            common,
+            cdk_common::CurrencyUnit::Custom("badcoin".to_string())
+        );
     }
 }


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

Canonicalize custom units during parsing, construction, and protocol conversions so case variants compare equally and round-trip consistently.

Cover JSON, TLV, gRPC, and FFI boundaries with regression tests.



closes https://github.com/cashubtc/cdk/issues/2243

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
