### PR TITLE
fix(bdk): avoid genesis scans for new Bitcoin Core wallets

### DIFF
--- a/crates/cdk-bdk/README.md
+++ b/crates/cdk-bdk/README.md
@@ -38,6 +38,7 @@ let chain_source = ChainSource::BitcoinRpc(BitcoinRpcConfig {
     port: 18443,
     user: "user".to_string(),
     password: "password".to_string(),
+    wallet_rescan_from_height: None,
 });
 
 let backend = CdkBdk::new(
@@ -87,6 +88,12 @@ blocks per wallet-lock acquisition) so user-facing operations like address
 reveal and batch construction are not blocked during long chain catch-ups.
 Chain-source clients are reused across sync iterations and rebuilt only on
 error.
+
+Fresh Bitcoin Core wallets checkpoint at the current chain tip instead of
+scanning from genesis. When restoring from a mnemonic, set
+`BitcoinRpcConfig::wallet_rescan_from_height` to the wallet's known birthday
+height. This setting only affects wallet creation and never rewinds persisted
+wallet state.
 
 ## Finality and Confirmation Policy
 

--- a/crates/cdk-bdk/src/chain/bitcoin_rpc.rs
+++ b/crates/cdk-bdk/src/chain/bitcoin_rpc.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client, Error as BitcoinRpcError, RawTx, RpcApi};
 use bdk_bitcoind_rpc::{BlockEvent, Emitter, NO_EXPECTED_MEMPOOL_TXS};
 use bdk_wallet::bitcoin::{Block, Transaction};
+use bdk_wallet::chain::BlockId;
 use tokio::sync::Mutex;
 use tokio::time::{interval, Duration};
 use tokio_util::sync::CancellationToken;
@@ -11,6 +12,39 @@ use tokio_util::sync::CancellationToken;
 use crate::chain::{BitcoinRpcConfig, BroadcastErrorKind, BroadcastFailure, BroadcastOutcome};
 use crate::error::Error;
 use crate::{CdkBdk, WalletWithDb};
+
+pub(crate) fn initial_checkpoint(config: &BitcoinRpcConfig) -> Result<BlockId, Error> {
+    let client = Client::new(
+        &format!("http://{}:{}", config.host, config.port),
+        Auth::UserPass(config.user.clone(), config.password.clone()),
+    )
+    .map_err(|source| Error::ChainTipFetchFailed { source })?;
+    let chain_info = client
+        .get_blockchain_info()
+        .map_err(|source| Error::ChainTipFetchFailed { source })?;
+    let tip = u32::try_from(chain_info.blocks).map_err(|_| {
+        Error::InvalidConfig(format!(
+            "Bitcoin Core tip height {} exceeds the supported u32 range",
+            chain_info.blocks
+        ))
+    })?;
+    let height = config.wallet_rescan_from_height.unwrap_or(tip);
+
+    if height > tip {
+        return Err(Error::WalletRescanHeightTooHigh {
+            requested: height,
+            tip,
+        });
+    }
+
+    let hash = if height == tip {
+        chain_info.best_block_hash
+    } else {
+        client.get_block_hash(u64::from(height))?
+    };
+
+    Ok(BlockId { height, hash })
+}
 
 /// Apply a chunk of blocks to the wallet under a single lock acquisition,
 /// then persist.
@@ -340,7 +374,149 @@ pub(crate) async fn fetch_fee_rate_bitcoin_rpc(
 
 #[cfg(test)]
 mod tests {
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::TcpListener;
+    use std::str::FromStr;
+    use std::thread;
+
+    use bdk_wallet::bitcoin::BlockHash;
+    use serde_json::{json, Value};
+
     use super::*;
+
+    const TIP_HASH: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+    const BIRTHDAY_HASH: &str = "2222222222222222222222222222222222222222222222222222222222222222";
+
+    fn chain_info(tip: u32) -> Value {
+        json!({
+            "chain": "regtest",
+            "blocks": tip,
+            "headers": tip,
+            "bestblockhash": TIP_HASH,
+            "difficulty": 1.0,
+            "mediantime": 0,
+            "verificationprogress": 1.0,
+            "initialblockdownload": false,
+            "chainwork": "00",
+            "size_on_disk": 0,
+            "pruned": false,
+            "warnings": ""
+        })
+    }
+
+    fn network_info() -> Value {
+        json!({ "version": 290000 })
+    }
+
+    fn spawn_rpc_server(results: Vec<Value>) -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test RPC server");
+        let port = listener.local_addr().expect("test RPC address").port();
+
+        thread::spawn(move || {
+            for result in results {
+                let (mut stream, _) = listener.accept().expect("accept test RPC connection");
+                let mut reader = BufReader::new(&mut stream);
+                let mut content_length = None;
+                loop {
+                    let mut line = String::new();
+                    reader
+                        .read_line(&mut line)
+                        .expect("read test RPC request header");
+                    if line == "\r\n" {
+                        break;
+                    }
+                    if let Some(value) = line
+                        .to_ascii_lowercase()
+                        .strip_prefix("content-length:")
+                        .map(str::trim)
+                    {
+                        content_length =
+                            Some(value.parse::<usize>().expect("valid content length"));
+                    }
+                }
+                let mut request_body = vec![0; content_length.expect("request content length")];
+                reader
+                    .read_exact(&mut request_body)
+                    .expect("read test RPC request body");
+                let request: Value =
+                    serde_json::from_slice(&request_body).expect("valid JSON-RPC request");
+                let id = request["id"].clone();
+                drop(reader);
+
+                let body = json!({
+                    "jsonrpc": "2.0",
+                    "result": result,
+                    "error": null,
+                    "id": id
+                })
+                .to_string();
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )
+                .expect("write test RPC response");
+                stream.flush().expect("flush test RPC response");
+            }
+        });
+
+        port
+    }
+
+    fn rpc_config(port: u16, wallet_rescan_from_height: Option<u32>) -> BitcoinRpcConfig {
+        BitcoinRpcConfig {
+            host: "127.0.0.1".to_string(),
+            port,
+            user: "user".to_string(),
+            password: "password".to_string(),
+            wallet_rescan_from_height,
+        }
+    }
+
+    #[test]
+    fn fresh_wallet_defaults_to_current_tip() {
+        let port = spawn_rpc_server(vec![chain_info(100), network_info()]);
+
+        let checkpoint = initial_checkpoint(&rpc_config(port, None))
+            .expect("current tip should become the initial checkpoint");
+
+        assert_eq!(checkpoint.height, 100);
+        assert_eq!(
+            checkpoint.hash,
+            BlockHash::from_str(TIP_HASH).expect("valid tip hash")
+        );
+    }
+
+    #[test]
+    fn fresh_wallet_can_rescan_from_birthday_height() {
+        let port = spawn_rpc_server(vec![chain_info(100), network_info(), json!(BIRTHDAY_HASH)]);
+
+        let checkpoint = initial_checkpoint(&rpc_config(port, Some(42)))
+            .expect("birthday block should become the initial checkpoint");
+
+        assert_eq!(checkpoint.height, 42);
+        assert_eq!(
+            checkpoint.hash,
+            BlockHash::from_str(BIRTHDAY_HASH).expect("valid birthday hash")
+        );
+    }
+
+    #[test]
+    fn fresh_wallet_rejects_rescan_height_above_tip() {
+        let port = spawn_rpc_server(vec![chain_info(100), network_info()]);
+
+        let error = initial_checkpoint(&rpc_config(port, Some(101)))
+            .expect_err("future birthday height should fail");
+
+        assert!(matches!(
+            error,
+            Error::WalletRescanHeightTooHigh {
+                requested: 101,
+                tip: 100
+            }
+        ));
+    }
 
     #[test]
     fn classify_bitcoin_rpc_broadcast_errors() {

--- a/crates/cdk-bdk/src/chain/mod.rs
+++ b/crates/cdk-bdk/src/chain/mod.rs
@@ -1,4 +1,5 @@
 use bdk_wallet::bitcoin::Transaction;
+use bdk_wallet::chain::BlockId;
 use tokio_util::sync::CancellationToken;
 
 use crate::error::Error;
@@ -21,6 +22,12 @@ pub struct BitcoinRpcConfig {
     pub user: String,
     /// Password for Bitcoin RPC authentication
     pub password: String,
+    /// Optional wallet birthday height used when creating a fresh wallet.
+    ///
+    /// If unset, a fresh wallet starts at the current Bitcoin Core tip. Set
+    /// this when restoring a wallet from seed to scan from a known birthday
+    /// height. Existing wallets are never rewound.
+    pub wallet_rescan_from_height: Option<u32>,
 }
 
 /// Configuration for connecting to Esplora
@@ -104,6 +111,15 @@ impl ChainSource {
         }
 
         Ok(())
+    }
+
+    pub(crate) fn initial_checkpoint(&self) -> Result<Option<BlockId>, Error> {
+        match self {
+            #[cfg(feature = "bitcoin-rpc")]
+            Self::BitcoinRpc(config) => bitcoin_rpc::initial_checkpoint(config).map(Some),
+            #[allow(unreachable_patterns)]
+            _ => Ok(None),
+        }
     }
 
     pub async fn sync_wallet(

--- a/crates/cdk-bdk/src/error.rs
+++ b/crates/cdk-bdk/src/error.rs
@@ -55,6 +55,24 @@ pub enum Error {
     #[error("Bitcoin RPC error: {0}")]
     BitcoinRpc(#[from] bdk_bitcoind_rpc::bitcoincore_rpc::Error),
 
+    /// The Bitcoin Core chain tip could not be determined for a fresh wallet.
+    #[cfg(feature = "bitcoin-rpc")]
+    #[error("Failed to determine the Bitcoin Core chain tip for a fresh wallet: {source}")]
+    ChainTipFetchFailed {
+        /// Underlying Bitcoin Core RPC error.
+        #[source]
+        source: bdk_bitcoind_rpc::bitcoincore_rpc::Error,
+    },
+
+    /// The configured fresh-wallet rescan height is above the current chain tip.
+    #[error("Wallet rescan height {requested} is above the current chain tip {tip}")]
+    WalletRescanHeightTooHigh {
+        /// Configured rescan height.
+        requested: u32,
+        /// Current Bitcoin Core chain tip.
+        tip: u32,
+    },
+
     /// Esplora error
     #[error("Esplora error: {0}")]
     Esplora(String),

--- a/crates/cdk-bdk/src/lib.rs
+++ b/crates/cdk-bdk/src/lib.rs
@@ -18,7 +18,7 @@ use bdk_wallet::keys::bip39::Mnemonic;
 use bdk_wallet::keys::{DerivableKey, ExtendedKey};
 use bdk_wallet::rusqlite::Connection;
 use bdk_wallet::template::Bip84;
-use bdk_wallet::{KeychainKind, PersistedWallet, Wallet};
+use bdk_wallet::{KeychainKind, PersistedWallet, Update, Wallet};
 use cdk_common::common::FeeReserve;
 use cdk_common::database::KVStore;
 use cdk_common::nuts::nut30::MeltQuoteOnchainFeeOption;
@@ -269,12 +269,36 @@ impl CdkBdk {
             .load_wallet(&mut db)
             .map_err(|e| Error::Wallet(e.to_string()))?;
 
+        // A fresh Bitcoin Core wallet should start at the current tip rather
+        // than scanning from genesis. An explicit rescan height overrides the
+        // tip for seed recovery. Fetch this before creating the wallet so an
+        // unreachable or misconfigured node cannot persist a genesis-pinned
+        // wallet by accident.
+        let initial_checkpoint = match wallet_opt.is_none() {
+            true => chain_source.initial_checkpoint()?,
+            false => None,
+        };
+
         let mut wallet = match wallet_opt {
             Some(wallet) => wallet,
-            None => Wallet::create(descriptor, change_descriptor)
-                .network(network)
-                .create_wallet(&mut db)
-                .map_err(|e| Error::Wallet(e.to_string()))?,
+            None => {
+                let mut wallet = Wallet::create(descriptor, change_descriptor)
+                    .network(network)
+                    .create_wallet(&mut db)
+                    .map_err(|e| Error::Wallet(e.to_string()))?;
+
+                if let Some(block_id) = initial_checkpoint {
+                    let checkpoint = wallet.latest_checkpoint().insert(block_id);
+                    wallet
+                        .apply_update(Update {
+                            chain: Some(checkpoint),
+                            ..Default::default()
+                        })
+                        .map_err(|e| Error::Wallet(e.to_string()))?;
+                }
+
+                wallet
+            }
         };
 
         wallet.persist(&mut db)?;

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -157,6 +157,9 @@ onchain_backend = "fakewallet"
 # # bitcoind_rpc_port = 18443
 # # bitcoind_rpc_user = "user"
 # # bitcoind_rpc_password = "pass"
+# # Fresh wallets start at the current tip by default. When restoring a
+# # mnemonic, set its known birthday height to scan historical blocks.
+# # wallet_rescan_from_height = 850000
 #
 # # Esplora configuration (when chain_source_type = "esplora")
 # # esplora_url = "https://mutinynet.com/api"

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -382,6 +382,12 @@ pub struct Bdk {
     pub bitcoind_rpc_user: Option<String>,
     /// Bitcoin RPC password
     pub bitcoind_rpc_password: Option<String>,
+    /// Optional birthday height used when creating a fresh Bitcoin RPC wallet.
+    ///
+    /// If unset, the wallet starts at the current chain tip. Set this when
+    /// restoring from a mnemonic to rescan from a known height. Existing
+    /// wallets are not rewound.
+    pub wallet_rescan_from_height: Option<u32>,
     /// BIP-39 mnemonic for the BDK wallet
     pub mnemonic: Option<String>,
     /// Batch processor configuration
@@ -422,6 +428,7 @@ impl Default for Bdk {
             bitcoind_rpc_port: None,
             bitcoind_rpc_user: None,
             bitcoind_rpc_password: None,
+            wallet_rescan_from_height: None,
             mnemonic: None,
             batch_config: BatchConfig::default(),
             num_confs: default_bdk_num_confs(),
@@ -1305,6 +1312,7 @@ mod tests {
         std::env::remove_var(crate::env_vars::BDK_ESPLORA_URL_ENV_VAR);
         std::env::remove_var(crate::env_vars::BDK_ELECTRUM_URL_ENV_VAR);
         std::env::remove_var(crate::env_vars::BDK_ELECTRUM_BATCH_SIZE_ENV_VAR);
+        std::env::remove_var(crate::env_vars::BDK_WALLET_RESCAN_FROM_HEIGHT_ENV_VAR);
         std::env::remove_var(crate::env_vars::BDK_MIN_SEND_AMOUNT_SAT_ENV_VAR);
         std::env::remove_var(crate::env_vars::BDK_TARGET_BLOCK_TIME_SECS_ENV_VAR);
         std::env::remove_var(crate::env_vars::BDK_FEE_OPTIONS_ENV_VAR);
@@ -1445,6 +1453,33 @@ min_send_amount_sat = 1200
                 .expect("bdk config should be present")
                 .min_send_amount_sat,
             777
+        );
+
+        clear_bdk_env_vars();
+    }
+
+    #[cfg(feature = "bdk")]
+    #[test]
+    fn test_bdk_env_wallet_rescan_height_override() {
+        let _guard = config_env_lock();
+        clear_bdk_env_vars();
+        std::env::set_var(crate::env_vars::ENV_ONCHAIN_BACKEND, "bdk");
+        std::env::set_var(crate::env_vars::BDK_NETWORK_ENV_VAR, "regtest");
+        std::env::set_var(
+            crate::env_vars::BDK_WALLET_RESCAN_FROM_HEIGHT_ENV_VAR,
+            "850000",
+        );
+
+        let mut settings = Settings::default();
+        settings.from_env().expect("Failed to apply env vars");
+
+        assert_eq!(
+            settings
+                .bdk
+                .as_ref()
+                .expect("bdk config should be present")
+                .wallet_rescan_from_height,
+            Some(850000)
         );
 
         clear_bdk_env_vars();

--- a/crates/cdk-mintd/src/env_vars/bdk.rs
+++ b/crates/cdk-mintd/src/env_vars/bdk.rs
@@ -10,6 +10,7 @@ pub const BDK_BITCOIND_RPC_HOST_ENV_VAR: &str = "CDK_MINTD_BDK_BITCOIND_RPC_HOST
 pub const BDK_BITCOIND_RPC_PORT_ENV_VAR: &str = "CDK_MINTD_BDK_BITCOIND_RPC_PORT";
 pub const BDK_BITCOIND_RPC_USER_ENV_VAR: &str = "CDK_MINTD_BDK_BITCOIND_RPC_USER";
 pub const BDK_BITCOIND_RPC_PASSWORD_ENV_VAR: &str = "CDK_MINTD_BDK_BITCOIND_RPC_PASSWORD";
+pub const BDK_WALLET_RESCAN_FROM_HEIGHT_ENV_VAR: &str = "CDK_MINTD_BDK_WALLET_RESCAN_FROM_HEIGHT";
 pub const BDK_CHAIN_SOURCE_TYPE_ENV_VAR: &str = "CDK_MINTD_BDK_CHAIN_SOURCE_TYPE";
 pub const BDK_ESPLORA_URL_ENV_VAR: &str = "CDK_MINTD_BDK_ESPLORA_URL";
 pub const BDK_ESPLORA_PARALLEL_REQUESTS_ENV_VAR: &str = "CDK_MINTD_BDK_ESPLORA_PARALLEL_REQUESTS";
@@ -61,6 +62,12 @@ impl Bdk {
 
         if let Ok(bitcoind_rpc_password) = env::var(BDK_BITCOIND_RPC_PASSWORD_ENV_VAR) {
             self.bitcoind_rpc_password = Some(bitcoind_rpc_password);
+        }
+
+        if let Ok(wallet_rescan_from_height) = env::var(BDK_WALLET_RESCAN_FROM_HEIGHT_ENV_VAR) {
+            if let Ok(wallet_rescan_from_height) = wallet_rescan_from_height.parse::<u32>() {
+                self.wallet_rescan_from_height = Some(wallet_rescan_from_height);
+            }
         }
 
         if let Ok(chain_source_type) = env::var(BDK_CHAIN_SOURCE_TYPE_ENV_VAR) {

--- a/crates/cdk-mintd/src/setup.rs
+++ b/crates/cdk-mintd/src/setup.rs
@@ -672,6 +672,7 @@ impl crate::config::Bdk {
                         port,
                         user,
                         password,
+                        wallet_rescan_from_height: self.wallet_rescan_from_height,
                     },
                 ))
             }
@@ -683,6 +684,25 @@ impl crate::config::Bdk {
 #[cfg(all(test, feature = "bdk"))]
 mod bdk_tests {
     use super::*;
+
+    #[test]
+    fn forwards_bitcoin_rpc_wallet_rescan_height() {
+        let config = config::Bdk {
+            chain_source_type: Some("bitcoinrpc".to_string()),
+            wallet_rescan_from_height: Some(850000),
+            ..Default::default()
+        };
+
+        match config
+            .chain_source()
+            .expect("Bitcoin RPC config should parse")
+        {
+            cdk_bdk::ChainSource::BitcoinRpc(config) => {
+                assert_eq!(config.wallet_rescan_from_height, Some(850000));
+            }
+            _ => panic!("expected a Bitcoin RPC chain source"),
+        }
+    }
 
     #[test]
     fn parses_electrum_chain_source() {


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----


Checkpoint newly created wallets at the current Bitcoin Core tip while allowing operators to configure a birthday height for seed recovery. Reject future heights and abort creation when tip lookup fails so a fresh wallet is never accidentally pinned to genesis.

Keep persisted wallet checkpoints intact and expose the recovery height through mintd configuration and environment variables.


Same idea as https://github.com/lightningdevkit/ldk-node/pull/884

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
