### PR TITLE
Make wallet creation atomic per mint and unit

### DIFF
--- a/crates/cdk-ffi/src/wallet_repository.rs
+++ b/crates/cdk-ffi/src/wallet_repository.rs
@@ -162,6 +162,33 @@ impl WalletRepository {
         Ok(())
     }
 
+    /// Get the wallet for a mint URL and unit, creating it if it does not exist
+    ///
+    /// Unlike `create_wallet`, an existing wallet is returned untouched: its
+    /// configuration is not replaced.
+    pub async fn get_or_create_wallet(
+        &self,
+        mint_url: MintUrl,
+        unit: CurrencyUnit,
+        target_proof_count: Option<u32>,
+    ) -> Result<Arc<crate::wallet::Wallet>, FfiError> {
+        let cdk_mint_url: cdk::mint_url::MintUrl = mint_url.try_into()?;
+
+        let config = target_proof_count.map(|count| {
+            cdk::wallet::wallet_repository::WalletConfig::new()
+                .with_target_proof_count(count as usize)
+        });
+
+        let wallet = self
+            .inner
+            .get_or_create_wallet(cdk_mint_url, unit.into(), config)
+            .await?;
+
+        Ok(Arc::new(crate::wallet::Wallet::from_inner(Arc::new(
+            wallet,
+        ))))
+    }
+
     /// Remove mint from WalletRepository
     pub async fn remove_wallet(
         &self,
@@ -302,5 +329,115 @@ impl From<cdk::wallet::TokenData> for TokenData {
             unit: data.unit.into(),
             redeem_fee: data.redeem_fee.map(Into::into),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::custom_wallet_store;
+    use crate::sqlite::WalletSqliteDatabase;
+
+    const MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    fn test_repository() -> WalletRepository {
+        let db = WalletSqliteDatabase::new_in_memory().expect("in-memory wallet db should open");
+        WalletRepository::new(MNEMONIC.to_string(), custom_wallet_store(db))
+            .expect("repository should be created")
+    }
+
+    fn mint_url() -> MintUrl {
+        MintUrl::new("https://mint.example.com".to_string()).expect("valid mint url")
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_or_create_wallet_creates_a_missing_wallet() {
+        let repo = test_repository();
+
+        let wallet = repo
+            .get_or_create_wallet(mint_url(), CurrencyUnit::Sat, None)
+            .await
+            .expect("wallet should be created");
+
+        assert_eq!(wallet.mint_url(), mint_url());
+        assert_eq!(wallet.unit(), CurrencyUnit::Sat);
+        assert!(repo.get_wallet(mint_url(), CurrencyUnit::Sat).await.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_or_create_wallet_returns_the_existing_wallet() {
+        let repo = test_repository();
+
+        repo.create_wallet(mint_url(), Some(CurrencyUnit::Sat), Some(5))
+            .await
+            .expect("wallet should be created");
+
+        let wallet = repo
+            .get_or_create_wallet(mint_url(), CurrencyUnit::Sat, Some(99))
+            .await
+            .expect("wallet should be returned");
+
+        assert_eq!(wallet.inner().target_proof_count, 5);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_or_create_wallet_is_keyed_by_unit() {
+        let repo = test_repository();
+
+        let sat = repo
+            .get_or_create_wallet(mint_url(), CurrencyUnit::Sat, None)
+            .await
+            .expect("sat wallet should be created");
+        let usd = repo
+            .get_or_create_wallet(mint_url(), CurrencyUnit::Usd, None)
+            .await
+            .expect("usd wallet should be created");
+
+        assert_eq!(sat.unit(), CurrencyUnit::Sat);
+        assert_eq!(usd.unit(), CurrencyUnit::Usd);
+        assert!(repo.get_wallet(mint_url(), CurrencyUnit::Sat).await.is_ok());
+        assert!(repo.get_wallet(mint_url(), CurrencyUnit::Usd).await.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_or_create_wallet_converges_under_concurrency() {
+        let repo = Arc::new(test_repository());
+
+        let calls = (1..=8u32).map(|target_proof_count| {
+            let repo = repo.clone();
+            tokio::spawn(async move {
+                repo.get_or_create_wallet(mint_url(), CurrencyUnit::Sat, Some(target_proof_count))
+                    .await
+                    .expect("wallet should be created")
+            })
+        });
+
+        let mut counts = Vec::new();
+        for call in calls {
+            let wallet = call.await.expect("task should not panic");
+            counts.push(wallet.inner().target_proof_count);
+        }
+
+        // Whichever caller built the wallet, every other caller must observe
+        // that same one rather than a wallet of its own.
+        assert!(
+            counts.windows(2).all(|pair| pair[0] == pair[1]),
+            "{counts:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_or_create_wallet_rejects_an_invalid_mint_url() {
+        let repo = test_repository();
+
+        // Bindings can build the record directly, bypassing `MintUrl::new`.
+        let invalid = MintUrl {
+            url: "not a url".to_string(),
+        };
+
+        assert!(repo
+            .get_or_create_wallet(invalid, CurrencyUnit::Sat, None)
+            .await
+            .is_err());
     }
 }

--- a/crates/cdk/src/wallet/wallet_repository.rs
+++ b/crates/cdk/src/wallet/wallet_repository.rs
@@ -388,21 +388,43 @@ impl WalletRepository {
 
         let mut wallets = Vec::new();
         for unit in supported_units {
-            // Skip if wallet already exists for this unit
-            if self.has_wallet(&mint_url, unit).await {
-                if let Ok(existing) = self.get_wallet(&mint_url, unit).await {
-                    wallets.push(existing);
-                }
-                continue;
-            }
-
             let wallet = self
-                .create_wallet(mint_url.clone(), unit.clone(), config.clone())
+                .get_or_create_wallet(mint_url.clone(), unit.clone(), config.clone())
                 .await?;
             wallets.push(wallet);
         }
 
         Ok(wallets)
+    }
+
+    /// Return the wallet for a mint and unit, creating it if it does not exist yet.
+    ///
+    /// An existing wallet is returned untouched. Use [`Self::create_wallet`] to
+    /// replace it with a new configuration.
+    ///
+    /// The write lock is held across the lookup and the insert so that concurrent
+    /// callers for the same mint and unit all observe the same wallet instead of
+    /// each building one and the last writer winning.
+    #[instrument(skip(self))]
+    pub async fn get_or_create_wallet(
+        &self,
+        mint_url: MintUrl,
+        unit: CurrencyUnit,
+        config: Option<WalletConfig>,
+    ) -> Result<Wallet, Error> {
+        let key = WalletKey::new(mint_url.clone(), unit.clone());
+        let mut wallets = self.wallets.write().await;
+
+        if let Some(existing) = wallets.get(&key) {
+            return Ok(existing.clone());
+        }
+
+        let wallet = self
+            .create_wallet_internal(mint_url, unit, config.as_ref())
+            .await?;
+        wallets.insert(key, wallet.clone());
+
+        Ok(wallet)
     }
 
     /// Update configuration for an existing mint and unit
@@ -714,18 +736,8 @@ impl WalletRepository {
                 .unwrap_or_else(|| vec![CurrencyUnit::Sat]);
 
             for unit in units {
-                let key = WalletKey::new(mint_url.clone(), unit.clone());
-                // Skip if wallet already exists
-                if self.wallets.read().await.contains_key(&key) {
-                    continue;
-                }
-
-                let wallet = self
-                    .create_wallet_internal(mint_url.clone(), unit, None)
+                self.get_or_create_wallet(mint_url.clone(), unit, None)
                     .await?;
-
-                let mut wallets = self.wallets.write().await;
-                wallets.insert(key, wallet);
             }
         }
 
@@ -1139,6 +1151,46 @@ mod tests {
         assert!(repo.has_wallet(&mint_url, &CurrencyUnit::Sat).await);
         let retrieved = repo.get_wallet(&mint_url, &CurrencyUnit::Sat).await;
         assert!(retrieved.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_or_create_wallet_keeps_the_existing_wallet() {
+        let repo = create_test_repository().await;
+        let mint_url: MintUrl = "https://mint.example.com".parse().unwrap();
+
+        repo.create_wallet(
+            mint_url.clone(),
+            CurrencyUnit::Sat,
+            Some(WalletConfig::new().with_target_proof_count(5)),
+        )
+        .await
+        .expect("Failed to create wallet");
+
+        let wallet = repo
+            .get_or_create_wallet(
+                mint_url.clone(),
+                CurrencyUnit::Sat,
+                Some(WalletConfig::new().with_target_proof_count(99)),
+            )
+            .await
+            .expect("Failed to get wallet");
+
+        assert_eq!(wallet.target_proof_count, 5);
+    }
+
+    #[tokio::test]
+    async fn test_get_or_create_wallet_creates_a_missing_wallet() {
+        let repo = create_test_repository().await;
+        let mint_url: MintUrl = "https://mint.example.com".parse().unwrap();
+
+        let wallet = repo
+            .get_or_create_wallet(mint_url.clone(), CurrencyUnit::Sat, None)
+            .await
+            .expect("Failed to create wallet");
+
+        assert_eq!(wallet.mint_url, mint_url);
+        assert_eq!(wallet.unit, CurrencyUnit::Sat);
+        assert!(repo.has_wallet(&mint_url, &CurrencyUnit::Sat).await);
     }
 
     #[tokio::test]


### PR DESCRIPTION

### Description

Adding a mint did check-then-act across three separate lock acquisitions, so two concurrent callers for the same mint could both pass the existence check, both build a wallet, and the second overwrite the first.

get_or_create_wallet now holds the write lock across the lookup, the build and the insert, and never replaces an existing wallet. It is public and exposed through the FFI so bindings get the same guarantee without reimplementing the check from the foreign side. create_wallet keeps its replacing behavior, which set_mint_config relies on.


-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
