### PR TITLE
fix(nix): avoid copying build outputs from JJ workspaces

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -208,6 +208,16 @@
           if static_toolchain != null then (crane.mkLib pkgs).overrideToolchain static_toolchain else null;
         craneLibNightly = (crane.mkLib pkgs).overrideToolchain nightly_toolchain;
 
+        # Include only checked-in fuzzing inputs. Using ./fuzz directly would also
+        # copy generated directories such as fuzz/target, corpus, and artifacts.
+        fuzzSrc = lib.fileset.unions [
+          ./fuzz/Cargo.toml
+          ./fuzz/Cargo.lock
+          ./fuzz/fuzz_targets
+          ./fuzz/seeds
+          ./fuzz/src
+        ];
+
         # Source for crane builds - uses lib.fileset for efficient filtering
         # This is much faster than nix-gitignore when large directories (like target/) exist
         # because it uses a whitelist approach rather than scanning everything first
@@ -224,7 +234,7 @@
               ./README.md
               ./.cargo
               ./crates
-              ./fuzz
+              fuzzSrc
               ./bindings
             ]
           );
@@ -245,7 +255,7 @@
               ./README.md
               ./.cargo
               ./crates
-              ./fuzz
+              fuzzSrc
               ./bindings
             ]
           );

--- a/justfile
+++ b/justfile
@@ -7,6 +7,41 @@ alias t := test
 default:
   @just --list
 
+# Enter a Nix development shell without copying ignored files from JJ workspaces.
+develop shell="stable":
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  shell_name={{quote(shell)}}
+  case "$shell_name" in
+    ""|*[!a-zA-Z0-9._-]*)
+      echo "Error: invalid development shell name: $shell_name" >&2
+      exit 2
+      ;;
+  esac
+
+  flake_ref=".#${shell_name}"
+  if command -v jj >/dev/null 2>&1 && jj root >/dev/null 2>&1; then
+    revision=$(jj log -r @ --no-graph -T commit_id)
+
+    if git_dir=$(jj git root 2>/dev/null); then
+      case "$git_dir" in
+        */.git)
+          git_source=${git_dir%/.git}
+          ;;
+        *)
+          git_source=$git_dir
+          ;;
+      esac
+
+      flake_ref="git+file://${git_source}?rev=${revision}#${shell_name}"
+    else
+      echo "Warning: JJ repository is not Git-backed; using the workspace path." >&2
+    fi
+  fi
+
+  exec nix develop "$flake_ref" -c "${SHELL:-bash}"
+
 # Create a new SQL migration file
 new-migration target name:
   #!/usr/bin/env bash


### PR DESCRIPTION
Resolve development shells through the shared Git backing store at the current JJ commit, while retaining the normal local flake path for Git repositories.

Restrict Crane fuzz sources to manifests, harnesses, seeds, and shared code so generated targets, corpora, and artifacts are excluded.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
