### PR TITLE
fix(wallet): harden WebSocket reconnects and NUT-19 replay

### DIFF
--- a/crates/cdk-common/src/pub_sub/error.rs
+++ b/crates/cdk-common/src/pub_sub/error.rs
@@ -25,6 +25,10 @@ pub enum Error {
     #[error("Not supported")]
     NotSupported,
 
+    /// A terminal transport error that must not be retried
+    #[error("Terminal error {0}")]
+    Terminal(String),
+
     /// Channel is full
     #[error("Channel is full")]
     ChannelFull,

--- a/crates/cdk-common/src/pub_sub/remote_consumer.rs
+++ b/crates/cdk-common/src/pub_sub/remote_consumer.rs
@@ -225,12 +225,11 @@ where
                     )
                     .await
                 {
-                    retry_at = Some(Instant::now() + backoff);
-                    backoff =
-                        (backoff + STREAM_CONNECTION_BACKOFF).min(STREAM_CONNECTION_MAX_BACKOFF);
-
-                    if matches!(err, Error::NotSupported) {
+                    if matches!(&err, Error::NotSupported | Error::Terminal(_)) {
                         stream_supported = false;
+                    } else {
+                        retry_at = Some(Instant::now() + backoff);
+                        backoff = backoff.saturating_mul(2).min(STREAM_CONNECTION_MAX_BACKOFF);
                     }
                     tracing::error!("Long connection failed with error {:?}", err);
                 } else {
@@ -263,7 +262,7 @@ where
                     )
                     .await
                 {
-                    if matches!(err, Error::NotSupported) {
+                    if matches!(&err, Error::NotSupported | Error::Terminal(_)) {
                         poll_supported = false;
                     }
                     tracing::error!("Polling failed with error {:?}", err);
@@ -539,6 +538,12 @@ mod tests {
         rx: Mutex<mpsc::Receiver<Message>>,
     }
 
+    struct FailingStreamTransport {
+        name_ctr: AtomicUsize,
+        attempts: Arc<AtomicUsize>,
+        terminal: bool,
+    }
+
     impl TestTransport {
         fn new(
             support_long: bool,
@@ -561,6 +566,20 @@ mod tests {
             };
 
             (t, events_tx, observe_ctrl_rx)
+        }
+    }
+
+    impl FailingStreamTransport {
+        fn new(terminal: bool) -> (Self, Arc<AtomicUsize>) {
+            let attempts = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    name_ctr: AtomicUsize::new(1),
+                    attempts: attempts.clone(),
+                    terminal,
+                },
+                attempts,
+            )
         }
     }
 
@@ -633,6 +652,36 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
+    impl Transport for FailingStreamTransport {
+        type Spec = CustomPubSub;
+
+        fn new_name(&self) -> <Self::Spec as Spec>::SubscriptionId {
+            format!("sub-{}", self.name_ctr.fetch_add(1, Ordering::Relaxed))
+        }
+
+        async fn stream(
+            &self,
+            _subscribe_changes: mpsc::Receiver<StreamCtrl<Self::Spec>>,
+            _topics: Vec<SubscribeMessage<Self::Spec>>,
+            _reply_to: InternalRelay<Self::Spec>,
+        ) -> Result<(), Error> {
+            self.attempts.fetch_add(1, Ordering::Relaxed);
+            match self.terminal {
+                true => Err(Error::Terminal("permanent failure".to_string())),
+                false => Err(Error::InternalStr("temporary failure".to_string())),
+            }
+        }
+
+        async fn poll(
+            &self,
+            _topics: Vec<SubscribeMessage<Self::Spec>>,
+            _reply_to: InternalRelay<Self::Spec>,
+        ) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
     // ===== Helpers =====
 
     async fn recv_next<T: Transport>(
@@ -661,6 +710,16 @@ mod tests {
         })
         .await
         .expect("timed out waiting for control message")
+    }
+
+    async fn wait_for_attempts(attempts: &AtomicUsize, expected: usize) {
+        for _ in 0..20 {
+            if attempts.load(Ordering::Relaxed) >= expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("timed out waiting for {expected} stream attempts");
     }
 
     // ===== Tests =====
@@ -860,6 +919,42 @@ mod tests {
             .await
             .expect("event relayed via polling");
         assert_eq!(got, Message { foo: 9, bar: 5 });
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn terminal_stream_failure_is_not_retried() {
+        let (transport, attempts) = FailingStreamTransport::new(true);
+        let consumer = Consumer::new(transport, false, ());
+        let _subscription = consumer
+            .subscribe(SubscriptionReq::Foo("t".to_owned(), 1))
+            .expect("subscribe");
+
+        wait_for_attempts(&attempts, 1).await;
+        tokio::time::advance(Duration::from_secs(60)).await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(attempts.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn transient_stream_failures_use_increasing_backoff() {
+        let (transport, attempts) = FailingStreamTransport::new(false);
+        let consumer = Consumer::new(transport, false, ());
+        let _subscription = consumer
+            .subscribe(SubscriptionReq::Foo("t".to_owned(), 1))
+            .expect("subscribe");
+
+        wait_for_attempts(&attempts, 1).await;
+
+        tokio::time::advance(Duration::from_secs(3)).await;
+        wait_for_attempts(&attempts, 2).await;
+
+        tokio::time::advance(Duration::from_secs(3)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(attempts.load(Ordering::Relaxed), 2);
+
+        tokio::time::advance(Duration::from_secs(2)).await;
+        wait_for_attempts(&attempts, 3).await;
     }
 
     #[tokio::test]

--- a/crates/cdk-http-client/src/error.rs
+++ b/crates/cdk-http-client/src/error.rs
@@ -33,6 +33,18 @@ pub enum HttpError {
     Other(String),
 }
 
+impl HttpError {
+    /// Return whether this error is eligible for NUT-19 request replay.
+    ///
+    /// Only ambiguous transport failures are eligible. HTTP status responses
+    /// are never eligible because NUT-19 caches successful responses only; a
+    /// failed status therefore does not prove that replaying a side-effecting
+    /// request is safe.
+    pub fn is_replay_safe(&self) -> bool {
+        matches!(self, Self::Connection(_) | Self::Timeout)
+    }
+}
+
 #[cfg(all(
     feature = "bitreq",
     not(feature = "reqwest"),
@@ -138,5 +150,22 @@ mod tests {
             }
             _ => panic!("Expected HttpError::Serialization"),
         }
+    }
+
+    #[test]
+    fn test_replay_safe_error_classification() {
+        assert!(HttpError::Connection("reset".to_string()).is_replay_safe());
+        assert!(HttpError::Timeout.is_replay_safe());
+
+        for status in [400, 408, 429, 500, 503] {
+            assert!(!HttpError::Status {
+                status,
+                message: "request failed".to_string(),
+            }
+            .is_replay_safe());
+        }
+
+        assert!(!HttpError::Serialization("bad JSON".to_string()).is_replay_safe());
+        assert!(!HttpError::Other("attestation failed".to_string()).is_replay_safe());
     }
 }

--- a/crates/cdk-http-client/src/transport/tor_transport.rs
+++ b/crates/cdk-http-client/src/transport/tor_transport.rs
@@ -311,11 +311,11 @@ impl Transport for TorAsync {
         headers: &[(&str, &str)],
     ) -> Result<(crate::ws::WsSender, crate::ws::WsReceiver), crate::ws::WsError> {
         let parsed_url = Url::parse(url)
-            .map_err(|e| crate::ws::WsError::Connection(format!("Invalid URL: {e}")))?;
+            .map_err(|e| crate::ws::WsError::Terminal(format!("Invalid URL: {e}")))?;
         let pool = self
             .ensure_pool()
             .await
-            .map_err(|e| crate::ws::WsError::Connection(e.to_string()))?;
+            .map_err(|e| crate::ws::WsError::Transient(e.to_string()))?;
         let idx = self.index_for_request(&http::Method::GET, &parsed_url, None, pool.len());
 
         crate::ws::connect_tor(pool[idx].clone(), url, headers).await

--- a/crates/cdk-http-client/src/ws/error.rs
+++ b/crates/cdk-http-client/src/ws/error.rs
@@ -1,15 +1,82 @@
 //! WebSocket error types
 
-/// Errors that can occur during WebSocket operations
+/// Errors that can occur during WebSocket operations.
 #[derive(Debug, thiserror::Error)]
 pub enum WsError {
-    /// Failed to establish a WebSocket connection
-    #[error("WebSocket connection error: {0}")]
-    Connection(String),
-    /// Failed to send a WebSocket message
-    #[error("WebSocket send error: {0}")]
-    Send(String),
-    /// Failed to receive a WebSocket message
-    #[error("WebSocket receive error: {0}")]
-    Receive(String),
+    /// A temporary network or connection failure.
+    #[error("transient WebSocket error: {0}")]
+    Transient(String),
+    /// The remote endpoint does not support WebSocket subscriptions.
+    #[error("WebSocket subscriptions are not supported: {0}")]
+    NotSupported(String),
+    /// A permanent configuration, authentication, TLS, or protocol failure.
+    #[error("terminal WebSocket error: {0}")]
+    Terminal(String),
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl WsError {
+    pub(crate) fn from_tungstenite(error: tokio_tungstenite::tungstenite::Error) -> Self {
+        use tokio_tungstenite::tungstenite::Error;
+
+        let status = match &error {
+            Error::Http(response) => Some(response.status().as_u16()),
+            _ => None,
+        };
+        let message = error.to_string();
+
+        match status {
+            Some(404 | 405 | 501) => Self::NotSupported(message),
+            Some(408 | 429 | 500..=599) => Self::Transient(message),
+            Some(_) => Self::Terminal(message),
+            None => match error {
+                Error::ConnectionClosed | Error::AlreadyClosed | Error::Io(_) => {
+                    Self::Transient(message)
+                }
+                Error::Tls(_)
+                | Error::Capacity(_)
+                | Error::Protocol(_)
+                | Error::WriteBufferFull(_)
+                | Error::Utf8
+                | Error::AttackAttempt
+                | Error::Url(_)
+                | Error::Http(_)
+                | Error::HttpFormat(_) => Self::Terminal(message),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn classifies_http_upgrade_statuses() {
+        use tokio_tungstenite::tungstenite::http::{Response, StatusCode};
+        use tokio_tungstenite::tungstenite::Error;
+
+        let error_for_status = |status| {
+            Error::Http(
+                Response::builder()
+                    .status(status)
+                    .body(None)
+                    .expect("valid HTTP response"),
+            )
+        };
+
+        assert!(matches!(
+            WsError::from_tungstenite(error_for_status(StatusCode::NOT_FOUND)),
+            WsError::NotSupported(_)
+        ));
+        assert!(matches!(
+            WsError::from_tungstenite(error_for_status(StatusCode::UNAUTHORIZED)),
+            WsError::Terminal(_)
+        ));
+        assert!(matches!(
+            WsError::from_tungstenite(error_for_status(StatusCode::SERVICE_UNAVAILABLE)),
+            WsError::Transient(_)
+        ));
+    }
 }

--- a/crates/cdk-http-client/src/ws/native.rs
+++ b/crates/cdk-http-client/src/ws/native.rs
@@ -41,7 +41,7 @@ impl WsSender {
         self.inner
             .send(Message::Text(text.into()))
             .await
-            .map_err(|e| WsError::Send(e.to_string()))
+            .map_err(WsError::from_tungstenite)
     }
 
     /// Send a close frame
@@ -49,7 +49,7 @@ impl WsSender {
         self.inner
             .send(Message::Close(None))
             .await
-            .map_err(|e| WsError::Send(e.to_string()))
+            .map_err(WsError::from_tungstenite)
     }
 }
 
@@ -62,7 +62,7 @@ impl WsReceiver {
                 Some(Ok(Message::Text(text))) => return Some(Ok(text.to_string())),
                 Some(Ok(Message::Close(_))) | None => return None,
                 Some(Ok(_)) => continue, // skip binary, ping, pong
-                Some(Err(e)) => return Some(Err(WsError::Receive(e.to_string()))),
+                Some(Err(e)) => return Some(Err(WsError::from_tungstenite(e))),
             }
         }
     }
@@ -102,20 +102,27 @@ pub async fn connect(
 ) -> Result<(WsSender, WsReceiver), WsError> {
     let mut request = url
         .into_client_request()
-        .map_err(|e| WsError::Connection(e.to_string()))?;
+        .map_err(|e| WsError::Terminal(e.to_string()))?;
 
     for &(name, value) in headers {
-        if let (Ok(header_name), Ok(header_value)) = (
-            name.parse::<tokio_tungstenite::tungstenite::http::header::HeaderName>(),
-            value.parse::<tokio_tungstenite::tungstenite::http::header::HeaderValue>(),
-        ) {
-            request.headers_mut().insert(header_name, header_value);
-        }
+        let header_name = name
+            .parse::<tokio_tungstenite::tungstenite::http::header::HeaderName>()
+            .map_err(|error| {
+                WsError::Terminal(format!("invalid WebSocket header name `{name}`: {error}"))
+            })?;
+        let header_value = value
+            .parse::<tokio_tungstenite::tungstenite::http::header::HeaderValue>()
+            .map_err(|error| {
+                WsError::Terminal(format!(
+                    "invalid value for WebSocket header `{name}`: {error}"
+                ))
+            })?;
+        request.headers_mut().insert(header_name, header_value);
     }
 
     let (ws_stream, _) = tokio_tungstenite::connect_async(request)
         .await
-        .map_err(|e| WsError::Connection(e.to_string()))?;
+        .map_err(WsError::from_tungstenite)?;
 
     Ok(from_websocket_stream(ws_stream))
 }
@@ -128,37 +135,44 @@ pub(crate) async fn connect_tor(
     headers: &[(&str, &str)],
 ) -> Result<(WsSender, WsReceiver), WsError> {
     let parsed_url =
-        url::Url::parse(url).map_err(|e| WsError::Connection(format!("Invalid URL: {e}")))?;
+        url::Url::parse(url).map_err(|e| WsError::Terminal(format!("Invalid URL: {e}")))?;
 
     let host = parsed_url
         .host_str()
-        .ok_or_else(|| WsError::Connection("WebSocket URL must include a host".to_string()))?;
+        .ok_or_else(|| WsError::Terminal("WebSocket URL must include a host".to_string()))?;
     let port = parsed_url
         .port_or_known_default()
-        .ok_or_else(|| WsError::Connection("WebSocket URL must include a port".to_string()))?;
+        .ok_or_else(|| WsError::Terminal("WebSocket URL must include a port".to_string()))?;
 
     let mut request = url
         .into_client_request()
-        .map_err(|e| WsError::Connection(e.to_string()))?;
+        .map_err(|e| WsError::Terminal(e.to_string()))?;
 
     for &(name, value) in headers {
-        if let (Ok(header_name), Ok(header_value)) = (
-            name.parse::<tokio_tungstenite::tungstenite::http::header::HeaderName>(),
-            value.parse::<tokio_tungstenite::tungstenite::http::header::HeaderValue>(),
-        ) {
-            request.headers_mut().insert(header_name, header_value);
-        }
+        let header_name = name
+            .parse::<tokio_tungstenite::tungstenite::http::header::HeaderName>()
+            .map_err(|error| {
+                WsError::Terminal(format!("invalid WebSocket header name `{name}`: {error}"))
+            })?;
+        let header_value = value
+            .parse::<tokio_tungstenite::tungstenite::http::header::HeaderValue>()
+            .map_err(|error| {
+                WsError::Terminal(format!(
+                    "invalid value for WebSocket header `{name}`: {error}"
+                ))
+            })?;
+        request.headers_mut().insert(header_name, header_value);
     }
 
     let stream = tor_client
         .connect((host, port))
         .await
-        .map_err(|e| WsError::Connection(e.to_string()))?;
+        .map_err(|e| WsError::Transient(e.to_string()))?;
 
     let (ws_stream, _) =
         tokio_tungstenite::client_async_tls_with_config(request, stream, None, None)
             .await
-            .map_err(|e| WsError::Connection(e.to_string()))?;
+            .map_err(WsError::from_tungstenite)?;
 
     Ok(from_websocket_stream(ws_stream))
 }

--- a/crates/cdk-http-client/src/ws/wasm.rs
+++ b/crates/cdk-http-client/src/ws/wasm.rs
@@ -57,14 +57,14 @@ impl WsSender {
     pub async fn send(&mut self, text: String) -> Result<(), WsError> {
         self.ws
             .send_with_str(&text)
-            .map_err(|e| WsError::Send(format!("{:?}", e)))
+            .map_err(|e| WsError::Transient(format!("{:?}", e)))
     }
 
     /// Send a close frame
     pub async fn close(&mut self) -> Result<(), WsError> {
         self.ws
             .close()
-            .map_err(|e| WsError::Send(format!("{:?}", e)))
+            .map_err(|e| WsError::Transient(format!("{:?}", e)))
     }
 }
 
@@ -91,7 +91,7 @@ pub async fn connect(
         );
     }
 
-    let ws = WebSocket::new(url).map_err(|e| WsError::Connection(format!("{:?}", e)))?;
+    let ws = WebSocket::new(url).map_err(|e| WsError::Terminal(format!("{:?}", e)))?;
     ws.set_binary_type(BinaryType::Arraybuffer);
 
     let (msg_tx, msg_rx) = mpsc::unbounded::<Result<String, WsError>>();
@@ -123,11 +123,18 @@ pub async fn connect(
     let open_tx_err = Rc::clone(&open_tx);
     let msg_tx_err: mpsc::UnboundedSender<Result<String, WsError>> = msg_tx.clone();
     let onerror = Closure::<dyn FnMut(ErrorEvent)>::new(move |_e: ErrorEvent| {
-        let err = WsError::Connection("WebSocket error".to_string());
         if let Some(tx) = open_tx_err.borrow_mut().take() {
-            let _ = tx.send(Err(err));
+            // Browsers do not expose the HTTP status or handshake failure
+            // reason. Treat an initial failure as unsupported so a permanent
+            // 404 or authentication rejection falls back to polling instead
+            // of reconnecting forever.
+            let _ = tx.send(Err(WsError::NotSupported(
+                "the browser rejected the WebSocket connection".to_string(),
+            )));
         } else {
-            let _ = msg_tx_err.unbounded_send(Err(err));
+            let _ = msg_tx_err.unbounded_send(Err(WsError::Transient(
+                "WebSocket connection failed".to_string(),
+            )));
         }
     });
     ws.set_onerror(Some(onerror.as_ref().unchecked_ref()));
@@ -141,7 +148,7 @@ pub async fn connect(
     // Wait for the connection to open (or fail)
     open_rx
         .await
-        .map_err(|_| WsError::Connection("open channel dropped".to_string()))??;
+        .map_err(|_| WsError::Terminal("open channel dropped".to_string()))??;
 
     let ws_clone = ws.clone();
     Ok((

--- a/crates/cdk/src/wallet/mint_connector/http_client.rs
+++ b/crates/cdk/src/wallet/mint_connector/http_client.rs
@@ -33,6 +33,9 @@ use crate::OidcClient;
 
 type Cache = (u64, HashSet<(nut19::Method, nut19::Path)>);
 
+const HTTP_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(50);
+const HTTP_RETRY_MAX_BACKOFF: Duration = Duration::from_secs(1);
+
 fn payment_method_path_segment(method: &PaymentMethod) -> Result<&str, Error> {
     match method {
         PaymentMethod::Known(known) => Ok(known.as_str()),
@@ -270,6 +273,7 @@ where
             .unwrap_or_default();
 
         let transport = self.transport.clone();
+        let mut retry_delay = HTTP_RETRY_INITIAL_BACKOFF;
         loop {
             let url = match &path {
                 nut19::Path::Swap => self.mint_url.join_paths(&["v1", "swap"])?,
@@ -282,39 +286,49 @@ where
                 }
             };
 
-            let result = match method {
-                nut19::Method::Get => transport
-                    .http_get(url, auth_token.clone())
-                    .await
-                    .map_err(Self::map_http_error),
-                nut19::Method::Post => transport
-                    .http_post(url, auth_token.clone(), payload)
-                    .await
-                    .map_err(Self::map_http_error),
-            };
-
-            if result.is_ok() {
-                return result;
-            }
-
-            match result.as_ref() {
-                Err(Error::HttpError(status_code, _)) => {
-                    let status_code = status_code.to_owned().unwrap_or_default();
-                    if (400..=499).contains(&status_code) {
-                        // 4xx errors won't be 'solved' by retrying
-                        return result;
-                    }
-
-                    // retry request, if possible
-                    tracing::error!("Failed http_request {:?}", result.as_ref().err());
-
-                    if retriable_window < started.elapsed() {
-                        return result;
+            let request = async {
+                match method {
+                    nut19::Method::Get => transport.http_get(url, auth_token.clone()).await,
+                    nut19::Method::Post => {
+                        transport.http_post(url, auth_token.clone(), payload).await
                     }
                 }
-                Err(_) => return result,
-                _ => unreachable!(),
             };
+            let result = if retriable_window.is_zero() {
+                request.await
+            } else {
+                let remaining = retriable_window.saturating_sub(started.elapsed());
+                if remaining.is_zero() {
+                    return Err(Error::Timeout);
+                }
+
+                match tokio::time::timeout(remaining, request).await {
+                    Ok(result) => result,
+                    Err(_) => return Err(Error::Timeout),
+                }
+            };
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(http_error) => {
+                    let replay_safe = http_error.is_replay_safe();
+                    let error = Self::map_http_error(http_error);
+                    let elapsed = started.elapsed();
+
+                    if !replay_safe || elapsed >= retriable_window {
+                        return Err(error);
+                    }
+
+                    tracing::warn!(error = %error, "Replay-safe HTTP request failed");
+
+                    let remaining = retriable_window.saturating_sub(elapsed);
+                    tokio::time::sleep(retry_delay.min(remaining)).await;
+                    if started.elapsed() >= retriable_window {
+                        return Err(error);
+                    }
+                    retry_delay = retry_delay.saturating_mul(2).min(HTTP_RETRY_MAX_BACKOFF);
+                }
+            }
         }
     }
 }
@@ -1090,6 +1104,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
     use std::fmt;
     use std::str::FromStr;
     use std::sync::Mutex;
@@ -1118,6 +1133,10 @@ mod tests {
         get_urls: Arc<Mutex<Vec<String>>>,
         /// URLs passed to `http_post`.
         post_urls: Arc<Mutex<Vec<String>>>,
+        /// Errors returned by `http_post` before its canned success response.
+        post_errors: Arc<Mutex<VecDeque<HttpError>>>,
+        /// Artificial delay applied to each `http_post` call.
+        post_delay: Option<Duration>,
     }
 
     impl fmt::Debug for MockTransport {
@@ -1188,6 +1207,14 @@ mod tests {
                 .map_err(|e| HttpError::Serialization(e.to_string()))?;
             *self.captured_payload.lock().expect("lock") = Some(value);
 
+            if let Some(delay) = self.post_delay {
+                tokio::time::sleep(delay).await;
+            }
+
+            if let Some(error) = self.post_errors.lock().expect("lock").pop_front() {
+                return Err(error);
+            }
+
             // Return the canned response
             let json = self
                 .post_response
@@ -1246,6 +1273,8 @@ mod tests {
             get_response: Arc::new(Mutex::new(None)),
             get_urls: Arc::new(Mutex::new(Vec::new())),
             post_urls: Arc::new(Mutex::new(Vec::new())),
+            post_errors: Arc::new(Mutex::new(VecDeque::new())),
+            post_delay: None,
         };
         let captured = transport.captured_payload.clone();
 
@@ -1299,6 +1328,158 @@ mod tests {
         let parsed = parsed.expect("already checked");
         assert_eq!(parsed.amount, Some(cdk_common::Amount::from(1000)));
         assert_eq!(parsed.unit, cdk_common::CurrencyUnit::Sat);
+    }
+
+    #[tokio::test]
+    async fn retriable_request_retries_transient_transport_error() {
+        let transport = MockTransport {
+            post_response: Arc::new(Mutex::new(Some(
+                serde_json::json!({ "ok": true }).to_string(),
+            ))),
+            post_errors: Arc::new(Mutex::new(VecDeque::from([HttpError::Connection(
+                "connection reset".to_string(),
+            )]))),
+            ..Default::default()
+        };
+        let post_urls = transport.post_urls.clone();
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let client = HttpClient::with_transport(mint_url, transport, None);
+        *client.cache_support.write().expect("cache lock") =
+            (1, HashSet::from([(nut19::Method::Post, nut19::Path::Swap)]));
+
+        let started = Instant::now();
+        let response: serde_json::Value = client
+            .retriable_http_request(
+                nut19::Method::Post,
+                nut19::Path::Swap,
+                None,
+                &serde_json::json!({}),
+            )
+            .await
+            .expect("transient failure should be retried");
+
+        assert_eq!(response, serde_json::json!({ "ok": true }));
+        assert_eq!(post_urls.lock().expect("lock").len(), 2);
+        assert!(started.elapsed() >= HTTP_RETRY_INITIAL_BACKOFF);
+    }
+
+    #[tokio::test]
+    async fn retriable_request_does_not_replay_http_status_response() {
+        let transport = MockTransport {
+            post_response: Arc::new(Mutex::new(Some(
+                serde_json::json!({ "ok": true }).to_string(),
+            ))),
+            post_errors: Arc::new(Mutex::new(VecDeque::from([HttpError::Status {
+                status: 503,
+                message: "unavailable".to_string(),
+            }]))),
+            ..Default::default()
+        };
+        let post_urls = transport.post_urls.clone();
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let client = HttpClient::with_transport(mint_url, transport, None);
+        *client.cache_support.write().expect("cache lock") =
+            (1, HashSet::from([(nut19::Method::Post, nut19::Path::Swap)]));
+
+        let result: Result<serde_json::Value, Error> = client
+            .retriable_http_request(
+                nut19::Method::Post,
+                nut19::Path::Swap,
+                None,
+                &serde_json::json!({}),
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::HttpError(Some(503), _))));
+        assert_eq!(post_urls.lock().expect("lock").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn retriable_request_is_bounded_by_nut19_window() {
+        let transport = MockTransport {
+            post_response: Arc::new(Mutex::new(Some(
+                serde_json::json!({ "ok": true }).to_string(),
+            ))),
+            post_delay: Some(Duration::from_secs(5)),
+            ..Default::default()
+        };
+        let post_urls = transport.post_urls.clone();
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let client = HttpClient::with_transport(mint_url, transport, None);
+        *client.cache_support.write().expect("cache lock") =
+            (1, HashSet::from([(nut19::Method::Post, nut19::Path::Swap)]));
+
+        let started = Instant::now();
+        let result: Result<serde_json::Value, Error> = client
+            .retriable_http_request(
+                nut19::Method::Post,
+                nut19::Path::Swap,
+                None,
+                &serde_json::json!({}),
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::Timeout)));
+        assert!(started.elapsed() < Duration::from_secs(5));
+        assert_eq!(post_urls.lock().expect("lock").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn retriable_request_does_not_retry_terminal_transport_error() {
+        let transport = MockTransport {
+            post_response: Arc::new(Mutex::new(Some(
+                serde_json::json!({ "ok": true }).to_string(),
+            ))),
+            post_errors: Arc::new(Mutex::new(VecDeque::from([HttpError::Other(
+                "attestation failed".to_string(),
+            )]))),
+            ..Default::default()
+        };
+        let post_urls = transport.post_urls.clone();
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let client = HttpClient::with_transport(mint_url, transport, None);
+        *client.cache_support.write().expect("cache lock") =
+            (1, HashSet::from([(nut19::Method::Post, nut19::Path::Swap)]));
+
+        let result: Result<serde_json::Value, Error> = client
+            .retriable_http_request(
+                nut19::Method::Post,
+                nut19::Path::Swap,
+                None,
+                &serde_json::json!({}),
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::HttpError(None, _))));
+        assert_eq!(post_urls.lock().expect("lock").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn retriable_request_does_not_replay_without_nut19_cache_support() {
+        let transport = MockTransport {
+            post_response: Arc::new(Mutex::new(Some(
+                serde_json::json!({ "ok": true }).to_string(),
+            ))),
+            post_errors: Arc::new(Mutex::new(VecDeque::from([HttpError::Connection(
+                "connection reset".to_string(),
+            )]))),
+            ..Default::default()
+        };
+        let post_urls = transport.post_urls.clone();
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let client = HttpClient::with_transport(mint_url, transport, None);
+
+        let result: Result<serde_json::Value, Error> = client
+            .retriable_http_request(
+                nut19::Method::Post,
+                nut19::Path::Swap,
+                None,
+                &serde_json::json!({}),
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::HttpError(None, _))));
+        assert_eq!(post_urls.lock().expect("lock").len(), 1);
     }
 
     #[tokio::test]

--- a/crates/cdk/src/wallet/mint_connector/http_client.rs
+++ b/crates/cdk/src/wallet/mint_connector/http_client.rs
@@ -13,7 +13,7 @@ use cdk_http_client::HttpError;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio::sync::RwLock;
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout};
 use tracing::instrument;
 use url::Url;
 use web_time::{Duration, Instant};
@@ -34,11 +34,11 @@ use crate::OidcClient;
 
 type Cache = (u64, HashSet<(nut19::Method, nut19::Path)>);
 
-/// Delay before the first retry of a failed request.
-const INITIAL_RETRY_DELAY: Duration = Duration::from_millis(500);
+/// Delay before the first replay of a failed request.
+const HTTP_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(50);
 
-/// Upper bound for the exponential backoff between retries.
-const MAX_RETRY_DELAY: Duration = Duration::from_secs(8);
+/// Upper bound for the exponential backoff between replays.
+const HTTP_RETRY_MAX_BACKOFF: Duration = Duration::from_secs(1);
 
 fn payment_method_path_segment(method: &PaymentMethod) -> Result<&str, Error> {
     match method {
@@ -289,7 +289,7 @@ where
             .unwrap_or_default();
 
         let transport = self.transport.clone();
-        let mut retry_delay = INITIAL_RETRY_DELAY;
+        let mut retry_delay = HTTP_RETRY_INITIAL_BACKOFF;
         loop {
             let url = match &path {
                 nut19::Path::Swap => self.mint_url.join_paths(&["v1", "swap"])?,
@@ -302,45 +302,51 @@ where
                 }
             };
 
-            let result = match method {
-                nut19::Method::Get => transport
-                    .http_get(url, auth_token.clone())
-                    .await
-                    .map_err(Self::map_http_error),
-                nut19::Method::Post => transport
-                    .http_post(url, auth_token.clone(), payload)
-                    .await
-                    .map_err(Self::map_http_error),
-            };
-
-            if result.is_ok() {
-                return result;
-            }
-
-            match result.as_ref() {
-                Err(Error::HttpError(status_code, _)) => {
-                    let status_code = status_code.to_owned().unwrap_or_default();
-                    if (400..=499).contains(&status_code) {
-                        // 4xx errors won't be 'solved' by retrying
-                        return result;
+            let request = async {
+                match method {
+                    nut19::Method::Get => transport.http_get(url, auth_token.clone()).await,
+                    nut19::Method::Post => {
+                        transport.http_post(url, auth_token.clone(), payload).await
                     }
-
-                    // retry request, if possible
-                    tracing::error!("Failed http_request {:?}", result.as_ref().err());
-
-                    let remaining = retriable_window.saturating_sub(started.elapsed());
-                    if remaining.is_zero() {
-                        return result;
-                    }
-
-                    // Back off before retrying so a struggling mint is not hammered,
-                    // without ever sleeping past the end of the replay window.
-                    sleep(retry_delay.min(remaining)).await;
-                    retry_delay = (retry_delay * 2).min(MAX_RETRY_DELAY);
                 }
-                Err(_) => return result,
-                _ => unreachable!(),
             };
+            let result = if retriable_window.is_zero() {
+                request.await
+            } else {
+                let remaining = retriable_window.saturating_sub(started.elapsed());
+                if remaining.is_zero() {
+                    return Err(Error::Timeout);
+                }
+
+                match timeout(remaining, request).await {
+                    Ok(result) => result,
+                    Err(_) => return Err(Error::Timeout),
+                }
+            };
+
+            match result {
+                Ok(response) => return Ok(response),
+                Err(http_error) => {
+                    let replay_safe = http_error.is_replay_safe();
+                    let error = Self::map_http_error(http_error);
+                    let elapsed = started.elapsed();
+
+                    if !replay_safe || elapsed >= retriable_window {
+                        return Err(error);
+                    }
+
+                    tracing::warn!(error = %error, "Replay-safe HTTP request failed");
+
+                    // Back off before replaying so a struggling mint is not hammered,
+                    // without ever sleeping past the end of the replay window.
+                    let remaining = retriable_window.saturating_sub(elapsed);
+                    sleep(retry_delay.min(remaining)).await;
+                    if started.elapsed() >= retriable_window {
+                        return Err(error);
+                    }
+                    retry_delay = retry_delay.saturating_mul(2).min(HTTP_RETRY_MAX_BACKOFF);
+                }
+            }
         }
     }
 }
@@ -1126,6 +1132,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
     use std::fmt;
     use std::str::FromStr;
     use std::sync::Mutex;
@@ -1154,6 +1161,10 @@ mod tests {
         get_urls: Arc<Mutex<Vec<String>>>,
         /// URLs passed to `http_post`.
         post_urls: Arc<Mutex<Vec<String>>>,
+        /// Errors returned by `http_post` before its canned success response.
+        post_errors: Arc<Mutex<VecDeque<HttpError>>>,
+        /// Artificial delay applied to each `http_post` call.
+        post_delay: Option<Duration>,
     }
 
     impl fmt::Debug for MockTransport {
@@ -1224,6 +1235,14 @@ mod tests {
                 .map_err(|e| HttpError::Serialization(e.to_string()))?;
             *self.captured_payload.lock().expect("lock") = Some(value);
 
+            if let Some(delay) = self.post_delay {
+                tokio::time::sleep(delay).await;
+            }
+
+            if let Some(error) = self.post_errors.lock().expect("lock").pop_front() {
+                return Err(error);
+            }
+
             // Return the canned response
             let json = self
                 .post_response
@@ -1282,6 +1301,8 @@ mod tests {
             get_response: Arc::new(Mutex::new(None)),
             get_urls: Arc::new(Mutex::new(Vec::new())),
             post_urls: Arc::new(Mutex::new(Vec::new())),
+            post_errors: Arc::new(Mutex::new(VecDeque::new())),
+            post_delay: None,
         };
         let captured = transport.captured_payload.clone();
 
@@ -1335,6 +1356,158 @@ mod tests {
         let parsed = parsed.expect("already checked");
         assert_eq!(parsed.amount, Some(cdk_common::Amount::from(1000)));
         assert_eq!(parsed.unit, cdk_common::CurrencyUnit::Sat);
+    }
+
+    #[tokio::test]
+    async fn retriable_request_retries_transient_transport_error() {
+        let transport = MockTransport {
+            post_response: Arc::new(Mutex::new(Some(
+                serde_json::json!({ "ok": true }).to_string(),
+            ))),
+            post_errors: Arc::new(Mutex::new(VecDeque::from([HttpError::Connection(
+                "connection reset".to_string(),
+            )]))),
+            ..Default::default()
+        };
+        let post_urls = transport.post_urls.clone();
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let client = HttpClient::with_transport(mint_url, transport, None);
+        *client.cache_support.write().expect("cache lock") =
+            (1, HashSet::from([(nut19::Method::Post, nut19::Path::Swap)]));
+
+        let started = Instant::now();
+        let response: serde_json::Value = client
+            .retriable_http_request(
+                nut19::Method::Post,
+                nut19::Path::Swap,
+                None,
+                &serde_json::json!({}),
+            )
+            .await
+            .expect("transient failure should be retried");
+
+        assert_eq!(response, serde_json::json!({ "ok": true }));
+        assert_eq!(post_urls.lock().expect("lock").len(), 2);
+        assert!(started.elapsed() >= HTTP_RETRY_INITIAL_BACKOFF);
+    }
+
+    #[tokio::test]
+    async fn retriable_request_does_not_replay_http_status_response() {
+        let transport = MockTransport {
+            post_response: Arc::new(Mutex::new(Some(
+                serde_json::json!({ "ok": true }).to_string(),
+            ))),
+            post_errors: Arc::new(Mutex::new(VecDeque::from([HttpError::Status {
+                status: 503,
+                message: "unavailable".to_string(),
+            }]))),
+            ..Default::default()
+        };
+        let post_urls = transport.post_urls.clone();
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let client = HttpClient::with_transport(mint_url, transport, None);
+        *client.cache_support.write().expect("cache lock") =
+            (1, HashSet::from([(nut19::Method::Post, nut19::Path::Swap)]));
+
+        let result: Result<serde_json::Value, Error> = client
+            .retriable_http_request(
+                nut19::Method::Post,
+                nut19::Path::Swap,
+                None,
+                &serde_json::json!({}),
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::HttpError(Some(503), _))));
+        assert_eq!(post_urls.lock().expect("lock").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn retriable_request_is_bounded_by_nut19_window() {
+        let transport = MockTransport {
+            post_response: Arc::new(Mutex::new(Some(
+                serde_json::json!({ "ok": true }).to_string(),
+            ))),
+            post_delay: Some(Duration::from_secs(5)),
+            ..Default::default()
+        };
+        let post_urls = transport.post_urls.clone();
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let client = HttpClient::with_transport(mint_url, transport, None);
+        *client.cache_support.write().expect("cache lock") =
+            (1, HashSet::from([(nut19::Method::Post, nut19::Path::Swap)]));
+
+        let started = Instant::now();
+        let result: Result<serde_json::Value, Error> = client
+            .retriable_http_request(
+                nut19::Method::Post,
+                nut19::Path::Swap,
+                None,
+                &serde_json::json!({}),
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::Timeout)));
+        assert!(started.elapsed() < Duration::from_secs(5));
+        assert_eq!(post_urls.lock().expect("lock").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn retriable_request_does_not_retry_terminal_transport_error() {
+        let transport = MockTransport {
+            post_response: Arc::new(Mutex::new(Some(
+                serde_json::json!({ "ok": true }).to_string(),
+            ))),
+            post_errors: Arc::new(Mutex::new(VecDeque::from([HttpError::Other(
+                "attestation failed".to_string(),
+            )]))),
+            ..Default::default()
+        };
+        let post_urls = transport.post_urls.clone();
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let client = HttpClient::with_transport(mint_url, transport, None);
+        *client.cache_support.write().expect("cache lock") =
+            (1, HashSet::from([(nut19::Method::Post, nut19::Path::Swap)]));
+
+        let result: Result<serde_json::Value, Error> = client
+            .retriable_http_request(
+                nut19::Method::Post,
+                nut19::Path::Swap,
+                None,
+                &serde_json::json!({}),
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::HttpError(None, _))));
+        assert_eq!(post_urls.lock().expect("lock").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn retriable_request_does_not_replay_without_nut19_cache_support() {
+        let transport = MockTransport {
+            post_response: Arc::new(Mutex::new(Some(
+                serde_json::json!({ "ok": true }).to_string(),
+            ))),
+            post_errors: Arc::new(Mutex::new(VecDeque::from([HttpError::Connection(
+                "connection reset".to_string(),
+            )]))),
+            ..Default::default()
+        };
+        let post_urls = transport.post_urls.clone();
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let client = HttpClient::with_transport(mint_url, transport, None);
+
+        let result: Result<serde_json::Value, Error> = client
+            .retriable_http_request(
+                nut19::Method::Post,
+                nut19::Path::Swap,
+                None,
+                &serde_json::json!({}),
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::HttpError(None, _))));
+        assert_eq!(post_urls.lock().expect("lock").len(), 1);
     }
 
     #[tokio::test]

--- a/crates/cdk/src/wallet/subscription.rs
+++ b/crates/cdk/src/wallet/subscription.rs
@@ -548,7 +548,7 @@ async fn stream_client(
         };
 
         sub_id_to_kind.insert(name, kind);
-        let _ = sender.send(req).await;
+        sender.send(req).await.map_err(map_ws_error)?;
     }
 
     loop {
@@ -563,7 +563,7 @@ async fn stream_client(
                             continue;
                         };
                         sub_id_to_kind.insert(msg.0, kind);
-                        let _ = sender.send(req).await;
+                        sender.send(req).await.map_err(map_ws_error)?;
                     }
                     StreamCtrl::Unsubscribe(msg) => {
                         sub_id_to_kind.remove(&msg);
@@ -572,29 +572,29 @@ async fn stream_client(
                         } else {
                             continue;
                         };
-                        let _ = sender.send(req).await;
+                        sender.send(req).await.map_err(map_ws_error)?;
                     }
                     StreamCtrl::Stop => {
                         if let Err(err) = sender.close().await {
                             tracing::error!("Closing error {err:?}");
                         }
-                        break;
+                        return Ok(());
                     }
                 };
             }
             msg = receiver.recv() => {
                 let msg = match msg {
                     Some(Ok(msg)) => msg,
-                    Some(Err(_)) => {
+                    Some(Err(err)) => {
                         if let Err(err) = sender.close().await {
                             tracing::error!("Closing error {err:?}");
                         }
-                        sub_id_to_kind.clear();
-                        break;
+                        return Err(map_ws_error(err));
                     }
                     None => {
-                        sub_id_to_kind.clear();
-                        break;
+                        return Err(PubsubError::InternalStr(
+                            "WebSocket stream closed unexpectedly".to_string(),
+                        ));
                     }
                 };
                 let msg = match serde_json::from_str::<RawWsMessageOrResponse<String>>(&msg) {
@@ -629,14 +629,13 @@ async fn stream_client(
             }
         }
     }
-
-    Ok(())
 }
 
 fn map_ws_error(err: WsError) -> PubsubError {
     match err {
-        WsError::Connection(_) => PubsubError::NotSupported,
-        other => PubsubError::InternalStr(other.to_string()),
+        WsError::Transient(message) => PubsubError::InternalStr(message),
+        WsError::NotSupported(_) => PubsubError::NotSupported,
+        WsError::Terminal(message) => PubsubError::Terminal(message),
     }
 }
 
@@ -645,6 +644,27 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn transient_websocket_failure_keeps_streaming_enabled() {
+        let error = map_ws_error(WsError::Transient("temporary disconnect".to_string()));
+
+        assert!(matches!(error, PubsubError::InternalStr(_)));
+    }
+
+    #[test]
+    fn unsupported_websocket_failure_disables_streaming() {
+        let error = map_ws_error(WsError::NotSupported("404".to_string()));
+
+        assert!(matches!(error, PubsubError::NotSupported));
+    }
+
+    #[test]
+    fn terminal_websocket_failure_disables_streaming() {
+        let error = map_ws_error(WsError::Terminal("attestation failed".to_string()));
+
+        assert!(matches!(error, PubsubError::Terminal(_)));
+    }
 
     #[test]
     fn decode_proof_state_notification() {


### PR DESCRIPTION
While working on enclavia auto-reconnect feature of https://github.com/cashubtc/cdk/pull/2231 (not yet added to PR), I stumbled upon these improvements:

  ### Description

  Hardens wallet recovery from unreliable mint connections while preventing retry storms and unsafe request replays.

  - Classifies WebSocket failures as transient, unsupported, or terminal across native, WASM, and Tor transports.
  - Retries transient WebSocket failures with capped exponential backoff.
  - Falls back to polling when subscriptions are unsupported and stops retrying terminal failures.
  - Restricts NUT-19 replay to ambiguous connection failures and timeouts on routes explicitly advertised by the mint.
  - Enforces the NUT-19 cache window as an end-to-end deadline and never replays HTTP responses or terminal errors.
  - Adds coverage for failure classification, reconnect backoff, replay eligibility, route support, and deadline enforcement.

  -----

  ### Notes to the reviewers

  Browsers do not expose WebSocket handshake status codes. An initial WASM connection failure is therefore treated as unsupported, allowing the wallet to fall back to polling instead of reconnecting indefinitely.

  HTTP status responses—including 408, 429, and 5xx—are intentionally not replayed. NUT-19 only guarantees caching of successful responses, so replaying a side-effecting request after receiving an HTTP response may be unsafe.