### PR TITLE
perf(cashu): make CurrencyUnit::Custom hold Arc<str>

### DIFF
--- a/crates/cashu/src/amount.rs
+++ b/crates/cashu/src/amount.rs
@@ -1694,7 +1694,7 @@ mod tests {
 
     #[test]
     fn test_amount_new_with_custom_unit() {
-        let custom_unit = CurrencyUnit::Custom("BTC".to_string());
+        let custom_unit = CurrencyUnit::Custom("BTC".into());
         let amount = Amount::new(50, custom_unit.clone());
 
         assert_eq!(amount.value(), 50);
@@ -2088,7 +2088,7 @@ mod tests {
         let amount = Amount::new(100, CurrencyUnit::Usd);
         assert_eq!(amount.display_with_unit(), "100 usd");
 
-        let amount = Amount::new(123, CurrencyUnit::Custom("BTC".to_string()));
+        let amount = Amount::new(123, CurrencyUnit::Custom("BTC".into()));
         assert_eq!(amount.display_with_unit(), "123 btc");
     }
 

--- a/crates/cashu/src/nuts/nut00/mod.rs
+++ b/crates/cashu/src/nuts/nut00/mod.rs
@@ -8,6 +8,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 use std::string::FromUtf8Error;
+use std::sync::Arc;
 
 #[cfg(feature = "mint")]
 use bitcoin::hashes::Hash as BitcoinHash;
@@ -608,13 +609,13 @@ pub enum CurrencyUnit {
     /// Auth
     Auth,
     /// Custom currency unit
-    Custom(String),
+    Custom(Arc<str>),
 }
 
 impl CurrencyUnit {
     /// Construct a custom unit, normalizing to lowercase and trimming whitespace.
     pub fn custom<S: AsRef<str>>(value: S) -> Self {
-        Self::Custom(normalize_custom_unit(value.as_ref()))
+        Self::Custom(normalize_custom_unit(value.as_ref()).into())
     }
 }
 
@@ -681,7 +682,7 @@ impl fmt::Display for CurrencyUnit {
             CurrencyUnit::Usd => "USD",
             CurrencyUnit::Eur => "EUR",
             CurrencyUnit::Auth => "AUTH",
-            CurrencyUnit::Custom(unit) => unit,
+            CurrencyUnit::Custom(unit) => unit.as_ref(),
         };
 
         if let Some(width) = f.width() {
@@ -1416,7 +1417,7 @@ mod tests {
         let deserialized: CurrencyUnit = serde_json::from_str(&serialized).unwrap();
         let deserialized_uppercase: CurrencyUnit = serde_json::from_str(r#""BADCOIN""#).unwrap();
 
-        assert_eq!(unit, CurrencyUnit::Custom("badcoin".to_string()));
+        assert_eq!(unit, CurrencyUnit::Custom("badcoin".into()));
         assert_eq!(unit, CurrencyUnit::from_str("badcoin").unwrap());
         assert_eq!(unit, CurrencyUnit::custom("BADCOIN"));
         assert_eq!(unit.to_string(), "badcoin");
@@ -1429,7 +1430,7 @@ mod tests {
     fn test_currency_unit_custom_normalizes_and_stays_custom() {
         let unit = CurrencyUnit::custom(" usd\n");
 
-        assert_eq!(unit, CurrencyUnit::Custom("usd".to_string()));
+        assert_eq!(unit, CurrencyUnit::Custom("usd".into()));
         assert_ne!(unit, CurrencyUnit::default());
         assert_eq!(unit.to_string(), "usd");
     }
@@ -1450,11 +1451,11 @@ mod tests {
         // Custom
         assert_eq!(
             CurrencyUnit::from_str("custom").unwrap(),
-            CurrencyUnit::Custom("custom".to_string())
+            CurrencyUnit::Custom("custom".into())
         );
         assert_eq!(
             CurrencyUnit::from_str("CuStOm").unwrap(),
-            CurrencyUnit::Custom("custom".to_string())
+            CurrencyUnit::Custom("custom".into())
         );
     }
 
@@ -2252,9 +2253,6 @@ mod tests {
         assert_eq!(CurrencyUnit::Auth.derivation_index(), Some(4));
 
         // Custom units should return None
-        assert_eq!(
-            CurrencyUnit::Custom("btc".to_string()).derivation_index(),
-            None
-        );
+        assert_eq!(CurrencyUnit::Custom("btc".into()).derivation_index(), None);
     }
 }

--- a/crates/cashu/src/nuts/nut26/encoding.rs
+++ b/crates/cashu/src/nuts/nut26/encoding.rs
@@ -883,12 +883,12 @@ mod tests {
             CurrencyUnit::Auth
         );
         assert_eq!(
-            TlvUnit::from(CurrencyUnit::Custom("BADCOIN".to_string())),
+            TlvUnit::from(CurrencyUnit::Custom("BADCOIN".into())),
             TlvUnit::Custom("badcoin".to_string())
         );
         assert_eq!(
             CurrencyUnit::from(TlvUnit::Custom("BADCOIN".to_string())),
-            CurrencyUnit::Custom("badcoin".to_string())
+            CurrencyUnit::Custom("badcoin".into())
         );
     }
 
@@ -909,7 +909,7 @@ mod tests {
     fn test_one_byte_nonzero_unit_decodes_as_custom_unit() {
         let decoded = PaymentRequest::from_bech32_bytes(&[0x03, 0x00, 0x01, b'x']).unwrap();
 
-        assert_eq!(decoded.unit, Some(CurrencyUnit::Custom("x".to_string())));
+        assert_eq!(decoded.unit, Some(CurrencyUnit::Custom("x".into())));
     }
 
     #[test]
@@ -2514,7 +2514,7 @@ mod tests {
         let payment_request = PaymentRequest {
             payment_id: Some("custom_unit".to_string()),
             amount: Some(Amount::from(100)),
-            unit: Some(CurrencyUnit::Custom("btc".to_string())),
+            unit: Some(CurrencyUnit::Custom("btc".into())),
             single_use: None,
             mints: vec![MintUrl::from_str("https://mint.example.com").unwrap()],
             mint_preferred: None,
@@ -2534,7 +2534,7 @@ mod tests {
         let decoded =
             PaymentRequest::from_bech32_string(expected_encoded).expect("decoding should work");
 
-        assert_eq!(decoded.unit, Some(CurrencyUnit::Custom("btc".to_string())));
+        assert_eq!(decoded.unit, Some(CurrencyUnit::Custom("btc".into())));
         assert_eq!(decoded.payment_id, Some("custom_unit".to_string()));
     }
 

--- a/crates/cdk-ffi/src/types/amount.rs
+++ b/crates/cdk-ffi/src/types/amount.rs
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn custom_currency_unit_is_lowercase_across_ffi_boundary() {
-        let ffi = CurrencyUnit::from(CdkCurrencyUnit::Custom("BADCOIN".to_string()));
+        let ffi = CurrencyUnit::from(CdkCurrencyUnit::Custom("BADCOIN".into()));
         assert_eq!(
             ffi,
             CurrencyUnit::Custom {
@@ -202,6 +202,6 @@ mod tests {
         let cdk = CdkCurrencyUnit::from(CurrencyUnit::Custom {
             unit: "BADCOIN".to_string(),
         });
-        assert_eq!(cdk, CdkCurrencyUnit::Custom("badcoin".to_string()));
+        assert_eq!(cdk, CdkCurrencyUnit::Custom("badcoin".into()));
     }
 }

--- a/crates/cdk-signatory/src/proto/convert.rs
+++ b/crates/cdk-signatory/src/proto/convert.rs
@@ -411,7 +411,7 @@ mod tests {
 
     #[test]
     fn custom_currency_unit_is_lowercase_across_proto_boundary() {
-        let proto: CurrencyUnit = cdk_common::CurrencyUnit::Custom("BADCOIN".to_string()).into();
+        let proto: CurrencyUnit = cdk_common::CurrencyUnit::Custom("BADCOIN".into()).into();
 
         assert_eq!(
             proto.currency_unit,
@@ -428,9 +428,6 @@ mod tests {
         .try_into()
         .unwrap();
 
-        assert_eq!(
-            common,
-            cdk_common::CurrencyUnit::Custom("badcoin".to_string())
-        );
+        assert_eq!(common, cdk_common::CurrencyUnit::Custom("badcoin".into()));
     }
 }

--- a/fuzz/src/arbitrary_ext.rs
+++ b/fuzz/src/arbitrary_ext.rs
@@ -178,9 +178,9 @@ impl<'a> Arbitrary<'a> for CurrencyUnitArb {
                 let lowered = cleaned.to_lowercase();
                 let collides = matches!(lowered.as_str(), "sat" | "msat" | "usd" | "eur" | "auth");
                 if lowered.is_empty() || collides {
-                    CurrencyUnit::Custom("fuzz".to_string())
+                    CurrencyUnit::Custom("fuzz".into())
                 } else {
-                    CurrencyUnit::Custom(lowered)
+                    CurrencyUnit::Custom(lowered.into())
                 }
             }
         };


### PR DESCRIPTION


### Description

Fixes #2276

CurrencyUnit is passed by value and cloned constantly across the workspace. Its Custom variant held a String, so every clone of a custom-unit value allocated and copied. Switching the payload to Arc<str> makes cloning a refcount bump while keeping the value immutable, which it already was in practice.

The change stays inside the enum's module plus the direct construction sites; every external boundary (SQL, redb, proto, uniffi FFI, TLV, serde) already goes through the string form and is unaffected.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
