### PR TITLE
Signatory: share keysets across instances via periodic reload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,8 +277,8 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           useDaemon: false
         continue-on-error: true
-      - name: Run clippy and tests for cdk-postgres
-        run: nix develop -i -L .#regtest --command bash -c "start-postgres && cargo clippy -p cdk-postgres -- -D warnings && cargo test -p cdk-postgres"
+      - name: Run clippy and Postgres tests
+        run: nix develop -i -L .#regtest --command bash -c "start-postgres && cargo clippy -p cdk-postgres -- -D warnings && cargo test -p cdk-postgres && cargo test -p cdk-integration-tests --test signatory_rotation"
 
 # Tests for cdk-supabase that require a local Supabase stack (PostgREST + GoTrue + PostgreSQL)
   supabase-tests:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -636,6 +636,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -896,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67800fcf7f3ca52f7796d4466948a424326b225950c79d1e76d0458760bb25d"
+checksum = "5304e53726dbe5f93141535e102ed97b5bf4714fbecefdda8f9fb98d7fdaff0e"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.6.0",
@@ -1118,7 +1124,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1139,7 +1145,7 @@ dependencies = [
  "serde_with",
  "strum 0.27.2",
  "strum_macros 0.27.2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "unicode-normalization",
  "ur",
@@ -1185,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1232,7 +1238,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1286,7 +1292,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1332,7 +1338,7 @@ dependencies = [
  "cln-rpc",
  "futures",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1365,7 +1371,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tonic 0.14.6",
  "tracing",
@@ -1390,7 +1396,7 @@ dependencies = [
  "lightning-invoice",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1422,7 +1428,7 @@ dependencies = [
  "rand 0.9.5",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1490,7 +1496,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tls-api",
  "tls-api-native-tls",
  "tokio",
@@ -1526,7 +1532,9 @@ dependencies = [
  "cdk-lnd",
  "cdk-mintd",
  "cdk-nwc",
+ "cdk-postgres",
  "cdk-redb",
+ "cdk-signatory",
  "cdk-sqlite",
  "clap",
  "cln-rpc",
@@ -1569,7 +1577,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1595,7 +1603,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile 2.2.0",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tonic 0.14.6",
@@ -1621,7 +1629,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tonic 0.14.6",
  "tonic-prost",
@@ -1685,7 +1693,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1700,7 +1708,7 @@ dependencies = [
  "async-trait",
  "nostr-sdk",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1731,7 +1739,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1759,7 +1767,7 @@ dependencies = [
  "postgres-native-tls",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -1777,7 +1785,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1795,7 +1803,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -1806,6 +1814,7 @@ name = "cdk-signatory"
 version = "0.17.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "bip39",
  "bitcoin 0.32.102",
@@ -1816,7 +1825,7 @@ dependencies = [
  "home",
  "prost 0.14.4",
  "rustls",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tonic 0.14.6",
@@ -1838,7 +1847,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -1858,7 +1867,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -1880,7 +1889,7 @@ dependencies = [
  "scrypt 0.12.0",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -2012,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2022,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2097,7 +2106,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2204,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
  "percent-encoding",
  "time",
@@ -2215,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.22.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
 dependencies = [
  "cookie",
  "document-features",
@@ -2508,12 +2517,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -2532,10 +2541,11 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
+ "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -2556,20 +2566,20 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.119",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "der"
@@ -2588,6 +2598,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
+ "powerfmt",
  "serde_core",
 ]
 
@@ -2762,7 +2773,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2787,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "dnssec-prover"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4f825369fc7134da70ca4040fddc8e03b80a46d249ae38d9c1c39b7b4476bf"
+checksum = "869bf72abc8c654b350aa8d881c5d9957b85e1e1ed6569c10cd68e9f505d5435"
 dependencies = [
  "bitcoin_hashes 0.14.101",
 ]
@@ -2990,7 +3001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3112,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fixedbitset"
@@ -3652,7 +3663,7 @@ dependencies = [
  "rand 0.9.5",
  "ring 0.17.14",
  "rustls-pki-types",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tinyvec",
  "tokio",
@@ -3676,7 +3687,7 @@ dependencies = [
  "rand 0.9.5",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3710,11 +3721,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.12"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3941,7 +3952,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4140,9 +4151,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -4213,9 +4224,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4328,18 +4339,18 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "liblzma"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45aec2360b3933207e27908049d8e4df4e476b58180afb1e56b2a4fb72efe4ba"
+checksum = "2fe0a34ca854fd4f20c07f696fc8675aec78f87d88d29f5e10257a7490a1b2e1"
 dependencies = [
  "liblzma-sys",
 ]
 
 [[package]]
 name = "liblzma-sys"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a046c7f353ba30f810545151e04f63545833803f5b86ee3ddf1517247fe560a5"
+checksum = "a0dad045e4b1b7b170be4b60b54b780cafb4490165461bac7d1cf7b703f61d5f"
 dependencies = [
  "cc",
  "libc",
@@ -4354,9 +4365,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -4374,9 +4385,9 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a1ab99a13ab3343a9b4d1d25c455bf72322819fc5a5f05c5182e704528a583"
+checksum = "2ab16d2a714c0b26d7230bd388ac383a30fce231c8927c62752afc0471a36dc6"
 dependencies = [
  "bech32 0.11.1",
  "bitcoin 0.32.102",
@@ -4507,9 +4518,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-types"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c211dfcff95ca308247da8b1e0e81604bc9e568239967cd2c34572558511e869"
+checksum = "c77c676d4a34cceb2ae3756916e446b4d17f9430a24107e099981f0f9aec77e6"
 dependencies = [
  "bitcoin 0.32.102",
 ]
@@ -4749,9 +4760,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -4814,9 +4825,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.44.6"
+version = "0.44.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e826dd648489de2c5b293920e20b92932ef820302007c1987c758d4d06eeb2cf"
+checksum = "40ff7b77ef428b40aa2834a6acbae38a0e104c98b306208ca4b87a420d579a4b"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -4859,9 +4870,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-relay-pool"
-version = "0.44.2"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb94d61a467a869a6790b907838a9bea82c813d567d9fcbac995f207be8cee4b"
+checksum = "c85c54d6ca9aae4ae2bf19a7663ba9db5f45f783f1d24aff55f006386b8b99a1"
 dependencies = [
  "async-utility",
  "async-wsocket",
@@ -4905,7 +4916,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4936,9 +4947,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -5540,9 +5551,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "possiblyrandom"
@@ -5906,9 +5917,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+checksum = "ab1ad36992cead65f02aa399a373a42730922f1525d988172634fdefdecb8a60"
 dependencies = [
  "pulldown-cmark",
 ]
@@ -5951,7 +5962,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -5973,7 +5984,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5990,7 +6001,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6202,7 +6213,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6239,9 +6250,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6491,7 +6502,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6941,12 +6952,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.21.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64 0.22.1",
- "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -6961,11 +6971,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.21.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -7093,13 +7103,13 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -7432,10 +7442,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7478,11 +7488,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -7498,9 +7508,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7518,29 +7528,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.55"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
- "serde_core",
+ "serde",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.32"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -8818,7 +8829,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tracing-subscriber",
 ]
@@ -8915,7 +8926,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "utf-8",
 ]
 
@@ -8932,14 +8943,14 @@ dependencies = [
  "log",
  "rand 0.9.5",
  "sha1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "typed-index-collections"
-version = "3.5.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898160f1dfd383b4e92e17f0512a7d62f3c51c44937b23b6ffc3a1614a8eaccd"
+checksum = "3fd393dbd1e7b23e0cab7396570309b4068aa504e9dac2cd41d827583b4e9ab7"
 dependencies = [
  "bincode",
  "serde",
@@ -9007,9 +9018,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "uniffi"
@@ -9220,7 +9231,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28bccbac381852c37efd0217ce8c96742e5cf22f6dbb2a4f0f51418c7f3ab980"
 dependencies = [
- "bitcoin_hashes 1.1.0",
+ "bitcoin_hashes 1.2.0",
  "crc",
  "minicbor",
  "rand_xoshiro",
@@ -9228,11 +9239,11 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "cookie_store",
  "flate2",
  "log",
@@ -9248,11 +9259,11 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "http 1.5.0",
  "httparse",
  "log",
@@ -9422,9 +9433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9435,9 +9446,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9445,9 +9456,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9455,9 +9466,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9468,18 +9479,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0d555ca874445df8d314f94f5c948a4e74e5418f332c89f660a3d8310a96f4"
+checksum = "895a2607575412a4eda1df892084a375ea10dfeadc4d7d2ab87b854e4ddc7ba1"
 dependencies = [
  "async-trait",
  "cast",
@@ -9499,9 +9510,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
+checksum = "4288cb0ebe215033bf949ae1fd046726daa4c32a157f24b9dc6ac387a52aa759"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9510,9 +9521,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
+checksum = "33ff1c1b360982e93b6d8ea9c04836f71dba0817a16f91e229cf3a51bdd9d987"
 
 [[package]]
 name = "weak-table"
@@ -9522,9 +9533,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9636,7 +9647,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9651,7 +9662,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -9661,23 +9672,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
+ "windows-implement",
+ "windows-interface",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
 ]
 
 [[package]]
@@ -9692,32 +9690,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10031,18 +10007,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,9 @@ dependencies = [
  "cdk-lnd",
  "cdk-mintd",
  "cdk-nwc",
+ "cdk-postgres",
  "cdk-redb",
+ "cdk-signatory",
  "cdk-sqlite",
  "clap",
  "cln-rpc",
@@ -1824,6 +1826,7 @@ name = "cdk-signatory"
 version = "0.17.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "bip39",
  "bitcoin 0.32.102",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
@@ -2106,7 +2112,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2224,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
 dependencies = [
  "cookie",
  "document-features",
@@ -2402,7 +2408,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "futures-core",
  "mio",
@@ -2517,12 +2523,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -2541,11 +2547,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -2566,11 +2571,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
 ]
@@ -2580,6 +2585,37 @@ name = "data-encoding"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
 
 [[package]]
 name = "der"
@@ -2598,7 +2634,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -2773,7 +2808,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3001,7 +3036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3650,7 +3685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
@@ -3721,11 +3756,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3952,7 +3987,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4211,6 +4246,59 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"
@@ -4916,7 +5004,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4947,9 +5035,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -5030,7 +5118,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5085,7 +5173,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5556,6 +5644,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "possiblyrandom"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5910,7 +6007,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "memchr",
  "unicase",
 ]
@@ -6001,7 +6098,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6191,7 +6288,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -6369,7 +6466,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "once_cell",
  "serde",
  "serde_derive",
@@ -6404,7 +6501,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink 0.9.1",
@@ -6485,7 +6582,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6498,11 +6595,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6778,7 +6875,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -6791,7 +6888,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6952,15 +7049,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
  "serde_core",
@@ -6971,11 +7070,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -7103,9 +7202,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -7442,10 +7541,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7528,30 +7627,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -8085,7 +8183,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e51af4f36e96fe61833a4d94cf50c252a9958c162c0db2fa7a92ee2f0985c3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "caret",
  "derive_more",
@@ -8520,7 +8618,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "228eeb225054455c0545a4d5e06d188790e5bd85129eefb9b24c86cb18f22ce2"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "derive_more",
  "futures",
  "humantime 2.4.0",
@@ -8550,7 +8648,7 @@ checksum = "8b34733b319ff6aa7a146973647c00120d111aa77da221d28309bacf144e3239"
 dependencies = [
  "amplify",
  "base64ct",
- "bitflags",
+ "bitflags 2.13.1",
  "cipher 0.4.4",
  "derive_builder_fork_arti",
  "derive_more",
@@ -8775,7 +8873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8948,9 +9046,9 @@ dependencies = [
 
 [[package]]
 name = "typed-index-collections"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd393dbd1e7b23e0cab7396570309b4068aa504e9dac2cd41d827583b4e9ab7"
+checksum = "898160f1dfd383b4e92e17f0512a7d62f3c51c44937b23b6ffc3a1614a8eaccd"
 dependencies = [
  "bincode",
  "serde",
@@ -9018,9 +9116,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "uniffi"
@@ -9647,7 +9745,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9662,7 +9760,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core",
+ "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 
@@ -9672,10 +9770,23 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings",
 ]
 
 [[package]]
@@ -9690,10 +9801,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1373,7 +1373,7 @@ dependencies = [
  "serde_with",
  "thiserror 2.0.20",
  "tokio",
- "tonic 0.14.6",
+ "tonic 0.14.5",
  "tracing",
  "url",
  "uuid",
@@ -1606,7 +1606,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
- "tonic 0.14.6",
+ "tonic 0.14.5",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -1631,7 +1631,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "tonic 0.14.6",
+ "tonic 0.14.5",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -1743,7 +1743,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.14.6",
+ "tonic 0.14.5",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -1828,7 +1828,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
- "tonic 0.14.6",
+ "tonic 0.14.5",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -2636,7 +2636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c173dfcd5b92893ab05a8efb18b9522db4db6e0b93db5740f397573c027ce1e"
 dependencies = [
  "derive-deftly-macros",
- "heck 0.5.0",
+ "heck 0.4.1",
 ]
 
 [[package]]
@@ -2645,8 +2645,8 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216fa20211bcd18cc359b75413bfb6cf89f62568fa27bc5fed3778a7a16e17af"
 dependencies = [
- "heck 0.5.0",
- "indexmap 2.14.0",
+ "heck 0.4.1",
+ "indexmap 1.9.3",
  "itertools 0.12.1",
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -3001,7 +3001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3966,13 +3966,12 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -3980,12 +3979,13 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr 0.8.3",
  "writeable",
  "zerovec",
@@ -3993,10 +3993,11 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -4007,38 +4008,42 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
+ "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -4065,9 +4070,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -4193,15 +4198,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -4783,12 +4779,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "native-tls"
@@ -5780,7 +5770,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "log",
- "multimap 0.8.3",
+ "multimap",
  "petgraph 0.6.5",
  "prettyplease 0.1.25",
  "prost 0.11.9",
@@ -5797,10 +5787,10 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "log",
- "multimap 0.10.1",
+ "multimap",
  "once_cell",
  "petgraph 0.7.1",
  "prettyplease 0.2.37",
@@ -5817,10 +5807,10 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "log",
- "multimap 0.10.1",
+ "multimap",
  "petgraph 0.8.3",
  "prettyplease 0.2.37",
  "prost 0.14.4",
@@ -5852,7 +5842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5865,7 +5855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6001,7 +5991,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6502,7 +6492,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7442,10 +7432,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7582,6 +7572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -7955,9 +7946,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.6"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
@@ -7999,9 +7990,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.6"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
 dependencies = [
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -8011,20 +8002,20 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.6"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost 0.14.4",
- "tonic 0.14.6",
+ "tonic 0.14.5",
 ]
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.6"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
 dependencies = [
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -8033,7 +8024,7 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "tempfile",
- "tonic-build 0.14.6",
+ "tonic-build 0.14.5",
 ]
 
 [[package]]
@@ -10075,6 +10066,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -10083,6 +10075,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -636,6 +636,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -896,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67800fcf7f3ca52f7796d4466948a424326b225950c79d1e76d0458760bb25d"
+checksum = "5304e53726dbe5f93141535e102ed97b5bf4714fbecefdda8f9fb98d7fdaff0e"
 dependencies = [
  "bitcoin-consensus-encoding",
  "bitcoin-internals 0.6.0",
@@ -1118,7 +1124,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1139,7 +1145,7 @@ dependencies = [
  "serde_with",
  "strum 0.27.2",
  "strum_macros 0.27.2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "unicode-normalization",
  "ur",
@@ -1185,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1232,7 +1238,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1286,7 +1292,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1332,7 +1338,7 @@ dependencies = [
  "cln-rpc",
  "futures",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1355,6 +1361,7 @@ dependencies = [
  "criterion",
  "futures",
  "getrandom 0.2.17",
+ "gloo-timers",
  "jsonwebtoken",
  "lightning",
  "lightning-invoice",
@@ -1364,9 +1371,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tracing",
  "url",
  "uuid",
@@ -1389,7 +1396,7 @@ dependencies = [
  "lightning-invoice",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1421,7 +1428,7 @@ dependencies = [
  "rand 0.9.5",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1489,7 +1496,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tls-api",
  "tls-api-native-tls",
  "tokio",
@@ -1525,7 +1532,9 @@ dependencies = [
  "cdk-lnd",
  "cdk-mintd",
  "cdk-nwc",
+ "cdk-postgres",
  "cdk-redb",
+ "cdk-signatory",
  "cdk-sqlite",
  "clap",
  "cln-rpc",
@@ -1568,7 +1577,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1594,10 +1603,10 @@ dependencies = [
  "rustls",
  "rustls-pemfile 2.2.0",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -1620,9 +1629,9 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -1684,7 +1693,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1699,7 +1708,7 @@ dependencies = [
  "async-trait",
  "nostr-sdk",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1730,11 +1739,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -1758,7 +1767,7 @@ dependencies = [
  "postgres-native-tls",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -1776,7 +1785,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1794,7 +1803,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -1805,6 +1814,7 @@ name = "cdk-signatory"
 version = "0.17.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "bip39",
  "bitcoin 0.32.102",
@@ -1815,10 +1825,10 @@ dependencies = [
  "home",
  "prost 0.14.4",
  "rustls",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -1837,7 +1847,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -1857,7 +1867,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -1879,7 +1889,7 @@ dependencies = [
  "scrypt 0.12.0",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -2011,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2021,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2203,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
  "percent-encoding",
  "time",
@@ -2567,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "der"
@@ -2626,7 +2636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c173dfcd5b92893ab05a8efb18b9522db4db6e0b93db5740f397573c027ce1e"
 dependencies = [
  "derive-deftly-macros",
- "heck 0.4.1",
+ "heck 0.5.0",
 ]
 
 [[package]]
@@ -2635,8 +2645,8 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216fa20211bcd18cc359b75413bfb6cf89f62568fa27bc5fed3778a7a16e17af"
 dependencies = [
- "heck 0.4.1",
- "indexmap 1.9.3",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
  "itertools 0.12.1",
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -2788,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "dnssec-prover"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4f825369fc7134da70ca4040fddc8e03b80a46d249ae38d9c1c39b7b4476bf"
+checksum = "869bf72abc8c654b350aa8d881c5d9957b85e1e1ed6569c10cd68e9f505d5435"
 dependencies = [
  "bitcoin_hashes 0.14.101",
 ]
@@ -2991,7 +3001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3113,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fixedbitset"
@@ -3653,7 +3663,7 @@ dependencies = [
  "rand 0.9.5",
  "ring 0.17.14",
  "rustls-pki-types",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tinyvec",
  "tokio",
@@ -3677,7 +3687,7 @@ dependencies = [
  "rand 0.9.5",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3956,12 +3966,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -3969,13 +3980,12 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
- "serde",
  "tinystr 0.8.3",
  "writeable",
  "zerovec",
@@ -3983,11 +3993,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -3998,42 +4007,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "serde",
- "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -4060,9 +4065,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -4146,9 +4151,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -4193,6 +4198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4210,9 +4224,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4325,18 +4339,18 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "liblzma"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45aec2360b3933207e27908049d8e4df4e476b58180afb1e56b2a4fb72efe4ba"
+checksum = "2fe0a34ca854fd4f20c07f696fc8675aec78f87d88d29f5e10257a7490a1b2e1"
 dependencies = [
  "liblzma-sys",
 ]
 
 [[package]]
 name = "liblzma-sys"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a046c7f353ba30f810545151e04f63545833803f5b86ee3ddf1517247fe560a5"
+checksum = "a0dad045e4b1b7b170be4b60b54b780cafb4490165461bac7d1cf7b703f61d5f"
 dependencies = [
  "cc",
  "libc",
@@ -4351,9 +4365,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -4371,9 +4385,9 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a1ab99a13ab3343a9b4d1d25c455bf72322819fc5a5f05c5182e704528a583"
+checksum = "2ab16d2a714c0b26d7230bd388ac383a30fce231c8927c62752afc0471a36dc6"
 dependencies = [
  "bech32 0.11.1",
  "bitcoin 0.32.102",
@@ -4504,9 +4518,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-types"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c211dfcff95ca308247da8b1e0e81604bc9e568239967cd2c34572558511e869"
+checksum = "c77c676d4a34cceb2ae3756916e446b4d17f9430a24107e099981f0f9aec77e6"
 dependencies = [
  "bitcoin 0.32.102",
 ]
@@ -4746,9 +4760,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -4769,6 +4783,12 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "native-tls"
@@ -4805,9 +4825,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.44.6"
+version = "0.44.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e826dd648489de2c5b293920e20b92932ef820302007c1987c758d4d06eeb2cf"
+checksum = "40ff7b77ef428b40aa2834a6acbae38a0e104c98b306208ca4b87a420d579a4b"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -4850,9 +4870,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-relay-pool"
-version = "0.44.2"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb94d61a467a869a6790b907838a9bea82c813d567d9fcbac995f207be8cee4b"
+checksum = "c85c54d6ca9aae4ae2bf19a7663ba9db5f45f783f1d24aff55f006386b8b99a1"
 dependencies = [
  "async-utility",
  "async-wsocket",
@@ -5531,9 +5551,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "possiblyrandom"
@@ -5760,7 +5780,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "log",
- "multimap",
+ "multimap 0.8.3",
  "petgraph 0.6.5",
  "prettyplease 0.1.25",
  "prost 0.11.9",
@@ -5777,10 +5797,10 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
- "multimap",
+ "multimap 0.10.1",
  "once_cell",
  "petgraph 0.7.1",
  "prettyplease 0.2.37",
@@ -5797,10 +5817,10 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
- "multimap",
+ "multimap 0.10.1",
  "petgraph 0.8.3",
  "prettyplease 0.2.37",
  "prost 0.14.4",
@@ -5832,7 +5852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5845,7 +5865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5897,9 +5917,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+checksum = "ab1ad36992cead65f02aa399a373a42730922f1525d988172634fdefdecb8a60"
 dependencies = [
  "pulldown-cmark",
 ]
@@ -5942,7 +5962,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -5964,7 +5984,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5981,7 +6001,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6193,7 +6213,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6230,9 +6250,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6482,7 +6502,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7089,7 +7109,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -7422,10 +7442,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7468,11 +7488,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -7488,9 +7508,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7562,7 +7582,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
- "serde_core",
  "zerovec",
 ]
 
@@ -7936,9 +7955,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -7980,9 +7999,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -7992,20 +8011,20 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost 0.14.4",
- "tonic 0.14.5",
+ "tonic 0.14.6",
 ]
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -8014,7 +8033,7 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "tempfile",
- "tonic-build 0.14.5",
+ "tonic-build 0.14.6",
 ]
 
 [[package]]
@@ -8810,7 +8829,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tracing-subscriber",
 ]
@@ -8907,7 +8926,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "utf-8",
 ]
 
@@ -8924,7 +8943,7 @@ dependencies = [
  "log",
  "rand 0.9.5",
  "sha1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9212,7 +9231,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28bccbac381852c37efd0217ce8c96742e5cf22f6dbb2a4f0f51418c7f3ab980"
 dependencies = [
- "bitcoin_hashes 1.1.0",
+ "bitcoin_hashes 1.2.0",
  "crc",
  "minicbor",
  "rand_xoshiro",
@@ -9220,11 +9239,11 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "cookie_store",
  "flate2",
  "log",
@@ -9240,11 +9259,11 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "http 1.5.0",
  "httparse",
  "log",
@@ -9414,9 +9433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9427,9 +9446,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9437,9 +9456,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9447,9 +9466,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9460,18 +9479,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0d555ca874445df8d314f94f5c948a4e74e5418f332c89f660a3d8310a96f4"
+checksum = "895a2607575412a4eda1df892084a375ea10dfeadc4d7d2ab87b854e4ddc7ba1"
 dependencies = [
  "async-trait",
  "cast",
@@ -9491,9 +9510,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
+checksum = "4288cb0ebe215033bf949ae1fd046726daa4c32a157f24b9dc6ac387a52aa759"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9502,9 +9521,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
+checksum = "33ff1c1b360982e93b6d8ea9c04836f71dba0817a16f91e229cf3a51bdd9d987"
 
 [[package]]
 name = "weak-table"
@@ -9514,9 +9533,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9988,18 +10007,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10056,7 +10075,6 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
- "zerovec",
 ]
 
 [[package]]
@@ -10065,7 +10083,6 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
- "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 anyhow = "1"
+arc-swap = { version = "1.7.1", default-features = false }
 async-trait = "0.1"
 axum = { version = "0.8.1", features = ["ws"] }
 bitcoin = { version = "0.32.2", features = ["base64", "serde", "rand", "rand-std"] }

--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -131,6 +131,32 @@ pub trait KeysDatabaseTransaction<'a, Error>: DbTransactionFinalizer<Err = Error
 
     /// Add [`MintKeySetInfo`]
     async fn add_keyset_info(&mut self, keyset: MintKeySetInfo) -> Result<(), Error>;
+
+    /// Allocate the next derivation-path index for a unit.
+    ///
+    /// Returns `max(derivation_path_index) + 1` for the unit (1 when the unit
+    /// has no keysets yet). Backends where several processes may write
+    /// concurrently take a cross-process lock here, held until the transaction
+    /// commits, so two signatory instances rotating the same unit cannot
+    /// allocate the same index and derive divergent keysets. This is the
+    /// authoritative index source; callers must not compute it from
+    /// process-local state.
+    async fn next_derivation_index(&mut self, unit: &CurrencyUnit) -> Result<u32, Error>;
+
+    /// Read a unit's keyset infos inside the transaction, under the same
+    /// per-unit lock [`next_derivation_index`](Self::next_derivation_index)
+    /// takes.
+    ///
+    /// Boot-time reactivation uses this to pick a unit's highest-index keyset
+    /// and reassign the active pointer as one atomic step. Reading outside the
+    /// transaction (the plain [`KeysDatabase::get_keyset_infos`]) would let a
+    /// peer rotation commit a higher keyset in the gap, after which the booting
+    /// instance would reactivate the older one it read. Holding the lock across
+    /// the read and the reassignment closes that window.
+    async fn get_keyset_infos_by_unit(
+        &mut self,
+        unit: &CurrencyUnit,
+    ) -> Result<Vec<MintKeySetInfo>, Error>;
 }
 
 /// Mint Keys Database trait
@@ -155,6 +181,17 @@ pub trait KeysDatabase {
 
     /// Get [`MintKeySetInfo`]s
     async fn get_keyset_infos(&self) -> Result<Vec<MintKeySetInfo>, Self::Err>;
+
+    /// An opaque epoch for the current keyset set.
+    ///
+    /// It must change whenever the set changes, both when a keyset is added and
+    /// when the active pointer is reassigned. Callers only compare it for
+    /// equality to decide whether to reload their in-memory view, so an epoch
+    /// that misses reactivations would leave peers serving a stale active
+    /// keyset. The storage decides how to compute it cheaply (e.g. a counter
+    /// bumped inside every keyset-writing transaction); there is deliberately no
+    /// default, since a count-based fallback would not move on reactivation.
+    async fn keysets_epoch(&self) -> Result<u64, Self::Err>;
 }
 
 /// Mint Quote Database writer trait

--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -131,6 +131,49 @@ pub trait KeysDatabaseTransaction<'a, Error>: DbTransactionFinalizer<Err = Error
 
     /// Add [`MintKeySetInfo`]
     async fn add_keyset_info(&mut self, keyset: MintKeySetInfo) -> Result<(), Error>;
+
+    /// Allocate the next derivation-path index for a unit.
+    ///
+    /// Returns `max(derivation_path_index) + 1` for the unit (1 when the unit
+    /// has no keysets yet). The transaction holds the global keyset advisory
+    /// lock (taken when it begins), so all keyset transactions serialize and two
+    /// signatory instances rotating the same unit cannot allocate the same index
+    /// and derive divergent keysets. This is the authoritative index source;
+    /// callers must not compute it from process-local state.
+    async fn next_derivation_index(&mut self, unit: &CurrencyUnit) -> Result<u32, Error>;
+
+    /// Read a unit's keyset infos inside the transaction, under the global
+    /// keyset advisory lock the transaction holds.
+    ///
+    /// Boot-time reactivation uses this to pick a unit's highest-index keyset
+    /// and reassign the active pointer as one atomic step. Both happen inside the
+    /// transaction, under the global keyset lock, so a peer rotation cannot commit
+    /// a higher keyset between the read and the reassignment and get clobbered
+    /// back to the older one.
+    async fn get_keyset_infos_by_unit(
+        &mut self,
+        unit: &CurrencyUnit,
+    ) -> Result<Vec<MintKeySetInfo>, Error>;
+
+    /// Read all active keyset pointers inside the transaction.
+    ///
+    /// Keyset reads go through a transaction, which holds the global keyset lock,
+    /// so no other keyset transaction can commit between reads. The signatory
+    /// uses these transaction reads to reload its in-memory keysets, so the
+    /// collision check and default amounts see peers' committed rotations rather
+    /// than a stale snapshot.
+    async fn get_active_keysets(&mut self) -> Result<HashMap<CurrencyUnit, Id>, Error>;
+
+    /// Read all keyset infos inside the transaction. See
+    /// [`get_active_keysets`](Self::get_active_keysets) for why keyset reads go
+    /// through the transaction.
+    async fn get_keyset_infos(&mut self) -> Result<Vec<MintKeySetInfo>, Error>;
+
+    /// Read the keyset epoch inside the transaction.
+    ///
+    /// Transaction-scoped counterpart of [`KeysDatabase::keysets_epoch`], used to
+    /// gate the reload under the global lock.
+    async fn keysets_epoch(&mut self) -> Result<u64, Error>;
 }
 
 /// Mint Keys Database trait
@@ -140,21 +183,25 @@ pub trait KeysDatabase {
     type Err: Into<Error> + From<Error>;
 
     /// Begins a transaction
+    ///
+    /// All keyset reads and writes go through a transaction: it takes the global
+    /// keyset advisory lock, so the signatory's reload sees a consistent
+    /// snapshot. The autocommit reads that once existed here are gone; use the
+    /// transaction's read methods instead.
     async fn begin_transaction<'a>(
         &'a self,
     ) -> Result<Box<dyn KeysDatabaseTransaction<'a, Self::Err> + Send + Sync + 'a>, Error>;
 
-    /// Get Active Keyset
-    async fn get_active_keyset_id(&self, unit: &CurrencyUnit) -> Result<Option<Id>, Self::Err>;
-
-    /// Get all Active Keyset
-    async fn get_active_keysets(&self) -> Result<HashMap<CurrencyUnit, Id>, Self::Err>;
-
-    /// Get [`MintKeySetInfo`]
-    async fn get_keyset_info(&self, id: &Id) -> Result<Option<MintKeySetInfo>, Self::Err>;
-
-    /// Get [`MintKeySetInfo`]s
-    async fn get_keyset_infos(&self) -> Result<Vec<MintKeySetInfo>, Self::Err>;
+    /// An opaque epoch for the current keyset set.
+    ///
+    /// It must change whenever the set changes, both when a keyset is added and
+    /// when the active pointer is reassigned. Callers only compare it for
+    /// equality to decide whether to reload their in-memory view, so an epoch
+    /// that misses reactivations would leave peers serving a stale active
+    /// keyset. The storage decides how to compute it cheaply (e.g. a counter
+    /// bumped inside every keyset-writing transaction); there is deliberately no
+    /// default, since a count-based fallback would not move on reactivation.
+    async fn keysets_epoch(&self) -> Result<u64, Self::Err>;
 }
 
 /// Mint Quote Database writer trait

--- a/crates/cdk-common/src/database/mint/test/keys.rs
+++ b/crates/cdk-common/src/database/mint/test/keys.rs
@@ -14,6 +14,36 @@ fn standard_keyset_amounts(max_order: u32) -> Vec<u64> {
     (0..max_order).map(|n| 2u64.pow(n)).collect()
 }
 
+/// Read the active keyset id for a unit through a transaction.
+///
+/// Keyset reads go through a transaction now that the autocommit key reads were
+/// removed from [`KeysDatabase`]; the transaction takes the global keyset lock.
+async fn active_keyset_id<DB>(db: &DB, unit: &CurrencyUnit) -> Option<Id>
+where
+    DB: KeysDatabase<Err = Error>,
+{
+    let mut tx = KeysDatabase::begin_transaction(db).await.unwrap();
+    let id = tx.get_active_keysets().await.unwrap().get(unit).copied();
+    tx.commit().await.unwrap();
+    id
+}
+
+/// Read a keyset info by id through a transaction. See [`active_keyset_id`].
+async fn find_keyset_info<DB>(db: &DB, id: &Id) -> Option<MintKeySetInfo>
+where
+    DB: KeysDatabase<Err = Error>,
+{
+    let mut tx = KeysDatabase::begin_transaction(db).await.unwrap();
+    let info = tx
+        .get_keyset_infos()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|k| k.id == *id);
+    tx.commit().await.unwrap();
+    info
+}
+
 /// Test adding and retrieving keyset info
 pub async fn add_and_get_keyset_info<DB>(db: DB)
 where
@@ -39,7 +69,7 @@ where
     tx.commit().await.unwrap();
 
     // Retrieve keyset info
-    let retrieved = db.get_keyset_info(&keyset_id).await.unwrap();
+    let retrieved = find_keyset_info(&db, &keyset_id).await;
     assert!(retrieved.is_some());
     let retrieved = retrieved.unwrap();
     assert_eq!(retrieved.id, keyset_info.id);
@@ -81,7 +111,7 @@ where
     tx.commit().await.unwrap();
 
     // Verify keyset still exists
-    let retrieved = db.get_keyset_info(&keyset_id).await.unwrap();
+    let retrieved = find_keyset_info(&db, &keyset_id).await;
     assert!(retrieved.is_some());
 }
 
@@ -125,7 +155,9 @@ where
     tx.commit().await.unwrap();
 
     // Get all keyset infos
-    let all_keysets = db.get_keyset_infos().await.unwrap();
+    let mut tx = KeysDatabase::begin_transaction(&db).await.unwrap();
+    let all_keysets = tx.get_keyset_infos().await.unwrap();
+    tx.commit().await.unwrap();
     assert!(all_keysets.len() >= 2);
     assert!(all_keysets.iter().any(|k| k.id == keyset_id1));
     assert!(all_keysets.iter().any(|k| k.id == keyset_id2));
@@ -159,7 +191,7 @@ where
     tx.commit().await.unwrap();
 
     // Get active keyset
-    let active_id = db.get_active_keyset_id(&CurrencyUnit::Sat).await.unwrap();
+    let active_id = active_keyset_id(&db, &CurrencyUnit::Sat).await;
     assert!(active_id.is_some());
     assert_eq!(active_id.unwrap(), keyset_id);
 }
@@ -210,7 +242,9 @@ where
     tx.commit().await.unwrap();
 
     // Get all active keysets
-    let active_keysets = db.get_active_keysets().await.unwrap();
+    let mut tx = KeysDatabase::begin_transaction(&db).await.unwrap();
+    let active_keysets = tx.get_active_keysets().await.unwrap();
+    tx.commit().await.unwrap();
     assert!(active_keysets.len() >= 2);
     assert_eq!(active_keysets.get(&CurrencyUnit::Sat), Some(&keyset_id_sat));
     assert_eq!(active_keysets.get(&CurrencyUnit::Usd), Some(&keyset_id_usd));
@@ -259,7 +293,7 @@ where
     tx.commit().await.unwrap();
 
     // Verify first keyset is active
-    let active_id = db.get_active_keyset_id(&CurrencyUnit::Sat).await.unwrap();
+    let active_id = active_keyset_id(&db, &CurrencyUnit::Sat).await;
     assert_eq!(active_id, Some(keyset_id1));
 
     // Update to second keyset
@@ -270,7 +304,7 @@ where
     tx.commit().await.unwrap();
 
     // Verify second keyset is now active
-    let active_id = db.get_active_keyset_id(&CurrencyUnit::Sat).await.unwrap();
+    let active_id = active_keyset_id(&db, &CurrencyUnit::Sat).await;
     assert_eq!(active_id, Some(keyset_id2));
 }
 
@@ -282,7 +316,7 @@ where
     let keyset_id = Id::from_str("00916bbf7ef91a36").unwrap();
 
     // Try to get non-existent keyset
-    let retrieved = db.get_keyset_info(&keyset_id).await.unwrap();
+    let retrieved = find_keyset_info(&db, &keyset_id).await;
     assert!(retrieved.is_none());
 }
 
@@ -292,6 +326,6 @@ where
     DB: Database<Error> + KeysDatabase<Err = Error>,
 {
     // Try to get active keyset when none is set
-    let active_id = db.get_active_keyset_id(&CurrencyUnit::Sat).await.unwrap();
+    let active_id = active_keyset_id(&db, &CurrencyUnit::Sat).await;
     assert!(active_id.is_none());
 }

--- a/crates/cdk-integration-tests/Cargo.toml
+++ b/crates/cdk-integration-tests/Cargo.toml
@@ -69,6 +69,8 @@ bip39 = { workspace = true, features = ["rand"] }
 anyhow.workspace = true
 cdk-axum = { workspace = true }
 cdk-fake-wallet = { workspace = true }
+cdk-signatory = { workspace = true }
+cdk-postgres = { workspace = true }
 cdk-ffi = { workspace = true, features = ["npubcash", "bip353"] }
 tower-http = { workspace = true, features = ["cors"] }
 nwc = { version = "0.44.0", default-features = false }

--- a/crates/cdk-integration-tests/tests/mint.rs
+++ b/crates/cdk-integration-tests/tests/mint.rs
@@ -462,12 +462,15 @@ async fn test_builder_does_not_replace_all_expired_keysets() {
     // Mutate final_expiry to be in the past via localstore upsert.
     drop(mint);
     {
-        let mut info = KeysDatabase::get_keyset_info(&*localstore, &new_keyset.id)
+        let mut tx = KeysDatabase::begin_transaction(&*localstore).await.unwrap();
+        let mut info = tx
+            .get_keyset_infos()
             .await
             .unwrap()
+            .into_iter()
+            .find(|k| k.id == new_keyset.id)
             .expect("rotated keyset should be present in localstore");
         info.final_expiry = Some(unix_time().saturating_sub(1));
-        let mut tx = KeysDatabase::begin_transaction(&*localstore).await.unwrap();
         tx.add_keyset_info(info).await.unwrap();
         tx.commit().await.unwrap();
     }

--- a/crates/cdk-integration-tests/tests/signatory_rotation.rs
+++ b/crates/cdk-integration-tests/tests/signatory_rotation.rs
@@ -1,0 +1,102 @@
+//! Cross-instance keyset rotation against a shared Postgres database.
+//!
+//! Two `DbSignatory` instances, each with its own process-local rotation
+//! lock, drive concurrent rotations of the same unit through separate
+//! Postgres connection pools pointing at one schema. Nothing in-process
+//! serializes them: the only guard is `pg_advisory_xact_lock(hashtext(unit))`
+//! inside `next_derivation_index`. The test asserts every rotation still gets
+//! a unique keyset id and path index.
+//!
+//! Requires Postgres. Set `CDK_MINTD_DATABASE_URL` (or `PG_DB_URL`) to a
+//! reachable server (see `docker-compose.postgres.yaml`). With neither set the
+//! test prints a skip notice and passes, so a plain `cargo test` without
+//! Postgres does not fail.
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use cdk_common::database::{Error, MintKeysDatabase};
+use cdk_common::nut02::KeySetVersion;
+use cdk_common::nuts::CurrencyUnit;
+use cdk_postgres::MintPgDatabase;
+use cdk_signatory::db_signatory::DbSignatory;
+use cdk_signatory::signatory::{RotateKeyArguments, Signatory};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_rotations_across_pg_instances_do_not_collide() {
+    let Some(base_url) = std::env::var("CDK_MINTD_DATABASE_URL")
+        .or_else(|_| std::env::var("PG_DB_URL"))
+        .ok()
+    else {
+        eprintln!(
+            "skipping concurrent_rotations_across_pg_instances_do_not_collide: \
+             set CDK_MINTD_DATABASE_URL (or PG_DB_URL) to run"
+        );
+        return;
+    };
+
+    // Isolate this run in its own schema, matching the cdk-postgres conformance
+    // harness. Both pools use the same schema so they share the keyset table.
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let schema = format!(
+        "rot_{}_{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    );
+    let url = format!("{base_url} schema={schema}");
+
+    let store_a: Arc<dyn MintKeysDatabase<Err = Error> + Send + Sync> =
+        Arc::new(MintPgDatabase::new(url.as_str()).await.expect("pg db a"));
+    let store_b: Arc<dyn MintKeysDatabase<Err = Error> + Send + Sync> =
+        Arc::new(MintPgDatabase::new(url.as_str()).await.expect("pg db b"));
+
+    let seed = b"test-seed-cross-instance-pg-rotations";
+    let instance_a = Arc::new(
+        DbSignatory::new(store_a, seed, Default::default(), Default::default())
+            .await
+            .expect("DbSignatory::new a"),
+    );
+    let instance_b = Arc::new(
+        DbSignatory::new(store_b, seed, Default::default(), Default::default())
+            .await
+            .expect("DbSignatory::new b"),
+    );
+
+    const ROTATIONS: usize = 8;
+    let mut handles = Vec::with_capacity(ROTATIONS);
+    for i in 0..ROTATIONS {
+        let signatory = if i % 2 == 0 {
+            instance_a.clone()
+        } else {
+            instance_b.clone()
+        };
+        handles.push(tokio::spawn(async move {
+            signatory
+                .rotate_keyset(RotateKeyArguments {
+                    unit: CurrencyUnit::Sat,
+                    amounts: vec![1, 2, 4, 8],
+                    input_fee_ppk: 0,
+                    keyset_id_type: KeySetVersion::Version00,
+                    final_expiry: None,
+                })
+                .await
+                .expect("rotate_keyset")
+        }));
+    }
+
+    let mut ids = HashSet::new();
+    let mut versions = HashSet::new();
+    for handle in handles {
+        let keyset = handle.await.expect("join");
+        assert!(
+            ids.insert(keyset.id),
+            "duplicate keyset id from concurrent cross-instance rotation"
+        );
+        assert!(
+            versions.insert(keyset.version),
+            "duplicate path index from concurrent cross-instance rotation"
+        );
+    }
+    assert_eq!(ids.len(), ROTATIONS);
+}

--- a/crates/cdk-integration-tests/tests/signatory_rotation.rs
+++ b/crates/cdk-integration-tests/tests/signatory_rotation.rs
@@ -1,0 +1,103 @@
+//! Cross-instance keyset rotation against a shared Postgres database.
+//!
+//! Two `DbSignatory` instances, each with its own process-local rotation
+//! lock, drive concurrent rotations of the same unit through separate
+//! Postgres connection pools pointing at one schema. Nothing in-process
+//! serializes them: the only guard is the global keyset advisory lock
+//! (`pg_advisory_xact_lock(hashtext('cdk:keysets'))`) taken when each keyset
+//! transaction begins. The test asserts every rotation still gets a unique
+//! keyset id and path index.
+//!
+//! Requires Postgres. Set `CDK_MINTD_DATABASE_URL` (or `PG_DB_URL`) to a
+//! reachable server (see `docker-compose.postgres.yaml`). With neither set the
+//! test prints a skip notice and passes, so a plain `cargo test` without
+//! Postgres does not fail.
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use cdk_common::database::{Error, MintKeysDatabase};
+use cdk_common::nut02::KeySetVersion;
+use cdk_common::nuts::CurrencyUnit;
+use cdk_postgres::MintPgDatabase;
+use cdk_signatory::db_signatory::DbSignatory;
+use cdk_signatory::signatory::{RotateKeyArguments, Signatory};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_rotations_across_pg_instances_do_not_collide() {
+    let Some(base_url) = std::env::var("CDK_MINTD_DATABASE_URL")
+        .or_else(|_| std::env::var("PG_DB_URL"))
+        .ok()
+    else {
+        eprintln!(
+            "skipping concurrent_rotations_across_pg_instances_do_not_collide: \
+             set CDK_MINTD_DATABASE_URL (or PG_DB_URL) to run"
+        );
+        return;
+    };
+
+    // Isolate this run in its own schema, matching the cdk-postgres conformance
+    // harness. Both pools use the same schema so they share the keyset table.
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let schema = format!(
+        "rot_{}_{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    );
+    let url = format!("{base_url} schema={schema}");
+
+    let store_a: Arc<dyn MintKeysDatabase<Err = Error> + Send + Sync> =
+        Arc::new(MintPgDatabase::new(url.as_str()).await.expect("pg db a"));
+    let store_b: Arc<dyn MintKeysDatabase<Err = Error> + Send + Sync> =
+        Arc::new(MintPgDatabase::new(url.as_str()).await.expect("pg db b"));
+
+    let seed = b"test-seed-cross-instance-pg-rotations";
+    let instance_a = Arc::new(
+        DbSignatory::new(store_a, seed, Default::default(), Default::default())
+            .await
+            .expect("DbSignatory::new a"),
+    );
+    let instance_b = Arc::new(
+        DbSignatory::new(store_b, seed, Default::default(), Default::default())
+            .await
+            .expect("DbSignatory::new b"),
+    );
+
+    const ROTATIONS: usize = 8;
+    let mut handles = Vec::with_capacity(ROTATIONS);
+    for i in 0..ROTATIONS {
+        let signatory = if i % 2 == 0 {
+            instance_a.clone()
+        } else {
+            instance_b.clone()
+        };
+        handles.push(tokio::spawn(async move {
+            signatory
+                .rotate_keyset(RotateKeyArguments {
+                    unit: CurrencyUnit::Sat,
+                    amounts: vec![1, 2, 4, 8],
+                    input_fee_ppk: 0,
+                    keyset_id_type: KeySetVersion::Version00,
+                    final_expiry: None,
+                })
+                .await
+                .expect("rotate_keyset")
+        }));
+    }
+
+    let mut ids = HashSet::new();
+    let mut versions = HashSet::new();
+    for handle in handles {
+        let keyset = handle.await.expect("join");
+        assert!(
+            ids.insert(keyset.id),
+            "duplicate keyset id from concurrent cross-instance rotation"
+        );
+        assert!(
+            versions.insert(keyset.version),
+            "duplicate path index from concurrent cross-instance rotation"
+        );
+    }
+    assert_eq!(ids.len(), ROTATIONS);
+}

--- a/crates/cdk-signatory/Cargo.toml
+++ b/crates/cdk-signatory/Cargo.toml
@@ -16,6 +16,7 @@ sqlcipher = ["cdk-sqlite/sqlcipher"]
 grpc = ["dep:tonic", "tokio/full", "dep:tonic-prost", "dep:tonic-prost-build", "dep:prost"]
 
 [dependencies]
+arc-swap.workspace = true
 async-trait.workspace = true
 bitcoin.workspace = true
 cdk-common = { workspace = true, default-features = false, features = [

--- a/crates/cdk-signatory/src/bin/cli/mod.rs
+++ b/crates/cdk-signatory/src/bin/cli/mod.rs
@@ -18,6 +18,7 @@ use {
     std::net::SocketAddr,
     std::str::FromStr,
     std::sync::Arc,
+    std::time::Duration,
     std::{env, fs},
     tracing_subscriber::EnvFilter,
 };
@@ -92,6 +93,13 @@ struct Cli {
     /// Supported units with the format of name,fee and max_order
     #[arg(long, short, default_value = "sat,0,32")]
     units: Vec<String>,
+    /// How often, in milliseconds, to reload keysets from the shared database.
+    /// 0 (the default) disables it: a single signatory process owns its
+    /// database and needs no polling. Set a non-zero value to run several
+    /// signatory processes against one shared database, so each picks up
+    /// another's rotations without a restart.
+    #[arg(long, default_value = "0")]
+    keyset_refresh_interval_ms: u64,
 }
 
 /// Main function for the signatory standalone binary
@@ -187,13 +195,21 @@ pub async fn cli_main() -> Result<()> {
     };
     let seed = mnemonic.to_seed_normalized("");
 
-    let signatory =
+    let signatory = Arc::new(
         db_signatory::DbSignatory::new(localstore, &seed, supported_units, Default::default())
-            .await?;
+            .await?,
+    );
+
+    // Off by default. When enabled, periodically reload keysets from the shared
+    // database so multiple signatory processes can run active/active: a rotation
+    // by any instance is picked up on the next refresh without a restart.
+    let refresh_interval = (args.keyset_refresh_interval_ms != 0)
+        .then(|| Duration::from_millis(args.keyset_refresh_interval_ms));
+    signatory.spawn_keyset_refresh(refresh_interval);
 
     let socket_addr = SocketAddr::from_str(&format!("{}:{}", args.listen_addr, args.listen_port))?;
 
-    start_grpc_server(Arc::new(signatory), socket_addr, certs).await?;
+    start_grpc_server(signatory, socket_addr, certs).await?;
 
     Ok(())
 }

--- a/crates/cdk-signatory/src/common.rs
+++ b/crates/cdk-signatory/src/common.rs
@@ -18,55 +18,58 @@ pub async fn init_keysets(
     localstore: &Arc<dyn database::MintKeysDatabase<Err = database::Error> + Send + Sync>,
     supported_units: &HashMap<CurrencyUnit, (u64, Vec<u64>)>,
 ) -> Result<(), Error> {
-    let keysets_infos = localstore.get_keyset_infos().await?;
     let mut tx = localstore.begin_transaction().await?;
 
-    let keysets_by_unit: HashMap<CurrencyUnit, Vec<MintKeySetInfo>> =
-        keysets_infos.iter().fold(HashMap::new(), |mut acc, ks| {
-            acc.entry(ks.unit.clone()).or_default().push(ks.clone());
-            acc
-        });
+    // The transaction holds the global keyset advisory lock, so reading each
+    // unit's keysets and reassigning the active pointer is atomic against any
+    // concurrent rotation. A pre-transaction read would reopen that race.
+    //
+    // Iterate in a deterministic order for reproducibility; HashMap iteration
+    // order is randomized per process.
+    let mut units: Vec<_> = supported_units.iter().collect();
+    units.sort_by(|a, b| a.0.cmp(b.0));
 
-    for (unit, keysets) in keysets_by_unit {
-        // We only care about units that are supported
-        if let Some((input_fee_ppk, amounts)) = supported_units.get(&unit) {
-            let mut keysets = keysets;
-            keysets.sort_by_key(|b| std::cmp::Reverse(b.derivation_path_index));
+    for (unit, (input_fee_ppk, amounts)) in units {
+        let mut keysets = tx.get_keyset_infos_by_unit(unit).await?;
+        keysets.sort_by_key(|b| std::cmp::Reverse(b.derivation_path_index));
 
-            if let Some(highest_index_keyset) = keysets.first() {
-                if highest_index_keyset.is_expired() {
-                    tracing::info!(
-                        "Highest index keyset for unit {} has expired, skipping reactivation",
-                        unit
-                    );
-                    continue;
-                }
+        let Some(highest_index_keyset) = keysets.first() else {
+            continue;
+        };
 
-                // Check if it matches our criteria
-                if highest_index_keyset.input_fee_ppk == *input_fee_ppk
-                    && highest_index_keyset.amounts == *amounts
-                {
-                    tracing::debug!("Current highest index keyset matches expect fee and amounts. Setting active");
-                    let id = highest_index_keyset.id;
+        if highest_index_keyset.is_expired() {
+            tracing::info!(
+                "Highest index keyset for unit {} has expired, skipping reactivation",
+                unit
+            );
+            continue;
+        }
 
-                    // Validate we can generate it (sanity check)
-                    let _ = MintKeySet::generate_from_xpriv(
-                        secp_ctx,
-                        xpriv,
-                        &highest_index_keyset.amounts,
-                        highest_index_keyset.unit.clone(),
-                        highest_index_keyset.derivation_path.clone(),
-                        highest_index_keyset.input_fee_ppk,
-                        highest_index_keyset.final_expiry,
-                        highest_index_keyset.id.get_version(),
-                    );
+        // Check if it matches our criteria
+        if highest_index_keyset.input_fee_ppk == *input_fee_ppk
+            && highest_index_keyset.amounts == *amounts
+        {
+            tracing::debug!(
+                "Current highest index keyset matches expect fee and amounts. Setting active"
+            );
+            let id = highest_index_keyset.id;
 
-                    let mut keyset_info = highest_index_keyset.clone();
-                    keyset_info.active = true;
-                    tx.add_keyset_info(keyset_info).await?;
-                    tx.set_active_keyset(unit.clone(), id).await?;
-                }
-            }
+            // Validate we can generate it (sanity check)
+            let _ = MintKeySet::generate_from_xpriv(
+                secp_ctx,
+                xpriv,
+                &highest_index_keyset.amounts,
+                highest_index_keyset.unit.clone(),
+                highest_index_keyset.derivation_path.clone(),
+                highest_index_keyset.input_fee_ppk,
+                highest_index_keyset.final_expiry,
+                highest_index_keyset.id.get_version(),
+            );
+
+            let mut keyset_info = highest_index_keyset.clone();
+            keyset_info.active = true;
+            tx.add_keyset_info(keyset_info).await?;
+            tx.set_active_keyset(unit.clone(), id).await?;
         }
     }
 

--- a/crates/cdk-signatory/src/common.rs
+++ b/crates/cdk-signatory/src/common.rs
@@ -18,55 +18,61 @@ pub async fn init_keysets(
     localstore: &Arc<dyn database::MintKeysDatabase<Err = database::Error> + Send + Sync>,
     supported_units: &HashMap<CurrencyUnit, (u64, Vec<u64>)>,
 ) -> Result<(), Error> {
-    let keysets_infos = localstore.get_keyset_infos().await?;
     let mut tx = localstore.begin_transaction().await?;
 
-    let keysets_by_unit: HashMap<CurrencyUnit, Vec<MintKeySetInfo>> =
-        keysets_infos.iter().fold(HashMap::new(), |mut acc, ks| {
-            acc.entry(ks.unit.clone()).or_default().push(ks.clone());
-            acc
-        });
+    // Reading each unit's keysets inside the transaction, under the per-unit
+    // lock, is what makes selection and reassignment atomic against a concurrent
+    // rotation. A pre-transaction read would reopen the race this guards against.
+    //
+    // Iterate in a deterministic order: HashMap iteration order is randomized
+    // per process, so two instances booting concurrently could take the per-unit
+    // advisory locks (pg_advisory_xact_lock(hashtext(unit)), held to commit) in
+    // opposite order and deadlock (A B - B  A). Sorting the units makes every process
+    // acquire the locks in the same global order.
+    let mut units: Vec<_> = supported_units.iter().collect();
+    units.sort_by(|a, b| a.0.cmp(b.0));
 
-    for (unit, keysets) in keysets_by_unit {
-        // We only care about units that are supported
-        if let Some((input_fee_ppk, amounts)) = supported_units.get(&unit) {
-            let mut keysets = keysets;
-            keysets.sort_by_key(|b| std::cmp::Reverse(b.derivation_path_index));
+    for (unit, (input_fee_ppk, amounts)) in units {
+        let mut keysets = tx.get_keyset_infos_by_unit(unit).await?;
+        keysets.sort_by_key(|b| std::cmp::Reverse(b.derivation_path_index));
 
-            if let Some(highest_index_keyset) = keysets.first() {
-                if highest_index_keyset.is_expired() {
-                    tracing::info!(
-                        "Highest index keyset for unit {} has expired, skipping reactivation",
-                        unit
-                    );
-                    continue;
-                }
+        let Some(highest_index_keyset) = keysets.first() else {
+            continue;
+        };
 
-                // Check if it matches our criteria
-                if highest_index_keyset.input_fee_ppk == *input_fee_ppk
-                    && highest_index_keyset.amounts == *amounts
-                {
-                    tracing::debug!("Current highest index keyset matches expect fee and amounts. Setting active");
-                    let id = highest_index_keyset.id;
+        if highest_index_keyset.is_expired() {
+            tracing::info!(
+                "Highest index keyset for unit {} has expired, skipping reactivation",
+                unit
+            );
+            continue;
+        }
 
-                    // Validate we can generate it (sanity check)
-                    let _ = MintKeySet::generate_from_xpriv(
-                        secp_ctx,
-                        xpriv,
-                        &highest_index_keyset.amounts,
-                        highest_index_keyset.unit.clone(),
-                        highest_index_keyset.derivation_path.clone(),
-                        highest_index_keyset.input_fee_ppk,
-                        highest_index_keyset.final_expiry,
-                        highest_index_keyset.id.get_version(),
-                    );
+        // Check if it matches our criteria
+        if highest_index_keyset.input_fee_ppk == *input_fee_ppk
+            && highest_index_keyset.amounts == *amounts
+        {
+            tracing::debug!(
+                "Current highest index keyset matches expect fee and amounts. Setting active"
+            );
+            let id = highest_index_keyset.id;
 
-                    let mut keyset_info = highest_index_keyset.clone();
-                    keyset_info.active = true;
-                    tx.add_keyset_info(keyset_info).await?;
-                    tx.set_active_keyset(unit.clone(), id).await?;
-                }
-            }
+            // Validate we can generate it (sanity check)
+            let _ = MintKeySet::generate_from_xpriv(
+                secp_ctx,
+                xpriv,
+                &highest_index_keyset.amounts,
+                highest_index_keyset.unit.clone(),
+                highest_index_keyset.derivation_path.clone(),
+                highest_index_keyset.input_fee_ppk,
+                highest_index_keyset.final_expiry,
+                highest_index_keyset.id.get_version(),
+            );
+
+            let mut keyset_info = highest_index_keyset.clone();
+            keyset_info.active = true;
+            tx.add_keyset_info(keyset_info).await?;
+            tx.set_active_keyset(unit.clone(), id).await?;
         }
     }
 

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -11,20 +11,40 @@
 //! loaded and serving.
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use arc_swap::ArcSwap;
 use bitcoin::bip32::{DerivationPath, Xpriv};
 use bitcoin::secp256k1::{self, Secp256k1};
+use cdk_common::database::MintKeyDatabaseTransaction;
 use cdk_common::dhke::{sign_message, verify_message};
 use cdk_common::mint::MintKeySetInfo;
 use cdk_common::nuts::{BlindSignature, BlindedMessage, CurrencyUnit, Id, MintKeySet, Proof};
 use cdk_common::{database, Error, PublicKey};
-use tokio::sync::{watch, Mutex, RwLock};
+use tokio::sync::{watch, Mutex};
 use tracing::instrument;
 
 use crate::common::{
     check_unit_string_collision, create_new_keyset, derivation_path_from_unit, init_keysets,
 };
 use crate::signatory::{RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets};
+
+/// Immutable in-memory view of the keysets, swapped atomically on every change.
+///
+/// Readers load it lock-free; the periodic refresh and local rotations build a
+/// fresh one off to the side and store it in a single atomic swap, so signing
+/// never waits on a reload.
+#[derive(Default)]
+struct KeysetSnapshot {
+    /// All keysets keyed by id, with their derived keys.
+    by_id: HashMap<Id, (MintKeySetInfo, MintKeySet)>,
+    /// Active keyset id per unit.
+    active_by_unit: HashMap<CurrencyUnit, Id>,
+    /// Storage keyset epoch this snapshot was built from; `None` before the
+    /// first load. The refresh compares it against the storage token to decide
+    /// whether a reload is needed.
+    epoch: Option<u64>,
+}
 
 /// In-memory Signatory
 ///
@@ -34,12 +54,16 @@ use crate::signatory::{RotateKeyArguments, Signatory, SignatoryKeySet, Signatory
 /// is not accessible from the outside.
 #[allow(missing_debug_implementations)]
 pub struct DbSignatory {
-    keysets: RwLock<HashMap<Id, (MintKeySetInfo, MintKeySet)>>,
-    active_keysets: RwLock<HashMap<CurrencyUnit, Id>>,
-    /// Serializes keyset rotations. The standalone signatory gRPC server calls
-    /// rotate_keyset directly (no embedded single-runner), so two concurrent
-    /// rotations of the same unit could otherwise read the same path index and
-    /// derive duplicate keysets.
+    /// Lock-free in-memory keyset view. Reads load it without blocking;
+    /// reloads and rotations replace it wholesale. The database is the global
+    /// coordination point (advisory lock and epoch token); this only mirrors
+    /// it.
+    keysets: ArcSwap<KeysetSnapshot>,
+    /// Serializes local keyset rotations. The standalone signatory gRPC server
+    /// calls rotate_keyset directly (no embedded single-runner), so two
+    /// concurrent local rotations of the same unit could otherwise open nested
+    /// transactions on a single-connection backend. Cross-process
+    /// serialization is the database's job.
     rotation_lock: Mutex<()>,
     localstore: Arc<dyn database::MintKeysDatabase<Err = database::Error> + Send + Sync>,
     secp_ctx: Secp256k1<secp256k1::All>,
@@ -79,8 +103,7 @@ impl DbSignatory {
         });
 
         let signatory = Self {
-            keysets: Default::default(),
-            active_keysets: Default::default(),
+            keysets: ArcSwap::from_pointee(KeysetSnapshot::default()),
             rotation_lock: Default::default(),
             localstore,
             custom_paths,
@@ -94,6 +117,57 @@ impl DbSignatory {
         signatory.boot_load().await?;
 
         Ok(signatory)
+    }
+
+    /// Periodically reload keysets from the shared database, so a rotation
+    /// performed by any instance is picked up without a restart.
+    ///
+    /// This is off by default: a single signatory process owns its database and
+    /// needs no polling. Enabling it (passing an interval) is what lets several
+    /// signatory processes run against one shared database (active/active): each
+    /// process picks up peers' rotations within one interval. Rotation itself is
+    /// always safe to share, its derivation index is allocated authoritatively
+    /// in the database; this reload only closes the gap where a peer's change
+    /// would otherwise be invisible until the next boot.
+    ///
+    /// `interval` is `None` (or zero) to disable: no task is spawned and nothing
+    /// polls. A few seconds is a reasonable cadence. The refresh is aligned to a
+    /// shared wall-clock epoch (Unix time in
+    /// milliseconds floored to the interval) so every process reloads at about
+    /// the same moment, keeping the fleet's view close to consistent without any
+    /// inter-node messaging. The task holds a `Weak`, so it stops on its own once
+    /// the signatory is dropped.
+    pub fn spawn_keyset_refresh(self: &Arc<Self>, interval: Option<Duration>) {
+        let interval_ms = match interval.map(|d| d.as_millis() as u64) {
+            Some(ms) if ms > 0 => ms,
+            _ => return,
+        };
+
+        let weak = Arc::downgrade(self);
+
+        tokio::spawn(async move {
+            loop {
+                let now_ms = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as u64;
+                let next = (now_ms / interval_ms + 1) * interval_ms;
+                tokio::time::sleep(Duration::from_millis(next.saturating_sub(now_ms))).await;
+
+                let Some(signatory) = weak.upgrade() else {
+                    break;
+                };
+                // No rotation lock: the reload loads authoritative database
+                // state, and `load_keys_from_db` gates its swap on the database
+                // epoch, so it cannot publish out of order with a rotation's
+                // reload. It never blocks signing. It is also cheap when nothing
+                // changed (epoch gate, no row fetch, no key derivation), so a
+                // quiet refresh costs only a metadata read.
+                if let Err(err) = signatory.load_keys_from_db().await {
+                    tracing::warn!("periodic keyset reload from database failed: {err}");
+                }
+            }
+        });
     }
 
     /// Load keysets from the database into memory.
@@ -112,44 +186,125 @@ impl DbSignatory {
         Ok(())
     }
 
-    /// Hydrate the in-memory keysets from the database.
+    /// Hydrate the in-memory keysets from the database and swap them in.
     ///
-    /// This is the only path that reads keysets from the database. Since the
-    /// database is owned by this process, all keysets are loaded into memory
-    /// and memory is the primary source afterwards; the database is only the
-    /// persistence layer. Any later operation reads from and mutates memory,
-    /// never the database directly.
+    /// A cheap, lock-free epoch pre-check skips the whole reload when nothing
+    /// changed: one atomic read, no lock, no row fetch, no derivation. Only when
+    /// the epoch moved does it open a keyset transaction (which takes the global
+    /// keyset advisory lock) and reload a consistent snapshot through it, so a
+    /// quiet periodic tick stays a single query. The rebuild reuses the keys
+    /// already derived in the current snapshot, deriving only new keysets, and
+    /// swaps the result in atomically so readers never block.
     async fn load_keys_from_db(&self) -> Result<(), Error> {
-        let mut keysets = self.keysets.write().await;
-        let mut active_keysets = self.active_keysets.write().await;
-        keysets.clear();
-        active_keysets.clear();
-
-        let db_active_keysets = self.localstore.get_active_keysets().await?;
-
-        for mut info in self.localstore.get_keyset_infos().await? {
-            let id = info.id;
-            let keyset = self.generate_keyset(&info);
-            info.active = db_active_keysets.get(&info.unit) == Some(&info.id);
-            if info.active {
-                active_keysets.insert(info.unit.clone(), id);
-            }
-            keysets.insert(id, (info, keyset));
+        // Steady-state gate: a single atomic epoch read, lock-free (one
+        // statement is consistent on its own). Skip when it matches the loaded
+        // snapshot.
+        let epoch = self.localstore.keysets_epoch().await?;
+        if self.keysets.load().epoch == Some(epoch) {
+            return Ok(());
         }
 
-        self.publish_snapshot(&keysets);
-
+        // Something changed: reload under the global keyset lock so the
+        // multi-statement read is a consistent snapshot.
+        let mut tx = self.localstore.begin_transaction().await?;
+        self.reload_from_tx(&mut *tx).await?;
+        tx.commit().await?;
         Ok(())
     }
 
-    /// Publish the current keyset set to any subscribers of the watch channel.
+    /// Reload the in-memory keysets from committed state read through an open
+    /// keyset transaction.
     ///
-    /// Callers hold the `keysets` write lock while calling this so the published
-    /// snapshot stays consistent with the in-memory state that produced it.
-    fn publish_snapshot(&self, keysets: &HashMap<Id, (MintKeySetInfo, MintKeySet)>) {
-        self.keyset_updates.send_replace(SignatoryKeysets {
-            pubkey: self.xpub,
-            keysets: keysets.values().map(|k| k.into()).collect(),
+    /// The transaction holds the global keyset advisory lock (taken in
+    /// `begin_transaction`), so no other keyset transaction can commit between
+    /// the reads: they are a consistent snapshot and need no epoch bracketing.
+    /// `rotate_keyset` calls this on its own write transaction so the collision
+    /// check and default amounts see peers' committed rotations;
+    /// `load_keys_from_db` calls it on a dedicated read transaction.
+    async fn reload_from_tx(
+        &self,
+        tx: &mut (dyn MintKeyDatabaseTransaction<'_, database::Error> + Send + Sync),
+    ) -> Result<(), Error> {
+        let epoch = tx.keysets_epoch().await?;
+        if self.keysets.load().epoch == Some(epoch) {
+            return Ok(());
+        }
+
+        let db_active_keysets = tx.get_active_keysets().await?;
+        let db_infos = tx.get_keyset_infos().await?;
+
+        self.publish_snapshot(epoch, db_active_keysets, db_infos);
+        Ok(())
+    }
+
+    /// Build a keyset snapshot for `epoch` and publish it, reusing keys already
+    /// derived in the current snapshot (a memory copy, no crypto); only a
+    /// genuinely new keyset needs derivation.
+    ///
+    /// Publishing is conditional on the database epoch rather than a process
+    /// lock. `keysets_epoch` is a counter bumped in every keyset-writing
+    /// transaction, so it only ever increases and totally orders changes. Two
+    /// reloads can race here (a periodic refresh against a rotation's
+    /// post-commit reload, or an under-lock reload against the following
+    /// post-commit reload); the compare-and-swap lets the newer database view
+    /// win regardless of arrival order, so an older snapshot can never overwrite
+    /// a newer one. Signing only reads the pointer, so it stays lock-free.
+    fn publish_snapshot(
+        &self,
+        epoch: u64,
+        db_active_keysets: HashMap<CurrencyUnit, Id>,
+        db_infos: Vec<MintKeySetInfo>,
+    ) {
+        let current = self.keysets.load();
+        let mut by_id = HashMap::with_capacity(db_infos.len());
+        let mut active_by_unit = HashMap::new();
+        for mut info in db_infos {
+            let id = info.id;
+            info.active = db_active_keysets.get(&info.unit) == Some(&info.id);
+            if info.active {
+                active_by_unit.insert(info.unit.clone(), id);
+            }
+            let keyset = match current.by_id.get(&id) {
+                Some((_, keyset)) => keyset.clone(),
+                None => self.generate_keyset(&info),
+            };
+            by_id.insert(id, (info, keyset));
+        }
+
+        let snapshot = Arc::new(KeysetSnapshot {
+            by_id,
+            active_by_unit,
+            epoch: Some(epoch),
+        });
+
+        loop {
+            let current = self.keysets.load();
+            if current.epoch.is_some_and(|cur| epoch <= cur) {
+                // A concurrent reload already published an equal-or-newer view.
+                return;
+            }
+            let prev = self.keysets.compare_and_swap(&current, snapshot.clone());
+            if Arc::ptr_eq(&prev, &current) {
+                break;
+            }
+            // Lost the swap: another reload replaced the pointer between our load
+            // and CAS. Retry to re-check its epoch against ours.
+        }
+        self.publish_latest();
+    }
+
+    /// Publish the latest stored keyset snapshot to watch subscribers.
+    ///
+    /// Reads the current `ArcSwap` snapshot inside the watch send closure, which
+    /// holds the channel's send lock, so concurrent reloads publish in the
+    /// pointer's epoch order and the subscriber view never regresses. This
+    /// mirrors the compare-and-swap that orders the stored snapshot; without it
+    /// two swap winners could still send stale-then-fresh out of order.
+    fn publish_latest(&self) {
+        self.keyset_updates.send_modify(|out| {
+            let latest = self.keysets.load();
+            out.pubkey = self.xpub;
+            out.keysets = latest.by_id.values().map(|k| k.into()).collect();
         });
     }
 
@@ -166,14 +321,14 @@ impl DbSignatory {
         )
     }
 
-    /// Snapshot the current keysets from memory.
-    async fn keysets_snapshot(&self) -> SignatoryKeysets {
+    /// Snapshot the current keysets from memory (lock-free).
+    fn keysets_snapshot(&self) -> SignatoryKeysets {
         SignatoryKeysets {
             pubkey: self.xpub,
             keysets: self
                 .keysets
-                .read()
-                .await
+                .load()
+                .by_id
                 .values()
                 .map(|k| k.into())
                 .collect(),
@@ -192,7 +347,7 @@ impl Signatory for DbSignatory {
         &self,
         blinded_messages: Vec<BlindedMessage>,
     ) -> Result<Vec<BlindSignature>, Error> {
-        let keysets = self.keysets.read().await;
+        let keysets = self.keysets.load();
 
         blinded_messages
             .into_iter()
@@ -204,7 +359,7 @@ impl Signatory for DbSignatory {
                     ..
                 } = blinded_message;
 
-                let (info, key) = keysets.get(&keyset_id).ok_or(Error::UnknownKeySet)?;
+                let (info, key) = keysets.by_id.get(&keyset_id).ok_or(Error::UnknownKeySet)?;
                 if !info.active {
                     return Err(Error::InactiveKeyset);
                 }
@@ -230,10 +385,13 @@ impl Signatory for DbSignatory {
 
     #[tracing::instrument(skip_all)]
     async fn verify_proofs(&self, proofs: Vec<Proof>) -> Result<(), Error> {
-        let keysets = self.keysets.read().await;
+        let keysets = self.keysets.load();
 
         proofs.into_iter().try_for_each(|proof| {
-            let (_, key) = keysets.get(&proof.keyset_id).ok_or(Error::UnknownKeySet)?;
+            let (_, key) = keysets
+                .by_id
+                .get(&proof.keyset_id)
+                .ok_or(Error::UnknownKeySet)?;
             let key_pair = key.keys.get(&proof.amount).ok_or(Error::UnknownKeySet)?;
             verify_message(&key_pair.secret_key, proof.c, proof.secret.as_bytes())?;
             Ok(())
@@ -242,7 +400,7 @@ impl Signatory for DbSignatory {
 
     #[tracing::instrument(skip_all)]
     async fn keysets(&self) -> Result<SignatoryKeysets, Error> {
-        Ok(self.keysets_snapshot().await)
+        Ok(self.keysets_snapshot())
     }
 
     #[tracing::instrument(skip_all)]
@@ -254,29 +412,39 @@ impl Signatory for DbSignatory {
     /// Generate new keyset
     #[tracing::instrument(skip(self))]
     async fn rotate_keyset(&self, args: RotateKeyArguments) -> Result<SignatoryKeySet, Error> {
-        // Serialize rotations. The standalone signatory gRPC server invokes this
-        // directly (no embedded single-runner), so without this two concurrent
-        // rotations of the same unit could read the same path index below and
-        // derive duplicate keysets. Held for the whole method.
+        // Serialize local rotations. The standalone signatory gRPC server
+        // invokes this directly (no embedded single-runner), so without this two
+        // concurrent local rotations could open nested transactions on a
+        // single-connection backend. Held for the whole method. Cross-process
+        // rotations are serialized by the global keyset lock in the database.
         let _rotation = self.rotation_lock.lock().await;
 
-        // Derive the next path index and default amounts from the in-memory
-        // active keyset rather than the database. The rotation lock above keeps
-        // this read stable across the DB write and the in-memory update.
-        // Acquire keysets before active_keysets, the same order the write phase
-        // below uses (and load_keys_from_db), keeping lock ordering consistent.
-        let (path_index, amounts) = {
-            let keysets = self.keysets.read().await;
-            let active_keysets = self.active_keysets.read().await;
-            if let Some(current_keyset_id) = active_keysets.get(&args.unit) {
-                let (info, _) = keysets.get(current_keyset_id).ok_or(Error::UnknownKeySet)?;
-                (
-                    info.derivation_path_index.unwrap_or(1) + 1,
-                    info.amounts.clone(),
-                )
-            } else {
-                (1, vec![])
-            }
+        // Persist the rotation. This is the only path that writes to the
+        // database. Opening the transaction takes the global keyset advisory
+        // lock, held to commit, so all keyset transactions serialize across
+        // processes: index allocation is authoritative and two rotations cannot
+        // interleave.
+        let mut tx = self.localstore.begin_transaction().await?;
+        let path_index = tx.next_derivation_index(&args.unit).await?;
+
+        // Reload in-memory keysets from committed state through this
+        // transaction, under the global lock just taken. Both the default
+        // amounts below and the collision check further down then see peers'
+        // committed rotations rather than a possibly-stale in-memory snapshot.
+        self.reload_from_tx(&mut *tx).await?;
+
+        // Default amounts come from the in-memory active keyset and are only
+        // used when the caller does not specify any. The authoritative
+        // derivation index is allocated from the database above, not memory, so
+        // concurrent rotations across instances cannot pick the same index.
+        let default_amounts = {
+            let keysets = self.keysets.load();
+            keysets
+                .active_by_unit
+                .get(&args.unit)
+                .and_then(|id| keysets.by_id.get(id))
+                .map(|(info, _)| info.amounts.clone())
+                .unwrap_or_default()
         };
 
         let derivation_path = match self.custom_paths.get(&args.unit) {
@@ -286,10 +454,10 @@ impl Signatory for DbSignatory {
         };
 
         let amounts = if args.amounts.is_empty() {
-            if amounts.is_empty() {
+            if default_amounts.is_empty() {
                 return Err(Error::Custom("Amounts cannot be empty".to_string()));
             }
-            amounts
+            default_amounts
         } else {
             args.amounts
         };
@@ -306,37 +474,26 @@ impl Signatory for DbSignatory {
             args.keyset_id_type,
         );
 
-        let keysets = self.keysets_snapshot().await;
+        let keysets = self.keysets_snapshot();
         check_unit_string_collision(keysets.keysets, &info)?;
 
         let id = info.id;
 
-        // Persist the rotation. This is the only path that writes to the
-        // database.
-        let mut tx = self.localstore.begin_transaction().await?;
         tx.add_keyset_info(info.clone()).await?;
         tx.set_active_keyset(args.unit.clone(), id).await?;
         tx.commit().await?;
 
-        // Refresh the in-memory state to match what was just persisted, without
-        // reading the database back. This mirrors a fresh boot: the active
-        // pointer for the unit moves to the new keyset, so any previously active
-        // keyset for the unit becomes inactive.
         let mut info = info;
         info.active = true;
-        let signatory_keyset: SignatoryKeySet = (&(info.clone(), keyset.clone())).into();
+        let signatory_keyset: SignatoryKeySet = (&(info, keyset)).into();
 
-        let mut keysets = self.keysets.write().await;
-        let mut active_keysets = self.active_keysets.write().await;
-
-        if let Some(prev_id) = active_keysets.insert(args.unit, id) {
-            if let Some((prev_info, _)) = keysets.get_mut(&prev_id) {
-                prev_info.active = false;
-            }
-        }
-        keysets.insert(id, (info, keyset));
-
-        self.publish_snapshot(&keysets);
+        // Refresh from the full database state rather than patching memory by
+        // hand. This picks up any concurrent peer rotation too, and records the
+        // keyset epoch we loaded, so the periodic refresh does not reload
+        // again on its next tick. (Recording the epoch from a bare post-commit
+        // read would be unsafe: it could already include a peer change this
+        // instance has not loaded.)
+        self.load_keys_from_db().await?;
 
         Ok(signatory_keyset)
     }
@@ -348,11 +505,188 @@ mod test {
 
     use bitcoin::key::Secp256k1;
     use bitcoin::Network;
+    use cdk_common::database::MintKeysDatabase;
     use cdk_common::nuts::SecretKey;
     use cdk_common::util::{hex, unix_time};
     use cdk_common::{Amount, MintKeySet, PublicKey};
 
     use super::*;
+
+    #[tokio::test]
+    async fn keysets_epoch_moves_only_on_change() {
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let signatory = DbSignatory::new(
+            store.clone(),
+            b"test-seed-for-version",
+            Default::default(),
+            Default::default(),
+        )
+        .await
+        .expect("DbSignatory::new");
+
+        let rotate = |unit| RotateKeyArguments {
+            unit,
+            amounts: vec![1, 2, 4, 8],
+            input_fee_ppk: 0,
+            keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+            final_expiry: None,
+        };
+
+        let before = store.keysets_epoch().await.expect("epoch");
+        assert_eq!(
+            before,
+            store.keysets_epoch().await.expect("epoch"),
+            "epoch is stable when nothing changed"
+        );
+
+        // First keyset (becomes active), then a second (the first goes inactive).
+        let first = signatory
+            .rotate_keyset(rotate(CurrencyUnit::Sat))
+            .await
+            .expect("rotate_keyset");
+        let after_insert = store.keysets_epoch().await.expect("epoch");
+        assert_ne!(
+            before, after_insert,
+            "epoch changes after a rotation adds a keyset"
+        );
+
+        signatory
+            .rotate_keyset(rotate(CurrencyUnit::Sat))
+            .await
+            .expect("rotate_keyset");
+        let two_keysets = store.keysets_epoch().await.expect("epoch");
+
+        // Reactivate the first keyset: a pure active-pointer change, no insert.
+        let mut tx = MintKeysDatabase::begin_transaction(&*store)
+            .await
+            .expect("begin tx");
+        tx.set_active_keyset(CurrencyUnit::Sat, first.id)
+            .await
+            .expect("set active");
+        tx.commit().await.expect("commit");
+
+        assert_ne!(
+            two_keysets,
+            store.keysets_epoch().await.expect("epoch"),
+            "epoch changes on an active-pointer reassignment with no insert"
+        );
+    }
+
+    #[tokio::test]
+    async fn rotation_reloads_peer_keyset_under_lock() {
+        // Two signatories sharing one database, the shape ADR-0004 enables.
+        // Neither has the periodic refresh enabled, so the only way instance A
+        // learns of instance B's rotation before a restart is the under-lock
+        // reload inside its own rotate_keyset.
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let seed = b"test-seed-cross-instance-reload";
+        let instance_a =
+            DbSignatory::new(store.clone(), seed, Default::default(), Default::default())
+                .await
+                .expect("DbSignatory::new a");
+        let instance_b =
+            DbSignatory::new(store.clone(), seed, Default::default(), Default::default())
+                .await
+                .expect("DbSignatory::new b");
+
+        let rotate = |unit| RotateKeyArguments {
+            unit,
+            amounts: vec![1, 2, 4, 8],
+            input_fee_ppk: 0,
+            keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+            final_expiry: None,
+        };
+
+        // B rotates Sat and commits. A's in-memory view is untouched.
+        let b_keyset = instance_b
+            .rotate_keyset(rotate(CurrencyUnit::Sat))
+            .await
+            .expect("rotate_keyset b");
+
+        let a_before = instance_a.keysets().await.expect("keysets a");
+        assert!(
+            !a_before.keysets.iter().any(|k| k.id == b_keyset.id),
+            "instance A should not see B's keyset before it reloads"
+        );
+
+        // A rotates a different, non-colliding unit. The under-lock reload must
+        // pull B's committed keyset into A's snapshot.
+        instance_a
+            .rotate_keyset(rotate(CurrencyUnit::Usd))
+            .await
+            .expect("rotate_keyset a");
+
+        let a_after = instance_a.keysets().await.expect("keysets a after");
+        assert!(
+            a_after.keysets.iter().any(|k| k.id == b_keyset.id),
+            "instance A's under-lock reload did not pick up B's committed keyset"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_amount_rotation_adopts_peer_denominations() {
+        // A rotation with empty amounts must reuse the currently active
+        // keyset's denomination set. In an active/active fleet that active
+        // keyset may have been rotated by a peer, so the amounts must come from
+        // committed state read under the global keyset lock, not from this
+        // instance's possibly-stale in-memory snapshot. Without the under-lock
+        // reload in rotate_keyset this test reuses A's older [1, 2, 4, 8].
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let seed = b"test-seed-empty-amount-peer-denoms";
+        let instance_a =
+            DbSignatory::new(store.clone(), seed, Default::default(), Default::default())
+                .await
+                .expect("DbSignatory::new a");
+        let instance_b =
+            DbSignatory::new(store.clone(), seed, Default::default(), Default::default())
+                .await
+                .expect("DbSignatory::new b");
+
+        let rotate = |amounts: Vec<u64>| RotateKeyArguments {
+            unit: CurrencyUnit::Sat,
+            amounts,
+            input_fee_ppk: 0,
+            keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+            final_expiry: None,
+        };
+
+        // A establishes an active Sat keyset, then B rotates it to a distinct
+        // denomination set. A never reloads (no periodic refresh), so its
+        // snapshot still shows the [1, 2, 4, 8] keyset as active.
+        instance_a
+            .rotate_keyset(rotate(vec![1, 2, 4, 8]))
+            .await
+            .expect("rotate_keyset a");
+        instance_b
+            .rotate_keyset(rotate(vec![1, 2, 4, 8, 16, 32]))
+            .await
+            .expect("rotate_keyset b");
+
+        // A rotates with empty amounts: it must adopt B's committed [1, 2, 4,
+        // 8, 16, 32], not its stale local [1, 2, 4, 8].
+        let rotated = instance_a
+            .rotate_keyset(rotate(vec![]))
+            .await
+            .expect("rotate_keyset a empty");
+
+        assert_eq!(
+            rotated.amounts,
+            vec![1, 2, 4, 8, 16, 32],
+            "empty-amount rotation must reuse the peer's committed denomination set"
+        );
+    }
 
     #[tokio::test]
     async fn blind_sign_rejects_expired_keyset() {
@@ -441,6 +775,66 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn peer_rotation_is_reconciled_without_restart() {
+        // One shared store, two signatory instances with the same seed. A
+        // rotation on one must become visible on the other through the change
+        // subscription, not only after a restart.
+        let store: Arc<dyn database::MintKeysDatabase<Err = database::Error> + Send + Sync> =
+            Arc::new(
+                cdk_sqlite::mint::memory::empty()
+                    .await
+                    .expect("in-memory db"),
+            );
+
+        let seed = b"test-seed-for-multi-instance";
+        let instance_a = Arc::new(
+            DbSignatory::new(store.clone(), seed, Default::default(), Default::default())
+                .await
+                .expect("DbSignatory::new a"),
+        );
+        let instance_b = Arc::new(
+            DbSignatory::new(store.clone(), seed, Default::default(), Default::default())
+                .await
+                .expect("DbSignatory::new b"),
+        );
+
+        // Only B reloads from the database; A drives the rotation. A short
+        // interval keeps the test quick.
+        instance_b.spawn_keyset_refresh(Some(Duration::from_millis(500)));
+
+        let rotated = instance_a
+            .rotate_keyset(RotateKeyArguments {
+                unit: CurrencyUnit::Sat,
+                amounts: vec![1, 2, 4, 8],
+                input_fee_ppk: 0,
+                keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                final_expiry: None,
+            })
+            .await
+            .expect("rotate_keyset");
+
+        // B learns about it on its next periodic reload from the database.
+        let mut seen = false;
+        for _ in 0..40 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            let keysets = instance_b.keysets().await.expect("keysets");
+            if keysets
+                .keysets
+                .iter()
+                .any(|k| k.id == rotated.id && k.active)
+            {
+                seen = true;
+                break;
+            }
+        }
+
+        assert!(
+            seen,
+            "instance B should reconcile the peer rotation without a restart"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_rotations_do_not_collide() {
         let store = Arc::new(
             cdk_sqlite::mint::memory::empty()
@@ -493,6 +887,176 @@ mod test {
             );
         }
         assert_eq!(ids.len(), ROTATIONS);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_rotations_across_instances_do_not_collide() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use cdk_sqlite::mint::MintSqliteDatabase;
+
+        // Two independent instances, each with its own rotation_lock, sharing one
+        // on-disk SQLite file. The in-process lock cannot coordinate them; only
+        // the database can (BEGIN IMMEDIATE plus busy_timeout serialize the write
+        // transactions). A shared file is required because ":memory:" is always a
+        // private database per connection pool.
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "cdk-rot-{}-{}.sqlite",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        let path_str = path.to_str().expect("utf-8 temp path");
+
+        let store_a = Arc::new(
+            MintSqliteDatabase::new(path_str)
+                .await
+                .expect("shared-file db a"),
+        );
+        let store_b = Arc::new(
+            MintSqliteDatabase::new(path_str)
+                .await
+                .expect("shared-file db b"),
+        );
+
+        let seed = b"test-seed-cross-instance-rotations";
+        let instance_a = Arc::new(
+            DbSignatory::new(store_a, seed, Default::default(), Default::default())
+                .await
+                .expect("DbSignatory::new a"),
+        );
+        let instance_b = Arc::new(
+            DbSignatory::new(store_b, seed, Default::default(), Default::default())
+                .await
+                .expect("DbSignatory::new b"),
+        );
+
+        // Alternate rotations between the two instances so no single rotation_lock
+        // serializes them all.
+        const ROTATIONS: usize = 8;
+        let mut handles = Vec::with_capacity(ROTATIONS);
+        for i in 0..ROTATIONS {
+            let signatory = if i % 2 == 0 {
+                instance_a.clone()
+            } else {
+                instance_b.clone()
+            };
+            handles.push(tokio::spawn(async move {
+                signatory
+                    .rotate_keyset(RotateKeyArguments {
+                        unit: CurrencyUnit::Sat,
+                        amounts: vec![1, 2, 4, 8],
+                        input_fee_ppk: 0,
+                        keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                        final_expiry: None,
+                    })
+                    .await
+                    .expect("rotate_keyset")
+            }));
+        }
+
+        let mut ids = HashSet::new();
+        let mut versions = HashSet::new();
+        for handle in handles {
+            let keyset = handle.await.expect("join");
+            assert!(
+                ids.insert(keyset.id),
+                "duplicate keyset id from concurrent cross-instance rotation"
+            );
+            assert!(
+                versions.insert(keyset.version),
+                "duplicate path index from concurrent cross-instance rotation"
+            );
+        }
+        assert_eq!(ids.len(), ROTATIONS);
+
+        // Best-effort cleanup of the file and its WAL sidecars.
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(format!("{path_str}-wal"));
+        let _ = std::fs::remove_file(format!("{path_str}-shm"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn boot_does_not_downgrade_active_below_highest_index() {
+        // Boot reactivation and a peer rotation race on a shared store. Boot
+        // selects the highest-index keyset and reassigns the active pointer; if
+        // that selection reads outside the global keyset lock, a rotation
+        // committing a higher keyset in the gap gets clobbered back to the older
+        // one. The active pointer must always end at the highest index present.
+        let store: Arc<dyn database::MintKeysDatabase<Err = database::Error> + Send + Sync> =
+            Arc::new(
+                cdk_sqlite::mint::memory::empty()
+                    .await
+                    .expect("in-memory db"),
+            );
+        let seed = b"test-seed-boot-no-downgrade";
+        let supported: HashMap<CurrencyUnit, (u64, Vec<u64>)> =
+            HashMap::from([(CurrencyUnit::Sat, (0u64, vec![1, 2, 4, 8]))]);
+
+        let seeder = Arc::new(
+            DbSignatory::new(store.clone(), seed, supported.clone(), Default::default())
+                .await
+                .expect("DbSignatory::new seeder"),
+        );
+        // Establish an initial active keyset so later rotations advance the index.
+        seeder
+            .rotate_keyset(RotateKeyArguments {
+                unit: CurrencyUnit::Sat,
+                amounts: vec![1, 2, 4, 8],
+                input_fee_ppk: 0,
+                keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                final_expiry: None,
+            })
+            .await
+            .expect("seed rotation");
+
+        for _ in 0..16 {
+            let rotate = {
+                let seeder = seeder.clone();
+                tokio::spawn(async move {
+                    seeder
+                        .rotate_keyset(RotateKeyArguments {
+                            unit: CurrencyUnit::Sat,
+                            amounts: vec![1, 2, 4, 8],
+                            input_fee_ppk: 0,
+                            keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                            final_expiry: None,
+                        })
+                        .await
+                        .expect("peer rotation")
+                })
+            };
+            let boot = {
+                let store = store.clone();
+                let supported = supported.clone();
+                tokio::spawn(async move {
+                    DbSignatory::new(store, seed, supported, Default::default())
+                        .await
+                        .expect("DbSignatory::new boot")
+                })
+            };
+            rotate.await.expect("join rotate");
+            boot.await.expect("join boot");
+
+            let mut tx = store.begin_transaction().await.expect("begin tx");
+            let infos = tx.get_keyset_infos().await.expect("keyset infos");
+            let active = tx
+                .get_active_keysets()
+                .await
+                .expect("active keysets")
+                .get(&CurrencyUnit::Sat)
+                .copied();
+            tx.commit().await.expect("commit");
+            let highest = infos
+                .iter()
+                .max_by_key(|k| k.derivation_path_index)
+                .expect("at least one keyset");
+            assert_eq!(
+                active,
+                Some(highest.id),
+                "boot must not reactivate a keyset below the highest index"
+            );
+        }
     }
 
     #[test]

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -11,20 +11,46 @@
 //! loaded and serving.
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use arc_swap::ArcSwap;
 use bitcoin::bip32::{DerivationPath, Xpriv};
 use bitcoin::secp256k1::{self, Secp256k1};
 use cdk_common::dhke::{sign_message, verify_message};
 use cdk_common::mint::MintKeySetInfo;
 use cdk_common::nuts::{BlindSignature, BlindedMessage, CurrencyUnit, Id, MintKeySet, Proof};
 use cdk_common::{database, Error, PublicKey};
-use tokio::sync::{watch, Mutex, RwLock};
+use tokio::sync::{watch, Mutex};
 use tracing::instrument;
+
+/// Default interval at which each instance reloads keysets from the shared
+/// database, when the reload is enabled. Reloads are aligned to this wall-clock
+/// epoch across the fleet. Callers pass their own interval to
+/// [`DbSignatory::spawn_keyset_refresh`]; the reload is off unless an interval
+/// is provided.
+pub const DEFAULT_KEYSET_REFRESH: Duration = Duration::from_secs(5);
 
 use crate::common::{
     check_unit_string_collision, create_new_keyset, derivation_path_from_unit, init_keysets,
 };
 use crate::signatory::{RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets};
+
+/// Immutable in-memory view of the keysets, swapped atomically on every change.
+///
+/// Readers load it lock-free; the periodic refresh and local rotations build a
+/// fresh one off to the side and store it in a single atomic swap, so signing
+/// never waits on a reload.
+#[derive(Default)]
+struct KeysetSnapshot {
+    /// All keysets keyed by id, with their derived keys.
+    by_id: HashMap<Id, (MintKeySetInfo, MintKeySet)>,
+    /// Active keyset id per unit.
+    active_by_unit: HashMap<CurrencyUnit, Id>,
+    /// Storage keyset epoch this snapshot was built from; `None` before the
+    /// first load. The refresh compares it against the storage token to decide
+    /// whether a reload is needed.
+    epoch: Option<u64>,
+}
 
 /// In-memory Signatory
 ///
@@ -34,12 +60,16 @@ use crate::signatory::{RotateKeyArguments, Signatory, SignatoryKeySet, Signatory
 /// is not accessible from the outside.
 #[allow(missing_debug_implementations)]
 pub struct DbSignatory {
-    keysets: RwLock<HashMap<Id, (MintKeySetInfo, MintKeySet)>>,
-    active_keysets: RwLock<HashMap<CurrencyUnit, Id>>,
-    /// Serializes keyset rotations. The standalone signatory gRPC server calls
-    /// rotate_keyset directly (no embedded single-runner), so two concurrent
-    /// rotations of the same unit could otherwise read the same path index and
-    /// derive duplicate keysets.
+    /// Lock-free in-memory keyset view. Reads load it without blocking;
+    /// reloads and rotations replace it wholesale. The database is the global
+    /// coordination point (advisory lock and epoch token); this only mirrors
+    /// it.
+    keysets: ArcSwap<KeysetSnapshot>,
+    /// Serializes local keyset rotations. The standalone signatory gRPC server
+    /// calls rotate_keyset directly (no embedded single-runner), so two
+    /// concurrent local rotations of the same unit could otherwise open nested
+    /// transactions on a single-connection backend. Cross-process
+    /// serialization is the database's job.
     rotation_lock: Mutex<()>,
     localstore: Arc<dyn database::MintKeysDatabase<Err = database::Error> + Send + Sync>,
     secp_ctx: Secp256k1<secp256k1::All>,
@@ -79,8 +109,7 @@ impl DbSignatory {
         });
 
         let signatory = Self {
-            keysets: Default::default(),
-            active_keysets: Default::default(),
+            keysets: ArcSwap::from_pointee(KeysetSnapshot::default()),
             rotation_lock: Default::default(),
             localstore,
             custom_paths,
@@ -94,6 +123,57 @@ impl DbSignatory {
         signatory.boot_load().await?;
 
         Ok(signatory)
+    }
+
+    /// Periodically reload keysets from the shared database, so a rotation
+    /// performed by any instance is picked up without a restart.
+    ///
+    /// This is off by default: a single signatory process owns its database and
+    /// needs no polling. Enabling it (passing an interval) is what lets several
+    /// signatory processes run against one shared database (active/active): each
+    /// process picks up peers' rotations within one interval. Rotation itself is
+    /// always safe to share, its derivation index is allocated authoritatively
+    /// in the database; this reload only closes the gap where a peer's change
+    /// would otherwise be invisible until the next boot.
+    ///
+    /// `interval` is `None` (or zero) to disable: no task is spawned and nothing
+    /// polls. Pass [`DEFAULT_KEYSET_REFRESH`] for the standard cadence. The
+    /// refresh is aligned to a shared wall-clock epoch (Unix time in
+    /// milliseconds floored to the interval) so every process reloads at about
+    /// the same moment, keeping the fleet's view close to consistent without any
+    /// inter-node messaging. The task holds a `Weak`, so it stops on its own once
+    /// the signatory is dropped.
+    pub fn spawn_keyset_refresh(self: &Arc<Self>, interval: Option<Duration>) {
+        let interval_ms = match interval.map(|d| d.as_millis() as u64) {
+            Some(ms) if ms > 0 => ms,
+            _ => return,
+        };
+
+        let weak = Arc::downgrade(self);
+
+        tokio::spawn(async move {
+            loop {
+                let now_ms = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as u64;
+                let next = (now_ms / interval_ms + 1) * interval_ms;
+                tokio::time::sleep(Duration::from_millis(next.saturating_sub(now_ms))).await;
+
+                let Some(signatory) = weak.upgrade() else {
+                    break;
+                };
+                // No rotation lock: the reload loads authoritative database
+                // state, and `load_keys_from_db` gates its swap on the database
+                // epoch, so it cannot publish out of order with a rotation's
+                // reload. It never blocks signing. It is also cheap when nothing
+                // changed (epoch gate, no row fetch, no key derivation), so a
+                // quiet refresh costs only a metadata read.
+                if let Err(err) = signatory.load_keys_from_db().await {
+                    tracing::warn!("periodic keyset reload from database failed: {err}");
+                }
+            }
+        });
     }
 
     /// Load keysets from the database into memory.
@@ -112,44 +192,122 @@ impl DbSignatory {
         Ok(())
     }
 
-    /// Hydrate the in-memory keysets from the database.
+    /// Hydrate the in-memory keysets from the database and swap them in.
     ///
-    /// This is the only path that reads keysets from the database. Since the
-    /// database is owned by this process, all keysets are loaded into memory
-    /// and memory is the primary source afterwards; the database is only the
-    /// persistence layer. Any later operation reads from and mutates memory,
-    /// never the database directly.
+    /// The database is read (cheap metadata only) on every call, but the
+    /// expensive part, re-deriving each keyset's keys from the seed, is skipped
+    /// when nothing changed: an epoch gate returns early when the storage token
+    /// matches the loaded snapshot. Only when a keyset was added or
+    /// (de)activated does it rebuild, and even then it reuses the keys already
+    /// derived in the current snapshot, deriving only the new keysets. The new
+    /// snapshot replaces the old one in a single atomic swap, so readers never
+    /// block. Memory mirrors the database, which stays the source of truth for
+    /// coordination.
     async fn load_keys_from_db(&self) -> Result<(), Error> {
-        let mut keysets = self.keysets.write().await;
-        let mut active_keysets = self.active_keysets.write().await;
-        keysets.clear();
-        active_keysets.clear();
-
-        let db_active_keysets = self.localstore.get_active_keysets().await?;
-
-        for mut info in self.localstore.get_keyset_infos().await? {
-            let id = info.id;
-            let keyset = self.generate_keyset(&info);
-            info.active = db_active_keysets.get(&info.unit) == Some(&info.id);
-            if info.active {
-                active_keysets.insert(info.unit.clone(), id);
-            }
-            keysets.insert(id, (info, keyset));
+        // Cheap gate: ask the storage for its keyset-epoch token and skip the
+        // reload entirely when it matches the snapshot we already loaded. This
+        // is the steady-state path, one aggregate query with no row fetch, no
+        // key derivation, and no swap.
+        let mut before = self.localstore.keysets_epoch().await?;
+        if self.keysets.load().epoch == Some(before) {
+            return Ok(());
         }
 
-        self.publish_snapshot(&keysets);
+        // Read a consistent snapshot. The active pointers and the keyset infos
+        // are two separate autocommit reads, so a peer rotation could commit
+        // between them and hand us a torn view (a keyset marked active by one
+        // read but absent from the other). Bracket both reads with the epoch
+        // token: it is bumped atomically inside every keyset-writing
+        // transaction, so an unchanged token across the pair proves nothing
+        // committed in between. This correctness rests on that invariant; both
+        // current mutators (`add_keyset_info`, `set_active_keyset`) bump it.
+        //
+        // Rotations are rare, so this converges on the first attempt in
+        // practice. The bound only guards a pathological continuous-rotation
+        // workload; on exhaustion we load the freshest reads but keep the older
+        // `before` as the recorded epoch, so the gate forces another reload on
+        // the next tick rather than freezing a possibly-torn snapshot. Recording
+        // an older-than-data epoch is always safe: it only costs a redundant
+        // reload.
+        const MAX_ATTEMPTS: usize = 4;
+        let (epoch, db_active_keysets, db_infos) = {
+            let mut attempt = 1;
+            loop {
+                let db_active_keysets = self.localstore.get_active_keysets().await?;
+                let db_infos = self.localstore.get_keyset_infos().await?;
+                let after = self.localstore.keysets_epoch().await?;
+                if after == before || attempt >= MAX_ATTEMPTS {
+                    let epoch = if after == before { after } else { before };
+                    break (epoch, db_active_keysets, db_infos);
+                }
+                before = after;
+                attempt += 1;
+            }
+        };
+
+        // Build the new snapshot off to the side, reusing keys already derived
+        // in the current snapshot (a memory copy, no crypto); only a genuinely
+        // new keyset needs derivation.
+        let current = self.keysets.load();
+        let mut by_id = HashMap::with_capacity(db_infos.len());
+        let mut active_by_unit = HashMap::new();
+        for mut info in db_infos {
+            let id = info.id;
+            info.active = db_active_keysets.get(&info.unit) == Some(&info.id);
+            if info.active {
+                active_by_unit.insert(info.unit.clone(), id);
+            }
+            let keyset = match current.by_id.get(&id) {
+                Some((_, keyset)) => keyset.clone(),
+                None => self.generate_keyset(&info),
+            };
+            by_id.insert(id, (info, keyset));
+        }
+
+        let snapshot = Arc::new(KeysetSnapshot {
+            by_id,
+            active_by_unit,
+            epoch: Some(epoch),
+        });
+
+        // Publish conditionally on the database epoch rather than under a
+        // process lock. `keysets_epoch` is a counter bumped in every
+        // keyset-writing transaction, so it only ever increases and totally
+        // orders changes. Two reloads can race here (a periodic refresh against
+        // a rotation's post-commit reload); the compare-and-swap lets the newer
+        // database view win regardless of arrival order, so an older snapshot
+        // can never overwrite a newer one. Signing only reads the pointer, so it
+        // stays lock-free.
+        loop {
+            let current = self.keysets.load();
+            if current.epoch.is_some_and(|cur| epoch <= cur) {
+                // A concurrent reload already published an equal-or-newer view.
+                return Ok(());
+            }
+            let prev = self.keysets.compare_and_swap(&current, snapshot.clone());
+            if Arc::ptr_eq(&prev, &current) {
+                break;
+            }
+            // Lost the swap: another reload replaced the pointer between our load
+            // and CAS. Retry to re-check its epoch against ours.
+        }
+        self.publish_latest();
 
         Ok(())
     }
 
-    /// Publish the current keyset set to any subscribers of the watch channel.
+    /// Publish the latest stored keyset snapshot to watch subscribers.
     ///
-    /// Callers hold the `keysets` write lock while calling this so the published
-    /// snapshot stays consistent with the in-memory state that produced it.
-    fn publish_snapshot(&self, keysets: &HashMap<Id, (MintKeySetInfo, MintKeySet)>) {
-        self.keyset_updates.send_replace(SignatoryKeysets {
-            pubkey: self.xpub,
-            keysets: keysets.values().map(|k| k.into()).collect(),
+    /// Reads the current `ArcSwap` snapshot inside the watch send closure, which
+    /// holds the channel's send lock, so concurrent reloads publish in the
+    /// pointer's epoch order and the subscriber view never regresses. This
+    /// mirrors the compare-and-swap that orders the stored snapshot; without it
+    /// two swap winners could still send stale-then-fresh out of order.
+    fn publish_latest(&self) {
+        self.keyset_updates.send_modify(|out| {
+            let latest = self.keysets.load();
+            out.pubkey = self.xpub;
+            out.keysets = latest.by_id.values().map(|k| k.into()).collect();
         });
     }
 
@@ -166,14 +324,14 @@ impl DbSignatory {
         )
     }
 
-    /// Snapshot the current keysets from memory.
-    async fn keysets_snapshot(&self) -> SignatoryKeysets {
+    /// Snapshot the current keysets from memory (lock-free).
+    fn keysets_snapshot(&self) -> SignatoryKeysets {
         SignatoryKeysets {
             pubkey: self.xpub,
             keysets: self
                 .keysets
-                .read()
-                .await
+                .load()
+                .by_id
                 .values()
                 .map(|k| k.into())
                 .collect(),
@@ -192,7 +350,7 @@ impl Signatory for DbSignatory {
         &self,
         blinded_messages: Vec<BlindedMessage>,
     ) -> Result<Vec<BlindSignature>, Error> {
-        let keysets = self.keysets.read().await;
+        let keysets = self.keysets.load();
 
         blinded_messages
             .into_iter()
@@ -204,7 +362,7 @@ impl Signatory for DbSignatory {
                     ..
                 } = blinded_message;
 
-                let (info, key) = keysets.get(&keyset_id).ok_or(Error::UnknownKeySet)?;
+                let (info, key) = keysets.by_id.get(&keyset_id).ok_or(Error::UnknownKeySet)?;
                 if !info.active {
                     return Err(Error::InactiveKeyset);
                 }
@@ -230,10 +388,13 @@ impl Signatory for DbSignatory {
 
     #[tracing::instrument(skip_all)]
     async fn verify_proofs(&self, proofs: Vec<Proof>) -> Result<(), Error> {
-        let keysets = self.keysets.read().await;
+        let keysets = self.keysets.load();
 
         proofs.into_iter().try_for_each(|proof| {
-            let (_, key) = keysets.get(&proof.keyset_id).ok_or(Error::UnknownKeySet)?;
+            let (_, key) = keysets
+                .by_id
+                .get(&proof.keyset_id)
+                .ok_or(Error::UnknownKeySet)?;
             let key_pair = key.keys.get(&proof.amount).ok_or(Error::UnknownKeySet)?;
             verify_message(&key_pair.secret_key, proof.c, proof.secret.as_bytes())?;
             Ok(())
@@ -242,7 +403,7 @@ impl Signatory for DbSignatory {
 
     #[tracing::instrument(skip_all)]
     async fn keysets(&self) -> Result<SignatoryKeysets, Error> {
-        Ok(self.keysets_snapshot().await)
+        Ok(self.keysets_snapshot())
     }
 
     #[tracing::instrument(skip_all)]
@@ -254,30 +415,33 @@ impl Signatory for DbSignatory {
     /// Generate new keyset
     #[tracing::instrument(skip(self))]
     async fn rotate_keyset(&self, args: RotateKeyArguments) -> Result<SignatoryKeySet, Error> {
-        // Serialize rotations. The standalone signatory gRPC server invokes this
-        // directly (no embedded single-runner), so without this two concurrent
-        // rotations of the same unit could read the same path index below and
-        // derive duplicate keysets. Held for the whole method.
+        // Serialize local rotations. The standalone signatory gRPC server
+        // invokes this directly (no embedded single-runner), so without this two
+        // concurrent local rotations of the same unit could open nested
+        // transactions on a single-connection backend. Held for the whole
+        // method. Cross-process rotations are serialized by the database.
         let _rotation = self.rotation_lock.lock().await;
 
-        // Derive the next path index and default amounts from the in-memory
-        // active keyset rather than the database. The rotation lock above keeps
-        // this read stable across the DB write and the in-memory update.
-        // Acquire keysets before active_keysets, the same order the write phase
-        // below uses (and load_keys_from_db), keeping lock ordering consistent.
-        let (path_index, amounts) = {
-            let keysets = self.keysets.read().await;
-            let active_keysets = self.active_keysets.read().await;
-            if let Some(current_keyset_id) = active_keysets.get(&args.unit) {
-                let (info, _) = keysets.get(current_keyset_id).ok_or(Error::UnknownKeySet)?;
-                (
-                    info.derivation_path_index.unwrap_or(1) + 1,
-                    info.amounts.clone(),
-                )
-            } else {
-                (1, vec![])
-            }
+        // Default amounts come from the in-memory active keyset and are only
+        // used when the caller does not specify any. The authoritative
+        // derivation index is allocated from the database below, not memory, so
+        // concurrent rotations across instances cannot pick the same index.
+        let default_amounts = {
+            let keysets = self.keysets.load();
+            keysets
+                .active_by_unit
+                .get(&args.unit)
+                .and_then(|id| keysets.by_id.get(id))
+                .map(|(info, _)| info.amounts.clone())
+                .unwrap_or_default()
         };
+
+        // Persist the rotation. This is the only path that writes to the
+        // database. The transaction is opened first so index allocation is
+        // authoritative: on shared backends `next_derivation_index` takes a
+        // per-unit lock held to commit, serializing rotations across processes.
+        let mut tx = self.localstore.begin_transaction().await?;
+        let path_index = tx.next_derivation_index(&args.unit).await?;
 
         let derivation_path = match self.custom_paths.get(&args.unit) {
             Some(path) => path.clone(),
@@ -286,10 +450,10 @@ impl Signatory for DbSignatory {
         };
 
         let amounts = if args.amounts.is_empty() {
-            if amounts.is_empty() {
+            if default_amounts.is_empty() {
                 return Err(Error::Custom("Amounts cannot be empty".to_string()));
             }
-            amounts
+            default_amounts
         } else {
             args.amounts
         };
@@ -306,37 +470,26 @@ impl Signatory for DbSignatory {
             args.keyset_id_type,
         );
 
-        let keysets = self.keysets_snapshot().await;
+        let keysets = self.keysets_snapshot();
         check_unit_string_collision(keysets.keysets, &info)?;
 
         let id = info.id;
 
-        // Persist the rotation. This is the only path that writes to the
-        // database.
-        let mut tx = self.localstore.begin_transaction().await?;
         tx.add_keyset_info(info.clone()).await?;
         tx.set_active_keyset(args.unit.clone(), id).await?;
         tx.commit().await?;
 
-        // Refresh the in-memory state to match what was just persisted, without
-        // reading the database back. This mirrors a fresh boot: the active
-        // pointer for the unit moves to the new keyset, so any previously active
-        // keyset for the unit becomes inactive.
         let mut info = info;
         info.active = true;
-        let signatory_keyset: SignatoryKeySet = (&(info.clone(), keyset.clone())).into();
+        let signatory_keyset: SignatoryKeySet = (&(info, keyset)).into();
 
-        let mut keysets = self.keysets.write().await;
-        let mut active_keysets = self.active_keysets.write().await;
-
-        if let Some(prev_id) = active_keysets.insert(args.unit, id) {
-            if let Some((prev_info, _)) = keysets.get_mut(&prev_id) {
-                prev_info.active = false;
-            }
-        }
-        keysets.insert(id, (info, keyset));
-
-        self.publish_snapshot(&keysets);
+        // Refresh from the full database state rather than patching memory by
+        // hand. This picks up any concurrent peer rotation too, and records the
+        // keyset epoch we loaded, so the periodic refresh does not reload
+        // again on its next tick. (Recording the epoch from a bare post-commit
+        // read would be unsafe: it could already include a peer change this
+        // instance has not loaded.)
+        self.load_keys_from_db().await?;
 
         Ok(signatory_keyset)
     }
@@ -348,11 +501,76 @@ mod test {
 
     use bitcoin::key::Secp256k1;
     use bitcoin::Network;
+    use cdk_common::database::MintKeysDatabase;
     use cdk_common::nuts::SecretKey;
     use cdk_common::util::{hex, unix_time};
     use cdk_common::{Amount, MintKeySet, PublicKey};
 
     use super::*;
+
+    #[tokio::test]
+    async fn keysets_epoch_moves_only_on_change() {
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let signatory = DbSignatory::new(
+            store.clone(),
+            b"test-seed-for-version",
+            Default::default(),
+            Default::default(),
+        )
+        .await
+        .expect("DbSignatory::new");
+
+        let rotate = |unit| RotateKeyArguments {
+            unit,
+            amounts: vec![1, 2, 4, 8],
+            input_fee_ppk: 0,
+            keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+            final_expiry: None,
+        };
+
+        let before = store.keysets_epoch().await.expect("epoch");
+        assert_eq!(
+            before,
+            store.keysets_epoch().await.expect("epoch"),
+            "epoch is stable when nothing changed"
+        );
+
+        // First keyset (becomes active), then a second (the first goes inactive).
+        let first = signatory
+            .rotate_keyset(rotate(CurrencyUnit::Sat))
+            .await
+            .expect("rotate_keyset");
+        let after_insert = store.keysets_epoch().await.expect("epoch");
+        assert_ne!(
+            before, after_insert,
+            "epoch changes after a rotation adds a keyset"
+        );
+
+        signatory
+            .rotate_keyset(rotate(CurrencyUnit::Sat))
+            .await
+            .expect("rotate_keyset");
+        let two_keysets = store.keysets_epoch().await.expect("epoch");
+
+        // Reactivate the first keyset: a pure active-pointer change, no insert.
+        let mut tx = MintKeysDatabase::begin_transaction(&*store)
+            .await
+            .expect("begin tx");
+        tx.set_active_keyset(CurrencyUnit::Sat, first.id)
+            .await
+            .expect("set active");
+        tx.commit().await.expect("commit");
+
+        assert_ne!(
+            two_keysets,
+            store.keysets_epoch().await.expect("epoch"),
+            "epoch changes on an active-pointer reassignment with no insert"
+        );
+    }
 
     #[tokio::test]
     async fn blind_sign_rejects_expired_keyset() {
@@ -441,6 +659,66 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn peer_rotation_is_reconciled_without_restart() {
+        // One shared store, two signatory instances with the same seed. A
+        // rotation on one must become visible on the other through the change
+        // subscription, not only after a restart.
+        let store: Arc<dyn database::MintKeysDatabase<Err = database::Error> + Send + Sync> =
+            Arc::new(
+                cdk_sqlite::mint::memory::empty()
+                    .await
+                    .expect("in-memory db"),
+            );
+
+        let seed = b"test-seed-for-multi-instance";
+        let instance_a = Arc::new(
+            DbSignatory::new(store.clone(), seed, Default::default(), Default::default())
+                .await
+                .expect("DbSignatory::new a"),
+        );
+        let instance_b = Arc::new(
+            DbSignatory::new(store.clone(), seed, Default::default(), Default::default())
+                .await
+                .expect("DbSignatory::new b"),
+        );
+
+        // Only B reloads from the database; A drives the rotation. A short
+        // interval keeps the test quick.
+        instance_b.spawn_keyset_refresh(Some(Duration::from_millis(500)));
+
+        let rotated = instance_a
+            .rotate_keyset(RotateKeyArguments {
+                unit: CurrencyUnit::Sat,
+                amounts: vec![1, 2, 4, 8],
+                input_fee_ppk: 0,
+                keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                final_expiry: None,
+            })
+            .await
+            .expect("rotate_keyset");
+
+        // B learns about it on its next periodic reload from the database.
+        let mut seen = false;
+        for _ in 0..40 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            let keysets = instance_b.keysets().await.expect("keysets");
+            if keysets
+                .keysets
+                .iter()
+                .any(|k| k.id == rotated.id && k.active)
+            {
+                seen = true;
+                break;
+            }
+        }
+
+        assert!(
+            seen,
+            "instance B should reconcile the peer rotation without a restart"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_rotations_do_not_collide() {
         let store = Arc::new(
             cdk_sqlite::mint::memory::empty()
@@ -493,6 +771,172 @@ mod test {
             );
         }
         assert_eq!(ids.len(), ROTATIONS);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_rotations_across_instances_do_not_collide() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use cdk_sqlite::mint::MintSqliteDatabase;
+
+        // Two independent instances, each with its own rotation_lock, sharing one
+        // on-disk SQLite file. The in-process lock cannot coordinate them; only
+        // the database can (BEGIN IMMEDIATE plus busy_timeout serialize the write
+        // transactions). A shared file is required because ":memory:" is always a
+        // private database per connection pool.
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "cdk-rot-{}-{}.sqlite",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        let path_str = path.to_str().expect("utf-8 temp path");
+
+        let store_a = Arc::new(
+            MintSqliteDatabase::new(path_str)
+                .await
+                .expect("shared-file db a"),
+        );
+        let store_b = Arc::new(
+            MintSqliteDatabase::new(path_str)
+                .await
+                .expect("shared-file db b"),
+        );
+
+        let seed = b"test-seed-cross-instance-rotations";
+        let instance_a = Arc::new(
+            DbSignatory::new(store_a, seed, Default::default(), Default::default())
+                .await
+                .expect("DbSignatory::new a"),
+        );
+        let instance_b = Arc::new(
+            DbSignatory::new(store_b, seed, Default::default(), Default::default())
+                .await
+                .expect("DbSignatory::new b"),
+        );
+
+        // Alternate rotations between the two instances so no single rotation_lock
+        // serializes them all.
+        const ROTATIONS: usize = 8;
+        let mut handles = Vec::with_capacity(ROTATIONS);
+        for i in 0..ROTATIONS {
+            let signatory = if i % 2 == 0 {
+                instance_a.clone()
+            } else {
+                instance_b.clone()
+            };
+            handles.push(tokio::spawn(async move {
+                signatory
+                    .rotate_keyset(RotateKeyArguments {
+                        unit: CurrencyUnit::Sat,
+                        amounts: vec![1, 2, 4, 8],
+                        input_fee_ppk: 0,
+                        keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                        final_expiry: None,
+                    })
+                    .await
+                    .expect("rotate_keyset")
+            }));
+        }
+
+        let mut ids = HashSet::new();
+        let mut versions = HashSet::new();
+        for handle in handles {
+            let keyset = handle.await.expect("join");
+            assert!(
+                ids.insert(keyset.id),
+                "duplicate keyset id from concurrent cross-instance rotation"
+            );
+            assert!(
+                versions.insert(keyset.version),
+                "duplicate path index from concurrent cross-instance rotation"
+            );
+        }
+        assert_eq!(ids.len(), ROTATIONS);
+
+        // Best-effort cleanup of the file and its WAL sidecars.
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(format!("{path_str}-wal"));
+        let _ = std::fs::remove_file(format!("{path_str}-shm"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn boot_does_not_downgrade_active_below_highest_index() {
+        // Boot reactivation and a peer rotation race on a shared store. Boot
+        // selects the highest-index keyset and reassigns the active pointer; if
+        // that selection reads outside the per-unit lock, a rotation committing
+        // a higher keyset in the gap gets clobbered back to the older one. The
+        // active pointer must always end at the highest index present.
+        let store: Arc<dyn database::MintKeysDatabase<Err = database::Error> + Send + Sync> =
+            Arc::new(
+                cdk_sqlite::mint::memory::empty()
+                    .await
+                    .expect("in-memory db"),
+            );
+        let seed = b"test-seed-boot-no-downgrade";
+        let supported: HashMap<CurrencyUnit, (u64, Vec<u64>)> =
+            HashMap::from([(CurrencyUnit::Sat, (0u64, vec![1, 2, 4, 8]))]);
+
+        let seeder = Arc::new(
+            DbSignatory::new(store.clone(), seed, supported.clone(), Default::default())
+                .await
+                .expect("DbSignatory::new seeder"),
+        );
+        // Establish an initial active keyset so later rotations advance the index.
+        seeder
+            .rotate_keyset(RotateKeyArguments {
+                unit: CurrencyUnit::Sat,
+                amounts: vec![1, 2, 4, 8],
+                input_fee_ppk: 0,
+                keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                final_expiry: None,
+            })
+            .await
+            .expect("seed rotation");
+
+        for _ in 0..16 {
+            let rotate = {
+                let seeder = seeder.clone();
+                tokio::spawn(async move {
+                    seeder
+                        .rotate_keyset(RotateKeyArguments {
+                            unit: CurrencyUnit::Sat,
+                            amounts: vec![1, 2, 4, 8],
+                            input_fee_ppk: 0,
+                            keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                            final_expiry: None,
+                        })
+                        .await
+                        .expect("peer rotation")
+                })
+            };
+            let boot = {
+                let store = store.clone();
+                let supported = supported.clone();
+                tokio::spawn(async move {
+                    DbSignatory::new(store, seed, supported, Default::default())
+                        .await
+                        .expect("DbSignatory::new boot")
+                })
+            };
+            rotate.await.expect("join rotate");
+            boot.await.expect("join boot");
+
+            let infos = store.get_keyset_infos().await.expect("keyset infos");
+            let highest = infos
+                .iter()
+                .max_by_key(|k| k.derivation_path_index)
+                .expect("at least one keyset");
+            let active = store
+                .get_active_keyset_id(&CurrencyUnit::Sat)
+                .await
+                .expect("active keyset id");
+            assert_eq!(
+                active,
+                Some(highest.id),
+                "boot must not reactivate a keyset below the highest index"
+            );
+        }
     }
 
     #[test]

--- a/crates/cdk-signatory/src/signatory.rs
+++ b/crates/cdk-signatory/src/signatory.rs
@@ -14,32 +14,9 @@ use cdk_common::{
     BlindSignature, BlindedMessage, CurrencyUnit, Id, KeySet, Keys, MintKeySet, Proof, PublicKey,
 };
 
-#[derive(Debug)]
-/// Type alias to make the keyset info API more useful, queryable by unit and Id
-pub enum KeysetIdentifier {
-    /// Mint Keyset by unit
-    Unit(CurrencyUnit),
-    /// Mint Keyset by Id
-    Id(Id),
-}
-
-impl From<Id> for KeysetIdentifier {
-    fn from(id: Id) -> Self {
-        Self::Id(id)
-    }
-}
-
-impl From<CurrencyUnit> for KeysetIdentifier {
-    fn from(unit: CurrencyUnit) -> Self {
-        Self::Unit(unit)
-    }
-}
-
 /// RotateKeyArguments
 ///
 /// This struct is used to pass the arguments to the rotate_keyset function
-///
-/// TODO: Change argument to accept a vector of Amount instead of max_order.
 #[derive(Debug, Clone)]
 pub struct RotateKeyArguments {
     /// Unit

--- a/crates/cdk-sql-common/src/mint/keys.rs
+++ b/crates/cdk-sql-common/src/mint/keys.rs
@@ -11,7 +11,7 @@ use cdk_common::mint::MintKeySetInfo;
 use cdk_common::{CurrencyUnit, Id};
 
 use super::{SQLMintDatabase, SQLTransaction};
-use crate::database::ConnectionWithTransaction;
+use crate::database::{ConnectionWithTransaction, DatabaseExecutor};
 use crate::pool::DatabasePool;
 use crate::stmt::{query, Column};
 use crate::{
@@ -65,6 +65,72 @@ pub(crate) fn sql_row_to_keyset_info(row: Vec<Column>) -> Result<MintKeySetInfo,
     })
 }
 
+/// The keyset-info columns, in the order [`sql_row_to_keyset_info`] expects.
+const KEYSET_INFO_COLUMNS: &str = r#"
+    id,
+    unit,
+    active,
+    valid_from,
+    valid_to,
+    derivation_path,
+    derivation_path_index,
+    amounts,
+    input_fee_ppk,
+    issuer_version
+"#;
+
+/// Read the active keyset pointer for each unit, over any executor.
+///
+/// Shared by the autocommit [`MintKeysDatabase`] read and the transaction-scoped
+/// [`MintKeyDatabaseTransaction`] read so the SQL lives in one place.
+async fn read_active_keysets<C>(conn: &C) -> Result<HashMap<CurrencyUnit, Id>, Error>
+where
+    C: DatabaseExecutor,
+{
+    query(r#"SELECT id, unit FROM keyset WHERE active = :active"#)?
+        .bind("active", true)
+        .fetch_all(conn)
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok((
+                column_as_string!(&row[1], CurrencyUnit::from_str),
+                column_as_string!(&row[0], Id::from_str, Id::from_bytes),
+            ))
+        })
+        .collect::<Result<HashMap<_, _>, Error>>()
+}
+
+/// Read every keyset info, over any executor. See [`read_active_keysets`].
+async fn read_keyset_infos<C>(conn: &C) -> Result<Vec<MintKeySetInfo>, Error>
+where
+    C: DatabaseExecutor,
+{
+    query(&format!("SELECT {KEYSET_INFO_COLUMNS} FROM keyset"))?
+        .fetch_all(conn)
+        .await?
+        .into_iter()
+        .map(sql_row_to_keyset_info)
+        .collect::<Result<Vec<_>, _>>()
+}
+
+/// Read the single-row keyset epoch counter, over any executor. See
+/// [`read_active_keysets`].
+async fn read_keysets_epoch<C>(conn: &C) -> Result<u64, Error>
+where
+    C: DatabaseExecutor,
+{
+    Ok(
+        match query(r#"SELECT epoch FROM keyset_epoch WHERE id = 0"#)?
+            .pluck(conn)
+            .await?
+        {
+            Some(column) => column_as_number!(column),
+            None => 0,
+        },
+    )
+}
+
 #[async_trait]
 impl<RM> MintKeyDatabaseTransaction<'_, Error> for SQLTransaction<RM>
 where
@@ -110,6 +176,8 @@ where
         .execute(&self.inner)
         .await?;
 
+        self.bump_keyset_epoch().await?;
+
         Ok(())
     }
 
@@ -124,6 +192,118 @@ where
             .bind("id", id.to_string())
             .execute(&self.inner)
             .await?;
+
+        self.bump_keyset_epoch().await?;
+
+        Ok(())
+    }
+
+    async fn next_derivation_index(&mut self, unit: &CurrencyUnit) -> Result<u32, Error> {
+        // No lock here: the transaction already holds the global keyset advisory
+        // lock (taken in `begin_transaction`), so all keyset transactions
+        // serialize and two rotations cannot read the same MAX index below.
+        let next = match query(
+            r#"SELECT COALESCE(MAX(derivation_path_index), 0) + 1 FROM keyset WHERE unit = :unit"#,
+        )?
+        .bind("unit", unit.to_string())
+        .pluck(&self.inner)
+        .await?
+        {
+            Some(column) => column_as_number!(column),
+            None => 1,
+        };
+
+        Ok(next)
+    }
+
+    async fn get_keyset_infos_by_unit(
+        &mut self,
+        unit: &CurrencyUnit,
+    ) -> Result<Vec<MintKeySetInfo>, Error> {
+        // No lock here: the transaction already holds the global keyset advisory
+        // lock, so a concurrent rotation cannot slip a higher keyset in between
+        // this read and the caller's active-pointer reassignment.
+        Ok(query(
+            r#"SELECT
+                id,
+                unit,
+                active,
+                valid_from,
+                valid_to,
+                derivation_path,
+                derivation_path_index,
+                amounts,
+                input_fee_ppk,
+                issuer_version
+            FROM
+                keyset
+                WHERE unit = :unit"#,
+        )?
+        .bind("unit", unit.to_string())
+        .fetch_all(&self.inner)
+        .await?
+        .into_iter()
+        .map(sql_row_to_keyset_info)
+        .collect::<Result<Vec<_>, _>>()?)
+    }
+
+    async fn get_active_keysets(&mut self) -> Result<HashMap<CurrencyUnit, Id>, Error> {
+        read_active_keysets(&self.inner).await
+    }
+
+    async fn get_keyset_infos(&mut self) -> Result<Vec<MintKeySetInfo>, Error> {
+        read_keyset_infos(&self.inner).await
+    }
+
+    async fn keysets_epoch(&mut self) -> Result<u64, Error> {
+        read_keysets_epoch(&self.inner).await
+    }
+}
+
+impl<RM> SQLTransaction<RM>
+where
+    RM: DatabasePool + 'static,
+{
+    /// Take the global keyset advisory lock, held until the transaction commits,
+    /// so every keyset transaction (rotation, reload, boot reactivation)
+    /// serializes across processes. This removes torn reads and index races
+    /// without per-unit lock bookkeeping.
+    ///
+    /// No-op on backends that already serialize writers (SQLite's
+    /// `BEGIN IMMEDIATE`). Postgres runs at `START TRANSACTION` isolation, which
+    /// does not serialize concurrent reads, so it takes an explicit,
+    /// non-standard lock. Dispatched by driver name, the same way migrations
+    /// are.
+    async fn lock_keysets(&self) -> Result<(), Error> {
+        if RM::Connection::name() == "postgres" {
+            query(r#"SELECT pg_advisory_xact_lock(hashtext('cdk:keysets'))"#)?
+                .execute(&self.inner)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Bump the persisted keyset epoch so any keyset change (insert or
+    /// active-pointer reassignment) is observable by peers, which reload when
+    /// the epoch they loaded no longer matches.
+    ///
+    /// Upsert rather than a bare `UPDATE`: a plain update would silently affect
+    /// zero rows if row 0 were ever absent, freezing the epoch at its fallback
+    /// and stalling every peer's reload. The insert path makes the row
+    /// self-healing.
+    async fn bump_keyset_epoch(&self) -> Result<(), Error> {
+        // Qualify the existing value with the table name: on Postgres a bare
+        // `epoch` in the update expression is ambiguous between the target row
+        // and `excluded`. Matches the upsert style used elsewhere in this crate.
+        query(
+            r#"
+            INSERT INTO keyset_epoch (id, epoch) VALUES (0, 1)
+            ON CONFLICT (id) DO UPDATE SET epoch = keyset_epoch.epoch + 1
+            "#,
+        )?
+        .execute(&self.inner)
+        .await?;
 
         Ok(())
     }
@@ -149,108 +329,24 @@ where
             .await?,
         };
 
+        // Serialize every keyset transaction on one global advisory lock, held
+        // to commit. All keyset reads and writes then see a consistent snapshot
+        // without per-unit locking or torn-read retries.
+        tx.lock_keysets().await?;
+
         Ok(Box::new(tx))
     }
 
-    async fn get_active_keyset_id(&self, unit: &CurrencyUnit) -> Result<Option<Id>, Self::Err> {
+    async fn keysets_epoch(&self) -> Result<u64, Self::Err> {
+        // A single-row counter bumped inside every keyset-writing transaction,
+        // so it moves on any change (insert or active-pointer reassignment). One
+        // row to read, far cheaper than reading every keyset.
         let conn = self
             .pool
             .get()
             .await
             .map_err(|e| Error::Database(Box::new(e)))?;
-        Ok(
-            query(r#" SELECT id FROM keyset WHERE active = :active AND unit = :unit"#)?
-                .bind("active", true)
-                .bind("unit", unit.to_string())
-                .pluck(&*conn)
-                .await?
-                .map(|id| match id {
-                    Column::Text(text) => Ok(Id::from_str(&text)?),
-                    Column::Blob(id) => Ok(Id::from_bytes(&id)?),
-                    _ => Err(Error::InvalidKeysetId),
-                })
-                .transpose()?,
-        )
-    }
-
-    async fn get_active_keysets(&self) -> Result<HashMap<CurrencyUnit, Id>, Self::Err> {
-        let conn = self
-            .pool
-            .get()
-            .await
-            .map_err(|e| Error::Database(Box::new(e)))?;
-        Ok(
-            query(r#"SELECT id, unit FROM keyset WHERE active = :active"#)?
-                .bind("active", true)
-                .fetch_all(&*conn)
-                .await?
-                .into_iter()
-                .map(|row| {
-                    Ok((
-                        column_as_string!(&row[1], CurrencyUnit::from_str),
-                        column_as_string!(&row[0], Id::from_str, Id::from_bytes),
-                    ))
-                })
-                .collect::<Result<HashMap<_, _>, Error>>()?,
-        )
-    }
-
-    async fn get_keyset_info(&self, id: &Id) -> Result<Option<MintKeySetInfo>, Self::Err> {
-        let conn = self
-            .pool
-            .get()
-            .await
-            .map_err(|e| Error::Database(Box::new(e)))?;
-        Ok(query(
-            r#"SELECT
-                id,
-                unit,
-                active,
-                valid_from,
-                valid_to,
-                derivation_path,
-                derivation_path_index,
-                amounts,
-                input_fee_ppk,
-                issuer_version
-            FROM
-                keyset
-                WHERE id=:id"#,
-        )?
-        .bind("id", id.to_string())
-        .fetch_one(&*conn)
-        .await?
-        .map(sql_row_to_keyset_info)
-        .transpose()?)
-    }
-
-    async fn get_keyset_infos(&self) -> Result<Vec<MintKeySetInfo>, Self::Err> {
-        let conn = self
-            .pool
-            .get()
-            .await
-            .map_err(|e| Error::Database(Box::new(e)))?;
-        Ok(query(
-            r#"SELECT
-                id,
-                unit,
-                active,
-                valid_from,
-                valid_to,
-                derivation_path,
-                derivation_path_index,
-                amounts,
-                input_fee_ppk,
-                issuer_version
-            FROM
-                keyset
-            "#,
-        )?
-        .fetch_all(&*conn)
-        .await?
-        .into_iter()
-        .map(sql_row_to_keyset_info)
-        .collect::<Result<Vec<_>, _>>()?)
+        read_keysets_epoch(&*conn).await
     }
 }
 

--- a/crates/cdk-sql-common/src/mint/keys.rs
+++ b/crates/cdk-sql-common/src/mint/keys.rs
@@ -11,7 +11,7 @@ use cdk_common::mint::MintKeySetInfo;
 use cdk_common::{CurrencyUnit, Id};
 
 use super::{SQLMintDatabase, SQLTransaction};
-use crate::database::ConnectionWithTransaction;
+use crate::database::{ConnectionWithTransaction, DatabaseExecutor};
 use crate::pool::DatabasePool;
 use crate::stmt::{query, Column};
 use crate::{
@@ -110,6 +110,8 @@ where
         .execute(&self.inner)
         .await?;
 
+        self.bump_keyset_epoch().await?;
+
         Ok(())
     }
 
@@ -124,6 +126,109 @@ where
             .bind("id", id.to_string())
             .execute(&self.inner)
             .await?;
+
+        self.bump_keyset_epoch().await?;
+
+        Ok(())
+    }
+
+    async fn next_derivation_index(&mut self, unit: &CurrencyUnit) -> Result<u32, Error> {
+        // Take the per-unit advisory lock (if the backend needs one) so two
+        // rotations of the same unit serialize and cannot read the same MAX
+        // index below. Held until the transaction commits.
+        self.advisory_lock(unit).await?;
+
+        let next = match query(
+            r#"SELECT COALESCE(MAX(derivation_path_index), 0) + 1 FROM keyset WHERE unit = :unit"#,
+        )?
+        .bind("unit", unit.to_string())
+        .pluck(&self.inner)
+        .await?
+        {
+            Some(column) => column_as_number!(column),
+            None => 1,
+        };
+
+        Ok(next)
+    }
+
+    async fn get_keyset_infos_by_unit(
+        &mut self,
+        unit: &CurrencyUnit,
+    ) -> Result<Vec<MintKeySetInfo>, Error> {
+        // Same per-unit lock rotations take, held to commit, so a concurrent
+        // rotation cannot slip a higher keyset in between this read and the
+        // caller's active-pointer reassignment.
+        self.advisory_lock(unit).await?;
+
+        Ok(query(
+            r#"SELECT
+                id,
+                unit,
+                active,
+                valid_from,
+                valid_to,
+                derivation_path,
+                derivation_path_index,
+                amounts,
+                input_fee_ppk,
+                issuer_version
+            FROM
+                keyset
+                WHERE unit = :unit"#,
+        )?
+        .bind("unit", unit.to_string())
+        .fetch_all(&self.inner)
+        .await?
+        .into_iter()
+        .map(sql_row_to_keyset_info)
+        .collect::<Result<Vec<_>, _>>()?)
+    }
+}
+
+impl<RM> SQLTransaction<RM>
+where
+    RM: DatabasePool + 'static,
+{
+    /// Take a transaction-scoped advisory lock keyed by `key`, serializing
+    /// concurrent writers across processes and held until commit.
+    ///
+    /// No-op on backends that already serialize writers (SQLite's
+    /// `BEGIN IMMEDIATE`). Postgres runs at `START TRANSACTION` isolation, which
+    /// does not serialize concurrent reads, so it takes an explicit,
+    /// non-standard lock. Dispatched by driver name, the same way migrations
+    /// are.
+    async fn advisory_lock<T: ToString + Send>(&self, key: T) -> Result<(), Error> {
+        if RM::Connection::name() == "postgres" {
+            query(r#"SELECT pg_advisory_xact_lock(hashtext(:key))"#)?
+                .bind("key", key.to_string())
+                .execute(&self.inner)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Bump the persisted keyset epoch so any keyset change (insert or
+    /// active-pointer reassignment) is observable by peers, which reload when
+    /// the epoch they loaded no longer matches.
+    ///
+    /// Upsert rather than a bare `UPDATE`: a plain update would silently affect
+    /// zero rows if row 0 were ever absent, freezing the epoch at its fallback
+    /// and stalling every peer's reload. The insert path makes the row
+    /// self-healing.
+    async fn bump_keyset_epoch(&self) -> Result<(), Error> {
+        // Qualify the existing value with the table name: on Postgres a bare
+        // `epoch` in the update expression is ambiguous between the target row
+        // and `excluded`. Matches the upsert style used elsewhere in this crate.
+        query(
+            r#"
+            INSERT INTO keyset_epoch (id, epoch) VALUES (0, 1)
+            ON CONFLICT (id) DO UPDATE SET epoch = keyset_epoch.epoch + 1
+            "#,
+        )?
+        .execute(&self.inner)
+        .await?;
 
         Ok(())
     }
@@ -251,6 +356,26 @@ where
         .into_iter()
         .map(sql_row_to_keyset_info)
         .collect::<Result<Vec<_>, _>>()?)
+    }
+
+    async fn keysets_epoch(&self) -> Result<u64, Self::Err> {
+        // A single-row counter bumped inside every keyset-writing transaction,
+        // so it moves on any change (insert or active-pointer reassignment). One
+        // row to read, far cheaper than reading every keyset.
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
+        Ok(
+            match query(r#"SELECT epoch FROM keyset_epoch WHERE id = 0"#)?
+                .pluck(&*conn)
+                .await?
+            {
+                Some(column) => column_as_number!(column),
+                None => 0,
+            },
+        )
     }
 }
 

--- a/crates/cdk-sql-common/src/mint/migrations/postgres/20260728000000_add_keyset_epoch.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/postgres/20260728000000_add_keyset_epoch.sql
@@ -1,0 +1,5 @@
+CREATE TABLE keyset_epoch (
+    id INTEGER PRIMARY KEY,
+    epoch BIGINT NOT NULL
+);
+INSERT INTO keyset_epoch (id, epoch) VALUES (0, (SELECT COUNT(*) FROM keyset));

--- a/crates/cdk-sql-common/src/mint/migrations/sqlite/20260728000000_add_keyset_epoch.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/sqlite/20260728000000_add_keyset_epoch.sql
@@ -1,0 +1,5 @@
+CREATE TABLE keyset_epoch (
+    id INTEGER PRIMARY KEY,
+    epoch BIGINT NOT NULL
+);
+INSERT INTO keyset_epoch (id, epoch) VALUES (0, (SELECT COUNT(*) FROM keyset));

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -33,7 +33,7 @@ tor = [
 prometheus = ["dep:cdk-prometheus"]
 
 [dependencies]
-arc-swap = "1.7.1"
+arc-swap.workspace = true
 cdk-common = { workspace = true, default-features = false }
 cbor-diag.workspace = true
 async-trait.workspace = true

--- a/crates/cdk/src/mint/builder.rs
+++ b/crates/cdk/src/mint/builder.rs
@@ -75,6 +75,11 @@ pub struct MintBuilder {
     max_inputs: usize,
     max_outputs: usize,
     max_batch_size: Option<u64>,
+    /// Interval at which the built signatory reloads keysets from the shared
+    /// database. `None` (the default) disables the reload for a single-instance
+    /// deployment that owns its database; set an interval only to run several
+    /// mints/signatories against one shared database.
+    keyset_refresh_interval: Option<std::time::Duration>,
 }
 
 impl std::fmt::Debug for MintBuilder {
@@ -118,12 +123,24 @@ impl MintBuilder {
             max_inputs: 1000,
             max_outputs: 1000,
             max_batch_size: None,
+            keyset_refresh_interval: None,
         }
     }
 
     /// Set use keyset v2
     pub fn with_keyset_v2(mut self, use_keyset_v2: Option<bool>) -> Self {
         self.use_keyset_v2 = use_keyset_v2;
+        self
+    }
+
+    /// Set how often the built signatory reloads keysets from the shared
+    /// database. `None` (the default) disables the reload: a single mint owns
+    /// its database and needs no polling. Set an interval only to run several
+    /// mints/signatories against one shared database, so each picks up peers'
+    /// rotations without a restart. [`cdk_signatory::db_signatory::DEFAULT_KEYSET_REFRESH`]
+    /// is the standard cadence.
+    pub fn with_keyset_refresh_interval(mut self, interval: Option<std::time::Duration>) -> Self {
+        self.keyset_refresh_interval = interval;
         self
     }
 
@@ -730,17 +747,23 @@ impl MintBuilder {
         keystore: Arc<dyn MintKeysDatabase<Err = cdk_database::Error> + Send + Sync>,
         seed: &[u8],
     ) -> Result<Mint, Error> {
-        let in_memory_signatory = cdk_signatory::db_signatory::DbSignatory::new(
-            keystore,
-            seed,
-            self.supported_units.clone(),
-            self.custom_paths.clone(),
-        )
-        .await?;
+        let in_memory_signatory = Arc::new(
+            cdk_signatory::db_signatory::DbSignatory::new(
+                keystore,
+                seed,
+                self.supported_units.clone(),
+                self.custom_paths.clone(),
+            )
+            .await?,
+        );
 
-        let signatory = Arc::new(cdk_signatory::embedded::Service::new(Arc::new(
-            in_memory_signatory,
-        )));
+        // Off by default: a single mint owns its database. When an interval is
+        // configured, periodically reload keysets from the shared database so
+        // multiple mints/signatories can run active/active, a rotation by any
+        // instance is picked up on the next refresh without a restart.
+        in_memory_signatory.spawn_keyset_refresh(self.keyset_refresh_interval);
+
+        let signatory = Arc::new(cdk_signatory::embedded::Service::new(in_memory_signatory));
 
         self.build_with_signatory(signatory).await
     }

--- a/crates/cdk/src/mint/builder.rs
+++ b/crates/cdk/src/mint/builder.rs
@@ -75,6 +75,11 @@ pub struct MintBuilder {
     max_inputs: usize,
     max_outputs: usize,
     max_batch_size: Option<u64>,
+    /// Interval at which the built signatory reloads keysets from the shared
+    /// database. `None` (the default) disables the reload for a single-instance
+    /// deployment that owns its database; set an interval only to run several
+    /// mints/signatories against one shared database.
+    keyset_refresh_interval: Option<std::time::Duration>,
 }
 
 impl std::fmt::Debug for MintBuilder {
@@ -118,12 +123,23 @@ impl MintBuilder {
             max_inputs: 1000,
             max_outputs: 1000,
             max_batch_size: None,
+            keyset_refresh_interval: None,
         }
     }
 
     /// Set use keyset v2
     pub fn with_keyset_v2(mut self, use_keyset_v2: Option<bool>) -> Self {
         self.use_keyset_v2 = use_keyset_v2;
+        self
+    }
+
+    /// Set how often the built signatory reloads keysets from the shared
+    /// database. `None` (the default) disables the reload: a single mint owns
+    /// its database and needs no polling. Set an interval only to run several
+    /// mints/signatories against one shared database, so each picks up peers'
+    /// rotations without a restart. A few seconds is a reasonable cadence.
+    pub fn with_keyset_refresh_interval(mut self, interval: Option<std::time::Duration>) -> Self {
+        self.keyset_refresh_interval = interval;
         self
     }
 
@@ -730,17 +746,23 @@ impl MintBuilder {
         keystore: Arc<dyn MintKeysDatabase<Err = cdk_database::Error> + Send + Sync>,
         seed: &[u8],
     ) -> Result<Mint, Error> {
-        let in_memory_signatory = cdk_signatory::db_signatory::DbSignatory::new(
-            keystore,
-            seed,
-            self.supported_units.clone(),
-            self.custom_paths.clone(),
-        )
-        .await?;
+        let in_memory_signatory = Arc::new(
+            cdk_signatory::db_signatory::DbSignatory::new(
+                keystore,
+                seed,
+                self.supported_units.clone(),
+                self.custom_paths.clone(),
+            )
+            .await?,
+        );
 
-        let signatory = Arc::new(cdk_signatory::embedded::Service::new(Arc::new(
-            in_memory_signatory,
-        )));
+        // Off by default: a single mint owns its database. When an interval is
+        // configured, periodically reload keysets from the shared database so
+        // multiple mints/signatories can run active/active, a rotation by any
+        // instance is picked up on the next refresh without a restart.
+        in_memory_signatory.spawn_keyset_refresh(self.keyset_refresh_interval);
+
+        let signatory = Arc::new(cdk_signatory::embedded::Service::new(in_memory_signatory));
 
         self.build_with_signatory(signatory).await
     }

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1714,6 +1714,57 @@ mod tests {
         mint.stop().await.expect("mint should stop");
     }
 
+    /// A mint may boot before any active keyset exists (for example a remote
+    /// signatory still connecting). Construction and `start()` must succeed
+    /// rather than failing with `NoActiveKeyset`, and keysets that arrive later
+    /// over the subscription must install without a restart.
+    #[tokio::test]
+    async fn mint_starts_without_active_keysets_then_installs_them() {
+        // A snapshot to install later; reuse its pubkey for the empty bootstrap
+        // snapshot so both carry the same signatory identity.
+        let snap = rotated_snapshots(1).await.remove(0);
+        let new_id = active_sat_id(&snap);
+
+        // Bootstrap from a snapshot with no keysets at all. This used to return
+        // Error::NoActiveKeyset from the constructor.
+        let mock = Arc::new(MockSignatory::new(SignatoryKeysets {
+            pubkey: snap.pubkey,
+            keysets: vec![],
+        }));
+        let mint = create_mint_with_signatory(mock.clone()).await;
+        mint.start()
+            .await
+            .expect("mint should start with no active keysets");
+
+        assert!(
+            mint.keysets.load().is_empty(),
+            "no keysets should be present before any arrive"
+        );
+
+        // Keysets arriving over the subscription install without a restart.
+        mock.push(snap);
+        let applied = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if mint
+                    .keysets
+                    .load()
+                    .iter()
+                    .any(|k| k.id == new_id && k.active)
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(
+            applied.is_ok(),
+            "keysets that arrive after an empty start should install"
+        );
+
+        mint.stop().await.expect("mint should stop");
+    }
+
     /// Regression test for the bootstrap/subscribe race: a rotation that lands
     /// between mint construction and `start()` must still reach the mint.
     ///

--- a/docs/adr/0004-signatory-multi-instance-sharing.md
+++ b/docs/adr/0004-signatory-multi-instance-sharing.md
@@ -1,0 +1,178 @@
+# Multiple signatory instances sharing one database
+
+* Status: accepted
+* Authors: Cesar Rodas
+* Date: 2026-07-28
+* Targeted modules: cdk-signatory (DbSignatory), cdk-common
+  (KeysDatabaseTransaction), cdk-sql-common
+
+## Context and Problem Statement
+
+ADR-0003 made the keys database persistence-only and, as a direct consequence,
+assumed a single writer: "correctness depends on this process being the only
+writer. An out-of-band database mutation is not observed until the next boot."
+That rules out running more than one signatory (or embedded mint) against the
+same database for high availability or horizontal scale.
+
+Two concrete things break with multiple instances:
+
+1. A rotation performed by one instance is invisible to the others until they
+   restart. They keep signing with the old active keyset and reject the new
+   one as unknown.
+2. `rotate_keyset` computed the next derivation index from process-local
+   memory. The in-process `rotation_lock` only serializes rotations within one
+   process, so two instances could read the same index and derive divergent
+   keysets for the same slot.
+
+The enabling fact is that keys are deterministic from the seed. Every instance
+shares the same seed, so two instances given the same `MintKeySetInfo` rows
+derive byte-identical keys. Only metadata (which keysets exist, which is
+active, the next index) has to be shared, never secret material.
+
+## Decision Drivers
+
+* Keep the hot paths (`blind_sign`, `verify_proofs`, `keysets`) memory-only.
+  The shared database must not land on the signing path (ADR-0003).
+* Rotation must allocate a unique derivation index even when two instances
+  rotate the same unit at the same time.
+* Propagating a peer's rotation should need no inter-node messaging
+  infrastructure to operate or deploy.
+
+## Considered Options
+
+#### Event-driven notification (Postgres LISTEN/NOTIFY, poll elsewhere)
+
+Rotation emits a notification; peers subscribe and reload on the event.
+
+* Good, because propagation is near-instant and idle cost is zero.
+* Bad, because it needs a per-backend pub/sub seam: a dedicated LISTEN
+  connection and a `NOTIFY` on commit for Postgres, a polling fallback for
+  SQLite, and a subscription method threaded through the database trait. More
+  surface than the problem needs.
+
+#### Epoch-aligned periodic reload (chosen)
+
+Every instance reloads keysets from the database on a shared wall-clock epoch
+(`unix_time` floored to a fixed interval). Rotation still writes through the
+database; peers pick the change up on the next reload.
+
+* Good, because it needs no notification channel, no extra connection, and no
+  backend-specific pub/sub. One periodic task per instance.
+* Good, because aligning to a shared epoch means the fleet reloads at about the
+  same moment, so their views converge within one interval rather than drifting
+  by arbitrary offsets.
+* Bad, because propagation is bounded by the interval, not instant. For keyset
+  rotation, which is rare and not latency-sensitive, this is acceptable.
+
+## Decision Outcome
+
+Chosen option: "epoch-aligned periodic reload", because it closes the
+staleness gap with the least machinery and rotation is not latency-sensitive.
+
+Two changes, one for each break above.
+
+### One global keyset advisory lock
+
+Every keyset transaction (rotation, reload, boot reactivation) takes a single
+global advisory lock when it begins, held to commit, so all keyset reads and
+writes serialize across processes. The lock is an internal helper on
+`SQLTransaction`, `lock_keysets`, run from the keys `begin_transaction`: Postgres
+runs at `START TRANSACTION` isolation, which does not serialize concurrent reads,
+so it takes a `pg_advisory_xact_lock(hashtext('cdk:keysets'))`; SQLite serializes
+writers with `BEGIN IMMEDIATE`, so it is a no-op there. Dispatch is by driver
+name, the same way migrations are.
+
+An earlier revision keyed the lock per unit to allow concurrent rotations of
+different units. One global lock is simpler and closes a gap the per-unit lock
+left open: two rotations of *different* units whose currency strings hash to the
+same derivation slot could both pass the cross-unit collision check
+concurrently. Under the global lock no two keyset transactions overlap, so that
+race cannot happen, and rotations (which are rare and not latency-sensitive)
+simply serialize.
+
+The next derivation index is allocated inside the rotation transaction through
+`KeysDatabaseTransaction::next_derivation_index`, not from memory. It returns
+`COALESCE(MAX(derivation_path_index), 0) + 1` for the unit, so a unit with no
+keysets yet starts at `1`; the global lock makes that read authoritative.
+`get_keyset_infos_by_unit` relies on the same lock, so a concurrent rotation
+cannot commit between that read and the caller's active-pointer reassignment.
+`rotate_keyset` opens the transaction first, allocates the index, derives the
+keyset, then writes and commits. The in-process `rotation_lock` stays as a cheap
+local optimization but is no longer the correctness boundary; the database is.
+
+### Periodic reload
+
+The reload is opt-in. `DbSignatory::spawn_keyset_refresh` takes the interval
+(`None`, the default, or zero disables it and spawns no task;
+`DEFAULT_KEYSET_REFRESH` is the standard cadence). A single process owns its
+database and never polls; enabling the reload is what lets several processes run
+against one shared database. Both construction sites, the embedded mint
+(`build_with_seed`, via `MintBuilder::with_keyset_refresh_interval`) and the
+standalone gRPC server (via `--keyset-refresh-interval-ms`), pass the configured
+interval; both default to off. When enabled, the task sleeps until the next epoch
+boundary (Unix time in milliseconds floored to the interval), then runs
+`load_keys_from_db`.
+
+The in-memory keysets live in an `ArcSwap<KeysetSnapshot>`: the hot read paths
+(`blind_sign`, `verify_proofs`, `keysets`) load it lock-free, and the reload
+builds a fresh snapshot off to the side and swaps it in atomically, so a reload
+never blocks signing. The snapshot carries the keyset epoch it was built from,
+so no separate lock guards it: the swap is a compare-and-swap loop that gives up
+when the pointer already holds an equal-or-newer epoch, so two reloads racing (a
+refresh tick against a rotation's post-commit reload) settle on the newer
+database view regardless of arrival order. Because the reload loads
+authoritative database state and swaps wholesale, it needs no `rotation_lock`:
+it can neither block signing nor interleave destructively with a local rotation.
+
+`load_keys_from_db` is cheap in the steady state. It first asks the storage for
+a `u64` keyset epoch, `KeysDatabase::keysets_epoch`, with a single lock-free
+autocommit read (one statement is consistent on its own), and returns early when
+it matches the loaded snapshot. The value is whatever the backend can compute
+cheaply; the SQL backend keeps a single-row `keyset_epoch` table (one `epoch`
+column), bumped inside every keyset-writing transaction (`add_keyset_info` and
+`set_active_keyset`), so it moves on any change, an insert or a pure
+active-pointer reassignment. Only when the epoch changed does it open a keyset
+transaction (which takes the global lock) and rebuild through it, and even then
+it reuses the keys already derived in the current snapshot (a memory copy, no
+crypto), deriving only the new keysets. Because the transaction holds the global
+lock, no other keyset transaction can commit between the active-pointer and
+keyset-infos reads, so they are a consistent snapshot with no epoch bracketing.
+On a real change it re-publishes the snapshot to the watch channel. The mint side
+is unchanged; it drains the signatory's watch channel into its keyset cache, so a
+peer's rotation reaches it once the reload republishes.
+
+A local `rotate_keyset` refreshes memory through this same `load_keys_from_db`
+after committing, rather than patching the maps by hand. That picks up any
+concurrent peer rotation and records the loaded epoch, so the next refresh tick
+sees no change and does not reload. Recording the epoch from a bare
+post-commit read would be unsafe: it could already reflect a peer change this
+instance has not loaded, and the instance would then skip it.
+
+### Positive Consequences
+
+* Multiple signatory instances can run active/active against one database.
+* The signing paths still never touch the database, and rotation still reads
+  nothing back from it.
+* No notification channel, extra connection, or backend pub/sub to operate.
+
+### Negative Consequences
+
+* A peer's rotation is visible only after the next reload (bounded by the
+  interval), not immediately.
+* Multi-process sharing is opt-in: it works only when the reload is enabled. Run
+  more than one process against a shared database without setting an interval and
+  a peer's rotation stays invisible until the next boot, the pre-ADR behavior.
+* When the reload is enabled, each process runs one cheap epoch-token query
+  against the database each interval. When the token is unchanged that is the
+  whole cost: no row fetch, no key derivation, no swap. Only when it moves does
+  the process fetch rows and rebuild, reusing the already-derived keys, deriving
+  only the new keysets, and swapping the snapshot in atomically. A lone process
+  leaves the reload off and never polls.
+
+## Links
+
+* Supersedes the single-writer assumption in
+  [ADR-0003](0003-signatory-database-persistence-only.md); the persistence-only
+  model and strict boot are unchanged.
+* Builds on [ADR-0002](0002-signatory-keyset-subscription.md): the watch
+  publish contract is preserved, now gated on an actual change.

--- a/docs/adr/0004-signatory-multi-instance-sharing.md
+++ b/docs/adr/0004-signatory-multi-instance-sharing.md
@@ -1,0 +1,174 @@
+# Multiple signatory instances sharing one database
+
+* Status: accepted
+* Authors: Cesar Rodas
+* Date: 2026-07-28
+* Targeted modules: cdk-signatory (DbSignatory), cdk-common
+  (KeysDatabaseTransaction), cdk-sql-common
+
+## Context and Problem Statement
+
+ADR-0003 made the keys database persistence-only and, as a direct consequence,
+assumed a single writer: "correctness depends on this process being the only
+writer. An out-of-band database mutation is not observed until the next boot."
+That rules out running more than one signatory (or embedded mint) against the
+same database for high availability or horizontal scale.
+
+Two concrete things break with multiple instances:
+
+1. A rotation performed by one instance is invisible to the others until they
+   restart. They keep signing with the old active keyset and reject the new
+   one as unknown.
+2. `rotate_keyset` computed the next derivation index from process-local
+   memory. The in-process `rotation_lock` only serializes rotations within one
+   process, so two instances could read the same index and derive divergent
+   keysets for the same slot.
+
+The enabling fact is that keys are deterministic from the seed. Every instance
+shares the same seed, so two instances given the same `MintKeySetInfo` rows
+derive byte-identical keys. Only metadata (which keysets exist, which is
+active, the next index) has to be shared, never secret material.
+
+## Decision Drivers
+
+* Keep the hot paths (`blind_sign`, `verify_proofs`, `keysets`) memory-only.
+  The shared database must not land on the signing path (ADR-0003).
+* Rotation must allocate a unique derivation index even when two instances
+  rotate the same unit at the same time.
+* Propagating a peer's rotation should need no inter-node messaging
+  infrastructure to operate or deploy.
+
+## Considered Options
+
+#### Event-driven notification (Postgres LISTEN/NOTIFY, poll elsewhere)
+
+Rotation emits a notification; peers subscribe and reload on the event.
+
+* Good, because propagation is near-instant and idle cost is zero.
+* Bad, because it needs a per-backend pub/sub seam: a dedicated LISTEN
+  connection and a `NOTIFY` on commit for Postgres, a polling fallback for
+  SQLite, and a subscription method threaded through the database trait. More
+  surface than the problem needs.
+
+#### Epoch-aligned periodic reload (chosen)
+
+Every instance reloads keysets from the database on a shared wall-clock epoch
+(`unix_time` floored to a fixed interval). Rotation still writes through the
+database; peers pick the change up on the next reload.
+
+* Good, because it needs no notification channel, no extra connection, and no
+  backend-specific pub/sub. One periodic task per instance.
+* Good, because aligning to a shared epoch means the fleet reloads at about the
+  same moment, so their views converge within one interval rather than drifting
+  by arbitrary offsets.
+* Bad, because propagation is bounded by the interval, not instant. For keyset
+  rotation, which is rare and not latency-sensitive, this is acceptable.
+
+## Decision Outcome
+
+Chosen option: "epoch-aligned periodic reload", because it closes the
+staleness gap with the least machinery and rotation is not latency-sensitive.
+
+Two changes, one for each break above.
+
+### Authoritative index allocation
+
+The next derivation index is allocated inside the rotation transaction through
+a new `KeysDatabaseTransaction::next_derivation_index`, not from memory. It
+returns `COALESCE(MAX(derivation_path_index), 0) + 1` for the unit, so a unit
+with no keysets yet starts at `1`. On backends where several processes may write
+concurrently the transaction first takes a per-unit advisory lock held to
+commit, so two rotations of the same unit serialize and cannot read the same
+maximum.
+
+The lock itself is an internal generic helper on `SQLTransaction`,
+`advisory_lock<T>(key)`, that takes any key convertible to a string and runs the
+backend-specific (non-standard) lock, or nothing. Postgres runs at
+`START TRANSACTION` isolation, which does not serialize concurrent `MAX(...)+1`
+reads, so it takes a `pg_advisory_xact_lock`. SQLite serializes writers with
+`BEGIN IMMEDIATE`, so it is a no-op there and the plain `MAX(...)+1` is already
+safe. Dispatch is by driver name, the same way migrations are.
+`next_derivation_index` calls it before the `MAX(...)+1` read.
+`get_keyset_infos_by_unit` takes the same per-unit lock, so a concurrent
+rotation cannot commit between that read and the caller's active-pointer
+reassignment.
+`rotate_keyset` opens the transaction first, allocates the index, derives the
+keyset, then writes and commits. The in-process `rotation_lock` stays as a cheap
+local optimization but is no longer the correctness boundary; the database is.
+
+### Periodic reload
+
+The reload is opt-in. `DbSignatory::spawn_keyset_refresh` takes the interval
+(`None`, the default, or zero disables it and spawns no task;
+`DEFAULT_KEYSET_REFRESH` is the standard cadence). A single process owns its
+database and never polls; enabling the reload is what lets several processes run
+against one shared database. Both construction sites, the embedded mint
+(`build_with_seed`, via `MintBuilder::with_keyset_refresh_interval`) and the
+standalone gRPC server (via `--keyset-refresh-interval-ms`), pass the configured
+interval; both default to off. When enabled, the task sleeps until the next epoch
+boundary (Unix time in milliseconds floored to the interval), then runs
+`load_keys_from_db`.
+
+The in-memory keysets live in an `ArcSwap<KeysetSnapshot>`: the hot read paths
+(`blind_sign`, `verify_proofs`, `keysets`) load it lock-free, and the reload
+builds a fresh snapshot off to the side and swaps it in atomically, so a reload
+never blocks signing. The snapshot carries the keyset epoch it was built from,
+so no separate lock guards it: the swap is a compare-and-swap loop that gives up
+when the pointer already holds an equal-or-newer epoch, so two reloads racing (a
+refresh tick against a rotation's post-commit reload) settle on the newer
+database view regardless of arrival order. Because the reload loads
+authoritative database state and swaps wholesale, it needs no `rotation_lock`:
+it can neither block signing nor interleave destructively with a local rotation.
+
+`load_keys_from_db` is cheap in the steady state. It first asks the storage for
+a `u64` keyset epoch, `KeysDatabase::keysets_epoch`, and returns early when it
+matches the loaded snapshot. The value is whatever the backend can compute
+cheaply; the SQL backend keeps a single-row `keyset_epoch` table (one `epoch`
+column), bumped inside every keyset-writing transaction (`add_keyset_info` and
+`set_active_keyset`), so it moves on any change, an insert or a pure
+active-pointer reassignment. Only when the epoch changed does it fetch the rows
+and rebuild, and even then it reuses the keys already derived in the current
+snapshot (a memory copy, no crypto), deriving only the new keysets. The active
+pointers and the keyset infos are two separate autocommit reads, so it brackets
+them with the epoch token (read before and after, bounded retry): an unchanged
+token across the pair proves nothing committed between them, giving a consistent
+snapshot without a read transaction. On a real change it re-publishes the
+snapshot to the watch channel. The mint side is unchanged; it drains the
+signatory's watch channel into its keyset cache, so a peer's rotation reaches it
+once the reload republishes.
+
+A local `rotate_keyset` refreshes memory through this same `load_keys_from_db`
+after committing, rather than patching the maps by hand. That picks up any
+concurrent peer rotation and records the loaded epoch, so the next refresh tick
+sees no change and does not reload. Recording the epoch from a bare
+post-commit read would be unsafe: it could already reflect a peer change this
+instance has not loaded, and the instance would then skip it.
+
+### Positive Consequences
+
+* Multiple signatory instances can run active/active against one database.
+* The signing paths still never touch the database, and rotation still reads
+  nothing back from it.
+* No notification channel, extra connection, or backend pub/sub to operate.
+
+### Negative Consequences
+
+* A peer's rotation is visible only after the next reload (bounded by the
+  interval), not immediately.
+* Multi-process sharing is opt-in: it works only when the reload is enabled. Run
+  more than one process against a shared database without setting an interval and
+  a peer's rotation stays invisible until the next boot, the pre-ADR behavior.
+* When the reload is enabled, each process runs one cheap epoch-token query
+  against the database each interval. When the token is unchanged that is the
+  whole cost: no row fetch, no key derivation, no swap. Only when it moves does
+  the process fetch rows and rebuild, reusing the already-derived keys, deriving
+  only the new keysets, and swapping the snapshot in atomically. A lone process
+  leaves the reload off and never polls.
+
+## Links
+
+* Supersedes the single-writer assumption in
+  [ADR-0003](0003-signatory-database-persistence-only.md); the persistence-only
+  model and strict boot are unchanged.
+* Builds on [ADR-0002](0002-signatory-keyset-subscription.md): the watch
+  publish contract is preserved, now gated on an actual change.

--- a/docs/adr/0004-signatory-multi-instance-sharing.md
+++ b/docs/adr/0004-signatory-multi-instance-sharing.md
@@ -102,11 +102,11 @@ local optimization but is no longer the correctness boundary; the database is.
 
 ### Periodic reload
 
-The reload is opt-in. `DbSignatory::spawn_keyset_refresh` takes the interval
-(`None`, the default, or zero disables it and spawns no task;
-`DEFAULT_KEYSET_REFRESH` is the standard cadence). A single process owns its
-database and never polls; enabling the reload is what lets several processes run
-against one shared database. Both construction sites, the embedded mint
+The reload is opt-in. `DbSignatory::spawn_keyset_refresh` takes the interval;
+`None` (the default) or zero disables it and spawns no task. A single process
+owns its database and never polls; enabling the reload is what lets several
+processes run against one shared database. Both construction sites, the
+embedded mint
 (`build_with_seed`, via `MintBuilder::with_keyset_refresh_interval`) and the
 standalone gRPC server (via `--keyset-refresh-interval-ms`), pass the configured
 interval; both default to off. When enabled, the task sleeps until the next epoch
@@ -151,8 +151,8 @@ instance has not loaded, and the instance would then skip it.
 ### Positive Consequences
 
 * Multiple signatory instances can run active/active against one database.
-* The signing paths still never touch the database, and rotation still reads
-  nothing back from it.
+* The signing paths still never touch the database. Rotation coordinates and
+  reloads through the database, but remains outside the signing hot path.
 * No notification channel, extra connection, or backend pub/sub to operate.
 
 ### Negative Consequences

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,3 +9,4 @@ than editing an old one.
 | [0001](0001-signatory-mint-key-segregation.md) | Signatory and mint key segregation | Accepted |
 | [0002](0002-signatory-keyset-subscription.md) | Signatory keyset subscription and push injection | Accepted |
 | [0003](0003-signatory-database-persistence-only.md) | Signatory database as persistence only | Accepted |
+| [0004](0004-signatory-multi-instance-sharing.md) | Multiple signatory instances sharing one database | Accepted |


### PR DESCRIPTION
### Description

This depends on #2270

Let multiple signatories (or embedded mints) run active/active on one keys database without putting it on the signing path. The derivation index is allocated in the database under a per-unit lock and a version token gates reloads, so peers stay consistent; keys are served from an ArcSwap so a reload never blocks signing. The reload is opt-in, off by default.

See docs/adr/0004-signatory-multi-instance-sharing.md.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
