### PR TITLE
feat(ci): add nightly mintd docker image builds

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -1,0 +1,103 @@
+name: "Docker - Nightly mintd images"
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: "37 3 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Publish even if this commit already has a nightly image'
+        type: boolean
+        default: false
+
+concurrency:
+  group: docker-nightly
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: cashubtc/mintd
+
+jobs:
+  prepare:
+    name: "Prepare nightly tag"
+    runs-on: ubuntu-latest
+    outputs:
+      nightly_tag: ${{ steps.prepare.outputs.nightly_tag }}
+      cdk_ref: ${{ steps.prepare.outputs.cdk_ref }}
+      publish: ${{ steps.prepare.outputs.publish }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve nightly tag and check for existing images
+        id: prepare
+        shell: bash
+        env:
+          FORCE: ${{ inputs.force }}
+        run: |
+          set -euo pipefail
+
+          SOURCE_SHA=$(git rev-parse HEAD)
+          SOURCE_SHORT=${SOURCE_SHA:0:7}
+          SOURCE_DATE=$(date -u +%Y%m%d)
+          WORKSPACE_VERSION=$(
+            sed -n '/^\[workspace\.package\]/,/^\[/p' Cargo.toml \
+              | sed -n 's/^version = "\([^"]*\)"/\1/p' \
+              | head -1
+          )
+          CDK_VERSION=${WORKSPACE_VERSION%%[-+]*}
+
+          if [[ ! "${CDK_VERSION}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "::error::Could not derive a stable SemVer core from workspace version ${WORKSPACE_VERSION}"
+            exit 1
+          fi
+
+          NIGHTLY_TAG="v${CDK_VERSION}-nightly.${SOURCE_DATE}.g${SOURCE_SHORT}"
+
+          {
+            echo "nightly_tag=${NIGHTLY_TAG}"
+            echo "cdk_ref=${SOURCE_SHA}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Nightly source: ${SOURCE_SHA}"
+          echo "Nightly tag: ${NIGHTLY_TAG}"
+
+          if [[ "${FORCE}" == "true" ]]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Forced publish requested"
+            exit 0
+          fi
+
+          # A nightly for this exact commit already exists when any tag on
+          # Docker Hub embeds its short SHA, e.g. 0.18.0-nightly.20260803.g1a2b3c4
+          response=$(curl -sfL \
+            "https://hub.docker.com/v2/repositories/${IMAGE_NAME}/tags/?name=g${SOURCE_SHORT}&page_size=100")
+
+          existing=$(jq -r \
+            '[.results[].name | select(contains("-nightly."))] | .[0] // ""' \
+            <<< "${response}")
+
+          if [[ -n "${existing}" ]]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "${SOURCE_SHA} is already published as ${existing}; skipping"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "${SOURCE_SHA} needs publishing"
+          fi
+
+  publish:
+    name: "Build and publish nightly images"
+    needs: prepare
+    if: needs.prepare.outputs.publish == 'true'
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      tag: ${{ needs.prepare.outputs.nightly_tag }}
+      ref: ${{ needs.prepare.outputs.cdk_ref }}
+      nightly: true
+    secrets: inherit

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,22 @@ on:
       tag:
         description: 'Tag to build and publish'
         required: true
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to build and publish'
+        type: string
+        required: true
+      ref:
+        description: 'Git ref to checkout. Defaults to the tag.'
+        type: string
+        required: false
+        default: ''
+      nightly:
+        description: 'Build a nightly image and move the nightly tag'
+        type: boolean
+        required: false
+        default: false
 
 env:
   REGISTRY: docker.io
@@ -46,7 +62,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ inputs.ref || inputs.tag || github.ref }}
+
+      - name: Validate nightly tag
+        if: ${{ inputs.nightly == true }}
+        shell: bash
+        env:
+          NIGHTLY_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${NIGHTLY_TAG}" =~ ^v?[0-9]+[.][0-9]+[.][0-9]+-nightly[.][0-9]{8}[.]g[0-9a-f]{7}$ ]]; then
+            echo "::error::Nightly tag must look like v0.18.0-nightly.20260803.g1a2b3c4; got ${NIGHTLY_TAG}"
+            exit 1
+          fi
 
       - name: Install Nix
         if: ${{ matrix.arch.install_nix }}
@@ -84,7 +112,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-          INPUT_TAG: ${{ github.event.inputs.tag }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           if [[ "$EVENT_NAME" == "release" ]]; then
             RAW_VERSION="$RELEASE_TAG"
@@ -131,7 +159,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-          INPUT_TAG: ${{ github.event.inputs.tag }}
+          INPUT_TAG: ${{ inputs.tag }}
           IS_STABLE: ${{ !github.event.release.prerelease && !contains(github.event.release.tag_name, 'rc') }}
         run: |
           if [[ "$EVENT_NAME" == "release" ]]; then
@@ -163,6 +191,16 @@ jobs:
         run: |
           docker buildx imagetools create \
             -t "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}${{ matrix.variant.tag_suffix }}" \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}${{ matrix.variant.tag_suffix }}-amd64" \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}${{ matrix.variant.tag_suffix }}-arm64"
+
+      - name: Create nightly manifest
+        if: ${{ inputs.nightly == true }}
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          docker buildx imagetools create \
+            -t "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly${{ matrix.variant.tag_suffix }}" \
             "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}${{ matrix.variant.tag_suffix }}-amd64" \
             "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}${{ matrix.variant.tag_suffix }}-arm64"
 


### PR DESCRIPTION
### Description

Adds nightly builds of the `cdk-mintd` Docker images, following the same pattern as the FFI nightly builds (#2283).

A new `docker-nightly.yml` workflow runs on a schedule (03:37 UTC) and on manual dispatch. It derives an immutable nightly tag from the workspace version, UTC date, and commit SHA (`v<version>-nightly.<yyyymmdd>.g<sha>`), checks Docker Hub for an already-published nightly of that exact commit, and — if needed — invokes the now-reusable `docker-publish.yml`.

Published tags per run (for both the `standard` and `-ldk-node` variants):

- Immutable: `<version>-nightly.<yyyymmdd>.g<sha>` (multi-arch manifest) plus the per-arch `-amd64` / `-arm64` tags
- Moving: `nightly` / `nightly-ldk-node`, so `docker pull cashubtc/mintd:nightly` always tracks the latest nightly

-----

### Notes to the reviewers

- `docker-publish.yml` is unchanged for `release` and manual `workflow_dispatch` runs; it only gained a `workflow_call` trigger with `tag` / `ref` / `nightly` inputs, a fail-fast nightly tag format validation, and a nightly manifest step. `latest` / `major.minor` manifests stay gated to stable releases.
- The dedup check queries the Docker Hub tags API with the commit's short SHA as the name filter, so it only pages over a handful of tags regardless of how many nightlies accumulate.
- Manual dispatch supports a `force` input to republish a commit that already has a nightly.
- The schedule is staggered after the FFI nightly (02:17 UTC) to avoid runner contention.
- Verified locally with `actionlint` and a live Docker Hub API query; end-to-end verification happens on the first scheduled/dispatched run after merge.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### ADDED

- Nightly `cdk-mintd` Docker image builds published as `cashubtc/mintd:nightly` (and `:nightly-ldk-node`) with immutable per-commit nightly tags

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)