### PR TITLE
analyze payment processor interfaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ cdk-ldk-node = { path = "./crates/cdk-ldk-node", version = "=0.17.0" }
 cdk-fake-wallet = { path = "./crates/cdk-fake-wallet", default-features = false, version = "=0.17.0" }
 cdk-ffi = { path = "./crates/cdk-ffi", default-features = false, version = "=0.17.0" }
 cdk-http-client = { path = "./crates/cdk-http-client", default-features = false, version = "=0.17.0" }
-cdk-payment-processor = { path = "./crates/cdk-payment-processor", default-features = true, version = "=0.17.0" }
+cdk-payment-processor = { path = "./crates/cdk-payment-processor", default-features = false, version = "=0.17.0" }
 cdk-mint-rpc = { path = "./crates/cdk-mint-rpc", version = "=0.17.0" }
 cdk-redb = { path = "./crates/cdk-redb", default-features = true, version = "=0.17.0" }
 cdk-sql-common = { path = "./crates/cdk-sql-common", default-features = true, version = "=0.17.0" }

--- a/crates/cdk-mintd/Cargo.toml
+++ b/crates/cdk-mintd/Cargo.toml
@@ -23,7 +23,7 @@ lnbits = ["dep:cdk-lnbits"]
 fakewallet = ["dep:cdk-fake-wallet"]
 ldk-node = ["dep:cdk-ldk-node"]
 bdk = ["dep:cdk-bdk", "cdk-bdk/bitcoin-rpc", "cdk-bdk/electrum", "cdk-bdk/esplora"]
-grpc-processor = ["dep:cdk-payment-processor", "cdk-signatory/grpc"]
+grpc-processor = ["cdk-signatory/grpc"]
 sqlcipher = ["sqlite", "cdk-sqlite/sqlcipher"]
 redis = ["cdk-axum/redis"]
 prometheus = ["cdk/prometheus", "dep:cdk-prometheus", "cdk-sqlite?/prometheus", "cdk-axum/prometheus"]
@@ -51,7 +51,7 @@ cdk-bdk = { workspace = true, optional = true }
 cdk-axum.workspace = true
 cdk-signatory.workspace = true
 cdk-mint-rpc = { workspace = true, optional = true }
-cdk-payment-processor = { workspace = true, optional = true }
+cdk-payment-processor = { workspace = true, default-features = false }
 config.workspace = true
 cdk-prometheus = { workspace = true, optional = true , features = ["system-metrics"]}
 clap.workspace = true

--- a/crates/cdk-mintd/Cargo.toml
+++ b/crates/cdk-mintd/Cargo.toml
@@ -23,7 +23,7 @@ lnbits = ["dep:cdk-lnbits"]
 fakewallet = ["dep:cdk-fake-wallet"]
 ldk-node = ["dep:cdk-ldk-node"]
 bdk = ["dep:cdk-bdk", "cdk-bdk/bitcoin-rpc", "cdk-bdk/electrum", "cdk-bdk/esplora"]
-grpc-processor = ["cdk-signatory/grpc"]
+grpc-processor = ["dep:cdk-payment-processor", "cdk-signatory/grpc"]
 sqlcipher = ["sqlite", "cdk-sqlite/sqlcipher"]
 redis = ["cdk-axum/redis"]
 prometheus = ["cdk/prometheus", "dep:cdk-prometheus", "cdk-sqlite?/prometheus", "cdk-axum/prometheus"]
@@ -51,7 +51,7 @@ cdk-bdk = { workspace = true, optional = true }
 cdk-axum.workspace = true
 cdk-signatory.workspace = true
 cdk-mint-rpc = { workspace = true, optional = true }
-cdk-payment-processor = { workspace = true, default-features = false }
+cdk-payment-processor = { workspace = true, default-features = false, optional = true }
 config.workspace = true
 cdk-prometheus = { workspace = true, optional = true , features = ["system-metrics"]}
 clap.workspace = true

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -900,15 +900,6 @@ where
     }
 }
 
-fn wrap_embedded_payment_processor<T>(payment_processor: T) -> DynMintPayment
-where
-    T: MintPayment<Err = cdk_common::payment::Error> + Send + Sync + 'static,
-{
-    wrap_payment_processor(cdk_payment_processor::PaymentProcessorClient::from_backend(
-        Arc::new(payment_processor),
-    ))
-}
-
 /// Configures Lightning Network backend based on the specified backend type
 async fn configure_lightning_backend(
     settings: &config::Settings,
@@ -954,7 +945,7 @@ async fn configure_lightning_backend(
                         _kv_store.clone(),
                     )
                     .await?;
-                let cln = wrap_embedded_payment_processor(cln);
+                let cln = wrap_payment_processor(cln);
 
                 mint_builder = configure_backend_for_unit(
                     settings,
@@ -973,7 +964,7 @@ async fn configure_lightning_backend(
                 let lnbits = lnbits_settings
                     .setup(settings, ln_entry.unit.clone(), None, work_dir, None)
                     .await?;
-                let lnbits = wrap_embedded_payment_processor(lnbits);
+                let lnbits = wrap_payment_processor(lnbits);
 
                 mint_builder = configure_backend_for_unit(
                     settings,
@@ -998,7 +989,7 @@ async fn configure_lightning_backend(
                         _kv_store.clone(),
                     )
                     .await?;
-                let lnd = wrap_embedded_payment_processor(lnd);
+                let lnd = wrap_payment_processor(lnd);
 
                 mint_builder = configure_backend_for_unit(
                     settings,
@@ -1027,7 +1018,7 @@ async fn configure_lightning_backend(
                         _kv_store.clone(),
                     )
                     .await?;
-                let fake = wrap_embedded_payment_processor(fake);
+                let fake = wrap_payment_processor(fake);
 
                 mint_builder = configure_backend_for_unit(
                     settings,
@@ -1084,7 +1075,7 @@ async fn configure_lightning_backend(
                         None,
                     )
                     .await?;
-                let ldk_node = wrap_embedded_payment_processor(ldk_node);
+                let ldk_node = wrap_payment_processor(ldk_node);
 
                 mint_builder = configure_backend_for_unit(
                     settings,
@@ -1177,7 +1168,7 @@ async fn configure_onchain_backend(
                         _kv_store,
                     )
                     .await?;
-                let bdk = wrap_embedded_payment_processor(bdk);
+                let bdk = wrap_payment_processor(bdk);
 
                 mint_builder = configure_backend_for_unit(
                     settings,
@@ -1216,7 +1207,7 @@ async fn configure_onchain_backend(
                         let fake = fake_wallet
                             .setup(settings, unit.clone(), None, _work_dir, _kv_store.clone())
                             .await?;
-                        let fake = wrap_embedded_payment_processor(fake);
+                        let fake = wrap_payment_processor(fake);
 
                         mint_builder = configure_backend_for_methods(
                             settings,

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -37,7 +37,7 @@ use cdk_common::database::DynMintDatabase;
 // internal crate modules
 #[cfg(feature = "prometheus")]
 use cdk_common::payment::MetricsMintPayment;
-use cdk_common::payment::MintPayment;
+use cdk_common::payment::{DynMintPayment, MintPayment};
 #[cfg(feature = "postgres")]
 use cdk_postgres::{MintPgAuthDatabase, MintPgDatabase, PgConfig};
 #[cfg(feature = "sqlite")]
@@ -884,6 +884,31 @@ fn configure_basic_info(settings: &config::Settings, mint_builder: MintBuilder) 
 
     builder
 }
+
+fn wrap_payment_processor<T>(payment_processor: T) -> DynMintPayment
+where
+    T: MintPayment<Err = cdk_common::payment::Error> + Send + Sync + 'static,
+{
+    #[cfg(feature = "prometheus")]
+    {
+        Arc::new(MetricsMintPayment::new(payment_processor))
+    }
+
+    #[cfg(not(feature = "prometheus"))]
+    {
+        Arc::new(payment_processor)
+    }
+}
+
+fn wrap_embedded_payment_processor<T>(payment_processor: T) -> DynMintPayment
+where
+    T: MintPayment<Err = cdk_common::payment::Error> + Send + Sync + 'static,
+{
+    wrap_payment_processor(cdk_payment_processor::PaymentProcessorClient::from_backend(
+        Arc::new(payment_processor),
+    ))
+}
+
 /// Configures Lightning Network backend based on the specified backend type
 async fn configure_lightning_backend(
     settings: &config::Settings,
@@ -929,15 +954,14 @@ async fn configure_lightning_backend(
                         _kv_store.clone(),
                     )
                     .await?;
-                #[cfg(feature = "prometheus")]
-                let cln = MetricsMintPayment::new(cln);
+                let cln = wrap_embedded_payment_processor(cln);
 
                 mint_builder = configure_backend_for_unit(
                     settings,
                     mint_builder,
                     ln_entry.unit.clone(),
                     mint_melt_limits,
-                    Arc::new(cln),
+                    cln,
                 )
                 .await?;
             }
@@ -949,15 +973,14 @@ async fn configure_lightning_backend(
                 let lnbits = lnbits_settings
                     .setup(settings, ln_entry.unit.clone(), None, work_dir, None)
                     .await?;
-                #[cfg(feature = "prometheus")]
-                let lnbits = MetricsMintPayment::new(lnbits);
+                let lnbits = wrap_embedded_payment_processor(lnbits);
 
                 mint_builder = configure_backend_for_unit(
                     settings,
                     mint_builder,
                     ln_entry.unit.clone(),
                     mint_melt_limits,
-                    Arc::new(lnbits),
+                    lnbits,
                 )
                 .await?;
             }
@@ -975,15 +998,14 @@ async fn configure_lightning_backend(
                         _kv_store.clone(),
                     )
                     .await?;
-                #[cfg(feature = "prometheus")]
-                let lnd = MetricsMintPayment::new(lnd);
+                let lnd = wrap_embedded_payment_processor(lnd);
 
                 mint_builder = configure_backend_for_unit(
                     settings,
                     mint_builder,
                     ln_entry.unit.clone(),
                     mint_melt_limits,
-                    Arc::new(lnd),
+                    lnd,
                 )
                 .await?;
             }
@@ -1005,15 +1027,14 @@ async fn configure_lightning_backend(
                         _kv_store.clone(),
                     )
                     .await?;
-                #[cfg(feature = "prometheus")]
-                let fake = MetricsMintPayment::new(fake);
+                let fake = wrap_embedded_payment_processor(fake);
 
                 mint_builder = configure_backend_for_unit(
                     settings,
                     mint_builder,
                     ln_entry.unit.clone(),
                     mint_melt_limits,
-                    Arc::new(fake),
+                    fake,
                 )
                 .await?;
 
@@ -1036,15 +1057,14 @@ async fn configure_lightning_backend(
                 let processor = grpc_processor
                     .setup(settings, ln_entry.unit.clone(), None, work_dir, None)
                     .await?;
-                #[cfg(feature = "prometheus")]
-                let processor = MetricsMintPayment::new(processor);
+                let processor = wrap_payment_processor(processor);
 
                 mint_builder = configure_backend_for_unit(
                     settings,
                     mint_builder,
                     ln_entry.unit.clone(),
                     mint_melt_limits,
-                    Arc::new(processor),
+                    processor,
                 )
                 .await?;
             }
@@ -1064,13 +1084,14 @@ async fn configure_lightning_backend(
                         None,
                     )
                     .await?;
+                let ldk_node = wrap_embedded_payment_processor(ldk_node);
 
                 mint_builder = configure_backend_for_unit(
                     settings,
                     mint_builder,
                     ln_entry.unit.clone(),
                     mint_melt_limits,
-                    Arc::new(ldk_node),
+                    ldk_node,
                 )
                 .await?;
             }
@@ -1156,7 +1177,7 @@ async fn configure_onchain_backend(
                         _kv_store,
                     )
                     .await?;
-                let bdk = Arc::new(bdk);
+                let bdk = wrap_embedded_payment_processor(bdk);
 
                 mint_builder = configure_backend_for_unit(
                     settings,
@@ -1195,15 +1216,14 @@ async fn configure_onchain_backend(
                         let fake = fake_wallet
                             .setup(settings, unit.clone(), None, _work_dir, _kv_store.clone())
                             .await?;
-                        #[cfg(feature = "prometheus")]
-                        let fake = MetricsMintPayment::new(fake);
+                        let fake = wrap_embedded_payment_processor(fake);
 
                         mint_builder = configure_backend_for_methods(
                             settings,
                             mint_builder,
                             unit,
                             mint_melt_limits,
-                            Arc::new(fake),
+                            fake,
                             vec![PaymentMethod::Known(KnownMethod::Onchain)],
                         )
                         .await?;
@@ -1226,7 +1246,7 @@ async fn configure_backend_for_unit(
     mint_builder: MintBuilder,
     unit: cdk::nuts::CurrencyUnit,
     mint_melt_limits: MintMeltLimits,
-    backend: Arc<dyn MintPayment<Err = cdk_common::payment::Error> + Send + Sync>,
+    backend: DynMintPayment,
 ) -> Result<MintBuilder> {
     let payment_settings = backend.get_settings().await?;
     validate_backend_unit(&unit, &payment_settings.unit)?;
@@ -1269,7 +1289,7 @@ async fn configure_backend_for_methods(
     mut mint_builder: MintBuilder,
     unit: cdk::nuts::CurrencyUnit,
     mint_melt_limits: MintMeltLimits,
-    backend: Arc<dyn MintPayment<Err = cdk_common::payment::Error> + Send + Sync>,
+    backend: DynMintPayment,
     methods: Vec<PaymentMethod>,
 ) -> Result<MintBuilder> {
     // Add all supported payment methods to the mint builder

--- a/crates/cdk-payment-processor/Cargo.toml
+++ b/crates/cdk-payment-processor/Cargo.toml
@@ -45,7 +45,7 @@ serde_with.workspace = true
 tonic = { workspace = true, features = ["transport", "tls-ring", "codegen", "router"] }
 tonic-prost.workspace = true
 prost.workspace = true
-tokio-stream.workspace = true
+tokio-stream = { workspace = true, features = ["net"] }
 tokio-util = { workspace = true, default-features = false }
 hex = "0.4"
 lightning = { workspace = true }

--- a/crates/cdk-payment-processor/src/bin/payment_processor.rs
+++ b/crates/cdk-payment-processor/src/bin/payment_processor.rs
@@ -162,7 +162,7 @@ async fn main() -> anyhow::Result<()> {
                 }
             };
 
-        let mut server = cdk_payment_processor::PaymentProcessorServer::new(
+        let server = cdk_payment_processor::PaymentProcessorServer::new(
             ln_backed,
             &listen_addr,
             listen_port,

--- a/crates/cdk-payment-processor/src/error.rs
+++ b/crates/cdk-payment-processor/src/error.rs
@@ -155,12 +155,19 @@ pub(crate) fn payment_error_from_status(status: Status) -> cdk_common::payment::
         Some("custom" | "invalid_backend_input" | "backend_error") => {
             cdk_common::payment::Error::Custom(status.message().to_owned())
         }
-        _ if status.code() == Code::AlreadyExists || status.message().contains("already paid") => {
+        // Servers predating the structured metadata key used
+        // `Code::AlreadyExists` for both already-paid and pending errors, so
+        // the message text must be consulted before the bare status code.
+        // Otherwise a legacy "Payment request pending" status would be
+        // misclassified as `InvoiceAlreadyPaid`.
+        _ if status.message().contains("already paid") => {
             cdk_common::payment::Error::InvoiceAlreadyPaid
         }
-        _ if status.code() == Code::Aborted || status.message().contains("pending") => {
+        _ if status.message().contains("pending") => {
             cdk_common::payment::Error::InvoicePaymentPending
         }
+        _ if status.code() == Code::AlreadyExists => cdk_common::payment::Error::InvoiceAlreadyPaid,
+        _ if status.code() == Code::Aborted => cdk_common::payment::Error::InvoicePaymentPending,
         _ => cdk_common::payment::Error::Custom(status.to_string()),
     }
 }
@@ -199,5 +206,19 @@ mod tests {
 
         let pending = payment_error_from_status(tonic::Status::aborted("Payment pending"));
         assert!(matches!(pending, PaymentError::InvoicePaymentPending));
+    }
+
+    #[test]
+    fn legacy_pending_status_is_not_promoted_to_already_paid() {
+        // Servers predating the structured metadata key used `AlreadyExists`
+        // for both already-paid and pending errors; the message text decides.
+        let pending =
+            payment_error_from_status(tonic::Status::already_exists("Payment request pending"));
+        assert!(matches!(pending, PaymentError::InvoicePaymentPending));
+
+        let already_paid = payment_error_from_status(tonic::Status::already_exists(
+            "Payment request already paid",
+        ));
+        assert!(matches!(already_paid, PaymentError::InvoiceAlreadyPaid));
     }
 }

--- a/crates/cdk-payment-processor/src/error.rs
+++ b/crates/cdk-payment-processor/src/error.rs
@@ -1,7 +1,10 @@
 //! Error for payment processor
 
 use thiserror::Error;
-use tonic::Status;
+use tonic::metadata::MetadataValue;
+use tonic::{Code, Status};
+
+const PAYMENT_ERROR_METADATA_KEY: &str = "cdk-payment-error";
 
 /// CDK Payment processor error
 #[derive(Debug, Error)]
@@ -66,7 +69,7 @@ impl From<Error> for Status {
             Error::Bolt12Parse => Status::invalid_argument("BOLT12 parse error"),
             Error::NUT00(err) => Status::internal(format!("NUT00 error: {err}")),
             Error::NUT05(err) => Status::internal(format!("NUT05 error: {err}")),
-            Error::Payment(err) => Status::internal(format!("Payment error: {err}")),
+            Error::Payment(err) => payment_error_to_status(err),
         }
     }
 }
@@ -92,5 +95,109 @@ impl From<Error> for cdk_common::payment::Error {
             Error::NUT05(err) => err.into(),
             Error::Payment(err) => err,
         }
+    }
+}
+
+pub(crate) fn payment_error_to_status(error: cdk_common::payment::Error) -> Status {
+    let (code, error_name) = match &error {
+        cdk_common::payment::Error::InvoiceAlreadyPaid => {
+            (Code::AlreadyExists, "invoice_already_paid")
+        }
+        cdk_common::payment::Error::InvoicePaymentPending => {
+            (Code::Aborted, "invoice_payment_pending")
+        }
+        cdk_common::payment::Error::UnsupportedUnit => (Code::InvalidArgument, "unsupported_unit"),
+        cdk_common::payment::Error::UnsupportedPaymentOption => {
+            (Code::Unimplemented, "unsupported_payment_option")
+        }
+        cdk_common::payment::Error::UnknownPaymentState => {
+            (Code::NotFound, "unknown_payment_state")
+        }
+        cdk_common::payment::Error::AmountMismatch => (Code::InvalidArgument, "amount_mismatch"),
+        cdk_common::payment::Error::InvalidExpiry => (Code::InvalidArgument, "invalid_expiry"),
+        cdk_common::payment::Error::InvalidHash => (Code::InvalidArgument, "invalid_hash"),
+        cdk_common::payment::Error::Serde(_)
+        | cdk_common::payment::Error::Parse(_)
+        | cdk_common::payment::Error::Amount(_)
+        | cdk_common::payment::Error::NUT04(_)
+        | cdk_common::payment::Error::NUT05(_)
+        | cdk_common::payment::Error::NUT23(_)
+        | cdk_common::payment::Error::Hex(_) => (Code::InvalidArgument, "invalid_backend_input"),
+        cdk_common::payment::Error::Lightning(_)
+        | cdk_common::payment::Error::Onchain(_)
+        | cdk_common::payment::Error::Anyhow(_) => (Code::Internal, "backend_error"),
+        cdk_common::payment::Error::Custom(_) => (Code::Internal, "custom"),
+    };
+
+    let mut status = Status::new(code, error.to_string());
+    status.metadata_mut().insert(
+        tonic::metadata::MetadataKey::from_static(PAYMENT_ERROR_METADATA_KEY),
+        MetadataValue::from_static(error_name),
+    );
+    status
+}
+
+pub(crate) fn payment_error_from_status(status: Status) -> cdk_common::payment::Error {
+    let error_name = status
+        .metadata()
+        .get(PAYMENT_ERROR_METADATA_KEY)
+        .and_then(|value| value.to_str().ok());
+
+    match error_name {
+        Some("invoice_already_paid") => cdk_common::payment::Error::InvoiceAlreadyPaid,
+        Some("invoice_payment_pending") => cdk_common::payment::Error::InvoicePaymentPending,
+        Some("unsupported_unit") => cdk_common::payment::Error::UnsupportedUnit,
+        Some("unsupported_payment_option") => cdk_common::payment::Error::UnsupportedPaymentOption,
+        Some("unknown_payment_state") => cdk_common::payment::Error::UnknownPaymentState,
+        Some("amount_mismatch") => cdk_common::payment::Error::AmountMismatch,
+        Some("invalid_expiry") => cdk_common::payment::Error::InvalidExpiry,
+        Some("invalid_hash") => cdk_common::payment::Error::InvalidHash,
+        Some("custom" | "invalid_backend_input" | "backend_error") => {
+            cdk_common::payment::Error::Custom(status.message().to_owned())
+        }
+        _ if status.code() == Code::AlreadyExists || status.message().contains("already paid") => {
+            cdk_common::payment::Error::InvoiceAlreadyPaid
+        }
+        _ if status.code() == Code::Aborted || status.message().contains("pending") => {
+            cdk_common::payment::Error::InvoicePaymentPending
+        }
+        _ => cdk_common::payment::Error::Custom(status.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cdk_common::payment::Error as PaymentError;
+
+    use super::{payment_error_from_status, payment_error_to_status};
+
+    #[test]
+    fn structured_payment_errors_roundtrip_through_status() {
+        let errors = [
+            PaymentError::InvoiceAlreadyPaid,
+            PaymentError::InvoicePaymentPending,
+            PaymentError::UnsupportedUnit,
+            PaymentError::UnsupportedPaymentOption,
+            PaymentError::UnknownPaymentState,
+            PaymentError::AmountMismatch,
+            PaymentError::InvalidExpiry,
+            PaymentError::InvalidHash,
+        ];
+
+        for error in errors {
+            let expected = error.to_string();
+            let roundtrip = payment_error_from_status(payment_error_to_status(error));
+            assert_eq!(roundtrip.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn legacy_payment_statuses_remain_supported() {
+        let already_paid =
+            payment_error_from_status(tonic::Status::already_exists("Payment already paid"));
+        assert!(matches!(already_paid, PaymentError::InvoiceAlreadyPaid));
+
+        let pending = payment_error_from_status(tonic::Status::aborted("Payment pending"));
+        assert!(matches!(pending, PaymentError::InvoicePaymentPending));
     }
 }

--- a/crates/cdk-payment-processor/src/error.rs
+++ b/crates/cdk-payment-processor/src/error.rs
@@ -30,6 +30,9 @@ pub enum Error {
     /// Hex decode error
     #[error(transparent)]
     Hex(#[from] hex::FromHexError),
+    /// JSON error
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
     /// BOLT12 parse error
     #[error("BOLT12 parse error")]
     Bolt12Parse,
@@ -59,6 +62,7 @@ impl From<Error> for Status {
             Error::MissingAmount => Status::invalid_argument("Missing amount field"),
             Error::Invoice(err) => Status::invalid_argument(format!("Invoice error: {err}")),
             Error::Hex(err) => Status::invalid_argument(format!("Hex decode error: {err}")),
+            Error::Json(err) => Status::invalid_argument(format!("JSON error: {err}")),
             Error::Bolt12Parse => Status::invalid_argument("BOLT12 parse error"),
             Error::NUT00(err) => Status::internal(format!("NUT00 error: {err}")),
             Error::NUT05(err) => Status::internal(format!("NUT05 error: {err}")),
@@ -82,6 +86,7 @@ impl From<Error> for cdk_common::payment::Error {
             Error::MissingAmount => Self::Custom("Missing amount field".to_string()),
             Error::Invoice(err) => Self::Custom(format!("Invoice error: {err}")),
             Error::Hex(err) => Self::Custom(format!("Hex decode error: {err}")),
+            Error::Json(err) => Self::Custom(format!("JSON error: {err}")),
             Error::Bolt12Parse => Self::Custom("BOLT12 parse error".to_string()),
             Error::NUT00(err) => Self::Custom(format!("NUT00 error: {err}")),
             Error::NUT05(err) => err.into(),

--- a/crates/cdk-payment-processor/src/proto/client.rs
+++ b/crates/cdk-payment-processor/src/proto/client.rs
@@ -15,184 +15,24 @@ use futures::{Stream, StreamExt};
 use tokio_util::sync::CancellationToken;
 use tonic::codegen::InterceptedService;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
-use tonic::{async_trait, Request, Status};
+use tonic::{async_trait, Request};
 use tracing::instrument;
 
-use super::cdk_payment_processor_server::CdkPaymentProcessor;
-use super::service::PaymentProcessorService;
 use crate::error::payment_error_from_status;
 use crate::proto::cdk_payment_processor_client::CdkPaymentProcessorClient;
 use crate::proto::{
-    CheckIncomingPaymentRequest, CheckIncomingPaymentResponse, CheckOutgoingPaymentRequest,
-    CreatePaymentRequest, CreatePaymentResponse, EmptyRequest, IncomingPaymentOptions,
-    IntoProtoAmount, MakePaymentRequest, MakePaymentResponse, OutgoingPaymentRequestType,
-    PaymentEventResponse, PaymentQuoteRequest, PaymentQuoteResponse, SettingsResponse,
+    CheckIncomingPaymentRequest, CheckOutgoingPaymentRequest, CreatePaymentRequest, EmptyRequest,
+    IncomingPaymentOptions, IntoProtoAmount, MakePaymentRequest, OutgoingPaymentRequestType,
+    PaymentQuoteRequest,
 };
 
 type RemotePaymentProcessorClient =
     CdkPaymentProcessorClient<InterceptedService<Channel, VersionInterceptor>>;
-type RpcPaymentEventStream =
-    Pin<Box<dyn Stream<Item = Result<PaymentEventResponse, Status>> + Send>>;
 
-#[derive(Clone)]
-enum PaymentProcessorTransport {
-    Remote(Arc<RemotePaymentProcessorClient>),
-    Local(PaymentProcessorService),
-}
-
-impl PaymentProcessorTransport {
-    async fn start(&self) -> Result<(), cdk_common::payment::Error> {
-        match self {
-            Self::Remote(_) => Ok(()),
-            Self::Local(service) => service.start().await,
-        }
-    }
-
-    async fn stop(&self) -> Result<(), cdk_common::payment::Error> {
-        match self {
-            Self::Remote(_) => Ok(()),
-            Self::Local(service) => service.stop().await,
-        }
-    }
-
-    fn cancel_payment_event_stream(&self) {
-        if let Self::Local(service) = self {
-            service.cancel_payment_event_stream();
-        }
-    }
-
-    async fn get_settings(&self, request: EmptyRequest) -> Result<SettingsResponse, Status> {
-        match self {
-            Self::Remote(client) => client
-                .as_ref()
-                .clone()
-                .get_settings(Request::new(request))
-                .await
-                .map(tonic::Response::into_inner),
-            Self::Local(service) => {
-                CdkPaymentProcessor::get_settings(service, Request::new(request))
-                    .await
-                    .map(tonic::Response::into_inner)
-            }
-        }
-    }
-
-    async fn create_payment(
-        &self,
-        request: CreatePaymentRequest,
-    ) -> Result<CreatePaymentResponse, Status> {
-        match self {
-            Self::Remote(client) => client
-                .as_ref()
-                .clone()
-                .create_payment(Request::new(request))
-                .await
-                .map(tonic::Response::into_inner),
-            Self::Local(service) => {
-                CdkPaymentProcessor::create_payment(service, Request::new(request))
-                    .await
-                    .map(tonic::Response::into_inner)
-            }
-        }
-    }
-
-    async fn get_payment_quote(
-        &self,
-        request: PaymentQuoteRequest,
-    ) -> Result<PaymentQuoteResponse, Status> {
-        match self {
-            Self::Remote(client) => client
-                .as_ref()
-                .clone()
-                .get_payment_quote(Request::new(request))
-                .await
-                .map(tonic::Response::into_inner),
-            Self::Local(service) => {
-                CdkPaymentProcessor::get_payment_quote(service, Request::new(request))
-                    .await
-                    .map(tonic::Response::into_inner)
-            }
-        }
-    }
-
-    async fn make_payment(
-        &self,
-        request: MakePaymentRequest,
-    ) -> Result<MakePaymentResponse, Status> {
-        match self {
-            Self::Remote(client) => client
-                .as_ref()
-                .clone()
-                .make_payment(Request::new(request))
-                .await
-                .map(tonic::Response::into_inner),
-            Self::Local(service) => {
-                CdkPaymentProcessor::make_payment(service, Request::new(request))
-                    .await
-                    .map(tonic::Response::into_inner)
-            }
-        }
-    }
-
-    async fn wait_payment_event(&self) -> Result<RpcPaymentEventStream, Status> {
-        match self {
-            Self::Remote(client) => client
-                .as_ref()
-                .clone()
-                .wait_payment_event(Request::new(EmptyRequest {}))
-                .await
-                .map(|response| Box::pin(response.into_inner()) as RpcPaymentEventStream),
-            Self::Local(service) => {
-                CdkPaymentProcessor::wait_payment_event(service, Request::new(EmptyRequest {}))
-                    .await
-                    .map(tonic::Response::into_inner)
-            }
-        }
-    }
-
-    async fn check_incoming_payment(
-        &self,
-        request: CheckIncomingPaymentRequest,
-    ) -> Result<CheckIncomingPaymentResponse, Status> {
-        match self {
-            Self::Remote(client) => client
-                .as_ref()
-                .clone()
-                .check_incoming_payment(Request::new(request))
-                .await
-                .map(tonic::Response::into_inner),
-            Self::Local(service) => {
-                CdkPaymentProcessor::check_incoming_payment(service, Request::new(request))
-                    .await
-                    .map(tonic::Response::into_inner)
-            }
-        }
-    }
-
-    async fn check_outgoing_payment(
-        &self,
-        request: CheckOutgoingPaymentRequest,
-    ) -> Result<MakePaymentResponse, Status> {
-        match self {
-            Self::Remote(client) => client
-                .as_ref()
-                .clone()
-                .check_outgoing_payment(Request::new(request))
-                .await
-                .map(tonic::Response::into_inner),
-            Self::Local(service) => {
-                CdkPaymentProcessor::check_outgoing_payment(service, Request::new(request))
-                    .await
-                    .map(tonic::Response::into_inner)
-            }
-        }
-    }
-}
-
-/// Payment Processor
+/// Remote gRPC payment processor adapter implementing [`MintPayment`].
 #[derive(Clone)]
 pub struct PaymentProcessorClient {
-    transport: PaymentProcessorTransport,
+    inner: RemotePaymentProcessorClient,
     payment_event_stream_is_active: Arc<AtomicBool>,
     cancel_payment_event_stream: Arc<Mutex<CancellationToken>>,
 }
@@ -235,7 +75,7 @@ impl std::fmt::Debug for PaymentProcessorClient {
 }
 
 impl PaymentProcessorClient {
-    /// Payment Processor
+    /// Connect to a remote payment processor.
     pub async fn new(addr: &str, port: u16, tls_dir: Option<PathBuf>) -> anyhow::Result<Self> {
         let scheme = if tls_dir.is_some() { "https" } else { "http" };
         let endpoint = format!("{scheme}://{addr}:{port}");
@@ -286,21 +126,10 @@ impl PaymentProcessorClient {
         let client = CdkPaymentProcessorClient::with_interceptor(channel, interceptor);
 
         Ok(Self {
-            transport: PaymentProcessorTransport::Remote(Arc::new(client)),
+            inner: client,
             payment_event_stream_is_active: Arc::new(AtomicBool::new(false)),
             cancel_payment_event_stream: Arc::new(Mutex::new(CancellationToken::new())),
         })
-    }
-
-    /// Create an in-process client for an embedded payment processor.
-    pub fn from_backend(payment_processor: cdk_common::payment::DynMintPayment) -> Self {
-        Self {
-            transport: PaymentProcessorTransport::Local(PaymentProcessorService::new(
-                payment_processor,
-            )),
-            payment_event_stream_is_active: Arc::new(AtomicBool::new(false)),
-            cancel_payment_event_stream: Arc::new(Mutex::new(CancellationToken::new())),
-        }
     }
 }
 
@@ -309,22 +138,28 @@ impl MintPayment for PaymentProcessorClient {
     type Err = cdk_common::payment::Error;
 
     async fn start(&self) -> Result<(), Self::Err> {
-        self.transport.start().await
+        // The remote server owns the backend lifecycle. The connection is
+        // established by `new`, so there is no client-side startup work.
+        Ok(())
     }
 
     async fn stop(&self) -> Result<(), Self::Err> {
-        self.transport.stop().await
+        // Release any client-side streaming work. The remote server remains
+        // responsible for stopping its backend.
+        self.cancel_payment_event_stream();
+        Ok(())
     }
 
     async fn get_settings(&self) -> Result<cdk_common::payment::SettingsResponse, Self::Err> {
-        let settings = self
-            .transport
-            .get_settings(EmptyRequest {})
+        let mut inner = self.inner.clone();
+        let response = inner
+            .get_settings(Request::new(EmptyRequest {}))
             .await
             .map_err(|err| {
                 tracing::error!("Could not get settings: {}", err);
                 payment_error_from_status(err)
             })?;
+        let settings = response.into_inner();
 
         Ok(cdk_common::payment::SettingsResponse {
             unit: settings.unit,
@@ -395,16 +230,17 @@ impl MintPayment for PaymentProcessorClient {
             },
         };
 
-        let response = self
-            .transport
-            .create_payment(CreatePaymentRequest {
+        let mut inner = self.inner.clone();
+        let response = inner
+            .create_payment(Request::new(CreatePaymentRequest {
                 options: Some(proto_options),
-            })
+            }))
             .await
             .map_err(|err| {
                 tracing::error!("Could not create payment request: {}", err);
                 payment_error_from_status(err)
-            })?;
+            })?
+            .into_inner();
 
         Ok(response.try_into().map_err(|_| {
             cdk_common::payment::Error::Anyhow(anyhow!("Could not create create payment response"))
@@ -483,9 +319,9 @@ impl MintPayment for PaymentProcessorClient {
             cdk_common::payment::OutgoingPaymentOptions::Onchain(opts) => opts.quote_id.to_string(),
         };
 
-        let response = self
-            .transport
-            .get_payment_quote(PaymentQuoteRequest {
+        let mut inner = self.inner.clone();
+        let response = inner
+            .get_payment_quote(Request::new(PaymentQuoteRequest {
                 request: proto_request,
                 unit: unit.to_string(),
                 options: proto_options.map(Into::into),
@@ -495,12 +331,13 @@ impl MintPayment for PaymentProcessorClient {
                 onchain_options,
                 amount,
                 custom_method,
-            })
+            }))
             .await
             .map_err(|err| {
                 tracing::error!("Could not get payment quote: {}", err);
                 payment_error_from_status(err)
-            })?;
+            })?
+            .into_inner();
 
         Ok(response.try_into().map_err(|_| {
             cdk_common::payment::Error::Custom(
@@ -573,19 +410,20 @@ impl MintPayment for PaymentProcessorClient {
             }
         };
 
-        let response = self
-            .transport
-            .make_payment(MakePaymentRequest {
+        let mut inner = self.inner.clone();
+        let response = inner
+            .make_payment(Request::new(MakePaymentRequest {
                 payment_options: Some(payment_options),
                 partial_amount: None,
                 max_fee_amount: None,
                 unit: unit.to_string(),
-            })
+            }))
             .await
             .map_err(|err| {
                 tracing::error!("Could not pay payment request: {}", err);
                 payment_error_from_status(err)
-            })?;
+            })?
+            .into_inner();
 
         Ok(response.try_into().map_err(|_err| {
             cdk_common::payment::Error::Anyhow(anyhow!("could not make payment"))
@@ -597,12 +435,17 @@ impl MintPayment for PaymentProcessorClient {
         &self,
     ) -> Result<Pin<Box<dyn Stream<Item = cdk_common::payment::Event> + Send>>, Self::Err> {
         tracing::debug!("Client waiting for payment");
-        let stream = self.transport.wait_payment_event().await.map_err(|err| {
-            self.payment_event_stream_is_active
-                .store(false, Ordering::SeqCst);
-            tracing::error!("Could not open payment event stream: {}", err);
-            payment_error_from_status(err)
-        })?;
+        let mut inner = self.inner.clone();
+        let stream = inner
+            .wait_payment_event(Request::new(EmptyRequest {}))
+            .await
+            .map_err(|err| {
+                self.payment_event_stream_is_active
+                    .store(false, Ordering::SeqCst);
+                tracing::error!("Could not open payment event stream: {}", err);
+                payment_error_from_status(err)
+            })?
+            .into_inner();
 
         self.payment_event_stream_is_active
             .store(true, Ordering::SeqCst);
@@ -644,7 +487,6 @@ impl MintPayment for PaymentProcessorClient {
 
     /// Cancel payment event stream
     fn cancel_payment_event_stream(&self) {
-        self.transport.cancel_payment_event_stream();
         let mut cancel_token = self
             .cancel_payment_event_stream
             .lock()
@@ -657,16 +499,17 @@ impl MintPayment for PaymentProcessorClient {
         &self,
         payment_identifier: &cdk_common::payment::PaymentIdentifier,
     ) -> Result<Vec<WaitPaymentResponse>, Self::Err> {
-        let check_incoming = self
-            .transport
-            .check_incoming_payment(CheckIncomingPaymentRequest {
+        let mut inner = self.inner.clone();
+        let check_incoming = inner
+            .check_incoming_payment(Request::new(CheckIncomingPaymentRequest {
                 request_identifier: Some(payment_identifier.clone().into()),
-            })
+            }))
             .await
             .map_err(|err| {
                 tracing::error!("Could not check incoming payment: {}", err);
                 payment_error_from_status(err)
-            })?;
+            })?
+            .into_inner();
 
         check_incoming
             .payments
@@ -679,16 +522,17 @@ impl MintPayment for PaymentProcessorClient {
         &self,
         payment_identifier: &cdk_common::payment::PaymentIdentifier,
     ) -> Result<CdkMakePaymentResponse, Self::Err> {
-        let check_outgoing = self
-            .transport
-            .check_outgoing_payment(CheckOutgoingPaymentRequest {
+        let mut inner = self.inner.clone();
+        let check_outgoing = inner
+            .check_outgoing_payment(Request::new(CheckOutgoingPaymentRequest {
                 request_identifier: Some(payment_identifier.clone().into()),
-            })
+            }))
             .await
             .map_err(|err| {
                 tracing::error!("Could not check outgoing payment: {}", err);
                 payment_error_from_status(err)
-            })?;
+            })?
+            .into_inner();
 
         Ok(check_outgoing
             .try_into()
@@ -823,77 +667,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_transport_preserves_custom_method_and_lifecycle() {
-        let starts = Arc::new(AtomicUsize::new(0));
-        let stops = Arc::new(AtomicUsize::new(0));
-        let backend = recording_backend(starts.clone(), stops.clone());
-        let client = PaymentProcessorClient::from_backend(backend);
-
-        client.start().await.expect("local backend should start");
-        assert_eq!(starts.load(Ordering::SeqCst), 1);
-
-        let settings = client
-            .get_settings()
-            .await
-            .expect("settings should pass through the local RPC contract");
-        assert!(settings.custom.contains_key("venmo"));
-
-        let incoming = client
-            .create_incoming_payment_request(IncomingPaymentOptions::Custom(Box::new(
-                CustomIncomingPaymentOptions {
-                    method: "venmo".to_string(),
-                    description: None,
-                    amount: Some(Amount::new(20, CurrencyUnit::Sat)),
-                    unix_expiry: None,
-                    extra_json: None,
-                },
-            )))
-            .await
-            .expect("custom incoming method should survive the RPC conversion");
-        assert!(incoming.request.starts_with("venmo:"));
-        assert_eq!(incoming.extra_json, None);
-
-        let quote = client
-            .get_payment_quote(&CurrencyUnit::Sat, custom_options("venmo"))
-            .await
-            .expect("custom quote method should survive the RPC conversion");
-        assert_eq!(quote.amount, Amount::new(20, CurrencyUnit::Sat));
-        assert_eq!(
-            quote.extra_json,
-            Some(serde_json::json!({ "recipient": "alice" }))
-        );
-
-        let payment = client
-            .make_payment(&CurrencyUnit::Sat, custom_options("venmo"))
-            .await
-            .expect("custom payment method should survive the RPC conversion");
-        assert_eq!(
-            payment.payment_proof,
-            Some("venmo-payment-request".to_string())
-        );
-
-        client.stop().await.expect("local backend should stop");
-        assert_eq!(stops.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn local_and_remote_transports_have_matching_contracts() {
-        let local_starts = Arc::new(AtomicUsize::new(0));
-        let local_stops = Arc::new(AtomicUsize::new(0));
-        let local = PaymentProcessorClient::from_backend(recording_backend(
-            local_starts.clone(),
-            local_stops.clone(),
-        ));
-        local.start().await.expect("local backend should start");
-
+    async fn remote_adapter_preserves_mint_payment_contract() {
         let remote_starts = Arc::new(AtomicUsize::new(0));
         let remote_stops = Arc::new(AtomicUsize::new(0));
-        let mut server = super::super::PaymentProcessorServer::new(
+        let server = super::super::PaymentProcessorServer::new(
             recording_backend(remote_starts.clone(), remote_stops.clone()),
             "127.0.0.1",
             0,
         )
         .expect("server should be constructed");
+        let server_clone = server.clone();
         server
             .start(None)
             .await
@@ -912,43 +695,95 @@ mod tests {
         .await
         .expect("remote client should connect");
 
-        let local_settings = local.get_settings().await.expect("local settings");
-        let remote_settings = remote.get_settings().await.expect("remote settings");
-        assert_eq!(local_settings, remote_settings);
-
-        let local_quote = local
-            .get_payment_quote(&CurrencyUnit::Sat, custom_options("venmo"))
+        remote
+            .start()
             .await
-            .expect("local quote");
+            .expect("remote adapter start should succeed");
+        assert_eq!(
+            remote_starts.load(Ordering::SeqCst),
+            1,
+            "the remote server owns its backend lifecycle"
+        );
+
+        let remote_settings = remote.get_settings().await.expect("remote settings");
+        assert!(remote_settings.custom.contains_key("venmo"));
+
+        let mut stream = remote
+            .wait_payment_event()
+            .await
+            .expect("remote payment stream should open");
+        assert!(remote.is_payment_event_stream_active());
+
+        let incoming = remote
+            .create_incoming_payment_request(IncomingPaymentOptions::Custom(Box::new(
+                CustomIncomingPaymentOptions {
+                    method: "venmo".to_string(),
+                    description: None,
+                    amount: Some(Amount::new(20, CurrencyUnit::Sat)),
+                    unix_expiry: None,
+                    extra_json: None,
+                },
+            )))
+            .await
+            .expect("custom incoming method should survive gRPC");
+        assert!(incoming.request.starts_with("venmo:"));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .expect("remote payment event should arrive")
+            .expect("remote payment stream should remain open");
+        assert!(matches!(event, Event::PaymentReceived(_)));
+
+        remote.cancel_payment_event_stream();
+        let end = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .expect("remote payment stream cancellation should complete");
+        assert!(end.is_none());
+        drop(stream);
+        assert!(!remote.is_payment_event_stream_active());
+
         let remote_quote = remote
             .get_payment_quote(&CurrencyUnit::Sat, custom_options("venmo"))
             .await
             .expect("remote quote");
-        assert_eq!(local_quote.amount, remote_quote.amount);
-        assert_eq!(local_quote.fee, remote_quote.fee);
-        assert_eq!(local_quote.state, remote_quote.state);
-        assert_eq!(local_quote.extra_json, remote_quote.extra_json);
+        assert_eq!(remote_quote.amount, Amount::new(20, CurrencyUnit::Sat));
+        assert_eq!(
+            remote_quote.extra_json,
+            Some(serde_json::json!({ "recipient": "alice" }))
+        );
 
-        let local_error = local
-            .get_payment_quote(&CurrencyUnit::Sat, custom_options("unsupported"))
+        let payment = remote
+            .make_payment(&CurrencyUnit::Sat, custom_options("venmo"))
             .await
-            .expect_err("local unsupported method should fail");
+            .expect("custom payment method should survive gRPC");
+        assert_eq!(
+            payment.payment_proof,
+            Some("venmo-payment-request".to_string())
+        );
+
         let remote_error = remote
             .get_payment_quote(&CurrencyUnit::Sat, custom_options("unsupported"))
             .await
             .expect_err("remote unsupported method should fail");
         assert!(matches!(
-            local_error,
-            cdk_common::payment::Error::UnsupportedPaymentOption
-        ));
-        assert!(matches!(
             remote_error,
             cdk_common::payment::Error::UnsupportedPaymentOption
         ));
 
-        local.stop().await.expect("local backend should stop");
-        server.stop().await.expect("remote backend should stop");
-        assert_eq!(local_stops.load(Ordering::SeqCst), 1);
+        remote
+            .stop()
+            .await
+            .expect("remote adapter stop should succeed");
+        assert_eq!(
+            remote_stops.load(Ordering::SeqCst),
+            0,
+            "the remote server owns its backend lifecycle"
+        );
+
+        server_clone
+            .stop()
+            .await
+            .expect("a cloned server handle should stop the remote backend");
         assert_eq!(remote_stops.load(Ordering::SeqCst), 1);
 
         server
@@ -966,7 +801,7 @@ mod tests {
         let address = listener.local_addr().expect("listener address");
         let starts = Arc::new(AtomicUsize::new(0));
         let stops = Arc::new(AtomicUsize::new(0));
-        let mut server = super::super::PaymentProcessorServer::new(
+        let server = super::super::PaymentProcessorServer::new(
             recording_backend(starts.clone(), stops.clone()),
             &address.ip().to_string(),
             address.port(),
@@ -984,23 +819,5 @@ mod tests {
             .await
             .expect("stopping a server that never started should succeed");
         assert_eq!(stops.load(Ordering::SeqCst), 0);
-    }
-
-    #[test]
-    fn cancelling_event_stream_does_not_require_async_runtime() {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("test runtime");
-        let client = {
-            let _runtime_guard = runtime.enter();
-            PaymentProcessorClient::from_backend(recording_backend(
-                Arc::new(AtomicUsize::new(0)),
-                Arc::new(AtomicUsize::new(0)),
-            ))
-        };
-        drop(runtime);
-
-        client.cancel_payment_event_stream();
     }
 }

--- a/crates/cdk-payment-processor/src/proto/client.rs
+++ b/crates/cdk-payment-processor/src/proto/client.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use anyhow::anyhow;
@@ -12,15 +12,15 @@ use cdk_common::payment::{
     PaymentQuoteResponse as CdkPaymentQuoteResponse, WaitPaymentResponse,
 };
 use futures::{Stream, StreamExt};
-use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tonic::codegen::InterceptedService;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
-use tonic::{async_trait, Code, Request, Status};
+use tonic::{async_trait, Request, Status};
 use tracing::instrument;
 
 use super::cdk_payment_processor_server::CdkPaymentProcessor;
-use super::server::PaymentProcessorService;
+use super::service::PaymentProcessorService;
+use crate::error::payment_error_from_status;
 use crate::proto::cdk_payment_processor_client::CdkPaymentProcessorClient;
 use crate::proto::{
     CheckIncomingPaymentRequest, CheckIncomingPaymentResponse, CheckOutgoingPaymentRequest,
@@ -323,7 +323,7 @@ impl MintPayment for PaymentProcessorClient {
             .await
             .map_err(|err| {
                 tracing::error!("Could not get settings: {}", err);
-                cdk_common::payment::Error::Custom(err.to_string())
+                payment_error_from_status(err)
             })?;
 
         Ok(cdk_common::payment::SettingsResponse {
@@ -403,7 +403,7 @@ impl MintPayment for PaymentProcessorClient {
             .await
             .map_err(|err| {
                 tracing::error!("Could not create payment request: {}", err);
-                cdk_common::payment::Error::Custom(err.to_string())
+                payment_error_from_status(err)
             })?;
 
         Ok(response.try_into().map_err(|_| {
@@ -499,7 +499,7 @@ impl MintPayment for PaymentProcessorClient {
             .await
             .map_err(|err| {
                 tracing::error!("Could not get payment quote: {}", err);
-                cdk_common::payment::Error::Custom(err.to_string())
+                payment_error_from_status(err)
             })?;
 
         Ok(response.try_into().map_err(|_| {
@@ -584,14 +584,7 @@ impl MintPayment for PaymentProcessorClient {
             .await
             .map_err(|err| {
                 tracing::error!("Could not pay payment request: {}", err);
-
-                if err.code() == Code::AlreadyExists || err.message().contains("already paid") {
-                    cdk_common::payment::Error::InvoiceAlreadyPaid
-                } else if err.code() == Code::Aborted || err.message().contains("pending") {
-                    cdk_common::payment::Error::InvoicePaymentPending
-                } else {
-                    cdk_common::payment::Error::Custom(err.to_string())
-                }
+                payment_error_from_status(err)
             })?;
 
         Ok(response.try_into().map_err(|_err| {
@@ -608,13 +601,17 @@ impl MintPayment for PaymentProcessorClient {
             self.payment_event_stream_is_active
                 .store(false, Ordering::SeqCst);
             tracing::error!("Could not open payment event stream: {}", err);
-            cdk_common::payment::Error::Custom(err.to_string())
+            payment_error_from_status(err)
         })?;
 
         self.payment_event_stream_is_active
             .store(true, Ordering::SeqCst);
 
-        let cancel_token = self.cancel_payment_event_stream.lock().await.clone();
+        let cancel_token = self
+            .cancel_payment_event_stream
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone();
         let cancel_fut = cancel_token.cancelled_owned();
         let active_flag = self.payment_event_stream_is_active.clone();
 
@@ -648,13 +645,12 @@ impl MintPayment for PaymentProcessorClient {
     /// Cancel payment event stream
     fn cancel_payment_event_stream(&self) {
         self.transport.cancel_payment_event_stream();
-        let cancel_payment_event_stream = Arc::clone(&self.cancel_payment_event_stream);
-
-        tokio::spawn(async move {
-            let mut cancel_token = cancel_payment_event_stream.lock().await;
-            cancel_token.cancel();
-            *cancel_token = CancellationToken::new();
-        });
+        let mut cancel_token = self
+            .cancel_payment_event_stream
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        cancel_token.cancel();
+        *cancel_token = CancellationToken::new();
     }
 
     async fn check_incoming_payment_status(
@@ -669,7 +665,7 @@ impl MintPayment for PaymentProcessorClient {
             .await
             .map_err(|err| {
                 tracing::error!("Could not check incoming payment: {}", err);
-                cdk_common::payment::Error::Custom(err.to_string())
+                payment_error_from_status(err)
             })?;
 
         check_incoming
@@ -691,7 +687,7 @@ impl MintPayment for PaymentProcessorClient {
             .await
             .map_err(|err| {
                 tracing::error!("Could not check outgoing payment: {}", err);
-                cdk_common::payment::Error::Custom(err.to_string())
+                payment_error_from_status(err)
             })?;
 
         Ok(check_outgoing
@@ -719,6 +715,39 @@ mod tests {
         inner: FakeWallet,
         starts: Arc<AtomicUsize>,
         stops: Arc<AtomicUsize>,
+    }
+
+    fn recording_backend(starts: Arc<AtomicUsize>, stops: Arc<AtomicUsize>) -> DynMintPayment {
+        let wallet = FakeWallet::new(
+            FeeReserve {
+                min_fee_reserve: 0.into(),
+                percent_fee_reserve: 0.0,
+            },
+            HashMap::new(),
+            HashSet::new(),
+            0,
+            CurrencyUnit::Sat,
+        )
+        .with_custom_payment_methods(HashMap::from([("venmo".to_string(), "{}".to_string())]));
+
+        Arc::new(RecordingBackend {
+            inner: wallet,
+            starts,
+            stops,
+        })
+    }
+
+    fn custom_options(method: &str) -> OutgoingPaymentOptions {
+        OutgoingPaymentOptions::Custom(Box::new(CustomOutgoingPaymentOptions {
+            method: method.to_owned(),
+            request: "venmo-payment-request".to_string(),
+            amount: Some(Amount::new(20, CurrencyUnit::Sat)),
+            max_fee_amount: None,
+            timeout_secs: None,
+            melt_options: None,
+            extra_json: Some(r#"{"recipient":"alice"}"#.to_string()),
+            quote_id: QuoteId::new(),
+        }))
     }
 
     #[async_trait]
@@ -797,22 +826,7 @@ mod tests {
     async fn local_transport_preserves_custom_method_and_lifecycle() {
         let starts = Arc::new(AtomicUsize::new(0));
         let stops = Arc::new(AtomicUsize::new(0));
-        let wallet = FakeWallet::new(
-            FeeReserve {
-                min_fee_reserve: 0.into(),
-                percent_fee_reserve: 0.0,
-            },
-            HashMap::new(),
-            HashSet::new(),
-            0,
-            CurrencyUnit::Sat,
-        )
-        .with_custom_payment_methods(HashMap::from([("venmo".to_string(), "{}".to_string())]));
-        let backend: DynMintPayment = Arc::new(RecordingBackend {
-            inner: wallet,
-            starts: starts.clone(),
-            stops: stops.clone(),
-        });
+        let backend = recording_backend(starts.clone(), stops.clone());
         let client = PaymentProcessorClient::from_backend(backend);
 
         client.start().await.expect("local backend should start");
@@ -839,21 +853,8 @@ mod tests {
         assert!(incoming.request.starts_with("venmo:"));
         assert_eq!(incoming.extra_json, None);
 
-        let custom_options = || {
-            OutgoingPaymentOptions::Custom(Box::new(CustomOutgoingPaymentOptions {
-                method: "venmo".to_string(),
-                request: "venmo-payment-request".to_string(),
-                amount: Some(Amount::new(20, CurrencyUnit::Sat)),
-                max_fee_amount: None,
-                timeout_secs: None,
-                melt_options: None,
-                extra_json: Some(r#"{"recipient":"alice"}"#.to_string()),
-                quote_id: QuoteId::new(),
-            }))
-        };
-
         let quote = client
-            .get_payment_quote(&CurrencyUnit::Sat, custom_options())
+            .get_payment_quote(&CurrencyUnit::Sat, custom_options("venmo"))
             .await
             .expect("custom quote method should survive the RPC conversion");
         assert_eq!(quote.amount, Amount::new(20, CurrencyUnit::Sat));
@@ -863,7 +864,7 @@ mod tests {
         );
 
         let payment = client
-            .make_payment(&CurrencyUnit::Sat, custom_options())
+            .make_payment(&CurrencyUnit::Sat, custom_options("venmo"))
             .await
             .expect("custom payment method should survive the RPC conversion");
         assert_eq!(
@@ -873,5 +874,133 @@ mod tests {
 
         client.stop().await.expect("local backend should stop");
         assert_eq!(stops.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn local_and_remote_transports_have_matching_contracts() {
+        let local_starts = Arc::new(AtomicUsize::new(0));
+        let local_stops = Arc::new(AtomicUsize::new(0));
+        let local = PaymentProcessorClient::from_backend(recording_backend(
+            local_starts.clone(),
+            local_stops.clone(),
+        ));
+        local.start().await.expect("local backend should start");
+
+        let remote_starts = Arc::new(AtomicUsize::new(0));
+        let remote_stops = Arc::new(AtomicUsize::new(0));
+        let mut server = super::super::PaymentProcessorServer::new(
+            recording_backend(remote_starts.clone(), remote_stops.clone()),
+            "127.0.0.1",
+            0,
+        )
+        .expect("server should be constructed");
+        server
+            .start(None)
+            .await
+            .expect("remote backend should start");
+        assert_eq!(remote_starts.load(Ordering::SeqCst), 1);
+
+        let second_start = server.start(None).await;
+        assert!(second_start.is_err(), "double start should be rejected");
+        assert_eq!(remote_starts.load(Ordering::SeqCst), 1);
+
+        let remote = PaymentProcessorClient::new(
+            &server.local_addr().ip().to_string(),
+            server.local_addr().port(),
+            None,
+        )
+        .await
+        .expect("remote client should connect");
+
+        let local_settings = local.get_settings().await.expect("local settings");
+        let remote_settings = remote.get_settings().await.expect("remote settings");
+        assert_eq!(local_settings, remote_settings);
+
+        let local_quote = local
+            .get_payment_quote(&CurrencyUnit::Sat, custom_options("venmo"))
+            .await
+            .expect("local quote");
+        let remote_quote = remote
+            .get_payment_quote(&CurrencyUnit::Sat, custom_options("venmo"))
+            .await
+            .expect("remote quote");
+        assert_eq!(local_quote.amount, remote_quote.amount);
+        assert_eq!(local_quote.fee, remote_quote.fee);
+        assert_eq!(local_quote.state, remote_quote.state);
+        assert_eq!(local_quote.extra_json, remote_quote.extra_json);
+
+        let local_error = local
+            .get_payment_quote(&CurrencyUnit::Sat, custom_options("unsupported"))
+            .await
+            .expect_err("local unsupported method should fail");
+        let remote_error = remote
+            .get_payment_quote(&CurrencyUnit::Sat, custom_options("unsupported"))
+            .await
+            .expect_err("remote unsupported method should fail");
+        assert!(matches!(
+            local_error,
+            cdk_common::payment::Error::UnsupportedPaymentOption
+        ));
+        assert!(matches!(
+            remote_error,
+            cdk_common::payment::Error::UnsupportedPaymentOption
+        ));
+
+        local.stop().await.expect("local backend should stop");
+        server.stop().await.expect("remote backend should stop");
+        assert_eq!(local_stops.load(Ordering::SeqCst), 1);
+        assert_eq!(remote_stops.load(Ordering::SeqCst), 1);
+
+        server
+            .stop()
+            .await
+            .expect("repeated server stop should be harmless");
+        assert_eq!(remote_stops.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn server_bind_failure_does_not_start_backend() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener should bind");
+        let address = listener.local_addr().expect("listener address");
+        let starts = Arc::new(AtomicUsize::new(0));
+        let stops = Arc::new(AtomicUsize::new(0));
+        let mut server = super::super::PaymentProcessorServer::new(
+            recording_backend(starts.clone(), stops.clone()),
+            &address.ip().to_string(),
+            address.port(),
+        )
+        .expect("server should be constructed");
+
+        server
+            .start(None)
+            .await
+            .expect_err("occupied address should fail");
+        assert_eq!(starts.load(Ordering::SeqCst), 0);
+
+        server
+            .stop()
+            .await
+            .expect("stopping a server that never started should succeed");
+        assert_eq!(stops.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn cancelling_event_stream_does_not_require_async_runtime() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        let client = {
+            let _runtime_guard = runtime.enter();
+            PaymentProcessorClient::from_backend(recording_backend(
+                Arc::new(AtomicUsize::new(0)),
+                Arc::new(AtomicUsize::new(0)),
+            ))
+        };
+        drop(runtime);
+
+        client.cancel_payment_event_stream();
     }
 }

--- a/crates/cdk-payment-processor/src/proto/client.rs
+++ b/crates/cdk-payment-processor/src/proto/client.rs
@@ -16,20 +16,183 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tonic::codegen::InterceptedService;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
-use tonic::{async_trait, Request};
+use tonic::{async_trait, Code, Request, Status};
 use tracing::instrument;
 
+use super::cdk_payment_processor_server::CdkPaymentProcessor;
+use super::server::PaymentProcessorService;
 use crate::proto::cdk_payment_processor_client::CdkPaymentProcessorClient;
 use crate::proto::{
-    CheckIncomingPaymentRequest, CheckOutgoingPaymentRequest, CreatePaymentRequest, EmptyRequest,
-    IncomingPaymentOptions, IntoProtoAmount, MakePaymentRequest, OutgoingPaymentRequestType,
-    PaymentQuoteRequest,
+    CheckIncomingPaymentRequest, CheckIncomingPaymentResponse, CheckOutgoingPaymentRequest,
+    CreatePaymentRequest, CreatePaymentResponse, EmptyRequest, IncomingPaymentOptions,
+    IntoProtoAmount, MakePaymentRequest, MakePaymentResponse, OutgoingPaymentRequestType,
+    PaymentEventResponse, PaymentQuoteRequest, PaymentQuoteResponse, SettingsResponse,
 };
+
+type RemotePaymentProcessorClient =
+    CdkPaymentProcessorClient<InterceptedService<Channel, VersionInterceptor>>;
+type RpcPaymentEventStream =
+    Pin<Box<dyn Stream<Item = Result<PaymentEventResponse, Status>> + Send>>;
+
+#[derive(Clone)]
+enum PaymentProcessorTransport {
+    Remote(Arc<RemotePaymentProcessorClient>),
+    Local(PaymentProcessorService),
+}
+
+impl PaymentProcessorTransport {
+    async fn start(&self) -> Result<(), cdk_common::payment::Error> {
+        match self {
+            Self::Remote(_) => Ok(()),
+            Self::Local(service) => service.start().await,
+        }
+    }
+
+    async fn stop(&self) -> Result<(), cdk_common::payment::Error> {
+        match self {
+            Self::Remote(_) => Ok(()),
+            Self::Local(service) => service.stop().await,
+        }
+    }
+
+    fn cancel_payment_event_stream(&self) {
+        if let Self::Local(service) = self {
+            service.cancel_payment_event_stream();
+        }
+    }
+
+    async fn get_settings(&self, request: EmptyRequest) -> Result<SettingsResponse, Status> {
+        match self {
+            Self::Remote(client) => client
+                .as_ref()
+                .clone()
+                .get_settings(Request::new(request))
+                .await
+                .map(tonic::Response::into_inner),
+            Self::Local(service) => {
+                CdkPaymentProcessor::get_settings(service, Request::new(request))
+                    .await
+                    .map(tonic::Response::into_inner)
+            }
+        }
+    }
+
+    async fn create_payment(
+        &self,
+        request: CreatePaymentRequest,
+    ) -> Result<CreatePaymentResponse, Status> {
+        match self {
+            Self::Remote(client) => client
+                .as_ref()
+                .clone()
+                .create_payment(Request::new(request))
+                .await
+                .map(tonic::Response::into_inner),
+            Self::Local(service) => {
+                CdkPaymentProcessor::create_payment(service, Request::new(request))
+                    .await
+                    .map(tonic::Response::into_inner)
+            }
+        }
+    }
+
+    async fn get_payment_quote(
+        &self,
+        request: PaymentQuoteRequest,
+    ) -> Result<PaymentQuoteResponse, Status> {
+        match self {
+            Self::Remote(client) => client
+                .as_ref()
+                .clone()
+                .get_payment_quote(Request::new(request))
+                .await
+                .map(tonic::Response::into_inner),
+            Self::Local(service) => {
+                CdkPaymentProcessor::get_payment_quote(service, Request::new(request))
+                    .await
+                    .map(tonic::Response::into_inner)
+            }
+        }
+    }
+
+    async fn make_payment(
+        &self,
+        request: MakePaymentRequest,
+    ) -> Result<MakePaymentResponse, Status> {
+        match self {
+            Self::Remote(client) => client
+                .as_ref()
+                .clone()
+                .make_payment(Request::new(request))
+                .await
+                .map(tonic::Response::into_inner),
+            Self::Local(service) => {
+                CdkPaymentProcessor::make_payment(service, Request::new(request))
+                    .await
+                    .map(tonic::Response::into_inner)
+            }
+        }
+    }
+
+    async fn wait_payment_event(&self) -> Result<RpcPaymentEventStream, Status> {
+        match self {
+            Self::Remote(client) => client
+                .as_ref()
+                .clone()
+                .wait_payment_event(Request::new(EmptyRequest {}))
+                .await
+                .map(|response| Box::pin(response.into_inner()) as RpcPaymentEventStream),
+            Self::Local(service) => {
+                CdkPaymentProcessor::wait_payment_event(service, Request::new(EmptyRequest {}))
+                    .await
+                    .map(tonic::Response::into_inner)
+            }
+        }
+    }
+
+    async fn check_incoming_payment(
+        &self,
+        request: CheckIncomingPaymentRequest,
+    ) -> Result<CheckIncomingPaymentResponse, Status> {
+        match self {
+            Self::Remote(client) => client
+                .as_ref()
+                .clone()
+                .check_incoming_payment(Request::new(request))
+                .await
+                .map(tonic::Response::into_inner),
+            Self::Local(service) => {
+                CdkPaymentProcessor::check_incoming_payment(service, Request::new(request))
+                    .await
+                    .map(tonic::Response::into_inner)
+            }
+        }
+    }
+
+    async fn check_outgoing_payment(
+        &self,
+        request: CheckOutgoingPaymentRequest,
+    ) -> Result<MakePaymentResponse, Status> {
+        match self {
+            Self::Remote(client) => client
+                .as_ref()
+                .clone()
+                .check_outgoing_payment(Request::new(request))
+                .await
+                .map(tonic::Response::into_inner),
+            Self::Local(service) => {
+                CdkPaymentProcessor::check_outgoing_payment(service, Request::new(request))
+                    .await
+                    .map(tonic::Response::into_inner)
+            }
+        }
+    }
+}
 
 /// Payment Processor
 #[derive(Clone)]
 pub struct PaymentProcessorClient {
-    inner: CdkPaymentProcessorClient<InterceptedService<Channel, VersionInterceptor>>,
+    transport: PaymentProcessorTransport,
     payment_event_stream_is_active: Arc<AtomicBool>,
     cancel_payment_event_stream: Arc<Mutex<CancellationToken>>,
 }
@@ -123,10 +286,21 @@ impl PaymentProcessorClient {
         let client = CdkPaymentProcessorClient::with_interceptor(channel, interceptor);
 
         Ok(Self {
-            inner: client,
+            transport: PaymentProcessorTransport::Remote(Arc::new(client)),
             payment_event_stream_is_active: Arc::new(AtomicBool::new(false)),
             cancel_payment_event_stream: Arc::new(Mutex::new(CancellationToken::new())),
         })
+    }
+
+    /// Create an in-process client for an embedded payment processor.
+    pub fn from_backend(payment_processor: cdk_common::payment::DynMintPayment) -> Self {
+        Self {
+            transport: PaymentProcessorTransport::Local(PaymentProcessorService::new(
+                payment_processor,
+            )),
+            payment_event_stream_is_active: Arc::new(AtomicBool::new(false)),
+            cancel_payment_event_stream: Arc::new(Mutex::new(CancellationToken::new())),
+        }
     }
 }
 
@@ -134,17 +308,23 @@ impl PaymentProcessorClient {
 impl MintPayment for PaymentProcessorClient {
     type Err = cdk_common::payment::Error;
 
+    async fn start(&self) -> Result<(), Self::Err> {
+        self.transport.start().await
+    }
+
+    async fn stop(&self) -> Result<(), Self::Err> {
+        self.transport.stop().await
+    }
+
     async fn get_settings(&self) -> Result<cdk_common::payment::SettingsResponse, Self::Err> {
-        let mut inner = self.inner.clone();
-        let response = inner
-            .get_settings(Request::new(EmptyRequest {}))
+        let settings = self
+            .transport
+            .get_settings(EmptyRequest {})
             .await
             .map_err(|err| {
                 tracing::error!("Could not get settings: {}", err);
                 cdk_common::payment::Error::Custom(err.to_string())
             })?;
-
-        let settings = response.into_inner();
 
         Ok(cdk_common::payment::SettingsResponse {
             unit: settings.unit,
@@ -176,8 +356,6 @@ impl MintPayment for PaymentProcessorClient {
         &self,
         options: CdkIncomingPaymentOptions,
     ) -> Result<CreateIncomingPaymentResponse, Self::Err> {
-        let mut inner = self.inner.clone();
-
         let proto_options = match options {
             CdkIncomingPaymentOptions::Custom(opts) => IncomingPaymentOptions {
                 options: Some(super::incoming_payment_options::Options::Custom(
@@ -186,6 +364,7 @@ impl MintPayment for PaymentProcessorClient {
                         amount: opts.amount.map(Into::into),
                         unix_expiry: opts.unix_expiry,
                         extra_json: opts.extra_json.clone(),
+                        method: Some(opts.method.clone()),
                     },
                 )),
             },
@@ -216,17 +395,16 @@ impl MintPayment for PaymentProcessorClient {
             },
         };
 
-        let response = inner
-            .create_payment(Request::new(CreatePaymentRequest {
+        let response = self
+            .transport
+            .create_payment(CreatePaymentRequest {
                 options: Some(proto_options),
-            }))
+            })
             .await
             .map_err(|err| {
                 tracing::error!("Could not create payment request: {}", err);
                 cdk_common::payment::Error::Custom(err.to_string())
             })?;
-
-        let response = response.into_inner();
 
         Ok(response.try_into().map_err(|_| {
             cdk_common::payment::Error::Anyhow(anyhow!("Could not create create payment response"))
@@ -238,8 +416,6 @@ impl MintPayment for PaymentProcessorClient {
         unit: &cdk_common::CurrencyUnit,
         options: cdk_common::payment::OutgoingPaymentOptions,
     ) -> Result<CdkPaymentQuoteResponse, Self::Err> {
-        let mut inner = self.inner.clone();
-
         let request_type = match &options {
             cdk_common::payment::OutgoingPaymentOptions::Custom(_) => {
                 OutgoingPaymentRequestType::Custom
@@ -288,6 +464,11 @@ impl MintPayment for PaymentProcessorClient {
             _ => None,
         };
 
+        let custom_method = match &options {
+            cdk_common::payment::OutgoingPaymentOptions::Custom(opts) => Some(opts.method.clone()),
+            _ => None,
+        };
+
         let amount = match &options {
             cdk_common::payment::OutgoingPaymentOptions::Custom(opts) => {
                 opts.amount.clone().into_proto()
@@ -302,8 +483,9 @@ impl MintPayment for PaymentProcessorClient {
             cdk_common::payment::OutgoingPaymentOptions::Onchain(opts) => opts.quote_id.to_string(),
         };
 
-        let response = inner
-            .get_payment_quote(Request::new(PaymentQuoteRequest {
+        let response = self
+            .transport
+            .get_payment_quote(PaymentQuoteRequest {
                 request: proto_request,
                 unit: unit.to_string(),
                 options: proto_options.map(Into::into),
@@ -312,14 +494,13 @@ impl MintPayment for PaymentProcessorClient {
                 quote_id,
                 onchain_options,
                 amount,
-            }))
+                custom_method,
+            })
             .await
             .map_err(|err| {
                 tracing::error!("Could not get payment quote: {}", err);
                 cdk_common::payment::Error::Custom(err.to_string())
             })?;
-
-        let response = response.into_inner();
 
         Ok(response.try_into().map_err(|_| {
             cdk_common::payment::Error::Custom(
@@ -333,7 +514,6 @@ impl MintPayment for PaymentProcessorClient {
         unit: &cdk_common::CurrencyUnit,
         options: cdk_common::payment::OutgoingPaymentOptions,
     ) -> Result<CdkMakePaymentResponse, Self::Err> {
-        let mut inner = self.inner.clone();
         let payment_options = match options {
             cdk_common::payment::OutgoingPaymentOptions::Custom(opts) => {
                 super::OutgoingPaymentVariant {
@@ -346,6 +526,7 @@ impl MintPayment for PaymentProcessorClient {
                             melt_options: opts.melt_options.map(Into::into),
                             extra_json: opts.extra_json.clone(),
                             quote_id: opts.quote_id.to_string(),
+                            method: Some(opts.method.clone()),
                         },
                     )),
                 }
@@ -392,27 +573,26 @@ impl MintPayment for PaymentProcessorClient {
             }
         };
 
-        let response = inner
-            .make_payment(Request::new(MakePaymentRequest {
+        let response = self
+            .transport
+            .make_payment(MakePaymentRequest {
                 payment_options: Some(payment_options),
                 partial_amount: None,
                 max_fee_amount: None,
                 unit: unit.to_string(),
-            }))
+            })
             .await
             .map_err(|err| {
                 tracing::error!("Could not pay payment request: {}", err);
 
-                if err.message().contains("already paid") {
+                if err.code() == Code::AlreadyExists || err.message().contains("already paid") {
                     cdk_common::payment::Error::InvoiceAlreadyPaid
-                } else if err.message().contains("pending") {
+                } else if err.code() == Code::Aborted || err.message().contains("pending") {
                     cdk_common::payment::Error::InvoicePaymentPending
                 } else {
                     cdk_common::payment::Error::Custom(err.to_string())
                 }
             })?;
-
-        let response = response.into_inner();
 
         Ok(response.try_into().map_err(|_err| {
             cdk_common::payment::Error::Anyhow(anyhow!("could not make payment"))
@@ -424,17 +604,12 @@ impl MintPayment for PaymentProcessorClient {
         &self,
     ) -> Result<Pin<Box<dyn Stream<Item = cdk_common::payment::Event> + Send>>, Self::Err> {
         tracing::debug!("Client waiting for payment");
-        let mut inner = self.inner.clone();
-        let stream = inner
-            .wait_payment_event(Request::new(EmptyRequest {}))
-            .await
-            .map_err(|err| {
-                self.payment_event_stream_is_active
-                    .store(false, Ordering::SeqCst);
-                tracing::error!("Could not open payment event stream: {}", err);
-                cdk_common::payment::Error::Custom(err.to_string())
-            })?
-            .into_inner();
+        let stream = self.transport.wait_payment_event().await.map_err(|err| {
+            self.payment_event_stream_is_active
+                .store(false, Ordering::SeqCst);
+            tracing::error!("Could not open payment event stream: {}", err);
+            cdk_common::payment::Error::Custom(err.to_string())
+        })?;
 
         self.payment_event_stream_is_active
             .store(true, Ordering::SeqCst);
@@ -472,6 +647,7 @@ impl MintPayment for PaymentProcessorClient {
 
     /// Cancel payment event stream
     fn cancel_payment_event_stream(&self) {
+        self.transport.cancel_payment_event_stream();
         let cancel_payment_event_stream = Arc::clone(&self.cancel_payment_event_stream);
 
         tokio::spawn(async move {
@@ -485,18 +661,17 @@ impl MintPayment for PaymentProcessorClient {
         &self,
         payment_identifier: &cdk_common::payment::PaymentIdentifier,
     ) -> Result<Vec<WaitPaymentResponse>, Self::Err> {
-        let mut inner = self.inner.clone();
-        let response = inner
-            .check_incoming_payment(Request::new(CheckIncomingPaymentRequest {
+        let check_incoming = self
+            .transport
+            .check_incoming_payment(CheckIncomingPaymentRequest {
                 request_identifier: Some(payment_identifier.clone().into()),
-            }))
+            })
             .await
             .map_err(|err| {
                 tracing::error!("Could not check incoming payment: {}", err);
                 cdk_common::payment::Error::Custom(err.to_string())
             })?;
 
-        let check_incoming = response.into_inner();
         check_incoming
             .payments
             .into_iter()
@@ -508,21 +683,195 @@ impl MintPayment for PaymentProcessorClient {
         &self,
         payment_identifier: &cdk_common::payment::PaymentIdentifier,
     ) -> Result<CdkMakePaymentResponse, Self::Err> {
-        let mut inner = self.inner.clone();
-        let response = inner
-            .check_outgoing_payment(Request::new(CheckOutgoingPaymentRequest {
+        let check_outgoing = self
+            .transport
+            .check_outgoing_payment(CheckOutgoingPaymentRequest {
                 request_identifier: Some(payment_identifier.clone().into()),
-            }))
+            })
             .await
             .map_err(|err| {
                 tracing::error!("Could not check outgoing payment: {}", err);
                 cdk_common::payment::Error::Custom(err.to_string())
             })?;
 
-        let check_outgoing = response.into_inner();
-
         Ok(check_outgoing
             .try_into()
             .map_err(|_| cdk_common::payment::Error::UnknownPaymentState)?)
+    }
+}
+
+#[cfg(all(test, feature = "fake"))]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::sync::atomic::AtomicUsize;
+
+    use cdk_common::common::FeeReserve;
+    use cdk_common::payment::{
+        CustomIncomingPaymentOptions, CustomOutgoingPaymentOptions, DynMintPayment, Event,
+        IncomingPaymentOptions, OutgoingPaymentOptions, PaymentIdentifier,
+    };
+    use cdk_common::{Amount, CurrencyUnit, QuoteId};
+    use cdk_fake_wallet::FakeWallet;
+
+    use super::*;
+
+    struct RecordingBackend {
+        inner: FakeWallet,
+        starts: Arc<AtomicUsize>,
+        stops: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl MintPayment for RecordingBackend {
+        type Err = cdk_common::payment::Error;
+
+        async fn start(&self) -> Result<(), Self::Err> {
+            self.starts.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn stop(&self) -> Result<(), Self::Err> {
+            self.stops.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn get_settings(&self) -> Result<cdk_common::payment::SettingsResponse, Self::Err> {
+            self.inner.get_settings().await
+        }
+
+        async fn create_incoming_payment_request(
+            &self,
+            options: IncomingPaymentOptions,
+        ) -> Result<CreateIncomingPaymentResponse, Self::Err> {
+            self.inner.create_incoming_payment_request(options).await
+        }
+
+        async fn get_payment_quote(
+            &self,
+            unit: &CurrencyUnit,
+            options: OutgoingPaymentOptions,
+        ) -> Result<CdkPaymentQuoteResponse, Self::Err> {
+            self.inner.get_payment_quote(unit, options).await
+        }
+
+        async fn make_payment(
+            &self,
+            unit: &CurrencyUnit,
+            options: OutgoingPaymentOptions,
+        ) -> Result<CdkMakePaymentResponse, Self::Err> {
+            self.inner.make_payment(unit, options).await
+        }
+
+        async fn wait_payment_event(
+            &self,
+        ) -> Result<Pin<Box<dyn Stream<Item = Event> + Send>>, Self::Err> {
+            self.inner.wait_payment_event().await
+        }
+
+        fn is_payment_event_stream_active(&self) -> bool {
+            self.inner.is_payment_event_stream_active()
+        }
+
+        fn cancel_payment_event_stream(&self) {
+            self.inner.cancel_payment_event_stream();
+        }
+
+        async fn check_incoming_payment_status(
+            &self,
+            payment_identifier: &PaymentIdentifier,
+        ) -> Result<Vec<WaitPaymentResponse>, Self::Err> {
+            self.inner
+                .check_incoming_payment_status(payment_identifier)
+                .await
+        }
+
+        async fn check_outgoing_payment(
+            &self,
+            payment_identifier: &PaymentIdentifier,
+        ) -> Result<CdkMakePaymentResponse, Self::Err> {
+            self.inner.check_outgoing_payment(payment_identifier).await
+        }
+    }
+
+    #[tokio::test]
+    async fn local_transport_preserves_custom_method_and_lifecycle() {
+        let starts = Arc::new(AtomicUsize::new(0));
+        let stops = Arc::new(AtomicUsize::new(0));
+        let wallet = FakeWallet::new(
+            FeeReserve {
+                min_fee_reserve: 0.into(),
+                percent_fee_reserve: 0.0,
+            },
+            HashMap::new(),
+            HashSet::new(),
+            0,
+            CurrencyUnit::Sat,
+        )
+        .with_custom_payment_methods(HashMap::from([("venmo".to_string(), "{}".to_string())]));
+        let backend: DynMintPayment = Arc::new(RecordingBackend {
+            inner: wallet,
+            starts: starts.clone(),
+            stops: stops.clone(),
+        });
+        let client = PaymentProcessorClient::from_backend(backend);
+
+        client.start().await.expect("local backend should start");
+        assert_eq!(starts.load(Ordering::SeqCst), 1);
+
+        let settings = client
+            .get_settings()
+            .await
+            .expect("settings should pass through the local RPC contract");
+        assert!(settings.custom.contains_key("venmo"));
+
+        let incoming = client
+            .create_incoming_payment_request(IncomingPaymentOptions::Custom(Box::new(
+                CustomIncomingPaymentOptions {
+                    method: "venmo".to_string(),
+                    description: None,
+                    amount: Some(Amount::new(20, CurrencyUnit::Sat)),
+                    unix_expiry: None,
+                    extra_json: None,
+                },
+            )))
+            .await
+            .expect("custom incoming method should survive the RPC conversion");
+        assert!(incoming.request.starts_with("venmo:"));
+        assert_eq!(incoming.extra_json, None);
+
+        let custom_options = || {
+            OutgoingPaymentOptions::Custom(Box::new(CustomOutgoingPaymentOptions {
+                method: "venmo".to_string(),
+                request: "venmo-payment-request".to_string(),
+                amount: Some(Amount::new(20, CurrencyUnit::Sat)),
+                max_fee_amount: None,
+                timeout_secs: None,
+                melt_options: None,
+                extra_json: Some(r#"{"recipient":"alice"}"#.to_string()),
+                quote_id: QuoteId::new(),
+            }))
+        };
+
+        let quote = client
+            .get_payment_quote(&CurrencyUnit::Sat, custom_options())
+            .await
+            .expect("custom quote method should survive the RPC conversion");
+        assert_eq!(quote.amount, Amount::new(20, CurrencyUnit::Sat));
+        assert_eq!(
+            quote.extra_json,
+            Some(serde_json::json!({ "recipient": "alice" }))
+        );
+
+        let payment = client
+            .make_payment(&CurrencyUnit::Sat, custom_options())
+            .await
+            .expect("custom payment method should survive the RPC conversion");
+        assert_eq!(
+            payment.payment_proof,
+            Some("venmo-payment-request".to_string())
+        );
+
+        client.stop().await.expect("local backend should stop");
+        assert_eq!(stops.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/cdk-payment-processor/src/proto/mod.rs
+++ b/crates/cdk-payment-processor/src/proto/mod.rs
@@ -10,6 +10,7 @@ use cdk_common::{CurrencyUnit, MeltOptions as CdkMeltOptions};
 
 mod client;
 mod server;
+mod service;
 
 pub use client::PaymentProcessorClient;
 pub use server::PaymentProcessorServer;

--- a/crates/cdk-payment-processor/src/proto/mod.rs
+++ b/crates/cdk-payment-processor/src/proto/mod.rs
@@ -203,10 +203,10 @@ impl TryFrom<CreatePaymentResponse> for CreateIncomingPaymentResponse {
             request_lookup_id: request_identifier.try_into()?,
             request: value.request,
             expiry: value.expiry,
-            extra_json: Some(
-                serde_json::from_str(value.extra_json.as_deref().unwrap_or("{}"))
-                    .unwrap_or_default(),
-            ),
+            extra_json: value
+                .extra_json
+                .map(|value| serde_json::from_str(&value))
+                .transpose()?,
         })
     }
 }
@@ -256,8 +256,7 @@ impl TryFrom<PaymentQuoteResponse> for CdkPaymentQuoteResponse {
         let request_identifier = value.request_identifier;
 
         Ok(Self {
-            request_lookup_id: request_identifier
-                .map(|i| i.try_into().expect("valid request identifier")),
+            request_lookup_id: request_identifier.map(TryInto::try_into).transpose()?,
             amount: value
                 .amount
                 .ok_or(crate::error::Error::MissingAmount)?
@@ -269,7 +268,8 @@ impl TryFrom<PaymentQuoteResponse> for CdkPaymentQuoteResponse {
             state: state_val.into(),
             extra_json: value
                 .extra_json
-                .and_then(|value| serde_json::from_str::<serde_json::Value>(&value).ok()),
+                .map(|value| serde_json::from_str::<serde_json::Value>(&value))
+                .transpose()?,
             estimated_blocks: value.estimated_blocks,
             fee_options: (!value.fee_options.is_empty()).then(|| {
                 value

--- a/crates/cdk-payment-processor/src/proto/payment_processor.proto
+++ b/crates/cdk-payment-processor/src/proto/payment_processor.proto
@@ -56,6 +56,8 @@ message CustomIncomingPaymentOptions {
   // Extra payment-method-specific fields as JSON string
   // These fields are flattened into the JSON representation on the client side
   optional string extra_json = 4;
+  // Name of the configured custom payment method.
+  optional string method = 5;
 }
 message Bolt12IncomingPaymentOptions {
   optional string description = 1;
@@ -182,6 +184,8 @@ message PaymentQuoteRequest {
   optional OnchainOutgoingPaymentOptions onchain_options = 7;
   // Optional amount the wallet would like to pay for custom payment methods.
   optional AmountMessage amount = 8;
+  // Name of the configured custom payment method.
+  optional string custom_method = 9;
 }
 
 enum QuoteState {
@@ -243,6 +247,8 @@ message CustomOutgoingPaymentOptions {
   // The mint's quote_id for this melt. Required. Custom backends should use
   // this as the stable correlation key with the earlier get_payment_quote call.
   string quote_id = 7;
+  // Name of the configured custom payment method.
+  optional string method = 8;
 }
 
 message MakePaymentRequest {

--- a/crates/cdk-payment-processor/src/proto/server.rs
+++ b/crates/cdk-payment-processor/src/proto/server.rs
@@ -3,17 +3,17 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use cdk_common::grpc::create_version_check_interceptor;
-use cdk_common::payment::{IncomingPaymentOptions, MintPayment};
+use cdk_common::payment::{DynMintPayment, IncomingPaymentOptions};
 use cdk_common::{CurrencyUnit, QuoteId};
-use futures::{Stream, StreamExt};
+use futures::Stream;
 use lightning::offers::offer::Offer;
-use tokio::sync::{mpsc, Notify};
+use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, Instant};
-use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
 use tonic::{async_trait, Request, Response, Status};
 use tracing::instrument;
@@ -24,10 +24,70 @@ use crate::proto::{TryFromProtoAmount, *};
 
 type ResponseStream = Pin<Box<dyn Stream<Item = Result<PaymentEventResponse, Status>> + Send>>;
 
+#[derive(Clone)]
+pub(crate) struct PaymentProcessorService {
+    inner: DynMintPayment,
+}
+
+impl std::fmt::Debug for PaymentProcessorService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PaymentProcessorService")
+            .finish_non_exhaustive()
+    }
+}
+
+impl PaymentProcessorService {
+    pub(crate) fn new(inner: DynMintPayment) -> Self {
+        Self { inner }
+    }
+
+    pub(crate) async fn start(&self) -> Result<(), cdk_common::payment::Error> {
+        self.inner.start().await
+    }
+
+    pub(crate) async fn stop(&self) -> Result<(), cdk_common::payment::Error> {
+        self.inner.stop().await
+    }
+
+    pub(crate) fn cancel_payment_event_stream(&self) {
+        self.inner.cancel_payment_event_stream();
+    }
+}
+
+struct PaymentEventStream {
+    inner: Pin<Box<dyn Stream<Item = cdk_common::payment::Event> + Send>>,
+    payment_processor: DynMintPayment,
+    completed: bool,
+}
+
+impl Stream for PaymentEventStream {
+    type Item = Result<PaymentEventResponse, Status>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        match this.inner.as_mut().poll_next(cx) {
+            Poll::Ready(Some(event)) => Poll::Ready(Some(Ok(event.into()))),
+            Poll::Ready(None) => {
+                this.completed = true;
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Drop for PaymentEventStream {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.payment_processor.cancel_payment_event_stream();
+        }
+    }
+}
+
 /// Payment Processor
 #[derive(Clone)]
 pub struct PaymentProcessorServer {
-    inner: Arc<dyn MintPayment<Err = cdk_common::payment::Error> + Send + Sync>,
+    service: PaymentProcessorService,
     socket_addr: SocketAddr,
     shutdown: Arc<Notify>,
     handle: Option<Arc<JoinHandle<anyhow::Result<()>>>>,
@@ -43,21 +103,17 @@ impl std::fmt::Debug for PaymentProcessorServer {
 
 impl PaymentProcessorServer {
     /// Create new [`PaymentProcessorServer`]
-    pub fn new(
-        payment_processor: Arc<dyn MintPayment<Err = cdk_common::payment::Error> + Send + Sync>,
-        addr: &str,
-        port: u16,
-    ) -> anyhow::Result<Self> {
+    pub fn new(payment_processor: DynMintPayment, addr: &str, port: u16) -> anyhow::Result<Self> {
         let socket_addr = SocketAddr::new(addr.parse()?, port);
         Ok(Self {
-            inner: payment_processor,
+            service: PaymentProcessorService::new(payment_processor),
             socket_addr,
             shutdown: Arc::new(Notify::new()),
             handle: None,
         })
     }
 
-    /// Start fake wallet grpc server
+    /// Start the payment processor gRPC server.
     pub async fn start(&mut self, tls_dir: Option<PathBuf>) -> anyhow::Result<()> {
         tracing::info!("Starting RPC server {}", self.socket_addr);
 
@@ -105,7 +161,7 @@ impl PaymentProcessorServer {
 
                 Server::builder().tls_config(tls_config)?.add_service(
                     CdkPaymentProcessorServer::with_interceptor(
-                        self.clone(),
+                        self.service.clone(),
                         create_version_check_interceptor(
                             cdk_common::grpc::VERSION_HEADER,
                             cdk_common::PAYMENT_PROCESSOR_PROTOCOL_VERSION,
@@ -116,7 +172,7 @@ impl PaymentProcessorServer {
             None => {
                 tracing::warn!("No valid TLS configuration found, starting insecure server");
                 Server::builder().add_service(CdkPaymentProcessorServer::with_interceptor(
-                    self.clone(),
+                    self.service.clone(),
                     create_version_check_interceptor(
                         cdk_common::grpc::VERSION_HEADER,
                         cdk_common::PAYMENT_PROCESSOR_PROTOCOL_VERSION,
@@ -124,6 +180,8 @@ impl PaymentProcessorServer {
                 ))
             }
         };
+
+        self.service.start().await?;
 
         let shutdown = self.shutdown.clone();
         let addr = self.socket_addr;
@@ -140,9 +198,11 @@ impl PaymentProcessorServer {
         Ok(())
     }
 
-    /// Stop fake wallet grpc server
+    /// Stop the payment processor gRPC server.
     pub async fn stop(&self) -> anyhow::Result<()> {
         const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+        self.service.cancel_payment_event_stream();
 
         if let Some(handle) = &self.handle {
             tracing::info!("Initiating server shutdown");
@@ -169,19 +229,22 @@ impl PaymentProcessorServer {
             tracing::info!("No server handle found, nothing to stop");
         }
 
+        self.service.stop().await?;
+
         Ok(())
     }
 }
 
 impl Drop for PaymentProcessorServer {
     fn drop(&mut self) {
-        tracing::debug!("Dropping payment process server");
+        tracing::debug!("Dropping payment processor server");
+        self.service.cancel_payment_event_stream();
         self.shutdown.notify_one();
     }
 }
 
 #[async_trait]
-impl CdkPaymentProcessor for PaymentProcessorServer {
+impl CdkPaymentProcessor for PaymentProcessorService {
     async fn get_settings(
         &self,
         _request: Request<EmptyRequest>,
@@ -233,7 +296,7 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
                 };
                 IncomingPaymentOptions::Custom(Box::new(
                     cdk_common::payment::CustomIncomingPaymentOptions {
-                        method: "".to_string(),
+                        method: opts.method.unwrap_or_default(),
                         description: opts.description,
                         amount,
                         unix_expiry: opts.unix_expiry,
@@ -337,7 +400,7 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
                 // Custom payment method - pass request as-is with no validation
                 cdk_common::payment::OutgoingPaymentOptions::Custom(Box::new(
                     cdk_common::payment::CustomOutgoingPaymentOptions {
-                        method: String::new(), // Will be set from variant
+                        method: request.custom_method.clone().unwrap_or_default(),
                         request: request.request.clone(),
                         amount,
                         max_fee_amount: None,
@@ -468,8 +531,8 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
 
                 cdk_common::payment::OutgoingPaymentOptions::Custom(Box::new(
                     cdk_common::payment::CustomOutgoingPaymentOptions {
-                        method: String::new(), // Method will be determined from context
-                        request: opts.offer,   // Reusing offer field for custom request string
+                        method: opts.method.unwrap_or_default(),
+                        request: opts.offer, // Reusing offer field for custom request string
                         amount,
                         max_fee_amount,
                         timeout_secs: opts.timeout_secs,
@@ -518,7 +581,7 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
                         Status::already_exists("Payment request already paid")
                     }
                     cdk_common::payment::Error::InvoicePaymentPending => {
-                        Status::already_exists("Payment request pending")
+                        Status::aborted("Payment request pending")
                     }
                     _ => Status::internal("Could not pay invoice"),
                 }
@@ -580,47 +643,17 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
         _request: Request<EmptyRequest>,
     ) -> Result<Response<Self::WaitPaymentEventStream>, Status> {
         tracing::debug!("Server waiting for payment stream");
-        let (tx, rx) = mpsc::channel(128);
+        let stream = self.inner.wait_payment_event().await.map_err(|err| {
+            tracing::warn!("Could not get payment event stream: {}", err);
+            Status::internal("Could not get payment event stream")
+        })?;
+        let output_stream = PaymentEventStream {
+            inner: stream,
+            payment_processor: self.inner.clone(),
+            completed: false,
+        };
 
-        let shutdown_clone = self.shutdown.clone();
-        let ln = self.inner.clone();
-        tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    _ = shutdown_clone.notified() => {
-                        tracing::info!("Shutdown signal received, stopping task");
-                        ln.cancel_payment_event_stream();
-                        break;
-                    }
-                    result = ln.wait_payment_event() => {
-                        match result {
-                            Ok(mut stream) => {
-                                while let Some(event) = stream.next().await {
-                                    match tx.send(Result::<_, Status>::Ok(event.into())).await {
-                                        Ok(_) => {
-                                            // Response was queued to be sent to client
-                                        }
-                                        Err(item) => {
-                                            tracing::error!("Error adding payment event to stream: {}", item);
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-                            Err(err) => {
-                                tracing::warn!("Could not get invoice stream: {}", err);
-                                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                            }
-                        }
-                    }
-                }
-            }
-        });
-
-        let output_stream = ReceiverStream::new(rx);
-        Ok(Response::new(
-            Box::pin(output_stream) as Self::WaitPaymentEventStream
-        ))
+        Ok(Response::new(Box::pin(output_stream)))
     }
 }
 

--- a/crates/cdk-payment-processor/src/proto/server.rs
+++ b/crates/cdk-payment-processor/src/proto/server.rs
@@ -2,6 +2,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
+use std::sync::{Arc, RwLock};
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -11,6 +12,7 @@ use cdk_common::{CurrencyUnit, QuoteId};
 use futures::Stream;
 use lightning::offers::offer::Offer;
 use tokio::net::TcpListener;
+use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -56,19 +58,51 @@ impl Drop for PaymentEventStream {
     }
 }
 
-/// Payment Processor
-pub struct PaymentProcessorServer {
-    service: PaymentProcessorService,
-    socket_addr: SocketAddr,
+struct PaymentProcessorServerState {
     shutdown: Option<CancellationToken>,
     handle: Option<JoinHandle<anyhow::Result<()>>>,
     backend_started: bool,
 }
 
+struct PaymentProcessorServerInner {
+    service: PaymentProcessorService,
+    socket_addr: RwLock<SocketAddr>,
+    state: Mutex<PaymentProcessorServerState>,
+}
+
+impl Drop for PaymentProcessorServerInner {
+    fn drop(&mut self) {
+        tracing::debug!("Dropping payment processor server");
+        self.service.cancel_payment_event_stream();
+
+        let state = self.state.get_mut();
+        if let Some(shutdown) = &state.shutdown {
+            shutdown.cancel();
+        }
+        if let Some(handle) = &state.handle {
+            handle.abort();
+        }
+        if state.backend_started {
+            tracing::warn!(
+                "Payment processor server dropped while running; backend stop was not awaited"
+            );
+        }
+    }
+}
+
+/// Clonable handle to a payment processor gRPC server.
+///
+/// Clones share the same listener address, server task, shutdown state, and
+/// backend lifecycle.
+#[derive(Clone)]
+pub struct PaymentProcessorServer {
+    inner: Arc<PaymentProcessorServerInner>,
+}
+
 impl std::fmt::Debug for PaymentProcessorServer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PaymentProcessorServer")
-            .field("socket_addr", &self.socket_addr)
+            .field("socket_addr", &self.local_addr())
             .finish_non_exhaustive()
     }
 }
@@ -78,26 +112,36 @@ impl PaymentProcessorServer {
     pub fn new(payment_processor: DynMintPayment, addr: &str, port: u16) -> anyhow::Result<Self> {
         let socket_addr = SocketAddr::new(addr.parse()?, port);
         Ok(Self {
-            service: PaymentProcessorService::new(payment_processor),
-            socket_addr,
-            shutdown: None,
-            handle: None,
-            backend_started: false,
+            inner: Arc::new(PaymentProcessorServerInner {
+                service: PaymentProcessorService::new(payment_processor),
+                socket_addr: RwLock::new(socket_addr),
+                state: Mutex::new(PaymentProcessorServerState {
+                    shutdown: None,
+                    handle: None,
+                    backend_started: false,
+                }),
+            }),
         })
     }
 
     /// Return the address on which the server is configured or currently listening.
     pub fn local_addr(&self) -> SocketAddr {
-        self.socket_addr
+        *self
+            .inner
+            .socket_addr
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
     }
 
     /// Start the payment processor gRPC server.
-    pub async fn start(&mut self, tls_dir: Option<PathBuf>) -> anyhow::Result<()> {
-        if self.handle.is_some() || self.backend_started {
+    pub async fn start(&self, tls_dir: Option<PathBuf>) -> anyhow::Result<()> {
+        let mut state = self.inner.state.lock().await;
+
+        if state.handle.is_some() || state.backend_started {
             anyhow::bail!("Payment processor server is already running");
         }
 
-        tracing::info!("Starting RPC server {}", self.socket_addr);
+        tracing::info!("Starting RPC server {}", self.local_addr());
 
         let server = match tls_dir {
             Some(tls_dir) => {
@@ -143,7 +187,7 @@ impl PaymentProcessorServer {
 
                 Server::builder().tls_config(tls_config)?.add_service(
                     CdkPaymentProcessorServer::with_interceptor(
-                        self.service.clone(),
+                        self.inner.service.clone(),
                         create_version_check_interceptor(
                             cdk_common::grpc::VERSION_HEADER,
                             cdk_common::PAYMENT_PROCESSOR_PROTOCOL_VERSION,
@@ -154,7 +198,7 @@ impl PaymentProcessorServer {
             None => {
                 tracing::warn!("No valid TLS configuration found, starting insecure server");
                 Server::builder().add_service(CdkPaymentProcessorServer::with_interceptor(
-                    self.service.clone(),
+                    self.inner.service.clone(),
                     create_version_check_interceptor(
                         cdk_common::grpc::VERSION_HEADER,
                         cdk_common::PAYMENT_PROCESSOR_PROTOCOL_VERSION,
@@ -163,17 +207,21 @@ impl PaymentProcessorServer {
             }
         };
 
-        let listener = TcpListener::bind(self.socket_addr).await?;
-        self.socket_addr = listener.local_addr()?;
+        let listener = TcpListener::bind(self.local_addr()).await?;
+        *self
+            .inner
+            .socket_addr
+            .write()
+            .unwrap_or_else(|error| error.into_inner()) = listener.local_addr()?;
         let incoming = TcpListenerStream::new(listener);
 
-        self.service.start().await?;
-        self.backend_started = true;
+        self.inner.service.start().await?;
+        state.backend_started = true;
 
         let shutdown = CancellationToken::new();
         let shutdown_future = shutdown.clone().cancelled_owned();
-        self.shutdown = Some(shutdown);
-        self.handle = Some(tokio::spawn(async move {
+        state.shutdown = Some(shutdown);
+        state.handle = Some(tokio::spawn(async move {
             server
                 .serve_with_incoming_shutdown(incoming, shutdown_future)
                 .await?;
@@ -184,17 +232,19 @@ impl PaymentProcessorServer {
     }
 
     /// Stop the payment processor gRPC server.
-    pub async fn stop(&mut self) -> anyhow::Result<()> {
+    pub async fn stop(&self) -> anyhow::Result<()> {
         const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
-        self.service.cancel_payment_event_stream();
+        let mut state = self.inner.state.lock().await;
 
-        if let Some(shutdown) = self.shutdown.take() {
+        self.inner.service.cancel_payment_event_stream();
+
+        if let Some(shutdown) = state.shutdown.take() {
             tracing::info!("Initiating server shutdown");
             shutdown.cancel();
         }
 
-        let server_result = match self.handle.take() {
+        let server_result = match state.handle.take() {
             Some(mut handle) => match timeout(SHUTDOWN_TIMEOUT, &mut handle).await {
                 Ok(Ok(result)) => result,
                 Ok(Err(error)) => Err(error.into()),
@@ -213,33 +263,15 @@ impl PaymentProcessorServer {
             None => Ok(()),
         };
 
-        let backend_result = if self.backend_started {
-            self.backend_started = false;
-            self.service.stop().await.map_err(anyhow::Error::from)
+        let backend_result = if state.backend_started {
+            state.backend_started = false;
+            self.inner.service.stop().await.map_err(anyhow::Error::from)
         } else {
             Ok(())
         };
 
         backend_result?;
         server_result
-    }
-}
-
-impl Drop for PaymentProcessorServer {
-    fn drop(&mut self) {
-        tracing::debug!("Dropping payment processor server");
-        self.service.cancel_payment_event_stream();
-        if let Some(shutdown) = &self.shutdown {
-            shutdown.cancel();
-        }
-        if let Some(handle) = &self.handle {
-            handle.abort();
-        }
-        if self.backend_started {
-            tracing::warn!(
-                "Payment processor server dropped while running; backend stop was not awaited"
-            );
-        }
     }
 }
 

--- a/crates/cdk-payment-processor/src/proto/server.rs
+++ b/crates/cdk-payment-processor/src/proto/server.rs
@@ -2,7 +2,6 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -11,48 +10,21 @@ use cdk_common::payment::{DynMintPayment, IncomingPaymentOptions};
 use cdk_common::{CurrencyUnit, QuoteId};
 use futures::Stream;
 use lightning::offers::offer::Offer;
-use tokio::sync::Notify;
+use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
-use tokio::time::{sleep, Instant};
+use tokio::time::timeout;
+use tokio_stream::wrappers::TcpListenerStream;
+use tokio_util::sync::CancellationToken;
 use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
 use tonic::{async_trait, Request, Response, Status};
 use tracing::instrument;
 
 use super::cdk_payment_processor_server::{CdkPaymentProcessor, CdkPaymentProcessorServer};
-use crate::error::Error;
+use super::service::PaymentProcessorService;
+use crate::error::{payment_error_to_status, Error};
 use crate::proto::{TryFromProtoAmount, *};
 
 type ResponseStream = Pin<Box<dyn Stream<Item = Result<PaymentEventResponse, Status>> + Send>>;
-
-#[derive(Clone)]
-pub(crate) struct PaymentProcessorService {
-    inner: DynMintPayment,
-}
-
-impl std::fmt::Debug for PaymentProcessorService {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PaymentProcessorService")
-            .finish_non_exhaustive()
-    }
-}
-
-impl PaymentProcessorService {
-    pub(crate) fn new(inner: DynMintPayment) -> Self {
-        Self { inner }
-    }
-
-    pub(crate) async fn start(&self) -> Result<(), cdk_common::payment::Error> {
-        self.inner.start().await
-    }
-
-    pub(crate) async fn stop(&self) -> Result<(), cdk_common::payment::Error> {
-        self.inner.stop().await
-    }
-
-    pub(crate) fn cancel_payment_event_stream(&self) {
-        self.inner.cancel_payment_event_stream();
-    }
-}
 
 struct PaymentEventStream {
     inner: Pin<Box<dyn Stream<Item = cdk_common::payment::Event> + Send>>,
@@ -85,12 +57,12 @@ impl Drop for PaymentEventStream {
 }
 
 /// Payment Processor
-#[derive(Clone)]
 pub struct PaymentProcessorServer {
     service: PaymentProcessorService,
     socket_addr: SocketAddr,
-    shutdown: Arc<Notify>,
-    handle: Option<Arc<JoinHandle<anyhow::Result<()>>>>,
+    shutdown: Option<CancellationToken>,
+    handle: Option<JoinHandle<anyhow::Result<()>>>,
+    backend_started: bool,
 }
 
 impl std::fmt::Debug for PaymentProcessorServer {
@@ -108,13 +80,23 @@ impl PaymentProcessorServer {
         Ok(Self {
             service: PaymentProcessorService::new(payment_processor),
             socket_addr,
-            shutdown: Arc::new(Notify::new()),
+            shutdown: None,
             handle: None,
+            backend_started: false,
         })
+    }
+
+    /// Return the address on which the server is configured or currently listening.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.socket_addr
     }
 
     /// Start the payment processor gRPC server.
     pub async fn start(&mut self, tls_dir: Option<PathBuf>) -> anyhow::Result<()> {
+        if self.handle.is_some() || self.backend_started {
+            anyhow::bail!("Payment processor server is already running");
+        }
+
         tracing::info!("Starting RPC server {}", self.socket_addr);
 
         let server = match tls_dir {
@@ -181,57 +163,65 @@ impl PaymentProcessorServer {
             }
         };
 
+        let listener = TcpListener::bind(self.socket_addr).await?;
+        self.socket_addr = listener.local_addr()?;
+        let incoming = TcpListenerStream::new(listener);
+
         self.service.start().await?;
+        self.backend_started = true;
 
-        let shutdown = self.shutdown.clone();
-        let addr = self.socket_addr;
-
-        self.handle = Some(Arc::new(tokio::spawn(async move {
-            let server = server.serve_with_shutdown(addr, async {
-                shutdown.notified().await;
-            });
-
-            server.await?;
+        let shutdown = CancellationToken::new();
+        let shutdown_future = shutdown.clone().cancelled_owned();
+        self.shutdown = Some(shutdown);
+        self.handle = Some(tokio::spawn(async move {
+            server
+                .serve_with_incoming_shutdown(incoming, shutdown_future)
+                .await?;
             Ok(())
-        })));
+        }));
 
         Ok(())
     }
 
     /// Stop the payment processor gRPC server.
-    pub async fn stop(&self) -> anyhow::Result<()> {
+    pub async fn stop(&mut self) -> anyhow::Result<()> {
         const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
         self.service.cancel_payment_event_stream();
 
-        if let Some(handle) = &self.handle {
+        if let Some(shutdown) = self.shutdown.take() {
             tracing::info!("Initiating server shutdown");
-            self.shutdown.notify_waiters();
+            shutdown.cancel();
+        }
 
-            let start = Instant::now();
-
-            while !handle.is_finished() {
-                if start.elapsed() >= SHUTDOWN_TIMEOUT {
+        let server_result = match self.handle.take() {
+            Some(mut handle) => match timeout(SHUTDOWN_TIMEOUT, &mut handle).await {
+                Ok(Ok(result)) => result,
+                Ok(Err(error)) => Err(error.into()),
+                Err(_) => {
                     tracing::error!(
                         "Server shutdown timed out after {} seconds, aborting handle",
                         SHUTDOWN_TIMEOUT.as_secs()
                     );
                     handle.abort();
-                    break;
+                    let _ = handle.await;
+                    Err(anyhow::anyhow!(
+                        "Payment processor server shutdown timed out"
+                    ))
                 }
-                sleep(Duration::from_millis(100)).await;
-            }
+            },
+            None => Ok(()),
+        };
 
-            if handle.is_finished() {
-                tracing::info!("Server shutdown completed successfully");
-            }
+        let backend_result = if self.backend_started {
+            self.backend_started = false;
+            self.service.stop().await.map_err(anyhow::Error::from)
         } else {
-            tracing::info!("No server handle found, nothing to stop");
-        }
+            Ok(())
+        };
 
-        self.service.stop().await?;
-
-        Ok(())
+        backend_result?;
+        server_result
     }
 }
 
@@ -239,7 +229,17 @@ impl Drop for PaymentProcessorServer {
     fn drop(&mut self) {
         tracing::debug!("Dropping payment processor server");
         self.service.cancel_payment_event_stream();
-        self.shutdown.notify_one();
+        if let Some(shutdown) = &self.shutdown {
+            shutdown.cancel();
+        }
+        if let Some(handle) = &self.handle {
+            handle.abort();
+        }
+        if self.backend_started {
+            tracing::warn!(
+                "Payment processor server dropped while running; backend stop was not awaited"
+            );
+        }
     }
 }
 
@@ -253,7 +253,7 @@ impl CdkPaymentProcessor for PaymentProcessorService {
             .inner
             .get_settings()
             .await
-            .map_err(|_| Status::internal("Could not get settings"))?;
+            .map_err(payment_error_to_status)?;
 
         Ok(Response::new(SettingsResponse {
             unit: settings.unit,
@@ -345,7 +345,7 @@ impl CdkPaymentProcessor for PaymentProcessorService {
             .inner
             .create_incoming_payment_request(proto_options)
             .await
-            .map_err(|_| Status::internal("Could not create invoice"))?;
+            .map_err(payment_error_to_status)?;
 
         Ok(Response::new(invoice_response.into()))
     }
@@ -453,7 +453,7 @@ impl CdkPaymentProcessor for PaymentProcessorService {
             .await
             .map_err(|err| {
                 tracing::error!("Could not get payment quote: {}", err);
-                Status::internal("Could not get quote")
+                payment_error_to_status(err)
             })?;
 
         Ok(Response::new(payment_quote.into()))
@@ -575,16 +575,7 @@ impl CdkPaymentProcessor for PaymentProcessorService {
             .await
             .map_err(|err| {
                 tracing::error!("Could not make payment: {}", err);
-
-                match err {
-                    cdk_common::payment::Error::InvoiceAlreadyPaid => {
-                        Status::already_exists("Payment request already paid")
-                    }
-                    cdk_common::payment::Error::InvoicePaymentPending => {
-                        Status::aborted("Payment request pending")
-                    }
-                    _ => Status::internal("Could not pay invoice"),
-                }
+                payment_error_to_status(err)
             })?;
 
         Ok(Response::new(pay_response.into()))
@@ -606,7 +597,7 @@ impl CdkPaymentProcessor for PaymentProcessorService {
             .inner
             .check_incoming_payment_status(&payment_identifier)
             .await
-            .map_err(|_| Status::internal("Could not check incoming payment status"))?;
+            .map_err(payment_error_to_status)?;
 
         Ok(Response::new(CheckIncomingPaymentResponse {
             payments: check_responses.into_iter().map(|r| r.into()).collect(),
@@ -629,7 +620,7 @@ impl CdkPaymentProcessor for PaymentProcessorService {
             .inner
             .check_outgoing_payment(&payment_identifier)
             .await
-            .map_err(|_| Status::internal("Could not check outgoing payment status"))?;
+            .map_err(payment_error_to_status)?;
 
         Ok(Response::new(check_response.into()))
     }
@@ -645,7 +636,7 @@ impl CdkPaymentProcessor for PaymentProcessorService {
         tracing::debug!("Server waiting for payment stream");
         let stream = self.inner.wait_payment_event().await.map_err(|err| {
             tracing::warn!("Could not get payment event stream: {}", err);
-            Status::internal("Could not get payment event stream")
+            payment_error_to_status(err)
         })?;
         let output_stream = PaymentEventStream {
             inner: stream,

--- a/crates/cdk-payment-processor/src/proto/server.rs
+++ b/crates/cdk-payment-processor/src/proto/server.rs
@@ -90,7 +90,7 @@ impl Drop for PaymentProcessorServerInner {
     }
 }
 
-/// Clonable handle to a payment processor gRPC server.
+/// Cloneable handle to a payment processor gRPC server.
 ///
 /// Clones share the same listener address, server task, shutdown state, and
 /// backend lifecycle.

--- a/crates/cdk-payment-processor/src/proto/service.rs
+++ b/crates/cdk-payment-processor/src/proto/service.rs
@@ -1,0 +1,31 @@
+use cdk_common::payment::DynMintPayment;
+
+#[derive(Clone)]
+pub(crate) struct PaymentProcessorService {
+    pub(super) inner: DynMintPayment,
+}
+
+impl std::fmt::Debug for PaymentProcessorService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PaymentProcessorService")
+            .finish_non_exhaustive()
+    }
+}
+
+impl PaymentProcessorService {
+    pub(crate) fn new(inner: DynMintPayment) -> Self {
+        Self { inner }
+    }
+
+    pub(crate) async fn start(&self) -> Result<(), cdk_common::payment::Error> {
+        self.inner.start().await
+    }
+
+    pub(crate) async fn stop(&self) -> Result<(), cdk_common::payment::Error> {
+        self.inner.stop().await
+    }
+
+    pub(crate) fn cancel_payment_event_stream(&self) {
+        self.inner.cancel_payment_event_stream();
+    }
+}

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -891,6 +891,15 @@ impl Mint {
                                     }
                                 }
                             }
+
+                            // The payment event stream ended unexpectedly.
+                            // Back off before re-subscribing so a backend that
+                            // repeatedly ends its stream does not cause a tight
+                            // reconnect loop.
+                            tracing::warn!(
+                                "Payment event stream ended unexpectedly, re-subscribing"
+                            );
+                            tokio::time::sleep(Duration::from_secs(5)).await;
                         }
 
                         Err(e) => {


### PR DESCRIPTION
### Description
This branch hardens and standardizes the remote payment-processor integration while keeping `MintPayment` as the internal interface.

- Adds the three required proto fields for existing custom payment methods.
- Preserves optional JSON data and safely handles malformed responses.
- Propagates typed payment errors through gRPC status metadata with legacy fallback.
- Improves server startup, shared lifecycle state, shutdown, bind-error handling, and ephemeral-port support.
- Replaces channel-based event forwarding with direct, cancellation-aware streaming.
- Removes a cancellation-token race in the remote client.
- Consolidates mintd backend and metrics wrapping.
- Prevents unused payment-processor backend features from being pulled into mintd.
- Adds tests for custom payments, remote streaming, error propagation, lifecycle handling, and bind failures.


<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
