### PR TITLE
Authenticate protected websocket connections in-band

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,6 +1545,7 @@ version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "bip39",
  "bitcoin",
  "bitcoincore-rpc",

--- a/crates/cashu/src/nuts/nut17/ws.rs
+++ b/crates/cashu/src/nuts/nut17/ws.rs
@@ -69,6 +69,14 @@ pub struct RawNotificationInner<I> {
     pub payload: serde_json::Value,
 }
 
+/// The response to an authenticate request (NUT-22)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "UPPERCASE")]
+pub enum WsAuthenticateResponse {
+    /// Authentication succeeded
+    Ok,
+}
+
 /// Responses from the web socket server
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "I: Serialize + DeserializeOwned")]
@@ -78,6 +86,12 @@ pub enum WsResponseResult<I> {
     Subscribe(WsSubscribeResponse<I>),
     /// Unsubscribe
     Unsubscribe(WsUnsubscribeResponse<I>),
+    /// A response to an authenticate request
+    ///
+    /// Declared last so untagged deserialization tries the subscribe and
+    /// unsubscribe variants first: both require a `subId`, so a body without
+    /// one only matches here.
+    Authenticate(WsAuthenticateResponse),
 }
 
 impl<I> From<WsSubscribeResponse<I>> for WsResponseResult<I> {
@@ -92,6 +106,12 @@ impl<I> From<WsUnsubscribeResponse<I>> for WsResponseResult<I> {
     }
 }
 
+impl<I> From<WsAuthenticateResponse> for WsResponseResult<I> {
+    fn from(response: WsAuthenticateResponse) -> Self {
+        WsResponseResult::Authenticate(response)
+    }
+}
+
 /// The request to unsubscribe
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "I: Serialize + DeserializeOwned")]
@@ -99,6 +119,17 @@ pub struct WsUnsubscribeRequest<I> {
     /// Subscription ID
     #[serde(rename = "subId")]
     pub sub_id: I,
+}
+
+/// The request to authenticate a connection (NUT-22)
+///
+/// Carries a blind authentication token (BAT), the serialized `authA...`
+/// string, so browser wallets can authenticate a protected connection in-band
+/// (the WebSocket API cannot set the `Blind-auth` header).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WsAuthenticateRequest {
+    /// The blind authentication token
+    pub token: String,
 }
 
 /// The inner method of the websocket request
@@ -110,6 +141,8 @@ pub enum WsMethodRequest<I> {
     Subscribe(Params<I>),
     /// Unsubscribe method
     Unsubscribe(WsUnsubscribeRequest<I>),
+    /// Authenticate method (NUT-22)
+    Authenticate(WsAuthenticateRequest),
 }
 
 /// Websocket request
@@ -257,5 +290,48 @@ mod tests {
             }
             other => panic!("expected notification, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn authenticate_request_round_trips() {
+        let request: WsRequest<String> = (
+            WsMethodRequest::Authenticate(WsAuthenticateRequest {
+                token: "authAeyJ0ZXN0IjoxfQ".to_string(),
+            }),
+            0,
+        )
+            .into();
+
+        let json = serde_json::to_value(&request).expect("serialize authenticate");
+        assert_eq!(json["method"], "authenticate");
+        assert_eq!(json["params"]["token"], "authAeyJ0ZXN0IjoxfQ");
+        assert_eq!(json["id"], 0);
+
+        let decoded: WsRequest<String> =
+            serde_json::from_value(json).expect("deserialize authenticate");
+        match decoded.method {
+            WsMethodRequest::Authenticate(req) => assert_eq!(req.token, "authAeyJ0ZXN0IjoxfQ"),
+            other => panic!("expected authenticate, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn authenticate_response_is_distinct_from_subscribe() {
+        // An authenticate OK body has no subId, so untagged decoding must not
+        // mistake it for a subscribe/unsubscribe response.
+        let decoded: WsResponseResult<String> =
+            serde_json::from_str(r#"{"status":"OK"}"#).expect("authenticate response");
+        assert!(matches!(decoded, WsResponseResult::Authenticate(_)));
+
+        let decoded: WsResponseResult<String> =
+            serde_json::from_str(r#"{"status":"OK","subId":"sub-1"}"#).expect("subscribe response");
+        assert!(matches!(decoded, WsResponseResult::Subscribe(_)));
+    }
+
+    #[test]
+    fn authenticate_response_serializes_with_status_ok() {
+        let result: WsResponseResult<String> = WsAuthenticateResponse::Ok.into();
+        let json = serde_json::to_value(&result).expect("serialize authenticate response");
+        assert_eq!(json, serde_json::json!({ "status": "OK" }));
     }
 }

--- a/crates/cashu/src/nuts/nut17/ws.rs
+++ b/crates/cashu/src/nuts/nut17/ws.rs
@@ -15,7 +15,7 @@ pub const JSON_RPC_VERSION: &str = "2.0";
 /// request they sent.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound = "I: Serialize + DeserializeOwned")]
-pub struct WsResponseResult<I> {
+pub struct WsSubscriptionResult<I> {
     /// Status
     pub status: String,
     /// Subscription ID
@@ -62,6 +62,40 @@ pub struct RawNotificationInner<I> {
     pub payload: serde_json::Value,
 }
 
+/// The response to an authenticate request (NUT-22)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "UPPERCASE")]
+pub enum WsAuthenticateResponse {
+    /// Authentication succeeded
+    Ok,
+}
+
+/// Responses from the web socket server
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "I: Serialize + DeserializeOwned")]
+#[serde(untagged)]
+pub enum WsResponseResult<I> {
+    /// A response to a subscribe or unsubscribe request
+    Subscription(WsSubscriptionResult<I>),
+    /// A response to an authenticate request
+    ///
+    /// Declared last so untagged deserialization tries the subscription variant
+    /// first: it requires a `subId`, so a body without one only matches here.
+    Authenticate(WsAuthenticateResponse),
+}
+
+impl<I> From<WsSubscriptionResult<I>> for WsResponseResult<I> {
+    fn from(response: WsSubscriptionResult<I>) -> Self {
+        WsResponseResult::Subscription(response)
+    }
+}
+
+impl<I> From<WsAuthenticateResponse> for WsResponseResult<I> {
+    fn from(response: WsAuthenticateResponse) -> Self {
+        WsResponseResult::Authenticate(response)
+    }
+}
+
 /// The request to unsubscribe
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "I: Serialize + DeserializeOwned")]
@@ -69,6 +103,17 @@ pub struct WsUnsubscribeRequest<I> {
     /// Subscription ID
     #[serde(rename = "subId")]
     pub sub_id: I,
+}
+
+/// The request to authenticate a connection (NUT-22)
+///
+/// Carries a blind authentication token (BAT), the serialized `authA...`
+/// string, so browser wallets can authenticate a protected connection in-band
+/// (the WebSocket API cannot set the `Blind-auth` header).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WsAuthenticateRequest {
+    /// The blind authentication token
+    pub token: String,
 }
 
 /// The inner method of the websocket request
@@ -80,6 +125,8 @@ pub enum WsMethodRequest<I> {
     Subscribe(Params<I>),
     /// Unsubscribe method
     Unsubscribe(WsUnsubscribeRequest<I>),
+    /// Authenticate method (NUT-22)
+    Authenticate(WsAuthenticateRequest),
 }
 
 /// Websocket request
@@ -222,10 +269,10 @@ mod tests {
         assert_eq!(decoded.id, 7);
         assert_eq!(
             decoded.result,
-            WsResponseResult {
+            WsResponseResult::Subscription(WsSubscriptionResult {
                 status: "OK".to_string(),
                 sub_id: "sub-id".to_string(),
-            }
+            })
         );
         assert_eq!(
             serde_json::to_value(decoded).expect("serialized NUT-17 response"),
@@ -257,5 +304,46 @@ mod tests {
             }
             other => panic!("expected notification, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn authenticate_request_round_trips() {
+        let request: WsRequest<String> = (
+            WsMethodRequest::Authenticate(WsAuthenticateRequest {
+                token: "authAeyJ0ZXN0IjoxfQ".to_string(),
+            }),
+            0,
+        )
+            .into();
+
+        let json = serde_json::to_value(&request).expect("serialize authenticate");
+        assert_eq!(json["method"], "authenticate");
+        assert_eq!(json["params"]["token"], "authAeyJ0ZXN0IjoxfQ");
+        assert_eq!(json["id"], 0);
+
+        let decoded: WsRequest<String> =
+            serde_json::from_value(json).expect("deserialize authenticate");
+        match decoded.method {
+            WsMethodRequest::Authenticate(req) => assert_eq!(req.token, "authAeyJ0ZXN0IjoxfQ"),
+            other => panic!("expected authenticate, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn authenticate_response_is_distinct_from_subscribe() {
+        let decoded: WsResponseResult<String> =
+            serde_json::from_str(r#"{"status":"OK"}"#).expect("authenticate response");
+        assert!(matches!(decoded, WsResponseResult::Authenticate(_)));
+
+        let decoded: WsResponseResult<String> =
+            serde_json::from_str(r#"{"status":"OK","subId":"sub-1"}"#).expect("subscribe response");
+        assert!(matches!(decoded, WsResponseResult::Subscription(_)));
+    }
+
+    #[test]
+    fn authenticate_response_serializes_with_status_ok() {
+        let result: WsResponseResult<String> = WsAuthenticateResponse::Ok.into();
+        let json = serde_json::to_value(&result).expect("serialize authenticate response");
+        assert_eq!(json, serde_json::json!({ "status": "OK" }));
     }
 }

--- a/crates/cdk-axum/src/router_handlers.rs
+++ b/crates/cdk-axum/src/router_handlers.rs
@@ -6,7 +6,7 @@ use axum::response::{IntoResponse, Response};
 use cdk::error::ErrorResponse;
 use cdk::nuts::nut21::{Method, ProtectedEndpoint, RoutePath};
 use cdk::nuts::{
-    CheckStateRequest, CheckStateResponse, Id, KeysResponse, KeysetResponse, MintInfo,
+    AuthToken, CheckStateRequest, CheckStateResponse, Id, KeysResponse, KeysetResponse, MintInfo,
     RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
 };
 use cdk::util::unix_time;
@@ -129,16 +129,33 @@ pub(crate) async fn ws_handler(
     State(state): State<MintState>,
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, Response> {
-    state
-        .mint
-        .verify_auth(
-            auth.into(),
-            &ProtectedEndpoint::new(Method::Get, RoutePath::Ws),
-        )
-        .await
-        .map_err(into_response)?;
+    let endpoint = ProtectedEndpoint::new(Method::Get, RoutePath::Ws);
+    let token: Option<AuthToken> = auth.into();
 
-    Ok(ws.on_upgrade(|ws| main_websocket(ws, state)))
+    // A browser WebSocket cannot set the `Blind-auth` header, so a header-less
+    // upgrade to a protected endpoint is allowed and deferred to the in-band
+    // NUT-22 `authenticate` command instead of being rejected here.
+    let authenticated = match state
+        .mint
+        .is_protected(&endpoint)
+        .await
+        .map_err(into_response)?
+    {
+        None => true,
+        Some(_) => match token {
+            Some(token) => {
+                state
+                    .mint
+                    .verify_auth(Some(token), &endpoint)
+                    .await
+                    .map_err(into_response)?;
+                true
+            }
+            None => false,
+        },
+    };
+
+    Ok(ws.on_upgrade(move |ws| main_websocket(ws, state, authenticated)))
 }
 
 /// Check whether a proof is spent already or is pending in a transaction

--- a/crates/cdk-axum/src/router_handlers.rs
+++ b/crates/cdk-axum/src/router_handlers.rs
@@ -6,8 +6,8 @@ use axum::response::{IntoResponse, Response};
 use cdk::error::ErrorResponse;
 use cdk::nuts::nut21::{Method, ProtectedEndpoint, RoutePath};
 use cdk::nuts::{
-    AuthToken, CheckStateRequest, CheckStateResponse, Id, KeysResponse, KeysetResponse, MintInfo,
-    RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
+    AuthRequired, AuthToken, CheckStateRequest, CheckStateResponse, Id, KeysResponse,
+    KeysetResponse, MintInfo, RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
 };
 use cdk::util::unix_time;
 use paste::paste;
@@ -123,6 +123,14 @@ pub(crate) async fn get_keysets(
     Ok(Json(state.mint.keysets()))
 }
 
+/// Upgrade a websocket connection, authenticating it when the endpoint is
+/// protected.
+///
+/// A browser WebSocket cannot set the `Blind-auth` header, so a header-less
+/// upgrade to a blind-protected endpoint is deferred to the in-band NUT-22
+/// `authenticate` command instead of being rejected here. Clear auth has no
+/// in-band command, so it stays a header check and a missing token is refused
+/// at the upgrade.
 #[instrument(skip_all)]
 pub(crate) async fn ws_handler(
     auth: AuthHeader,
@@ -132,9 +140,6 @@ pub(crate) async fn ws_handler(
     let endpoint = ProtectedEndpoint::new(Method::Get, RoutePath::Ws);
     let token: Option<AuthToken> = auth.into();
 
-    // A browser WebSocket cannot set the `Blind-auth` header, so a header-less
-    // upgrade to a protected endpoint is allowed and deferred to the in-band
-    // NUT-22 `authenticate` command instead of being rejected here.
     let authenticated = match state
         .mint
         .is_protected(&endpoint)
@@ -142,7 +147,7 @@ pub(crate) async fn ws_handler(
         .map_err(into_response)?
     {
         None => true,
-        Some(_) => match token {
+        Some(AuthRequired::Blind) => match token {
             Some(token) => {
                 state
                     .mint
@@ -153,6 +158,14 @@ pub(crate) async fn ws_handler(
             }
             None => false,
         },
+        Some(AuthRequired::Clear) => {
+            state
+                .mint
+                .verify_auth(token, &endpoint)
+                .await
+                .map_err(into_response)?;
+            true
+        }
     };
 
     Ok(ws.on_upgrade(move |ws| main_websocket(ws, state, authenticated)))

--- a/crates/cdk-axum/src/router_handlers.rs
+++ b/crates/cdk-axum/src/router_handlers.rs
@@ -123,6 +123,13 @@ pub(crate) async fn get_keysets(
     Ok(Json(state.mint.keysets()))
 }
 
+/// Largest websocket frame the mint will buffer.
+///
+/// Comfortably above the biggest legitimate request (a subscribe carrying the
+/// maximum number of filters) while keeping an unauthenticated connection from
+/// making the mint hold megabytes on its behalf.
+const MAX_WS_MESSAGE_SIZE: usize = 1024 * 1024;
+
 /// Upgrade a websocket connection, authenticating it when the endpoint is
 /// protected.
 ///
@@ -167,6 +174,10 @@ pub(crate) async fn ws_handler(
             true
         }
     };
+
+    let ws = ws
+        .max_message_size(MAX_WS_MESSAGE_SIZE)
+        .max_frame_size(MAX_WS_MESSAGE_SIZE);
 
     Ok(ws.on_upgrade(move |ws| main_websocket(ws, state, authenticated)))
 }

--- a/crates/cdk-axum/src/ws/authenticate.rs
+++ b/crates/cdk-axum/src/ws/authenticate.rs
@@ -1,0 +1,47 @@
+use std::str::FromStr;
+
+use cdk::error::ErrorCode;
+use cdk::nuts::nut21::{Method, ProtectedEndpoint, RoutePath};
+use cdk::nuts::{AuthToken, BlindAuthToken};
+use cdk::ws::{WsAuthenticateRequest, WsAuthenticateResponse, WsResponseResult};
+
+use super::{WsContext, WsError};
+
+/// Handle a NUT-22 `authenticate` command.
+///
+/// Verifies and spends the blind authentication token, then marks the whole
+/// connection authenticated for its lifetime. A single BAT authenticates the
+/// connection; later commands do not consume additional tokens.
+pub(crate) async fn handle(
+    context: &mut WsContext,
+    req: WsAuthenticateRequest,
+) -> Result<WsResponseResult, WsError> {
+    // A single BAT authenticates the connection for its lifetime (NUT-22), so a
+    // repeat authenticate is a no-op and must not spend another token.
+    if context.authenticated {
+        return Ok(WsAuthenticateResponse::Ok.into());
+    }
+
+    let token = BlindAuthToken::from_str(&req.token).map_err(|_| blind_auth_failed())?;
+
+    context
+        .state
+        .mint
+        .verify_auth(
+            Some(AuthToken::BlindAuth(token)),
+            &ProtectedEndpoint::new(Method::Get, RoutePath::Ws),
+        )
+        .await
+        .map_err(|_| blind_auth_failed())?;
+
+    context.authenticated = true;
+
+    Ok(WsAuthenticateResponse::Ok.into())
+}
+
+fn blind_auth_failed() -> WsError {
+    WsError::ServerError(
+        ErrorCode::BlindAuthFailed.to_code() as i32,
+        "Blind authentication failed".to_string(),
+    )
+}

--- a/crates/cdk-axum/src/ws/authenticate.rs
+++ b/crates/cdk-axum/src/ws/authenticate.rs
@@ -6,12 +6,17 @@ use cdk::nuts::{AuthToken, BlindAuthToken};
 use cdk::ws::{WsAuthenticateRequest, WsAuthenticateResponse, WsResponseResult};
 
 use super::{WsContext, WsError};
+use crate::MintState;
 
 /// Handle a NUT-22 `authenticate` command.
 ///
 /// Verifies and spends the blind authentication token, then marks the whole
 /// connection authenticated for its lifetime. A single BAT authenticates the
 /// connection; later commands do not consume additional tokens.
+///
+/// Every rejected token costs a full signature verification on a connection
+/// nobody has paid for yet, so failures are counted and the caller closes the
+/// connection once too many pile up.
 pub(crate) async fn handle(
     context: &mut WsContext,
     req: WsAuthenticateRequest,
@@ -22,21 +27,29 @@ pub(crate) async fn handle(
         return Ok(WsAuthenticateResponse::Ok.into());
     }
 
+    match verify(&context.state, req).await {
+        Ok(()) => {
+            context.authenticated = true;
+            Ok(WsAuthenticateResponse::Ok.into())
+        }
+        Err(err) => {
+            context.failed_auth_attempts += 1;
+            Err(err)
+        }
+    }
+}
+
+async fn verify(state: &MintState, req: WsAuthenticateRequest) -> Result<(), WsError> {
     let token = BlindAuthToken::from_str(&req.token).map_err(|_| blind_auth_failed())?;
 
-    context
-        .state
+    state
         .mint
         .verify_auth(
             Some(AuthToken::BlindAuth(token)),
             &ProtectedEndpoint::new(Method::Get, RoutePath::Ws),
         )
         .await
-        .map_err(|_| blind_auth_failed())?;
-
-    context.authenticated = true;
-
-    Ok(WsAuthenticateResponse::Ok.into())
+        .map_err(|_| blind_auth_failed())
 }
 
 fn blind_auth_failed() -> WsError {

--- a/crates/cdk-axum/src/ws/mod.rs
+++ b/crates/cdk-axum/src/ws/mod.rs
@@ -109,10 +109,13 @@ pub async fn main_websocket(mut socket: WebSocket, state: MintState, authenticat
             // authenticated connections are never closed by it.
             () = &mut auth_timeout, if !context.authenticated => {
                 tracing::info!("Closing websocket: no authentication within timeout");
-                let _ = socket.send(Message::Close(Some(CloseFrame {
+                // Best effort: the connection is dropped either way.
+                if let Err(err) = socket.send(Message::Close(Some(CloseFrame {
                     code: axum::extract::ws::close_code::POLICY,
                     reason: "authentication required".into(),
-                }))).await;
+                }))).await {
+                    tracing::debug!("Could not send close frame: {}", err);
+                }
                 break;
             }
             Some((sub_id, payload)) = subscriber.recv() => {

--- a/crates/cdk-axum/src/ws/mod.rs
+++ b/crates/cdk-axum/src/ws/mod.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::extract::ws::{CloseFrame, Message, WebSocket};
+use cdk::error::ErrorCode;
 use cdk::mint::QuoteId;
 use cdk::nuts::nut17::NotificationPayload;
 use cdk::subscription::SubId;
@@ -15,6 +17,7 @@ use tokio::sync::mpsc;
 
 use crate::MintState;
 
+mod authenticate;
 mod error;
 mod subscribe;
 mod unsubscribe;
@@ -22,13 +25,37 @@ mod unsubscribe;
 pub(crate) const MAX_SUBSCRIPTIONS_PER_CONNECTION: usize = 100;
 pub(crate) const MAX_FILTERS_PER_SUBSCRIPTION: usize = 1000;
 
+/// How long a connection that requires blind auth may stay open without
+/// authenticating before the mint closes it (NUT-22 SHOULD).
+const AUTH_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn blind_auth_required() -> WsError {
+    WsError::ServerError(
+        ErrorCode::BlindAuthRequired.to_code() as i32,
+        "Endpoint requires blind auth".to_string(),
+    )
+}
+
 async fn process(
     context: &mut WsContext,
     body: WsRequest,
 ) -> Result<serde_json::Value, serde_json::Error> {
     let response = match body.method {
-        WsMethodRequest::Subscribe(sub) => subscribe::handle(context, sub).await,
-        WsMethodRequest::Unsubscribe(unsub) => unsubscribe::handle(context, unsub).await,
+        WsMethodRequest::Authenticate(req) => authenticate::handle(context, req).await,
+        WsMethodRequest::Subscribe(sub) => {
+            if context.authenticated {
+                subscribe::handle(context, sub).await
+            } else {
+                Err(blind_auth_required())
+            }
+        }
+        WsMethodRequest::Unsubscribe(unsub) => {
+            if context.authenticated {
+                unsubscribe::handle(context, unsub).await
+            } else {
+                Err(blind_auth_required())
+            }
+        }
     }
     .map_err(WsErrorBody::from);
 
@@ -43,6 +70,10 @@ pub struct WsContext {
     state: MintState,
     subscriptions: HashMap<Arc<SubId>, tokio::task::JoinHandle<()>>,
     publisher: mpsc::Sender<(Arc<SubId>, NotificationPayload<QuoteId>)>,
+    /// Whether the connection may subscribe. Set at upgrade time for open
+    /// endpoints and header-authenticated connections, or by a successful
+    /// in-band `authenticate` command.
+    authenticated: bool,
 }
 
 impl Drop for WsContext {
@@ -59,16 +90,31 @@ impl Drop for WsContext {
 ///
 /// For simplicity sake this function will spawn tasks for each subscription and
 /// keep them in a hashmap, and will have a single subscriber for all of them.
-pub async fn main_websocket(mut socket: WebSocket, state: MintState) {
+pub async fn main_websocket(mut socket: WebSocket, state: MintState, authenticated: bool) {
     let (publisher, mut subscriber) = mpsc::channel(100);
     let mut context = WsContext {
         state,
         subscriptions: HashMap::new(),
         publisher,
+        authenticated,
     };
+
+    let auth_timeout = tokio::time::sleep(AUTH_TIMEOUT);
+    tokio::pin!(auth_timeout);
 
     loop {
         tokio::select! {
+            // Close connections that never authenticate. The guard disables
+            // this branch once the connection is authenticated, so open and
+            // authenticated connections are never closed by it.
+            () = &mut auth_timeout, if !context.authenticated => {
+                tracing::info!("Closing websocket: no authentication within timeout");
+                let _ = socket.send(Message::Close(Some(CloseFrame {
+                    code: axum::extract::ws::close_code::POLICY,
+                    reason: "authentication required".into(),
+                }))).await;
+                break;
+            }
             Some((sub_id, payload)) = subscriber.recv() => {
                 if !context.subscriptions.contains_key(&sub_id) {
                     // It may be possible an incoming message has come from a dropped Subscriptions that has not yet been
@@ -245,6 +291,10 @@ mod tests {
     }
 
     fn make_context(mint: Arc<Mint>) -> WsContext {
+        make_context_with_auth(mint, true)
+    }
+
+    fn make_context_with_auth(mint: Arc<Mint>, authenticated: bool) -> WsContext {
         let state = MintState {
             mint,
             cache: Arc::new(HttpCache::default()),
@@ -254,6 +304,7 @@ mod tests {
             state,
             subscriptions: HashMap::new(),
             publisher,
+            authenticated,
         }
     }
 
@@ -398,5 +449,104 @@ mod tests {
             "subscription filter count must not be capped by mint max_inputs; got {:?}",
             result.as_ref().err()
         );
+    }
+
+    fn subscribe_request(sub_id: &str) -> WsRequest {
+        WsRequest {
+            jsonrpc: "2.0".to_string(),
+            method: WsMethodRequest::Subscribe(make_params(sub_id)),
+            id: 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_subscribe_is_rejected_with_31001() {
+        let mint = create_test_mint().await;
+        let mut context = make_context_with_auth(mint, false);
+
+        let response = process(&mut context, subscribe_request("sub-unauth"))
+            .await
+            .expect("process serializes");
+
+        assert_eq!(response["error"]["code"], 31001);
+        assert!(
+            context.subscriptions.is_empty(),
+            "a rejected subscribe must not register a subscription"
+        );
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_unsubscribe_is_rejected_with_31001() {
+        let mint = create_test_mint().await;
+        let mut context = make_context_with_auth(mint, false);
+
+        let request = WsRequest {
+            jsonrpc: "2.0".to_string(),
+            method: WsMethodRequest::Unsubscribe(WsUnsubscribeRequest {
+                sub_id: Arc::new(SubId::from("sub-unauth")),
+            }),
+            id: 2,
+        };
+
+        let response = process(&mut context, request)
+            .await
+            .expect("process serializes");
+
+        assert_eq!(response["error"]["code"], 31001);
+    }
+
+    #[tokio::test]
+    async fn authenticate_with_garbage_token_returns_31002() {
+        let mint = create_test_mint().await;
+        let mut context = make_context_with_auth(mint, false);
+
+        let err = authenticate::handle(
+            &mut context,
+            cdk::ws::WsAuthenticateRequest {
+                token: "not-a-valid-bat".to_string(),
+            },
+        )
+        .await
+        .expect_err("garbage token must fail");
+
+        let body = cdk::ws::WsErrorBody::from(err);
+        assert_eq!(body.code, 31002);
+        assert!(
+            !context.authenticated,
+            "a failed authenticate must not authenticate the connection"
+        );
+    }
+
+    #[tokio::test]
+    async fn authenticated_subscribe_is_accepted() {
+        let mint = create_test_mint().await;
+        let mut context = make_context_with_auth(mint, true);
+
+        let response = process(&mut context, subscribe_request("sub-authed"))
+            .await
+            .expect("process serializes");
+
+        assert_eq!(response["result"]["status"], "OK");
+    }
+
+    #[tokio::test]
+    async fn authenticate_is_idempotent_when_already_authenticated() {
+        let mint = create_test_mint().await;
+        let mut context = make_context_with_auth(mint, true);
+
+        // Even an invalid token succeeds: an already-authenticated connection
+        // must short-circuit before any parse/verify/burn, so a repeat
+        // authenticate never spends a second BAT.
+        let result = authenticate::handle(
+            &mut context,
+            cdk::ws::WsAuthenticateRequest {
+                token: "not-a-valid-bat".to_string(),
+            },
+        )
+        .await
+        .expect("repeat authenticate on an authenticated connection is a no-op");
+
+        assert!(matches!(result, cdk::ws::WsResponseResult::Authenticate(_)));
+        assert!(context.authenticated);
     }
 }

--- a/crates/cdk-axum/src/ws/mod.rs
+++ b/crates/cdk-axum/src/ws/mod.rs
@@ -29,6 +29,15 @@ pub(crate) const MAX_FILTERS_PER_SUBSCRIPTION: usize = 1000;
 /// authenticating before the mint closes it (NUT-22 SHOULD).
 const AUTH_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// How many rejected `authenticate` commands a connection may make before the
+/// mint closes it.
+///
+/// Verifying a blind auth token costs an elliptic curve verification, and until
+/// the connection authenticates nobody has paid for it. Without a cap a single
+/// socket could burn that work in a loop for the whole [`AUTH_TIMEOUT`] window.
+/// The allowance is above one so a client that races a stale token can retry.
+const MAX_FAILED_AUTH_ATTEMPTS: usize = 3;
+
 fn blind_auth_required() -> WsError {
     WsError::ServerError(
         ErrorCode::BlindAuthRequired.to_code() as i32,
@@ -66,6 +75,19 @@ async fn process(
 
 pub use error::WsError;
 
+/// Send a policy close frame. Best effort: the connection is dropped either way.
+async fn close(socket: &mut WebSocket, reason: &'static str) {
+    if let Err(err) = socket
+        .send(Message::Close(Some(CloseFrame {
+            code: axum::extract::ws::close_code::POLICY,
+            reason: reason.into(),
+        })))
+        .await
+    {
+        tracing::debug!("Could not send close frame: {}", err);
+    }
+}
+
 pub struct WsContext {
     state: MintState,
     subscriptions: HashMap<Arc<SubId>, tokio::task::JoinHandle<()>>,
@@ -74,6 +96,9 @@ pub struct WsContext {
     /// endpoints and header-authenticated connections, or by a successful
     /// in-band `authenticate` command.
     authenticated: bool,
+    /// Rejected in-band `authenticate` commands so far, bounded by
+    /// [`MAX_FAILED_AUTH_ATTEMPTS`].
+    failed_auth_attempts: usize,
 }
 
 impl Drop for WsContext {
@@ -97,6 +122,7 @@ pub async fn main_websocket(mut socket: WebSocket, state: MintState, authenticat
         subscriptions: HashMap::new(),
         publisher,
         authenticated,
+        failed_auth_attempts: 0,
     };
 
     let auth_timeout = tokio::time::sleep(AUTH_TIMEOUT);
@@ -109,13 +135,7 @@ pub async fn main_websocket(mut socket: WebSocket, state: MintState, authenticat
             // authenticated connections are never closed by it.
             () = &mut auth_timeout, if !context.authenticated => {
                 tracing::info!("Closing websocket: no authentication within timeout");
-                // Best effort: the connection is dropped either way.
-                if let Err(err) = socket.send(Message::Close(Some(CloseFrame {
-                    code: axum::extract::ws::close_code::POLICY,
-                    reason: "authentication required".into(),
-                }))).await {
-                    tracing::debug!("Could not send close frame: {}", err);
-                }
+                close(&mut socket, "authentication required").await;
                 break;
             }
             Some((sub_id, payload)) = subscriber.recv() => {
@@ -196,6 +216,12 @@ pub async fn main_websocket(mut socket: WebSocket, state: MintState, authenticat
                             .await
                         {
                             tracing::error!("Could not send request: {}", err);
+                            break;
+                        }
+
+                        if context.failed_auth_attempts >= MAX_FAILED_AUTH_ATTEMPTS {
+                            tracing::info!("Closing websocket: too many failed authentications");
+                            close(&mut socket, "authentication failed").await;
                             break;
                         }
                     }
@@ -308,6 +334,7 @@ mod tests {
             subscriptions: HashMap::new(),
             publisher,
             authenticated,
+            failed_auth_attempts: 0,
         }
     }
 
@@ -530,6 +557,55 @@ mod tests {
             .expect("process serializes");
 
         assert_eq!(response["result"]["status"], "OK");
+    }
+
+    #[tokio::test]
+    async fn failed_authenticate_attempts_are_counted_up_to_the_cap() {
+        let mint = create_test_mint().await;
+        let mut context = make_context_with_auth(mint, false);
+
+        for expected in 1..=MAX_FAILED_AUTH_ATTEMPTS {
+            let response = process(
+                &mut context,
+                WsRequest {
+                    jsonrpc: "2.0".to_string(),
+                    method: WsMethodRequest::Authenticate(cdk::ws::WsAuthenticateRequest {
+                        token: "not-a-valid-bat".to_string(),
+                    }),
+                    id: expected,
+                },
+            )
+            .await
+            .expect("process serializes");
+
+            assert_eq!(response["error"]["code"], 31002);
+            assert_eq!(context.failed_auth_attempts, expected);
+        }
+
+        assert!(
+            context.failed_auth_attempts >= MAX_FAILED_AUTH_ATTEMPTS,
+            "the connection must be closable once the cap is reached"
+        );
+    }
+
+    #[tokio::test]
+    async fn repeat_authenticate_on_an_authenticated_connection_is_not_a_failure() {
+        let mint = create_test_mint().await;
+        let mut context = make_context_with_auth(mint, true);
+
+        authenticate::handle(
+            &mut context,
+            cdk::ws::WsAuthenticateRequest {
+                token: "not-a-valid-bat".to_string(),
+            },
+        )
+        .await
+        .expect("no-op");
+
+        assert_eq!(
+            context.failed_auth_attempts, 0,
+            "an already-authenticated connection must not accrue failures"
+        );
     }
 
     #[tokio::test]

--- a/crates/cdk-axum/src/ws/mod.rs
+++ b/crates/cdk-axum/src/ws/mod.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::extract::ws::{CloseFrame, Message, WebSocket};
+use cdk::error::ErrorCode;
 use cdk::mint::QuoteId;
 use cdk::nuts::nut17::NotificationPayload;
 use cdk::subscription::SubId;
@@ -14,6 +16,7 @@ use tokio::sync::mpsc;
 
 use crate::MintState;
 
+mod authenticate;
 mod error;
 mod subscribe;
 mod unsubscribe;
@@ -21,13 +24,37 @@ mod unsubscribe;
 pub(crate) const MAX_SUBSCRIPTIONS_PER_CONNECTION: usize = 100;
 pub(crate) const MAX_FILTERS_PER_SUBSCRIPTION: usize = 1000;
 
+/// How long a connection that requires blind auth may stay open without
+/// authenticating before the mint closes it (NUT-22 SHOULD).
+const AUTH_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn blind_auth_required() -> WsError {
+    WsError::ServerError(
+        ErrorCode::BlindAuthRequired.to_code() as i32,
+        "Endpoint requires blind auth".to_string(),
+    )
+}
+
 async fn process(
     context: &mut WsContext,
     body: WsRequest,
 ) -> Result<serde_json::Value, serde_json::Error> {
     let response = match body.method {
-        WsMethodRequest::Subscribe(sub) => subscribe::handle(context, sub).await,
-        WsMethodRequest::Unsubscribe(unsub) => unsubscribe::handle(context, unsub).await,
+        WsMethodRequest::Authenticate(req) => authenticate::handle(context, req).await,
+        WsMethodRequest::Subscribe(sub) => {
+            if context.authenticated {
+                subscribe::handle(context, sub).await
+            } else {
+                Err(blind_auth_required())
+            }
+        }
+        WsMethodRequest::Unsubscribe(unsub) => {
+            if context.authenticated {
+                unsubscribe::handle(context, unsub).await
+            } else {
+                Err(blind_auth_required())
+            }
+        }
     }
     .map_err(WsErrorBody::from);
 
@@ -42,6 +69,10 @@ pub struct WsContext {
     state: MintState,
     subscriptions: HashMap<Arc<SubId>, tokio::task::JoinHandle<()>>,
     publisher: mpsc::Sender<(Arc<SubId>, NotificationPayload<QuoteId>)>,
+    /// Whether the connection may subscribe. Set at upgrade time for open
+    /// endpoints and header-authenticated connections, or by a successful
+    /// in-band `authenticate` command.
+    authenticated: bool,
 }
 
 impl Drop for WsContext {
@@ -58,16 +89,31 @@ impl Drop for WsContext {
 ///
 /// For simplicity sake this function will spawn tasks for each subscription and
 /// keep them in a hashmap, and will have a single subscriber for all of them.
-pub async fn main_websocket(mut socket: WebSocket, state: MintState) {
+pub async fn main_websocket(mut socket: WebSocket, state: MintState, authenticated: bool) {
     let (publisher, mut subscriber) = mpsc::channel(100);
     let mut context = WsContext {
         state,
         subscriptions: HashMap::new(),
         publisher,
+        authenticated,
     };
+
+    let auth_timeout = tokio::time::sleep(AUTH_TIMEOUT);
+    tokio::pin!(auth_timeout);
 
     loop {
         tokio::select! {
+            // Close connections that never authenticate. The guard disables
+            // this branch once the connection is authenticated, so open and
+            // authenticated connections are never closed by it.
+            () = &mut auth_timeout, if !context.authenticated => {
+                tracing::info!("Closing websocket: no authentication within timeout");
+                let _ = socket.send(Message::Close(Some(CloseFrame {
+                    code: axum::extract::ws::close_code::POLICY,
+                    reason: "authentication required".into(),
+                }))).await;
+                break;
+            }
             Some((sub_id, payload)) = subscriber.recv() => {
                 if !context.subscriptions.contains_key(&sub_id) {
                     // It may be possible an incoming message has come from a dropped Subscriptions that has not yet been
@@ -241,6 +287,10 @@ mod tests {
     }
 
     fn make_context(mint: Arc<Mint>) -> WsContext {
+        make_context_with_auth(mint, true)
+    }
+
+    fn make_context_with_auth(mint: Arc<Mint>, authenticated: bool) -> WsContext {
         let state = MintState {
             mint,
             cache: Arc::new(HttpCache::default()),
@@ -250,6 +300,7 @@ mod tests {
             state,
             subscriptions: HashMap::new(),
             publisher,
+            authenticated,
         }
     }
 
@@ -394,5 +445,104 @@ mod tests {
             "subscription filter count must not be capped by mint max_inputs; got {:?}",
             result.as_ref().err()
         );
+    }
+
+    fn subscribe_request(sub_id: &str) -> WsRequest {
+        WsRequest {
+            jsonrpc: "2.0".to_string(),
+            method: WsMethodRequest::Subscribe(make_params(sub_id)),
+            id: 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_subscribe_is_rejected_with_31001() {
+        let mint = create_test_mint().await;
+        let mut context = make_context_with_auth(mint, false);
+
+        let response = process(&mut context, subscribe_request("sub-unauth"))
+            .await
+            .expect("process serializes");
+
+        assert_eq!(response["error"]["code"], 31001);
+        assert!(
+            context.subscriptions.is_empty(),
+            "a rejected subscribe must not register a subscription"
+        );
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_unsubscribe_is_rejected_with_31001() {
+        let mint = create_test_mint().await;
+        let mut context = make_context_with_auth(mint, false);
+
+        let request = WsRequest {
+            jsonrpc: "2.0".to_string(),
+            method: WsMethodRequest::Unsubscribe(WsUnsubscribeRequest {
+                sub_id: Arc::new(SubId::from("sub-unauth")),
+            }),
+            id: 2,
+        };
+
+        let response = process(&mut context, request)
+            .await
+            .expect("process serializes");
+
+        assert_eq!(response["error"]["code"], 31001);
+    }
+
+    #[tokio::test]
+    async fn authenticate_with_garbage_token_returns_31002() {
+        let mint = create_test_mint().await;
+        let mut context = make_context_with_auth(mint, false);
+
+        let err = authenticate::handle(
+            &mut context,
+            cdk::ws::WsAuthenticateRequest {
+                token: "not-a-valid-bat".to_string(),
+            },
+        )
+        .await
+        .expect_err("garbage token must fail");
+
+        let body = cdk::ws::WsErrorBody::from(err);
+        assert_eq!(body.code, 31002);
+        assert!(
+            !context.authenticated,
+            "a failed authenticate must not authenticate the connection"
+        );
+    }
+
+    #[tokio::test]
+    async fn authenticated_subscribe_is_accepted() {
+        let mint = create_test_mint().await;
+        let mut context = make_context_with_auth(mint, true);
+
+        let response = process(&mut context, subscribe_request("sub-authed"))
+            .await
+            .expect("process serializes");
+
+        assert_eq!(response["result"]["status"], "OK");
+    }
+
+    #[tokio::test]
+    async fn authenticate_is_idempotent_when_already_authenticated() {
+        let mint = create_test_mint().await;
+        let mut context = make_context_with_auth(mint, true);
+
+        // Even an invalid token succeeds: an already-authenticated connection
+        // must short-circuit before any parse/verify/burn, so a repeat
+        // authenticate never spends a second BAT.
+        let result = authenticate::handle(
+            &mut context,
+            cdk::ws::WsAuthenticateRequest {
+                token: "not-a-valid-bat".to_string(),
+            },
+        )
+        .await
+        .expect("repeat authenticate on an authenticated connection is a no-op");
+
+        assert!(matches!(result, cdk::ws::WsResponseResult::Authenticate(_)));
+        assert!(context.authenticated);
     }
 }

--- a/crates/cdk-axum/src/ws/subscribe.rs
+++ b/crates/cdk-axum/src/ws/subscribe.rs
@@ -1,5 +1,5 @@
 use cdk::subscription::Params;
-use cdk::ws::WsResponseResult;
+use cdk::ws::{WsResponseResult, WsSubscriptionResult};
 
 use super::{WsContext, WsError, MAX_FILTERS_PER_SUBSCRIPTION, MAX_SUBSCRIPTIONS_PER_CONNECTION};
 
@@ -51,8 +51,9 @@ pub(crate) async fn handle(
             }
         }),
     );
-    Ok(WsResponseResult {
+    Ok(WsSubscriptionResult {
         status: "OK".to_string(),
         sub_id,
-    })
+    }
+    .into())
 }

--- a/crates/cdk-axum/src/ws/unsubscribe.rs
+++ b/crates/cdk-axum/src/ws/unsubscribe.rs
@@ -1,4 +1,4 @@
-use cdk::ws::{WsResponseResult, WsUnsubscribeRequest};
+use cdk::ws::{WsResponseResult, WsSubscriptionResult, WsUnsubscribeRequest};
 
 use super::{WsContext, WsError};
 
@@ -8,10 +8,11 @@ pub(crate) async fn handle(
 ) -> Result<WsResponseResult, WsError> {
     if let Some(handle) = context.subscriptions.remove(&req.sub_id) {
         handle.abort();
-        Ok(WsResponseResult {
+        Ok(WsSubscriptionResult {
             status: "OK".to_string(),
             sub_id: req.sub_id,
-        })
+        }
+        .into())
     } else {
         Err(WsError::InvalidParams)
     }

--- a/crates/cdk-common/src/ws.rs
+++ b/crates/cdk-common/src/ws.rs
@@ -23,6 +23,9 @@ pub type WsNotification = nut17::ws::WsNotification<SubId>;
 /// Result part of a websocket response
 pub type WsResponseResult = nut17::ws::WsResponseResult<SubId>;
 
+/// Result of a subscribe or unsubscribe request
+pub type WsSubscriptionResult = nut17::ws::WsSubscriptionResult<SubId>;
+
 /// Generic websocket request
 pub type WsRequest = nut17::ws::WsRequest<SubId>;
 
@@ -31,6 +34,11 @@ pub type WsResponse = nut17::ws::WsResponse<SubId>;
 
 /// Method-specific websocket request
 pub type WsMethodRequest = nut17::ws::WsMethodRequest<SubId>;
+
+/// Request to authenticate a connection (NUT-22)
+pub use nut17::ws::WsAuthenticateRequest;
+/// Response to an authenticate request (NUT-22)
+pub use nut17::ws::WsAuthenticateResponse;
 
 /// Error body for websocket responses
 pub type WsErrorBody = nut17::ws::WsErrorBody;

--- a/crates/cdk-common/src/ws.rs
+++ b/crates/cdk-common/src/ws.rs
@@ -38,6 +38,11 @@ pub type WsResponse = nut17::ws::WsResponse<SubId>;
 /// Method-specific websocket request
 pub type WsMethodRequest = nut17::ws::WsMethodRequest<SubId>;
 
+/// Request to authenticate a connection (NUT-22)
+pub use nut17::ws::WsAuthenticateRequest;
+/// Response to an authenticate request (NUT-22)
+pub use nut17::ws::WsAuthenticateResponse;
+
 /// Error body for websocket responses
 pub type WsErrorBody = nut17::ws::WsErrorBody;
 

--- a/crates/cdk-integration-tests/Cargo.toml
+++ b/crates/cdk-integration-tests/Cargo.toml
@@ -63,6 +63,7 @@ uuid = { workspace = true, features = ["js"] }
 [dev-dependencies]
 bip39 = { workspace = true, features = ["rand"] }
 anyhow.workspace = true
+axum.workspace = true
 cdk-axum = { workspace = true }
 cdk-fake-wallet = { workspace = true }
 cdk-signatory = { workspace = true }

--- a/crates/cdk-integration-tests/src/init_auth_mint.rs
+++ b/crates/cdk-integration-tests/src/init_auth_mint.rs
@@ -86,6 +86,7 @@ where
         ProtectedEndpoint::new(Method::Post, RoutePath::Swap),
         ProtectedEndpoint::new(Method::Post, RoutePath::Checkstate),
         ProtectedEndpoint::new(Method::Post, RoutePath::Restore),
+        ProtectedEndpoint::new(Method::Get, RoutePath::Ws),
     ];
 
     let blind_auth_endpoints =

--- a/crates/cdk-integration-tests/tests/fake_auth.rs
+++ b/crates/cdk-integration-tests/tests/fake_auth.rs
@@ -368,6 +368,72 @@ async fn test_mint_with_auth() {
     assert!(proofs.total_amount().expect("Could not get proofs amount") == mint_amount);
 }
 
+/// The `/v1/ws` endpoint is blind-auth protected. A browser cannot set the
+/// `Blind-auth` header, so the wallet authenticates the connection in-band with
+/// the NUT-22 `authenticate` command. This exercises that end-to-end: a
+/// subscription only receives notifications once the connection is
+/// authenticated.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_websocket_subscription_with_auth() {
+    use cdk::nuts::{MintQuoteState, NotificationPayload};
+    use cdk::wallet::WalletSubscription;
+
+    let db = Arc::new(memory::empty().await.unwrap());
+
+    let wallet = WalletBuilder::new()
+        .mint_url(MintUrl::from_str(MINT_URL).expect("Valid mint url"))
+        .unit(CurrencyUnit::Sat)
+        .localstore(db.clone())
+        .seed(Mnemonic::generate(12).unwrap().to_seed_normalized(""))
+        .build()
+        .expect("Wallet");
+
+    let mint_info = wallet
+        .fetch_mint_info()
+        .await
+        .expect("mint info")
+        .expect("could not get mint info");
+
+    let (access_token, _) = get_tokens(&mint_info, false)
+        .await
+        .expect("could not get access token");
+
+    wallet.set_cat(access_token).await.unwrap();
+    wallet
+        .mint_blind_auth(10.into())
+        .await
+        .expect("Could not mint blind auth");
+
+    let wallet = Arc::new(wallet);
+
+    let mint_quote = wallet
+        .mint_quote(PaymentMethod::BOLT11, Some(10.into()), None, None)
+        .await
+        .expect("mint quote");
+
+    // Opening this subscription connects to the protected `/v1/ws`, so the
+    // wallet must authenticate in-band before the mint accepts the subscribe.
+    let mut subscription = wallet
+        .subscribe(WalletSubscription::Bolt11MintQuoteState(vec![mint_quote
+            .id
+            .clone()]))
+        .await
+        .expect("failed to subscribe over authenticated websocket");
+
+    let msg = tokio::time::timeout(tokio::time::Duration::from_secs(10), subscription.recv())
+        .await
+        .expect("timeout waiting for notification")
+        .expect("no notification received");
+
+    match msg.into_inner() {
+        NotificationPayload::MintQuoteBolt11Response(response) => {
+            assert_eq!(response.quote.to_string(), mint_quote.id);
+            assert_eq!(response.state, MintQuoteState::Unpaid);
+        }
+        other => panic!("unexpected notification: {other:?}"),
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_swap_with_auth() {
     let db = Arc::new(memory::empty().await.unwrap());

--- a/crates/cdk-integration-tests/tests/websocket_auth.rs
+++ b/crates/cdk-integration-tests/tests/websocket_auth.rs
@@ -15,25 +15,30 @@ use bip39::Mnemonic;
 use cdk::amount::{Amount, SplitTarget};
 use cdk::cdk_database::WalletDatabase;
 use cdk::dhke::construct_proofs;
+use cdk::error::{ErrorCode, ErrorResponse};
 use cdk::mint::{Mint, MintBuilder, MintMeltLimits};
 use cdk::mint_url::MintUrl;
 use cdk::nuts::nut00::KnownMethod;
 use cdk::nuts::nut21::{Method, ProtectedEndpoint, RoutePath};
 use cdk::nuts::{
-    AuthProof, CurrencyUnit, MintQuoteState, NotificationPayload, PaymentMethod, PreMintSecrets,
-    State,
+    AuthProof, AuthRequired, CurrencyUnit, MintQuoteState, NotificationPayload, PaymentMethod,
+    PreMintSecrets, State,
 };
+use cdk::secret::Secret;
 use cdk::types::FeeReserve;
 use cdk::wallet::{WalletBuilder, WalletSubscription};
 use cdk_common::wallet::ProofInfo;
 use cdk_fake_wallet::FakeWallet;
 use cdk_sqlite::wallet::memory;
 use tokio::time::{timeout, Duration};
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::http::StatusCode;
+use tokio_tungstenite::tungstenite::Error as WsHandshakeError;
 
-/// Build an auth-enabled mint whose only blind-auth-protected endpoint is
-/// `/v1/ws`. `/v1/auth/blind/mint` is left unprotected (no clear auth), so no
-/// OIDC/CAT is involved anywhere in this test.
-async fn build_ws_protected_mint() -> Mint {
+/// Build an auth-enabled mint whose only protected endpoint is `/v1/ws`.
+/// `/v1/auth/blind/mint` is left unprotected (no clear auth), so no OIDC/CAT is
+/// involved anywhere in this test.
+async fn build_ws_protected_mint(auth: AuthRequired) -> Mint {
     let db = Arc::new(cdk_sqlite::mint::memory::empty().await.expect("mint db"));
     let auth_db = Arc::new(
         cdk_sqlite::mint::MintSqliteAuthDatabase::new(":memory:")
@@ -65,15 +70,25 @@ async fn build_ws_protected_mint() -> Mint {
         .await
         .expect("payment processor");
 
+    let ws_endpoint = ProtectedEndpoint::new(Method::Get, RoutePath::Ws);
+    let clear_endpoints = match auth {
+        AuthRequired::Clear => vec![ws_endpoint.clone()],
+        AuthRequired::Blind => vec![],
+    };
+
+    mint_builder = mint_builder.with_auth(
+        auth_db,
+        "https://example.com/.well-known/openid-configuration".to_string(),
+        "test-client".to_string(),
+        clear_endpoints,
+    );
+
+    if auth == AuthRequired::Blind {
+        mint_builder = mint_builder.with_blind_auth(50, vec![ws_endpoint]);
+    }
+
     let mnemonic = Mnemonic::generate(12).expect("mnemonic");
     let mint = mint_builder
-        .with_auth(
-            auth_db,
-            "https://example.com/.well-known/openid-configuration".to_string(),
-            "test-client".to_string(),
-            vec![],
-        )
-        .with_blind_auth(50, vec![ProtectedEndpoint::new(Method::Get, RoutePath::Ws)])
         .build_with_seed(db, &mnemonic.to_seed_normalized(""))
         .await
         .expect("mint");
@@ -138,7 +153,7 @@ async fn serve(mint: Arc<Mint>) -> MintUrl {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn websocket_connects_and_authenticates_in_band() {
-    let mint = Arc::new(build_ws_protected_mint().await);
+    let mint = Arc::new(build_ws_protected_mint(AuthRequired::Blind).await);
     let mint_url = serve(mint.clone()).await;
 
     let db = Arc::new(memory::empty().await.expect("wallet db"));
@@ -208,5 +223,120 @@ async fn websocket_connects_and_authenticates_in_band() {
         spendable.is_err(),
         "expected the BAT to be spent by in-band websocket auth, but it was still \
          spendable (was the subscription served over the HTTP poll fallback?): {spendable:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn clear_auth_websocket_rejects_a_header_less_upgrade() {
+    let mint = Arc::new(build_ws_protected_mint(AuthRequired::Clear).await);
+    let mint_url = serve(mint.clone()).await;
+
+    let ws_url = mint_url
+        .to_string()
+        .replacen("http://", "ws://", 1)
+        .trim_end_matches('/')
+        .to_string()
+        + "/v1/ws";
+
+    // Clear auth has no in-band command, so an upgrade without a `Clear-auth`
+    // header must be refused at the HTTP layer rather than left to idle until
+    // the mint's authentication timeout.
+    let err = connect_async(&ws_url)
+        .await
+        .expect_err("upgrade to a clear-auth protected endpoint must fail");
+
+    match err {
+        WsHandshakeError::Http(response) => {
+            // NUT-00: the mint answers errors with 400 and a coded body.
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let body = response.body().as_ref().expect("error body");
+            let error: ErrorResponse = serde_json::from_slice(body).expect("error response");
+            assert_eq!(error.code, ErrorCode::ClearAuthRequired);
+        }
+        other => panic!("expected the upgrade to be refused, got: {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rejected_blind_auth_tokens_stop_draining_the_wallet() {
+    // Mirrors `MAX_CONSECUTIVE_AUTH_FAILURES` in `cdk::wallet::subscription`.
+    const MAX_AUTH_ATTEMPTS: usize = 3;
+    const SEEDED_TOKENS: usize = 5;
+
+    let mint = Arc::new(build_ws_protected_mint(AuthRequired::Blind).await);
+    let mint_url = serve(mint.clone()).await;
+
+    let db = Arc::new(memory::empty().await.expect("wallet db"));
+    let wallet = WalletBuilder::new()
+        .mint_url(mint_url.clone())
+        .unit(CurrencyUnit::Sat)
+        .localstore(db.clone())
+        .seed(Mnemonic::generate(12).unwrap().to_seed_normalized(""))
+        .build()
+        .expect("wallet");
+
+    wallet
+        .fetch_mint_info()
+        .await
+        .expect("mint info")
+        .expect("mint info present");
+
+    // Seed tokens the mint will reject: the secret no longer matches the
+    // signature, which is what a stale token looks like to the mint.
+    let mut invalid = Vec::new();
+    for _ in 0..SEEDED_TOKENS {
+        let mut bat = mint_bat(&mint).await;
+        bat.secret = Secret::generate();
+        invalid.push(
+            ProofInfo::new(bat, mint_url.clone(), State::Unspent, CurrencyUnit::Auth)
+                .expect("proof info"),
+        );
+    }
+    db.update_proofs(invalid, vec![]).await.expect("seed bats");
+
+    let quote = wallet
+        .mint_quote(PaymentMethod::BOLT11, Some(10.into()), None, None)
+        .await
+        .expect("mint quote");
+
+    let _subscription = wallet
+        .subscribe(WalletSubscription::Bolt11MintQuoteState(vec![quote
+            .id
+            .clone()]))
+        .await
+        .expect("subscribe");
+
+    let remaining = || {
+        let db = db.clone();
+        let mint_url = mint_url.clone();
+        async move {
+            db.get_proofs(
+                Some(mint_url),
+                Some(CurrencyUnit::Auth),
+                Some(vec![State::Unspent]),
+                None,
+            )
+            .await
+            .expect("auth proofs")
+            .len()
+        }
+    };
+
+    let expected = SEEDED_TOKENS - MAX_AUTH_ATTEMPTS;
+    timeout(Duration::from_secs(60), async {
+        while remaining().await > expected {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    })
+    .await
+    .expect("wallet kept retrying past its blind auth failure limit");
+
+    // Once the failures are terminal the consumer falls back to HTTP polling and
+    // must not spend another token, however long it runs.
+    tokio::time::sleep(Duration::from_secs(10)).await;
+    assert_eq!(
+        remaining().await,
+        expected,
+        "a terminal websocket authentication failure must stop spending tokens"
     );
 }

--- a/crates/cdk-integration-tests/tests/websocket_auth.rs
+++ b/crates/cdk-integration-tests/tests/websocket_auth.rs
@@ -11,7 +11,8 @@ use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 
-use axum::extract::Request;
+use axum::extract::ws::WebSocketUpgrade;
+use axum::extract::{FromRequestParts, Request};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::Router;
@@ -34,10 +35,11 @@ use cdk::wallet::{WalletBuilder, WalletSubscription};
 use cdk_common::wallet::ProofInfo;
 use cdk_fake_wallet::FakeWallet;
 use cdk_sqlite::wallet::memory;
+use futures::{SinkExt, StreamExt};
 use tokio::time::{timeout, Duration};
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::http::StatusCode;
-use tokio_tungstenite::tungstenite::Error as WsHandshakeError;
+use tokio_tungstenite::tungstenite::{Error as WsHandshakeError, Message};
 
 /// Build an auth-enabled mint whose only protected endpoint is `/v1/ws`.
 /// `/v1/auth/blind/mint` is left unprotected (no clear auth), so no OIDC/CAT is
@@ -170,6 +172,31 @@ async fn serve_header_only_blind_auth(mint: Arc<Mint>) -> MintUrl {
         .await
         .layer(middleware::from_fn(reject_header_less_ws));
     serve_router(router).await
+}
+
+/// Serve a mint that accepts the websocket upgrade and then never answers.
+///
+/// Models a hostile mint, or a MITM on a plaintext `ws://` connection, that
+/// keeps the wallet's consumer blocked instead of refusing it outright.
+async fn serve_silent_ws(mint: Arc<Mint>) -> MintUrl {
+    let router = mint_router(mint)
+        .await
+        .layer(middleware::from_fn(swallow_ws));
+    serve_router(router).await
+}
+
+async fn swallow_ws(request: Request, next: Next) -> Response {
+    if !request.uri().path().ends_with("/v1/ws") {
+        return next.run(request).await;
+    }
+
+    let (mut parts, _body) = request.into_parts();
+    match WebSocketUpgrade::from_request_parts(&mut parts, &()).await {
+        Ok(upgrade) => {
+            upgrade.on_upgrade(|mut socket| async move { while socket.recv().await.is_some() {} })
+        }
+        Err(rejection) => rejection.into_response(),
+    }
 }
 
 async fn reject_header_less_ws(request: Request, next: Next) -> Response {
@@ -436,4 +463,78 @@ async fn rejected_blind_auth_tokens_stop_draining_the_wallet() {
         expected,
         "a terminal websocket authentication failure must stop spending tokens"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_mint_that_never_answers_authenticate_does_not_pin_the_wallet() {
+    // Mirrors `MAX_CONSECUTIVE_AUTH_FAILURES` in `cdk::wallet::subscription`.
+    const MAX_AUTH_ATTEMPTS: usize = 3;
+    const SEEDED_TOKENS: usize = 5;
+
+    let mint = Arc::new(build_ws_protected_mint(AuthRequired::Blind).await);
+    let mint_url = serve_silent_ws(mint.clone()).await;
+
+    let db = Arc::new(memory::empty().await.expect("wallet db"));
+    let wallet = WalletBuilder::new()
+        .mint_url(mint_url.clone())
+        .unit(CurrencyUnit::Sat)
+        .localstore(db.clone())
+        .seed(Mnemonic::generate(12).unwrap().to_seed_normalized(""))
+        .build()
+        .expect("wallet");
+
+    wallet
+        .fetch_mint_info()
+        .await
+        .expect("mint info")
+        .expect("mint info present");
+
+    let mut bats = Vec::new();
+    for _ in 0..SEEDED_TOKENS {
+        let bat = mint_bat(&mint).await;
+        bats.push(
+            ProofInfo::new(bat, mint_url.clone(), State::Unspent, CurrencyUnit::Auth)
+                .expect("proof info"),
+        );
+    }
+    db.update_proofs(bats, vec![]).await.expect("seed bats");
+
+    let quote = wallet
+        .mint_quote(PaymentMethod::BOLT11, Some(10.into()), None, None)
+        .await
+        .expect("mint quote");
+
+    let _subscription = wallet
+        .subscribe(WalletSubscription::Bolt11MintQuoteState(vec![quote
+            .id
+            .clone()]))
+        .await
+        .expect("subscribe");
+
+    let remaining = || {
+        let db = db.clone();
+        let mint_url = mint_url.clone();
+        async move {
+            db.get_proofs(
+                Some(mint_url),
+                Some(CurrencyUnit::Auth),
+                Some(vec![State::Unspent]),
+                None,
+            )
+            .await
+            .expect("auth proofs")
+            .len()
+        }
+    };
+
+    // Without a client-side timeout the very first authenticate blocks forever,
+    // the consumer never retries, and exactly one token is spent.
+    let expected = SEEDED_TOKENS - MAX_AUTH_ATTEMPTS;
+    timeout(Duration::from_secs(180), async {
+        while remaining().await > expected {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    })
+    .await
+    .expect("wallet stayed blocked waiting for an authenticate response");
 }

--- a/crates/cdk-integration-tests/tests/websocket_auth.rs
+++ b/crates/cdk-integration-tests/tests/websocket_auth.rs
@@ -1,0 +1,212 @@
+//! Self-contained NUT-22 WebSocket authentication test.
+//!
+//! Stands up an in-process mint whose NUT-17 `/v1/ws` endpoint is protected by
+//! blind auth, serves it over a real TCP socket, and verifies that a `Wallet`
+//! connects over the WebSocket and authenticates in-band (the NUT-22
+//! `authenticate` command) before its subscription is accepted. Blind auth is
+//! fully offline, so no OIDC server is needed: the BAT is minted directly from
+//! the mint and seeded into the wallet's store.
+
+use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use bip39::Mnemonic;
+use cdk::amount::{Amount, SplitTarget};
+use cdk::cdk_database::WalletDatabase;
+use cdk::dhke::construct_proofs;
+use cdk::mint::{Mint, MintBuilder, MintMeltLimits};
+use cdk::mint_url::MintUrl;
+use cdk::nuts::nut00::KnownMethod;
+use cdk::nuts::nut21::{Method, ProtectedEndpoint, RoutePath};
+use cdk::nuts::{
+    AuthProof, CurrencyUnit, MintQuoteState, NotificationPayload, PaymentMethod, PreMintSecrets,
+    State,
+};
+use cdk::types::FeeReserve;
+use cdk::wallet::{WalletBuilder, WalletSubscription};
+use cdk_common::wallet::ProofInfo;
+use cdk_fake_wallet::FakeWallet;
+use cdk_sqlite::wallet::memory;
+use tokio::time::{timeout, Duration};
+
+/// Build an auth-enabled mint whose only blind-auth-protected endpoint is
+/// `/v1/ws`. `/v1/auth/blind/mint` is left unprotected (no clear auth), so no
+/// OIDC/CAT is involved anywhere in this test.
+async fn build_ws_protected_mint() -> Mint {
+    let db = Arc::new(cdk_sqlite::mint::memory::empty().await.expect("mint db"));
+    let auth_db = Arc::new(
+        cdk_sqlite::mint::MintSqliteAuthDatabase::new(":memory:")
+            .await
+            .expect("auth db"),
+    );
+
+    let mut mint_builder = MintBuilder::new(db.clone());
+
+    let fee_reserve = FeeReserve {
+        min_fee_reserve: 1.into(),
+        percent_fee_reserve: 1.0,
+    };
+    let ln_fake_backend = FakeWallet::new(
+        fee_reserve,
+        HashMap::default(),
+        HashSet::default(),
+        2,
+        CurrencyUnit::Sat,
+    );
+
+    mint_builder
+        .add_payment_processor(
+            CurrencyUnit::Sat,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+            MintMeltLimits::new(1, 10_000),
+            Arc::new(ln_fake_backend),
+        )
+        .await
+        .expect("payment processor");
+
+    let mnemonic = Mnemonic::generate(12).expect("mnemonic");
+    let mint = mint_builder
+        .with_auth(
+            auth_db,
+            "https://example.com/.well-known/openid-configuration".to_string(),
+            "test-client".to_string(),
+            vec![],
+        )
+        .with_blind_auth(50, vec![ProtectedEndpoint::new(Method::Get, RoutePath::Ws)])
+        .build_with_seed(db, &mnemonic.to_seed_normalized(""))
+        .await
+        .expect("mint");
+
+    mint.start().await.expect("start mint");
+    mint
+}
+
+/// Mint one valid blind auth proof (BAT) directly from the mint's auth keyset,
+/// without going through the OIDC-gated HTTP mint endpoint.
+async fn mint_bat(mint: &Mint) -> cdk::nuts::Proof {
+    let auth_keyset_id = *mint
+        .get_active_keysets()
+        .get(&CurrencyUnit::Auth)
+        .expect("auth keyset active");
+
+    let keys = mint
+        .auth_pubkeys()
+        .expect("auth pubkeys")
+        .keysets
+        .into_iter()
+        .next()
+        .expect("one auth keyset")
+        .keys;
+
+    // The auth keyset supports only amount 1.
+    let fee_and_amounts = (0u64, vec![1u64]).into();
+    let premint = PreMintSecrets::random(
+        auth_keyset_id,
+        Amount::from(1),
+        &SplitTarget::Value(1.into()),
+        &fee_and_amounts,
+    )
+    .expect("premint secrets");
+
+    let mut signatures = Vec::new();
+    for message in premint.blinded_messages() {
+        signatures.push(mint.auth_blind_sign(&message).await.expect("blind sign"));
+    }
+
+    construct_proofs(signatures, premint.rs(), premint.secrets(), &keys)
+        .expect("construct proofs")
+        .into_iter()
+        .next()
+        .expect("one auth proof")
+}
+
+/// Serve a mint on an ephemeral local port and return its URL.
+async fn serve(mint: Arc<Mint>) -> MintUrl {
+    let router = cdk_axum::create_mint_router(mint, vec!["bolt11".to_string()])
+        .await
+        .expect("mint router");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("serve mint");
+    });
+    MintUrl::from_str(&format!("http://{addr}")).expect("mint url")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn websocket_connects_and_authenticates_in_band() {
+    let mint = Arc::new(build_ws_protected_mint().await);
+    let mint_url = serve(mint.clone()).await;
+
+    let db = Arc::new(memory::empty().await.expect("wallet db"));
+    let wallet = WalletBuilder::new()
+        .mint_url(mint_url.clone())
+        .unit(CurrencyUnit::Sat)
+        .localstore(db.clone())
+        .seed(Mnemonic::generate(12).unwrap().to_seed_normalized(""))
+        .build()
+        .expect("wallet");
+
+    // Fetch mint info so the wallet learns `/v1/ws` needs blind auth and builds
+    // its auth wallet (backed by the same localstore we seed below).
+    wallet
+        .fetch_mint_info()
+        .await
+        .expect("mint info")
+        .expect("mint info present");
+
+    // Seed one BAT into the wallet's store as an unspent Auth proof. The wallet
+    // turns it into the `authenticate` token on its own. Keep an `AuthProof`
+    // copy so we can later assert the mint actually spent it.
+    let bat = mint_bat(&mint).await;
+    let auth_proof: AuthProof = bat.clone().try_into().expect("auth proof");
+    let bat_info = ProofInfo::new(bat, mint_url.clone(), State::Unspent, CurrencyUnit::Auth)
+        .expect("proof info");
+    db.update_proofs(vec![bat_info], vec![])
+        .await
+        .expect("seed bat");
+
+    // Something to subscribe to. The mint quote endpoint is not protected.
+    let quote = wallet
+        .mint_quote(PaymentMethod::BOLT11, Some(10.into()), None, None)
+        .await
+        .expect("mint quote");
+
+    // Opening this subscription connects to the protected `/v1/ws`. If the
+    // in-band authentication did not succeed, the mint would reject the
+    // subscribe with error 31001 and no notification would arrive.
+    let mut subscription = wallet
+        .subscribe(WalletSubscription::Bolt11MintQuoteState(vec![quote
+            .id
+            .clone()]))
+        .await
+        .expect("subscribe over authenticated websocket");
+
+    let msg = timeout(Duration::from_secs(15), subscription.recv())
+        .await
+        .expect("timed out waiting for a notification")
+        .expect("subscription closed without a notification");
+
+    match msg.into_inner() {
+        NotificationPayload::MintQuoteBolt11Response(response) => {
+            assert_eq!(response.quote.to_string(), quote.id);
+            assert_eq!(response.state, MintQuoteState::Unpaid);
+        }
+        other => panic!("unexpected notification: {other:?}"),
+    }
+
+    // The notification alone does not prove the websocket authenticated: the
+    // wallet falls back to HTTP polling of the (unprotected) quote-status
+    // endpoint if the WS stream fails. Prove the in-band `authenticate` actually
+    // ran by checking the mint spent the BAT (polling never touches it). A
+    // freshly spent proof is no longer spendable.
+    let spendable = mint.check_blind_auth_proof_spendable(auth_proof).await;
+    assert!(
+        spendable.is_err(),
+        "expected the BAT to be spent by in-band websocket auth, but it was still \
+         spendable (was the subscription served over the HTTP poll fallback?): {spendable:?}"
+    );
+}

--- a/crates/cdk-integration-tests/tests/websocket_auth.rs
+++ b/crates/cdk-integration-tests/tests/websocket_auth.rs
@@ -538,3 +538,67 @@ async fn a_mint_that_never_answers_authenticate_does_not_pin_the_wallet() {
     .await
     .expect("wallet stayed blocked waiting for an authenticate response");
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn too_many_failed_authenticates_close_the_connection() {
+    // Mirrors `MAX_FAILED_AUTH_ATTEMPTS` in `cdk_axum::ws`.
+    const MAX_FAILED_AUTH_ATTEMPTS: usize = 3;
+
+    let mint = Arc::new(build_ws_protected_mint(AuthRequired::Blind).await);
+    let mint_url = serve(mint.clone()).await;
+
+    let ws_url = mint_url
+        .to_string()
+        .replacen("http://", "ws://", 1)
+        .trim_end_matches('/')
+        .to_string()
+        + "/v1/ws";
+
+    let (mut socket, _) = connect_async(&ws_url).await.expect("upgrade");
+
+    // Each rejected token costs the mint a signature verification on a
+    // connection nobody has paid for, so the mint must stop taking them well
+    // before its authentication timeout expires.
+    for id in 0..MAX_FAILED_AUTH_ATTEMPTS {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "authenticate",
+            "params": {"token": "not-a-valid-bat"},
+            "id": id,
+        });
+        socket
+            .send(Message::Text(request.to_string().into()))
+            .await
+            .expect("send authenticate");
+
+        let response = timeout(Duration::from_secs(5), socket.next())
+            .await
+            .expect("mint answers each attempt")
+            .expect("stream open")
+            .expect("no transport error");
+        let Message::Text(text) = response else {
+            panic!("expected a text response, got: {response:?}");
+        };
+        let response: serde_json::Value = serde_json::from_str(&text).expect("json response");
+        assert_eq!(
+            response["error"]["code"],
+            ErrorCode::BlindAuthFailed.to_code()
+        );
+    }
+
+    // The mint closes on its own, well inside its 30 second auth timeout.
+    let closed = timeout(Duration::from_secs(5), async {
+        while let Some(message) = socket.next().await {
+            match message {
+                Ok(Message::Close(_)) | Err(_) => return,
+                Ok(_) => continue,
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        closed.is_ok(),
+        "the mint must close a connection that keeps failing to authenticate"
+    );
+}

--- a/crates/cdk-integration-tests/tests/websocket_auth.rs
+++ b/crates/cdk-integration-tests/tests/websocket_auth.rs
@@ -11,6 +11,10 @@ use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 
+use axum::extract::Request;
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::Router;
 use bip39::Mnemonic;
 use cdk::amount::{Amount, SplitTarget};
 use cdk::cdk_database::WalletDatabase;
@@ -136,11 +140,8 @@ async fn mint_bat(mint: &Mint) -> cdk::nuts::Proof {
         .expect("one auth proof")
 }
 
-/// Serve a mint on an ephemeral local port and return its URL.
-async fn serve(mint: Arc<Mint>) -> MintUrl {
-    let router = cdk_axum::create_mint_router(mint, vec!["bolt11".to_string()])
-        .await
-        .expect("mint router");
+/// Serve a router on an ephemeral local port and return its URL.
+async fn serve_router(router: Router) -> MintUrl {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind");
@@ -149,6 +150,37 @@ async fn serve(mint: Arc<Mint>) -> MintUrl {
         axum::serve(listener, router).await.expect("serve mint");
     });
     MintUrl::from_str(&format!("http://{addr}")).expect("mint url")
+}
+
+async fn mint_router(mint: Arc<Mint>) -> Router {
+    cdk_axum::create_mint_router(mint, vec!["bolt11".to_string()])
+        .await
+        .expect("mint router")
+}
+
+/// Serve a mint on an ephemeral local port and return its URL.
+async fn serve(mint: Arc<Mint>) -> MintUrl {
+    serve_router(mint_router(mint).await).await
+}
+
+/// Serve a mint that behaves like one predating in-band authentication: the
+/// blind auth token has to be in the upgrade header or the upgrade is refused.
+async fn serve_header_only_blind_auth(mint: Arc<Mint>) -> MintUrl {
+    let router = mint_router(mint)
+        .await
+        .layer(middleware::from_fn(reject_header_less_ws));
+    serve_router(router).await
+}
+
+async fn reject_header_less_ws(request: Request, next: Next) -> Response {
+    if request.uri().path().ends_with("/v1/ws") && !request.headers().contains_key("Blind-auth") {
+        return (
+            axum::http::StatusCode::UNAUTHORIZED,
+            "blind auth header required",
+        )
+            .into_response();
+    }
+    next.run(request).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -222,6 +254,71 @@ async fn websocket_connects_and_authenticates_in_band() {
     assert!(
         spendable.is_err(),
         "expected the BAT to be spent by in-band websocket auth, but it was still \
+         spendable (was the subscription served over the HTTP poll fallback?): {spendable:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn websocket_falls_back_to_the_blind_auth_header() {
+    let mint = Arc::new(build_ws_protected_mint(AuthRequired::Blind).await);
+    let mint_url = serve_header_only_blind_auth(mint.clone()).await;
+
+    let db = Arc::new(memory::empty().await.expect("wallet db"));
+    let wallet = WalletBuilder::new()
+        .mint_url(mint_url.clone())
+        .unit(CurrencyUnit::Sat)
+        .localstore(db.clone())
+        .seed(Mnemonic::generate(12).unwrap().to_seed_normalized(""))
+        .build()
+        .expect("wallet");
+
+    wallet
+        .fetch_mint_info()
+        .await
+        .expect("mint info")
+        .expect("mint info present");
+
+    let bat = mint_bat(&mint).await;
+    let auth_proof: AuthProof = bat.clone().try_into().expect("auth proof");
+    let bat_info = ProofInfo::new(bat, mint_url.clone(), State::Unspent, CurrencyUnit::Auth)
+        .expect("proof info");
+    db.update_proofs(vec![bat_info], vec![])
+        .await
+        .expect("seed bat");
+
+    let quote = wallet
+        .mint_quote(PaymentMethod::BOLT11, Some(10.into()), None, None)
+        .await
+        .expect("mint quote");
+
+    // The header-less upgrade is refused here, and a refused upgrade retires
+    // the websocket for the life of the process. The wallet has to retry with
+    // the header instead of degrading to HTTP polling.
+    let mut subscription = wallet
+        .subscribe(WalletSubscription::Bolt11MintQuoteState(vec![quote
+            .id
+            .clone()]))
+        .await
+        .expect("subscribe over the header-authenticated websocket");
+
+    let msg = timeout(Duration::from_secs(15), subscription.recv())
+        .await
+        .expect("timed out waiting for a notification")
+        .expect("subscription closed without a notification");
+
+    match msg.into_inner() {
+        NotificationPayload::MintQuoteBolt11Response(response) => {
+            assert_eq!(response.quote.to_string(), quote.id);
+        }
+        other => panic!("unexpected notification: {other:?}"),
+    }
+
+    // As above: only the websocket path spends the BAT, so a spent token proves
+    // the notification did not come from the HTTP poll fallback.
+    let spendable = mint.check_blind_auth_proof_spendable(auth_proof).await;
+    assert!(
+        spendable.is_err(),
+        "expected the BAT to be spent by the header upgrade, but it was still \
          spendable (was the subscription served over the HTTP poll fallback?): {spendable:?}"
     );
 }

--- a/crates/cdk/src/wallet/subscription.rs
+++ b/crates/cdk/src/wallet/subscription.rs
@@ -7,7 +7,7 @@
 //! the HTTP client.
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use cdk_common::nut00::KnownMethod;
@@ -22,8 +22,10 @@ use cdk_common::pub_sub::remote_consumer::{
 };
 use cdk_common::pub_sub::{Error as PubsubError, Spec, Subscriber};
 use cdk_common::subscription::WalletParams;
-use cdk_common::ws_client::WsError;
-use cdk_common::{AuthRequired, CheckStateRequest, Method, PaymentMethod, RoutePath};
+use cdk_common::ws_client::{WsError, WsReceiver, WsSender};
+use cdk_common::{
+    AuthRequired, CheckStateRequest, Method, PaymentMethod, ProtectedEndpoint, RoutePath,
+};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -99,6 +101,7 @@ impl SubscriptionManager {
                         mint_url,
                         http_client: self.http_client.clone(),
                         req_id: 0.into(),
+                        auth_failures: 0.into(),
                     },
                     self.prefer_http,
                     (),
@@ -146,6 +149,7 @@ pub struct SubscriptionClient {
     http_client: Arc<dyn MintConnector + Send + Sync>,
     mint_url: MintUrl,
     req_id: AtomicUsize,
+    auth_failures: AtomicUsize,
 }
 
 impl SubscriptionClient {
@@ -191,8 +195,7 @@ impl SubscriptionClient {
                 filters: vec![filter],
                 id: id.into(),
             }),
-            self.req_id
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            self.req_id.fetch_add(1, Ordering::Relaxed),
         )
             .into();
 
@@ -207,8 +210,7 @@ impl SubscriptionClient {
     fn get_unsub_request(&self, sub_id: String) -> Option<(usize, String)> {
         let request: WsRequest<_> = (
             WsMethodRequest::Unsubscribe(WsUnsubscribeRequest { sub_id }),
-            self.req_id
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            self.req_id.fetch_add(1, Ordering::Relaxed),
         )
             .into();
 
@@ -224,8 +226,7 @@ impl SubscriptionClient {
     fn get_auth_request(&self, token: String) -> Option<(usize, String)> {
         let request: WsRequest<String> = (
             WsMethodRequest::Authenticate(WsAuthenticateRequest { token }),
-            self.req_id
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            self.req_id.fetch_add(1, Ordering::Relaxed),
         )
             .into();
 
@@ -235,6 +236,23 @@ impl SubscriptionClient {
             })
             .map(|json| (request.id, json))
             .ok()
+    }
+
+    fn reset_auth_failures(&self) {
+        self.auth_failures.store(0, Ordering::Relaxed);
+    }
+
+    /// Record a rejected `authenticate` and pick the error to fail the stream
+    /// with.
+    ///
+    /// Every attempt spends a blind auth token, so once the mint has rejected
+    /// enough of them in a row the error becomes terminal: the consumer stops
+    /// reconnecting and falls back to HTTP polling instead of draining the
+    /// wallet's token pool.
+    fn note_auth_failure(&self, message: String) -> PubsubError {
+        let failures = self.auth_failures.fetch_add(1, Ordering::Relaxed) + 1;
+
+        auth_failure_error(failures, message)
     }
 }
 
@@ -486,8 +504,20 @@ impl Transport for SubscriptionClient {
     }
 }
 
+/// How many consecutive rejected `authenticate` commands are tolerated before
+/// the websocket stream is abandoned for HTTP polling.
+const MAX_CONSECUTIVE_AUTH_FAILURES: usize = 3;
+
 fn new_subscription_id() -> String {
     Uuid::now_v7().to_string()
+}
+
+/// What `ensure_authenticated` needs to run: the endpoint being protected, the
+/// wallet holding the tokens, and whether blind auth applies at all.
+struct BlindAuth {
+    wallet: Option<AuthWallet>,
+    endpoint: ProtectedEndpoint,
+    required: bool,
 }
 
 /// Authenticate the connection with a blind auth token, once, just before the
@@ -496,26 +526,27 @@ fn new_subscription_id() -> String {
 /// A single BAT authenticates the connection for its lifetime, so this fetches
 /// and spends a token only on the first call and only when the endpoint needs
 /// blind auth. Because it runs after a successful connect and only when a
-/// subscribe is about to be sent, a failed connect never burns a BAT.
+/// subscribe is about to be sent, a failed connect never burns a BAT. It waits
+/// for the mint's answer so a rejected token fails here rather than as a 31001
+/// on the subscribe that follows.
 async fn ensure_authenticated(
     client: &SubscriptionClient,
-    sender: &mut cdk_common::ws_client::WsSender,
+    sender: &mut WsSender,
+    receiver: &mut WsReceiver,
     pending_requests: &mut HashMap<usize, PendingRequest>,
-    auth_wallet: Option<&AuthWallet>,
-    endpoint: &cdk_common::ProtectedEndpoint,
-    needs_blind_auth: bool,
+    auth: &BlindAuth,
     authenticated: &mut bool,
 ) -> Result<(), PubsubError> {
-    if !needs_blind_auth || *authenticated {
+    if !auth.required || *authenticated {
         return Ok(());
     }
 
-    let wallet = auth_wallet.ok_or_else(|| {
+    let wallet = auth.wallet.as_ref().ok_or_else(|| {
         PubsubError::InternalStr("blind auth required but no auth wallet".to_string())
     })?;
 
     let token = wallet
-        .get_auth_for_request(endpoint)
+        .get_auth_for_request(&auth.endpoint)
         .await
         .map_err(|err| {
             PubsubError::InternalStr(format!("failed to get blind auth token: {err:?}"))
@@ -528,20 +559,75 @@ async fn ensure_authenticated(
         PubsubError::InternalStr("failed to build authenticate request".to_string())
     })?;
 
-    // Only mark the connection authenticated once the command is actually on the
-    // wire. The BAT has already been spent from the wallet store, so a failed
-    // send must surface as an error (reconnect) rather than silently proceeding
-    // as if authenticated.
     sender.send(req).await.map_err(map_ws_error)?;
     pending_requests.insert(request_id, PendingRequest::Authenticate);
+    await_authenticate_response(client, receiver, pending_requests, request_id).await?;
     *authenticated = true;
     Ok(())
+}
+
+/// Read until the mint answers the `authenticate` command.
+///
+/// A rejected token must not be discovered later, as a 31001 on the following
+/// subscribe, because the BAT was already spent and the reconnect would spend
+/// another one. Nothing else can be in flight here: this only runs before the
+/// first subscribe of a connection, so the mint has no subscription to notify
+/// us about.
+async fn await_authenticate_response(
+    client: &SubscriptionClient,
+    receiver: &mut WsReceiver,
+    pending_requests: &mut HashMap<usize, PendingRequest>,
+    request_id: usize,
+) -> Result<(), PubsubError> {
+    loop {
+        let msg = match receiver.recv().await {
+            Some(Ok(msg)) => msg,
+            Some(Err(err)) => return Err(map_ws_error(err)),
+            None => {
+                return Err(PubsubError::InternalStr(
+                    "WebSocket stream closed while authenticating".to_string(),
+                ))
+            }
+        };
+
+        let msg = match serde_json::from_str::<RawWsMessageOrResponse<String>>(&msg) {
+            Ok(msg) => msg,
+            Err(_) => continue,
+        };
+
+        match msg {
+            RawWsMessageOrResponse::Response(response) if response.id == request_id => {
+                pending_requests.remove(&request_id);
+                return match response.result {
+                    WsResponseResult::Authenticate(_) => {
+                        tracing::debug!("Websocket connection authenticated");
+                        client.reset_auth_failures();
+                        Ok(())
+                    }
+                    WsResponseResult::Subscription(result) => {
+                        Err(client.note_auth_failure(format!(
+                            "unexpected subscription response for subId {}",
+                            result.sub_id
+                        )))
+                    }
+                };
+            }
+            RawWsMessageOrResponse::ErrorResponse(error) if error.id == request_id => {
+                pending_requests.remove(&request_id);
+                return Err(client.note_auth_failure(error.error.message));
+            }
+            other => tracing::warn!(
+                "Ignoring unexpected websocket message while authenticating: {:?}",
+                other
+            ),
+        }
+    }
 }
 
 /// Send a subscribe request and record its kind for notification decoding.
 async fn send_subscribe(
     client: &SubscriptionClient,
-    sender: &mut cdk_common::ws_client::WsSender,
+    sender: &mut WsSender,
     sub_id_to_kind: &mut HashMap<String, Kind>,
     pending_requests: &mut HashMap<usize, PendingRequest>,
     name: String,
@@ -578,7 +664,7 @@ async fn stream_client(
         url.set_scheme("ws").expect("Could not set scheme");
     }
 
-    let endpoint = cdk_common::ProtectedEndpoint::new(Method::Get, RoutePath::Ws);
+    let endpoint = ProtectedEndpoint::new(Method::Get, RoutePath::Ws);
     let auth_wallet = client.http_client.get_auth_wallet().await;
 
     // Learn the auth requirement without consuming a token. Only clear auth
@@ -601,7 +687,11 @@ async fn stream_client(
         }
     }
 
-    let needs_blind_auth = matches!(auth_required, Some(AuthRequired::Blind));
+    let auth = BlindAuth {
+        required: matches!(auth_required, Some(AuthRequired::Blind)),
+        wallet: auth_wallet,
+        endpoint,
+    };
 
     let url_str = url.to_string();
     let header_refs: Vec<(&str, &str)> = headers.iter().map(|(k, v)| (*k, v.as_str())).collect();
@@ -629,10 +719,9 @@ async fn stream_client(
         ensure_authenticated(
             client,
             &mut sender,
+            &mut receiver,
             &mut pending_requests,
-            auth_wallet.as_ref(),
-            &endpoint,
-            needs_blind_auth,
+            &auth,
             &mut authenticated,
         )
         .await?;
@@ -648,29 +737,15 @@ async fn stream_client(
     }
 
     loop {
+        // `ensure_authenticated` reads from `receiver`, which the `select!` below
+        // borrows for its own branch, so the subscribe is handled after it.
+        let mut to_subscribe = None;
+
         tokio::select! {
             Some(msg) = ctrl.recv() => {
                 match msg {
                     StreamCtrl::Subscribe(msg) => {
-                        ensure_authenticated(
-                            client,
-                            &mut sender,
-                            &mut pending_requests,
-                            auth_wallet.as_ref(),
-                            &endpoint,
-                            needs_blind_auth,
-                            &mut authenticated,
-                        )
-                        .await?;
-                        send_subscribe(
-                            client,
-                            &mut sender,
-                            &mut sub_id_to_kind,
-                            &mut pending_requests,
-                            msg.0,
-                            msg.1,
-                        )
-                        .await?;
+                        to_subscribe = Some(msg);
                     }
                     StreamCtrl::Unsubscribe(msg) => {
                         sub_id_to_kind.remove(&msg);
@@ -791,6 +866,27 @@ async fn stream_client(
                 }
             }
         }
+
+        if let Some((name, index)) = to_subscribe {
+            ensure_authenticated(
+                client,
+                &mut sender,
+                &mut receiver,
+                &mut pending_requests,
+                &auth,
+                &mut authenticated,
+            )
+            .await?;
+            send_subscribe(
+                client,
+                &mut sender,
+                &mut sub_id_to_kind,
+                &mut pending_requests,
+                name,
+                index,
+            )
+            .await?;
+        }
     }
 }
 
@@ -833,6 +929,16 @@ fn decode_notification_payload_for_stream(
             );
             None
         }
+    }
+}
+
+fn auth_failure_error(failures: usize, message: String) -> PubsubError {
+    if failures >= MAX_CONSECUTIVE_AUTH_FAILURES {
+        PubsubError::Terminal(format!(
+            "websocket authentication rejected repeatedly, giving up: {message}"
+        ))
+    } else {
+        PubsubError::InternalStr(format!("websocket authentication rejected: {message}"))
     }
 }
 
@@ -899,6 +1005,27 @@ mod tests {
         let error = map_ws_error(WsError::Terminal("attestation failed".to_string()));
 
         assert!(matches!(error, PubsubError::Terminal(_)));
+    }
+
+    #[test]
+    fn a_single_rejected_blind_auth_token_keeps_streaming_enabled() {
+        for failures in 1..MAX_CONSECUTIVE_AUTH_FAILURES {
+            assert!(matches!(
+                auth_failure_error(failures, "Blind authentication failed".to_string()),
+                PubsubError::InternalStr(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn repeatedly_rejected_blind_auth_tokens_disable_streaming() {
+        assert!(matches!(
+            auth_failure_error(
+                MAX_CONSECUTIVE_AUTH_FAILURES,
+                "Blind authentication failed".to_string()
+            ),
+            PubsubError::Terminal(_)
+        ));
     }
 
     #[test]

--- a/crates/cdk/src/wallet/subscription.rs
+++ b/crates/cdk/src/wallet/subscription.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use cdk_common::nut00::KnownMethod;
 use cdk_common::nut17::ws::{
@@ -521,6 +522,26 @@ impl Transport for SubscriptionClient {
 /// the websocket stream is abandoned for HTTP polling.
 const MAX_CONSECUTIVE_AUTH_FAILURES: usize = 3;
 
+/// How long to wait for the mint's answer to the `authenticate` command.
+///
+/// Answering costs the mint one signature verification, so a peer that accepts
+/// the upgrade and then goes quiet is not going to answer at all. Generous for
+/// a single round trip, short enough that a hostile or broken mint cannot pin
+/// the consumer.
+const AUTHENTICATE_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn sleep(duration: Duration) {
+    tokio::time::sleep(duration).await;
+}
+
+/// `tokio::time` has no timer driver under wasm, so fall back to the browser's
+/// `setTimeout` via gloo.
+#[cfg(target_arch = "wasm32")]
+async fn sleep(duration: Duration) {
+    gloo_timers::future::TimeoutFuture::new(duration.as_millis() as u32).await;
+}
+
 fn new_subscription_id() -> String {
     Uuid::now_v7().to_string()
 }
@@ -632,14 +653,34 @@ async fn ensure_authenticated(
     Ok(())
 }
 
-/// Read until the mint answers the `authenticate` command.
+/// Wait for the mint's answer to the `authenticate` command, but not forever.
 ///
 /// A rejected token must not be discovered later, as a 31001 on the following
 /// subscribe, because the BAT was already spent and the reconnect would spend
 /// another one. Nothing else can be in flight here: this only runs before the
 /// first subscribe of a connection, so the mint has no subscription to notify
 /// us about.
+///
+/// A mint that accepts the upgrade and then never answers, or floods
+/// undecodable messages, would otherwise block this consumer forever and starve
+/// every subscription to that mint, including the HTTP polling fallback. The
+/// timeout counts as an auth failure so the bounded-failure logic can give up
+/// on the websocket and degrade to polling.
 async fn await_authenticate_response(
+    client: &SubscriptionClient,
+    receiver: &mut WsReceiver,
+    pending_requests: &mut HashMap<usize, PendingRequest>,
+    request_id: usize,
+) -> Result<(), PubsubError> {
+    tokio::select! {
+        result = read_authenticate_response(client, receiver, pending_requests, request_id) => result,
+        () = sleep(AUTHENTICATE_TIMEOUT) => Err(client.note_auth_failure(
+            "timed out waiting for the authenticate response".to_string(),
+        )),
+    }
+}
+
+async fn read_authenticate_response(
     client: &SubscriptionClient,
     receiver: &mut WsReceiver,
     pending_requests: &mut HashMap<usize, PendingRequest>,

--- a/crates/cdk/src/wallet/subscription.rs
+++ b/crates/cdk/src/wallet/subscription.rs
@@ -12,7 +12,8 @@ use std::sync::Arc;
 
 use cdk_common::nut00::KnownMethod;
 use cdk_common::nut17::ws::{
-    RawWsMessageOrResponse, WsMethodRequest, WsRequest, WsUnsubscribeRequest,
+    RawWsMessageOrResponse, WsAuthenticateRequest, WsMethodRequest, WsRequest, WsResponseResult,
+    WsUnsubscribeRequest,
 };
 use cdk_common::nut17::{deserialize_payload_for_kind, Kind, NotificationId};
 use cdk_common::parking_lot::RwLock;
@@ -22,12 +23,13 @@ use cdk_common::pub_sub::remote_consumer::{
 use cdk_common::pub_sub::{Error as PubsubError, Spec, Subscriber};
 use cdk_common::subscription::WalletParams;
 use cdk_common::ws_client::WsError;
-use cdk_common::{CheckStateRequest, Method, PaymentMethod, RoutePath};
+use cdk_common::{AuthRequired, CheckStateRequest, Method, PaymentMethod, RoutePath};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::event::MintEvent;
 use crate::mint_url::MintUrl;
+use crate::wallet::auth::AuthWallet;
 use crate::wallet::MintConnector;
 
 /// Notification Payload
@@ -213,6 +215,23 @@ impl SubscriptionClient {
         serde_json::to_string(&request)
             .inspect_err(|err| {
                 tracing::error!("Could not serialize unsubscribe message: {:?}", err);
+            })
+            .map(|json| (request.id, json))
+            .ok()
+    }
+
+    /// Build a NUT-22 `authenticate` command carrying the serialized BAT.
+    fn get_auth_request(&self, token: String) -> Option<(usize, String)> {
+        let request: WsRequest<String> = (
+            WsMethodRequest::Authenticate(WsAuthenticateRequest { token }),
+            self.req_id
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        )
+            .into();
+
+        serde_json::to_string(&request)
+            .inspect_err(|err| {
+                tracing::error!("Could not serialize authenticate message: {:?}", err);
             })
             .map(|json| (request.id, json))
             .ok()
@@ -471,6 +490,74 @@ fn new_subscription_id() -> String {
     Uuid::now_v7().to_string()
 }
 
+/// Authenticate the connection with a blind auth token, once, just before the
+/// first subscribe.
+///
+/// A single BAT authenticates the connection for its lifetime, so this fetches
+/// and spends a token only on the first call and only when the endpoint needs
+/// blind auth. Because it runs after a successful connect and only when a
+/// subscribe is about to be sent, a failed connect never burns a BAT.
+async fn ensure_authenticated(
+    client: &SubscriptionClient,
+    sender: &mut cdk_common::ws_client::WsSender,
+    pending_requests: &mut HashMap<usize, PendingRequest>,
+    auth_wallet: Option<&AuthWallet>,
+    endpoint: &cdk_common::ProtectedEndpoint,
+    needs_blind_auth: bool,
+    authenticated: &mut bool,
+) -> Result<(), PubsubError> {
+    if !needs_blind_auth || *authenticated {
+        return Ok(());
+    }
+
+    let wallet = auth_wallet.ok_or_else(|| {
+        PubsubError::InternalStr("blind auth required but no auth wallet".to_string())
+    })?;
+
+    let token = wallet
+        .get_auth_for_request(endpoint)
+        .await
+        .map_err(|err| {
+            PubsubError::InternalStr(format!("failed to get blind auth token: {err:?}"))
+        })?
+        .ok_or_else(|| {
+            PubsubError::InternalStr("blind auth required but no token available".to_string())
+        })?;
+
+    let (request_id, req) = client.get_auth_request(token.to_string()).ok_or_else(|| {
+        PubsubError::InternalStr("failed to build authenticate request".to_string())
+    })?;
+
+    // Only mark the connection authenticated once the command is actually on the
+    // wire. The BAT has already been spent from the wallet store, so a failed
+    // send must surface as an error (reconnect) rather than silently proceeding
+    // as if authenticated.
+    sender.send(req).await.map_err(map_ws_error)?;
+    pending_requests.insert(request_id, PendingRequest::Authenticate);
+    *authenticated = true;
+    Ok(())
+}
+
+/// Send a subscribe request and record its kind for notification decoding.
+async fn send_subscribe(
+    client: &SubscriptionClient,
+    sender: &mut cdk_common::ws_client::WsSender,
+    sub_id_to_kind: &mut HashMap<String, Kind>,
+    pending_requests: &mut HashMap<usize, PendingRequest>,
+    name: String,
+    index: NotificationId<String>,
+) -> Result<(), PubsubError> {
+    let kind = SubscriptionClient::subscription_kind(&index);
+    let Some((request_id, req)) = client.get_sub_request(name.clone(), index) else {
+        return Ok(());
+    };
+
+    sub_id_to_kind.insert(name.clone(), kind);
+    sender.send(req).await.map_err(map_ws_error)?;
+    pending_requests.insert(request_id, PendingRequest::Subscribe { sub_id: name });
+    Ok(())
+}
+
 async fn stream_client(
     client: &SubscriptionClient,
     mut ctrl: mpsc::Receiver<StreamCtrl<MintSubTopics>>,
@@ -491,34 +578,30 @@ async fn stream_client(
         url.set_scheme("ws").expect("Could not set scheme");
     }
 
+    let endpoint = cdk_common::ProtectedEndpoint::new(Method::Get, RoutePath::Ws);
+    let auth_wallet = client.http_client.get_auth_wallet().await;
+
+    // Learn the auth requirement without consuming a token. Only clear auth
+    // travels in a header; blind auth is done in-band, and the BAT is fetched
+    // lazily just before the first subscribe (see `ensure_authenticated`), so a
+    // failed connect never burns a single-use BAT.
+    let auth_required = match auth_wallet.as_ref() {
+        Some(wallet) => wallet.is_protected(&endpoint).await,
+        None => None,
+    };
+
     let mut headers: Vec<(&str, String)> = Vec::new();
-
-    {
-        let auth_wallet = client.http_client.get_auth_wallet().await;
-        let token = match auth_wallet.as_ref() {
-            Some(auth_wallet) => {
-                let endpoint = cdk_common::ProtectedEndpoint::new(Method::Get, RoutePath::Ws);
-                match auth_wallet.get_auth_for_request(&endpoint).await {
-                    Ok(token) => token,
-                    Err(err) => {
-                        tracing::warn!("Failed to get auth token: {:?}", err);
-                        None
-                    }
-                }
+    if matches!(auth_required, Some(AuthRequired::Clear)) {
+        if let Some(wallet) = auth_wallet.as_ref() {
+            match wallet.get_auth_for_request(&endpoint).await {
+                Ok(Some(token)) => headers.push(("Clear-auth", token.to_string())),
+                Ok(None) => {}
+                Err(err) => tracing::warn!("Failed to get clear auth token: {:?}", err),
             }
-            None => None,
-        };
-
-        if let Some(auth_token) = token {
-            let header_key = match &auth_token {
-                cdk_common::AuthToken::ClearAuth(_) => "Clear-auth",
-                cdk_common::AuthToken::BlindAuth(_) => "Blind-auth",
-            };
-
-            let header_value = auth_token.to_string();
-            headers.push((header_key, header_value));
         }
     }
+
+    let needs_blind_auth = matches!(auth_required, Some(AuthRequired::Blind));
 
     let url_str = url.to_string();
     let header_refs: Vec<(&str, &str)> = headers.iter().map(|(k, v)| (*k, v.as_str())).collect();
@@ -535,17 +618,33 @@ async fn stream_client(
 
     tracing::debug!("Connected to {}", url);
 
-    for (name, index) in topics {
-        let kind = SubscriptionClient::subscription_kind(&index);
-        let (request_id, req) = if let Some(req) = client.get_sub_request(name.clone(), index) {
-            req
-        } else {
-            continue;
-        };
+    // Whether `authenticate` has been sent on this connection. A single BAT
+    // authenticates the connection for its lifetime, so we send it once, lazily,
+    // just before the first subscribe (a connection with no subscriptions never
+    // authenticates and the mint closes it after its auth timeout, which is
+    // fine).
+    let mut authenticated = false;
 
-        sub_id_to_kind.insert(name.clone(), kind);
-        sender.send(req).await.map_err(map_ws_error)?;
-        pending_requests.insert(request_id, PendingRequest::Subscribe { sub_id: name });
+    for (name, index) in topics {
+        ensure_authenticated(
+            client,
+            &mut sender,
+            &mut pending_requests,
+            auth_wallet.as_ref(),
+            &endpoint,
+            needs_blind_auth,
+            &mut authenticated,
+        )
+        .await?;
+        send_subscribe(
+            client,
+            &mut sender,
+            &mut sub_id_to_kind,
+            &mut pending_requests,
+            name,
+            index,
+        )
+        .await?;
     }
 
     loop {
@@ -553,18 +652,25 @@ async fn stream_client(
             Some(msg) = ctrl.recv() => {
                 match msg {
                     StreamCtrl::Subscribe(msg) => {
-                        let kind = SubscriptionClient::subscription_kind(&msg.1);
-                        let (request_id, req) = if let Some(req) = client.get_sub_request(msg.0.clone(), msg.1) {
-                            req
-                        } else {
-                            continue;
-                        };
-                        sub_id_to_kind.insert(msg.0.clone(), kind);
-                        sender.send(req).await.map_err(map_ws_error)?;
-                        pending_requests.insert(
-                            request_id,
-                            PendingRequest::Subscribe { sub_id: msg.0 },
-                        );
+                        ensure_authenticated(
+                            client,
+                            &mut sender,
+                            &mut pending_requests,
+                            auth_wallet.as_ref(),
+                            &endpoint,
+                            needs_blind_auth,
+                            &mut authenticated,
+                        )
+                        .await?;
+                        send_subscribe(
+                            client,
+                            &mut sender,
+                            &mut sub_id_to_kind,
+                            &mut pending_requests,
+                            msg.0,
+                            msg.1,
+                        )
+                        .await?;
                     }
                     StreamCtrl::Unsubscribe(msg) => {
                         sub_id_to_kind.remove(&msg);
@@ -634,27 +740,42 @@ async fn stream_client(
                             continue;
                         };
 
-                        if response.result.sub_id != request.sub_id() {
-                            tracing::warn!(
-                                "Received {} response for subId {}, expected {}",
-                                request.method(),
-                                response.result.sub_id,
-                                request.sub_id()
-                            );
-                            continue;
-                        }
+                        match response.result {
+                            WsResponseResult::Authenticate(_) => {
+                                if !matches!(request, PendingRequest::Authenticate) {
+                                    tracing::warn!(
+                                        "Received authenticate response for a {} request",
+                                        request.method()
+                                    );
+                                    continue;
+                                }
 
-                        tracing::debug!(
-                            "Received {} response from server for subId {} with status {}",
-                            request.method(),
-                            response.result.sub_id,
-                            response.result.status
-                        );
+                                tracing::debug!("Websocket connection authenticated");
+                            }
+                            WsResponseResult::Subscription(result) => {
+                                if Some(result.sub_id.as_str()) != request.sub_id() {
+                                    tracing::warn!(
+                                        "Received {} response for subId {}, expected {:?}",
+                                        request.method(),
+                                        result.sub_id,
+                                        request.sub_id()
+                                    );
+                                    continue;
+                                }
+
+                                tracing::debug!(
+                                    "Received {} response from server for subId {} with status {}",
+                                    request.method(),
+                                    result.sub_id,
+                                    result.status
+                                );
+                            }
+                        }
                     }
                     RawWsMessageOrResponse::ErrorResponse(error) => {
                         match pending_requests.remove(&error.id) {
                             Some(request) => tracing::debug!(
-                                "Received an error from server for {} request and subId {}: {}",
+                                "Received an error from server for {} request and subId {:?}: {}",
                                 request.method(),
                                 request.sub_id(),
                                 error.error.message
@@ -677,6 +798,7 @@ async fn stream_client(
 enum PendingRequest {
     Subscribe { sub_id: String },
     Unsubscribe { sub_id: String },
+    Authenticate,
 }
 
 impl PendingRequest {
@@ -684,12 +806,14 @@ impl PendingRequest {
         match self {
             Self::Subscribe { .. } => "subscribe",
             Self::Unsubscribe { .. } => "unsubscribe",
+            Self::Authenticate => "authenticate",
         }
     }
 
-    fn sub_id(&self) -> &str {
+    fn sub_id(&self) -> Option<&str> {
         match self {
-            Self::Subscribe { sub_id } | Self::Unsubscribe { sub_id } => sub_id,
+            Self::Subscribe { sub_id } | Self::Unsubscribe { sub_id } => Some(sub_id),
+            Self::Authenticate => None,
         }
     }
 }

--- a/crates/cdk/src/wallet/subscription.rs
+++ b/crates/cdk/src/wallet/subscription.rs
@@ -520,6 +520,56 @@ struct BlindAuth {
     required: bool,
 }
 
+/// Retry a rejected upgrade with the legacy `Blind-auth` header.
+///
+/// Mints older than in-band NUT-22 authentication reject a header-less upgrade
+/// to a blind-protected `/v1/ws`, and the consumer disables streaming for the
+/// rest of the process once a connect fails permanently. This spends a BAT, so
+/// it only runs after the header-less connect has already failed for a reason
+/// that will not fix itself. Browsers cannot set headers on a WebSocket, so the
+/// retry is skipped on wasm, where it would repeat the same request.
+async fn connect_with_legacy_blind_auth(
+    client: &SubscriptionClient,
+    url: &str,
+    auth: &BlindAuth,
+    err: &WsError,
+) -> Option<(WsSender, WsReceiver)> {
+    if cfg!(target_arch = "wasm32") || !auth.required {
+        return None;
+    }
+
+    if !matches!(err, WsError::Terminal(_) | WsError::NotSupported(_)) {
+        return None;
+    }
+
+    let token = match auth
+        .wallet
+        .as_ref()?
+        .get_auth_for_request(&auth.endpoint)
+        .await
+    {
+        Ok(Some(token)) => token,
+        Ok(None) => return None,
+        Err(err) => {
+            tracing::warn!("Failed to get blind auth token for legacy upgrade: {err:?}");
+            return None;
+        }
+    };
+
+    tracing::debug!("Retrying the websocket upgrade with the legacy Blind-auth header");
+    match client
+        .http_client
+        .connect_websocket(url, &[("Blind-auth", &token.to_string())])
+        .await
+    {
+        Ok(connection) => Some(connection),
+        Err(err) => {
+            tracing::debug!("Legacy Blind-auth upgrade failed as well: {err:?}");
+            None
+        }
+    }
+}
+
 /// Authenticate the connection with a blind auth token, once, just before the
 /// first subscribe.
 ///
@@ -697,23 +747,33 @@ async fn stream_client(
     let header_refs: Vec<(&str, &str)> = headers.iter().map(|(k, v)| (*k, v.as_str())).collect();
 
     tracing::debug!("Connecting to {}", url);
-    let (mut sender, mut receiver) = client
+
+    // Whether the connection is already authenticated. A single BAT authenticates
+    // the connection for its lifetime, so the in-band `authenticate` is sent once,
+    // lazily, just before the first subscribe (a connection with no subscriptions
+    // never authenticates and the mint closes it after its auth timeout, which is
+    // fine). The legacy header path below authenticates at the upgrade instead.
+    let mut authenticated = false;
+
+    let (mut sender, mut receiver) = match client
         .http_client
         .connect_websocket(&url_str, &header_refs)
         .await
-        .map_err(|err| {
-            tracing::error!("Error connecting: {err:?}");
-            map_ws_error(err)
-        })?;
+    {
+        Ok(connection) => connection,
+        Err(err) => match connect_with_legacy_blind_auth(client, &url_str, &auth, &err).await {
+            Some(connection) => {
+                authenticated = true;
+                connection
+            }
+            None => {
+                tracing::error!("Error connecting: {err:?}");
+                return Err(map_ws_error(err));
+            }
+        },
+    };
 
     tracing::debug!("Connected to {}", url);
-
-    // Whether `authenticate` has been sent on this connection. A single BAT
-    // authenticates the connection for its lifetime, so we send it once, lazily,
-    // just before the first subscribe (a connection with no subscriptions never
-    // authenticates and the mint closes it after its auth timeout, which is
-    // fine).
-    let mut authenticated = false;
 
     for (name, index) in topics {
         ensure_authenticated(

--- a/crates/cdk/src/wallet/subscription.rs
+++ b/crates/cdk/src/wallet/subscription.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use cdk_common::nut00::KnownMethod;
 use cdk_common::nut17::ws::{
-    RawWsMessageOrResponse, WsMethodRequest, WsRequest, WsUnsubscribeRequest,
+    RawWsMessageOrResponse, WsAuthenticateRequest, WsMethodRequest, WsRequest, WsUnsubscribeRequest,
 };
 use cdk_common::nut17::{deserialize_payload_for_kind, Kind, NotificationId};
 use cdk_common::parking_lot::RwLock;
@@ -22,12 +22,13 @@ use cdk_common::pub_sub::remote_consumer::{
 use cdk_common::pub_sub::{Error as PubsubError, Spec, Subscriber};
 use cdk_common::subscription::WalletParams;
 use cdk_common::ws_client::WsError;
-use cdk_common::{CheckStateRequest, Method, PaymentMethod, RoutePath};
+use cdk_common::{AuthRequired, CheckStateRequest, Method, PaymentMethod, RoutePath};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::event::MintEvent;
 use crate::mint_url::MintUrl;
+use crate::wallet::auth::AuthWallet;
 use crate::wallet::MintConnector;
 
 /// Notification Payload
@@ -214,6 +215,24 @@ impl SubscriptionClient {
             Ok(json) => Some(json),
             Err(err) => {
                 tracing::error!("Could not serialize unsubscribe message: {:?}", err);
+                None
+            }
+        }
+    }
+
+    /// Build a NUT-22 `authenticate` command carrying the serialized BAT.
+    fn get_auth_request(&self, token: String) -> Option<String> {
+        let request: WsRequest<String> = (
+            WsMethodRequest::Authenticate(WsAuthenticateRequest { token }),
+            self.req_id
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        )
+            .into();
+
+        match serde_json::to_string(&request) {
+            Ok(json) => Some(json),
+            Err(err) => {
+                tracing::error!("Could not serialize authenticate message: {:?}", err);
                 None
             }
         }
@@ -476,6 +495,70 @@ impl Transport for SubscriptionClient {
     }
 }
 
+/// Authenticate the connection with a blind auth token, once, just before the
+/// first subscribe.
+///
+/// A single BAT authenticates the connection for its lifetime, so this fetches
+/// and spends a token only on the first call and only when the endpoint needs
+/// blind auth. Because it runs after a successful connect and only when a
+/// subscribe is about to be sent, a failed connect never burns a BAT.
+async fn ensure_authenticated(
+    client: &SubscriptionClient,
+    sender: &mut cdk_common::ws_client::WsSender,
+    auth_wallet: Option<&AuthWallet>,
+    endpoint: &cdk_common::ProtectedEndpoint,
+    needs_blind_auth: bool,
+    authenticated: &mut bool,
+) -> Result<(), PubsubError> {
+    if !needs_blind_auth || *authenticated {
+        return Ok(());
+    }
+
+    let wallet = auth_wallet.ok_or_else(|| {
+        PubsubError::InternalStr("blind auth required but no auth wallet".to_string())
+    })?;
+
+    let token = wallet
+        .get_auth_for_request(endpoint)
+        .await
+        .map_err(|err| {
+            PubsubError::InternalStr(format!("failed to get blind auth token: {err:?}"))
+        })?
+        .ok_or_else(|| {
+            PubsubError::InternalStr("blind auth required but no token available".to_string())
+        })?;
+
+    let req = client.get_auth_request(token.to_string()).ok_or_else(|| {
+        PubsubError::InternalStr("failed to build authenticate request".to_string())
+    })?;
+
+    // Only mark the connection authenticated once the command is actually on the
+    // wire. The BAT has already been spent from the wallet store, so a failed
+    // send must surface as an error (reconnect) rather than silently proceeding
+    // as if authenticated.
+    sender
+        .send(req)
+        .await
+        .map_err(|err| PubsubError::InternalStr(format!("failed to send authenticate: {err:?}")))?;
+    *authenticated = true;
+    Ok(())
+}
+
+/// Send a subscribe request and record its kind for notification decoding.
+async fn send_subscribe(
+    client: &SubscriptionClient,
+    sender: &mut cdk_common::ws_client::WsSender,
+    sub_id_to_kind: &mut HashMap<String, Kind>,
+    name: String,
+    index: NotificationId<String>,
+) {
+    let kind = SubscriptionClient::subscription_kind(&index);
+    if let Some((_, req)) = client.get_sub_request(name.clone(), index) {
+        sub_id_to_kind.insert(name, kind);
+        let _ = sender.send(req).await;
+    }
+}
+
 async fn stream_client(
     client: &SubscriptionClient,
     mut ctrl: mpsc::Receiver<StreamCtrl<MintSubTopics>>,
@@ -495,34 +578,30 @@ async fn stream_client(
         url.set_scheme("ws").expect("Could not set scheme");
     }
 
+    let endpoint = cdk_common::ProtectedEndpoint::new(Method::Get, RoutePath::Ws);
+    let auth_wallet = client.http_client.get_auth_wallet().await;
+
+    // Learn the auth requirement without consuming a token. Only clear auth
+    // travels in a header; blind auth is done in-band, and the BAT is fetched
+    // lazily just before the first subscribe (see `ensure_authenticated`), so a
+    // failed connect never burns a single-use BAT.
+    let auth_required = match auth_wallet.as_ref() {
+        Some(wallet) => wallet.is_protected(&endpoint).await,
+        None => None,
+    };
+
     let mut headers: Vec<(&str, String)> = Vec::new();
-
-    {
-        let auth_wallet = client.http_client.get_auth_wallet().await;
-        let token = match auth_wallet.as_ref() {
-            Some(auth_wallet) => {
-                let endpoint = cdk_common::ProtectedEndpoint::new(Method::Get, RoutePath::Ws);
-                match auth_wallet.get_auth_for_request(&endpoint).await {
-                    Ok(token) => token,
-                    Err(err) => {
-                        tracing::warn!("Failed to get auth token: {:?}", err);
-                        None
-                    }
-                }
+    if matches!(auth_required, Some(AuthRequired::Clear)) {
+        if let Some(wallet) = auth_wallet.as_ref() {
+            match wallet.get_auth_for_request(&endpoint).await {
+                Ok(Some(token)) => headers.push(("Clear-auth", token.to_string())),
+                Ok(None) => {}
+                Err(err) => tracing::warn!("Failed to get clear auth token: {:?}", err),
             }
-            None => None,
-        };
-
-        if let Some(auth_token) = token {
-            let header_key = match &auth_token {
-                cdk_common::AuthToken::ClearAuth(_) => "Clear-auth",
-                cdk_common::AuthToken::BlindAuth(_) => "Blind-auth",
-            };
-
-            let header_value = auth_token.to_string();
-            headers.push((header_key, header_value));
         }
     }
+
+    let needs_blind_auth = matches!(auth_required, Some(AuthRequired::Blind));
 
     let url_str = url.to_string();
     let header_refs: Vec<(&str, &str)> = headers.iter().map(|(k, v)| (*k, v.as_str())).collect();
@@ -539,16 +618,24 @@ async fn stream_client(
 
     tracing::debug!("Connected to {}", url);
 
-    for (name, index) in topics {
-        let kind = SubscriptionClient::subscription_kind(&index);
-        let (_, req) = if let Some(req) = client.get_sub_request(name.clone(), index) {
-            req
-        } else {
-            continue;
-        };
+    // Whether `authenticate` has been sent on this connection. A single BAT
+    // authenticates the connection for its lifetime, so we send it once, lazily,
+    // just before the first subscribe (a connection with no subscriptions never
+    // authenticates and the mint closes it after its auth timeout, which is
+    // fine).
+    let mut authenticated = false;
 
-        sub_id_to_kind.insert(name, kind);
-        let _ = sender.send(req).await;
+    for (name, index) in topics {
+        ensure_authenticated(
+            client,
+            &mut sender,
+            auth_wallet.as_ref(),
+            &endpoint,
+            needs_blind_auth,
+            &mut authenticated,
+        )
+        .await?;
+        send_subscribe(client, &mut sender, &mut sub_id_to_kind, name, index).await;
     }
 
     loop {
@@ -556,14 +643,16 @@ async fn stream_client(
             Some(msg) = ctrl.recv() => {
                 match msg {
                     StreamCtrl::Subscribe(msg) => {
-                        let kind = SubscriptionClient::subscription_kind(&msg.1);
-                        let (_, req) = if let Some(req) = client.get_sub_request(msg.0.clone(), msg.1) {
-                            req
-                        } else {
-                            continue;
-                        };
-                        sub_id_to_kind.insert(msg.0, kind);
-                        let _ = sender.send(req).await;
+                        ensure_authenticated(
+                            client,
+                            &mut sender,
+                            auth_wallet.as_ref(),
+                            &endpoint,
+                            needs_blind_auth,
+                            &mut authenticated,
+                        )
+                        .await?;
+                        send_subscribe(client, &mut sender, &mut sub_id_to_kind, msg.0, msg.1).await;
                     }
                     StreamCtrl::Unsubscribe(msg) => {
                         sub_id_to_kind.remove(&msg);

--- a/crates/cdk/src/wallet/subscription.rs
+++ b/crates/cdk/src/wallet/subscription.rs
@@ -242,17 +242,30 @@ impl SubscriptionClient {
         self.auth_failures.store(0, Ordering::Relaxed);
     }
 
-    /// Record a rejected `authenticate` and pick the error to fail the stream
+    /// Record a failed `authenticate` and pick the error to fail the stream
     /// with.
     ///
-    /// Every attempt spends a blind auth token, so once the mint has rejected
-    /// enough of them in a row the error becomes terminal: the consumer stops
+    /// The token is spent the moment it is fetched, so a mint that answers
+    /// with an error and one that hangs up before answering drain the pool at
+    /// the same rate: every failure after the fetch counts here. Once enough
+    /// of them happen in a row the error becomes terminal, the consumer stops
     /// reconnecting and falls back to HTTP polling instead of draining the
     /// wallet's token pool.
     fn note_auth_failure(&self, message: String) -> PubsubError {
         let failures = self.auth_failures.fetch_add(1, Ordering::Relaxed) + 1;
 
         auth_failure_error(failures, message)
+    }
+
+    /// Fail an `authenticate` attempt that ended in a transport error.
+    ///
+    /// Errors that already stop the consumer are passed through untouched;
+    /// only the transient ones it would retry need the bound applied.
+    fn note_auth_ws_error(&self, err: WsError) -> PubsubError {
+        match map_ws_error(err) {
+            PubsubError::InternalStr(message) => self.note_auth_failure(message),
+            other => other,
+        }
     }
 }
 
@@ -504,7 +517,7 @@ impl Transport for SubscriptionClient {
     }
 }
 
-/// How many consecutive rejected `authenticate` commands are tolerated before
+/// How many consecutive failed `authenticate` attempts are tolerated before
 /// the websocket stream is abandoned for HTTP polling.
 const MAX_CONSECUTIVE_AUTH_FAILURES: usize = 3;
 
@@ -606,10 +619,13 @@ async fn ensure_authenticated(
         })?;
 
     let (request_id, req) = client.get_auth_request(token.to_string()).ok_or_else(|| {
-        PubsubError::InternalStr("failed to build authenticate request".to_string())
+        client.note_auth_failure("failed to build authenticate request".to_string())
     })?;
 
-    sender.send(req).await.map_err(map_ws_error)?;
+    sender
+        .send(req)
+        .await
+        .map_err(|err| client.note_auth_ws_error(err))?;
     pending_requests.insert(request_id, PendingRequest::Authenticate);
     await_authenticate_response(client, receiver, pending_requests, request_id).await?;
     *authenticated = true;
@@ -632,11 +648,10 @@ async fn await_authenticate_response(
     loop {
         let msg = match receiver.recv().await {
             Some(Ok(msg)) => msg,
-            Some(Err(err)) => return Err(map_ws_error(err)),
+            Some(Err(err)) => return Err(client.note_auth_ws_error(err)),
             None => {
-                return Err(PubsubError::InternalStr(
-                    "WebSocket stream closed while authenticating".to_string(),
-                ))
+                return Err(client
+                    .note_auth_failure("WebSocket stream closed while authenticating".to_string()))
             }
         };
 
@@ -995,10 +1010,10 @@ fn decode_notification_payload_for_stream(
 fn auth_failure_error(failures: usize, message: String) -> PubsubError {
     if failures >= MAX_CONSECUTIVE_AUTH_FAILURES {
         PubsubError::Terminal(format!(
-            "websocket authentication rejected repeatedly, giving up: {message}"
+            "websocket authentication failed repeatedly, giving up: {message}"
         ))
     } else {
-        PubsubError::InternalStr(format!("websocket authentication rejected: {message}"))
+        PubsubError::InternalStr(format!("websocket authentication failed: {message}"))
     }
 }
 
@@ -1012,9 +1027,12 @@ fn map_ws_error(err: WsError) -> PubsubError {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use serde_json::json;
 
     use super::*;
+    use crate::wallet::test_utils::MockMintConnector;
 
     #[test]
     fn nut17_subscription_ids_use_uuid_v7() {
@@ -1075,6 +1093,55 @@ mod tests {
                 PubsubError::InternalStr(_)
             ));
         }
+    }
+
+    fn test_client() -> SubscriptionClient {
+        SubscriptionClient {
+            http_client: Arc::new(MockMintConnector::new()),
+            mint_url: MintUrl::from_str("https://mint.test").expect("valid mint url"),
+            req_id: 0.into(),
+            auth_failures: 0.into(),
+        }
+    }
+
+    #[test]
+    fn dropped_connections_while_authenticating_count_toward_the_bound() {
+        let client = test_client();
+
+        for _ in 1..MAX_CONSECUTIVE_AUTH_FAILURES {
+            assert!(matches!(
+                client.note_auth_ws_error(WsError::Transient("connection closed".to_string())),
+                PubsubError::InternalStr(_)
+            ));
+        }
+
+        assert!(matches!(
+            client.note_auth_failure("WebSocket stream closed".to_string()),
+            PubsubError::Terminal(_)
+        ));
+    }
+
+    #[test]
+    fn a_successful_authentication_clears_earlier_failures() {
+        let client = test_client();
+
+        client.note_auth_ws_error(WsError::Transient("connection closed".to_string()));
+        client.reset_auth_failures();
+
+        assert!(matches!(
+            client.note_auth_ws_error(WsError::Transient("connection closed".to_string())),
+            PubsubError::InternalStr(_)
+        ));
+    }
+
+    #[test]
+    fn unsupported_websocket_failure_while_authenticating_is_not_rewritten() {
+        let client = test_client();
+
+        assert!(matches!(
+            client.note_auth_ws_error(WsError::NotSupported("404".to_string())),
+            PubsubError::NotSupported
+        ));
     }
 
     #[test]


### PR DESCRIPTION


### Description

This depends on https://github.com/cashubtc/nuts/pull/413

The browser WebSocket API cannot set the Blind-auth header, so a browser wallet could not authenticate a protected NUT-17 /v1/ws connection. NUT-22 solves this with an in-band JSON-RPC authenticate command sent after the connection is established.

Mint: add the authenticate command, gate subscribe/unsubscribe with error 31001 until a connection is authenticated, verify and spend the BAT via the existing verify_auth path, and close never-authenticated connections after a timeout. The upgrade handler no longer rejects a header-less upgrade to a protected endpoint; it defers to the in-band command.

Wallet: for blind auth on the websocket, send the authenticate command right after connecting instead of a Blind-auth header, so one code path serves native and browser targets. Only sent when the mint protects /v1/ws.


-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
