### PR TITLE
Make proof reservation all-or-nothing

### DIFF
--- a/crates/cdk-common/src/database/wallet/test/mod.rs
+++ b/crates/cdk-common/src/database/wallet/test/mod.rs
@@ -1526,6 +1526,47 @@ where
     assert!(result.is_err());
 }
 
+/// Test that a failed reservation leaves no proof reserved
+pub async fn reserve_proofs_is_atomic<DB>(db: DB)
+where
+    DB: Database<crate::database::Error>,
+{
+    let mint_url = test_mint_url();
+    let keyset_id = test_keyset_id();
+    let proof_info_1 = test_proof_info(keyset_id, 100, mint_url.clone());
+    let proof_info_2 = test_proof_info(keyset_id, 200, mint_url.clone());
+
+    db.update_proofs(vec![proof_info_1.clone(), proof_info_2.clone()], vec![])
+        .await
+        .unwrap();
+
+    let operation_id_1 = uuid::Uuid::new_v4();
+    db.reserve_proofs(vec![proof_info_1.y], &operation_id_1)
+        .await
+        .unwrap();
+
+    // The unspent proof comes first so a non-atomic implementation reserves it
+    // before hitting the already-reserved one.
+    let operation_id_2 = uuid::Uuid::new_v4();
+    let result = db
+        .reserve_proofs(vec![proof_info_2.y, proof_info_1.y], &operation_id_2)
+        .await;
+    assert!(result.is_err());
+
+    assert!(db
+        .get_reserved_proofs(&operation_id_2)
+        .await
+        .unwrap()
+        .is_empty());
+
+    let unspent = db
+        .get_proofs(None, None, Some(vec![State::Unspent]), None)
+        .await
+        .unwrap();
+    assert_eq!(unspent.len(), 1);
+    assert_eq!(unspent[0].y, proof_info_2.y);
+}
+
 /// Unit test that is expected to be passed for a correct wallet database implementation
 #[macro_export]
 macro_rules! wallet_db_test {
@@ -1575,7 +1616,8 @@ macro_rules! wallet_db_test {
             reserve_proofs,
             release_proofs,
             get_reserved_proofs,
-            reserve_proofs_already_reserved
+            reserve_proofs_already_reserved,
+            reserve_proofs_is_atomic
         );
     };
     ($make_db_fn:ident, $($name:ident),+ $(,)?) => {

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -1571,23 +1571,33 @@ where
             .await
             .map_err(|e| Error::Database(Box::new(e)))?;
 
-        for y in ys {
-            let rows_affected = query(
-                r#"
-                UPDATE proof
-                SET state = 'RESERVED', used_by_operation = :operation_id
-                WHERE y = :y AND state = 'UNSPENT'
-                "#,
-            )?
-            .bind("y", y.to_bytes().to_vec())
-            .bind("operation_id", operation_id.to_string())
-            .execute(&*conn)
-            .await?;
-
-            if rows_affected == 0 {
-                return Err(database::Error::ProofNotUnspent);
-            }
+        if ys.is_empty() {
+            return Ok(());
         }
+
+        let expected = ys.len();
+        let tx = ConnectionWithTransaction::new(conn).await?;
+
+        let rows_affected = query(
+            r#"
+            UPDATE proof
+            SET state = 'RESERVED', used_by_operation = :operation_id
+            WHERE y IN (:ys) AND state = 'UNSPENT'
+            "#,
+        )?
+        .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
+        .bind("operation_id", operation_id.to_string())
+        .execute(&tx)
+        .await?;
+
+        // Reserving is all-or-nothing: a partial match must not leave some of
+        // the proofs reserved.
+        if rows_affected != expected {
+            tx.rollback().await?;
+            return Err(database::Error::ProofNotUnspent);
+        }
+
+        tx.commit().await?;
 
         Ok(())
     }

--- a/crates/cdk-supabase/src/wallet.rs
+++ b/crates/cdk-supabase/src/wallet.rs
@@ -1991,41 +1991,43 @@ impl Database<DatabaseError> for SupabaseWalletDatabase {
         ys: Vec<PublicKey>,
         operation_id: &uuid::Uuid,
     ) -> Result<(), DatabaseError> {
-        let op_id_str = operation_id.to_string();
-        for y in &ys {
-            let y_hex = hex::encode(y.to_bytes());
-
-            // Update proof state to Reserved with operation_id atomically by filtering on state=Unspent
-            let update = serde_json::json!({
-                "state": State::Reserved.to_string(),
-                "used_by_operation": op_id_str,
-            });
-
-            // We filter on state=Unspent to ensure we only reserve proofs that are currently available.
-            // This prevents race conditions where two operations try to reserve the same proof.
-            let patch_path = format!(
-                "rest/v1/proof?y=eq.{}&state=eq.{}",
-                url_encode(&y_hex),
-                url_encode(&State::Unspent.to_string())
-            );
-
-            let (status, response_text) = self.patch_request(&patch_path, &update).await?;
-
-            if !status.is_success() {
-                return Err(DatabaseError::Internal(format!(
-                    "reserve_proofs: update failed: HTTP {} - {}",
-                    status, response_text
-                )));
-            }
-
-            // PostgREST returns 204 No Content for success.
-            // If the proof was already reserved or spent, the PATCH will succeed (HTTP 204)
-            // but no rows will be updated. We check if the proof is actually reserved.
-            let reserved_proofs = self.get_reserved_proofs(operation_id).await?;
-            if !reserved_proofs.iter().any(|p| p.y == *y) {
-                return Err(DatabaseError::ProofNotUnspent);
-            }
+        if ys.is_empty() {
+            return Ok(());
         }
+
+        let op_id_str = operation_id.to_string();
+        let update = serde_json::json!({
+            "state": State::Reserved.to_string(),
+            "used_by_operation": op_id_str,
+        });
+
+        // Filtering on state=Unspent keeps two operations from reserving the
+        // same proof, and a single PATCH keeps the whole set in one statement.
+        let y_list: Vec<String> = ys.iter().map(|y| hex::encode(y.to_bytes())).collect();
+        let patch_path = format!(
+            "rest/v1/proof?y=in.({})&state=eq.{}",
+            y_list.join(","),
+            url_encode(&State::Unspent.to_string())
+        );
+
+        let (status, response_text) = self.patch_request(&patch_path, &update).await?;
+
+        if !status.is_success() {
+            return Err(DatabaseError::Internal(format!(
+                "reserve_proofs: update failed: HTTP {} - {}",
+                status, response_text
+            )));
+        }
+
+        // PostgREST returns 204 No Content whether or not any row matched, so
+        // read back what was reserved. If some proof was not unspent, undo the
+        // partial reservation rather than leaving it behind.
+        let reserved_proofs = self.get_reserved_proofs(operation_id).await?;
+        if !ys.iter().all(|y| reserved_proofs.iter().any(|p| p.y == *y)) {
+            self.release_proofs(operation_id).await?;
+            return Err(DatabaseError::ProofNotUnspent);
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION


### Description

Reserving a set of proofs ran one UPDATE per proof with no enclosing transaction, so hitting a proof that was no longer unspent left every proof processed before it stuck in the reserved state with no way to release it. The Supabase backend had the same defect over HTTP.

The SQL backends now reserve in a single statement inside a transaction; Supabase issues one PATCH and compensates via release_proofs when the read-back is short. Covered by a shared test all backends run.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
