### PR TITLE
feat(payment-processor): propagate quote_id and pubkey on custom mint quotes

### DIFF
--- a/crates/cdk-common/src/lib.rs
+++ b/crates/cdk-common/src/lib.rs
@@ -19,7 +19,7 @@ pub mod auth;
 pub const MINT_RPC_PROTOCOL_VERSION: &str = "1.0.0";
 
 /// Protocol version for gRPC Payment Processor communication
-pub const PAYMENT_PROCESSOR_PROTOCOL_VERSION: &str = "3.0.0";
+pub const PAYMENT_PROCESSOR_PROTOCOL_VERSION: &str = "4.0.0";
 
 #[cfg(feature = "grpc")]
 pub mod grpc;

--- a/crates/cdk-common/src/payment.rs
+++ b/crates/cdk-common/src/payment.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 
 use crate::mint::{MeltPaymentRequest, MeltQuote};
 use crate::nuts::nut30::MeltQuoteOnchainFeeOption;
-use crate::nuts::{CurrencyUnit, MeltQuoteState};
+use crate::nuts::{CurrencyUnit, MeltQuoteState, PublicKey};
 use crate::{Amount, QuoteId};
 
 /// CDK Payment Error
@@ -231,6 +231,20 @@ pub struct CustomIncomingPaymentOptions {
     /// These fields are passed through to the payment processor for
     /// method-specific validation (e.g., ehash share).
     pub extra_json: Option<String>,
+    /// The mint's quote id for this mint quote. Generated before
+    /// `create_incoming_payment_request` is called, so backends whose rail is
+    /// keyed by the quote the wallet displays can register it up front and
+    /// use it as their stable correlation key — mirroring
+    /// [`OnchainIncomingPaymentOptions::quote_id`] and the melt-side
+    /// [`CustomOutgoingPaymentOptions::quote_id`].
+    pub quote_id: QuoteId,
+    /// NUT-20 locking pubkey of the quote, when the wallet supplied one.
+    ///
+    /// Lets backends enforce a locked-quotes-only policy at quote creation
+    /// for rails where the NUT-20 lock is the safety mechanism (the mint
+    /// itself only verifies signatures at mint time and does not require a
+    /// pubkey for custom methods).
+    pub pubkey: Option<PublicKey>,
 }
 
 /// Options for creating an onchain incoming payment request

--- a/crates/cdk-fake-wallet/src/lib.rs
+++ b/crates/cdk-fake-wallet/src/lib.rs
@@ -1160,6 +1160,8 @@ mod tests {
                     amount: Some(Amount::new(10, CurrencyUnit::Sat)),
                     unix_expiry: None,
                     extra_json: None,
+                    quote_id: cdk_common::QuoteId::new(),
+                    pubkey: None,
                 },
             )))
             .await

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -2383,11 +2383,18 @@ struct CustomPaymentProcessor {
     /// Captures the quote_id seen by `get_payment_quote` so tests can assert
     /// the mint propagates it correctly.
     last_quote_id: std::sync::Mutex<Option<cdk_common::QuoteId>>,
+    /// Captures the (quote_id, pubkey) seen by `create_incoming_payment_request`
+    /// so tests can assert the mint propagates them correctly.
+    last_incoming: std::sync::Mutex<Option<(cdk_common::QuoteId, Option<cashu::PublicKey>)>>,
 }
 
 impl CustomPaymentProcessor {
     fn last_quote_id(&self) -> Option<cdk_common::QuoteId> {
         self.last_quote_id.lock().expect("poisoned").clone()
+    }
+
+    fn last_incoming(&self) -> Option<(cdk_common::QuoteId, Option<cashu::PublicKey>)> {
+        self.last_incoming.lock().expect("poisoned").clone()
     }
 }
 
@@ -2407,9 +2414,26 @@ impl MintPayment for CustomPaymentProcessor {
 
     async fn create_incoming_payment_request(
         &self,
-        _options: cdk_common::payment::IncomingPaymentOptions,
+        options: cdk_common::payment::IncomingPaymentOptions,
     ) -> Result<cdk_common::payment::CreateIncomingPaymentResponse, Self::Err> {
-        Err(cdk_common::payment::Error::UnsupportedPaymentOption)
+        match options {
+            cdk_common::payment::IncomingPaymentOptions::Custom(custom) => {
+                // Capture the mint-supplied quote_id and NUT-20 pubkey so the
+                // regression test can assert both are propagated.
+                *self.last_incoming.lock().expect("poisoned") =
+                    Some((custom.quote_id.clone(), custom.pubkey));
+
+                Ok(cdk_common::payment::CreateIncomingPaymentResponse {
+                    request_lookup_id: PaymentIdentifier::CustomId(
+                        "custom-incoming-lookup-id".to_string(),
+                    ),
+                    request: "custom-incoming-request".to_string(),
+                    expiry: custom.unix_expiry,
+                    extra_json: None,
+                })
+            }
+            _ => Err(cdk_common::payment::Error::UnsupportedPaymentOption),
+        }
     }
 
     async fn get_payment_quote(
@@ -2626,6 +2650,73 @@ async fn test_custom_melt_quote_id_propagates_to_payment_processor() {
     assert_eq!(
         seen_by_processor, response_quote_id,
         "the quote_id passed to get_payment_quote must equal the quote_id surfaced to the wallet",
+    );
+}
+
+#[tokio::test]
+async fn test_custom_mint_quote_id_and_pubkey_propagate_to_payment_processor() {
+    setup_tracing();
+
+    let localstore = Arc::new(cdk_sqlite::mint::memory::empty().await.expect("memory db"));
+    let processor = Arc::new(CustomPaymentProcessor::default());
+
+    let mut mint_builder = cdk::mint::MintBuilder::new(localstore.clone());
+    let mnemonic = Mnemonic::generate(12).expect("mnemonic");
+    mint_builder
+        .add_payment_processor(
+            CurrencyUnit::Sat,
+            PaymentMethod::Custom("test-custom".to_string()),
+            cdk::mint::MintMeltLimits::new(1, 10_000),
+            processor.clone(),
+        )
+        .await
+        .expect("custom payment processor");
+
+    mint_builder = mint_builder
+        .with_name("mint quote-id propagation test".to_string())
+        .with_description("mint quote-id propagation test".to_string())
+        .with_urls(vec!["https://example-mint".to_string()])
+        .with_limits(2000, 2000);
+
+    let mint = mint_builder
+        .build_with_seed(localstore.clone(), &mnemonic.to_seed_normalized(""))
+        .await
+        .expect("mint build");
+
+    mint.set_quote_ttl(QuoteTTL::new(10_000, 10_000))
+        .await
+        .expect("quote ttl");
+
+    let secret_key = SecretKey::generate();
+    let pubkey = secret_key.public_key();
+
+    let response = mint
+        .get_mint_quote(cdk::mint::MintQuoteRequest::Custom {
+            method: PaymentMethod::Custom("test-custom".to_string()),
+            request: cdk::nuts::MintQuoteCustomRequest {
+                amount: Some(Amount::from(21)),
+                unit: CurrencyUnit::Sat,
+                description: None,
+                pubkey: Some(pubkey),
+                extra: serde_json::Value::Null,
+            },
+        })
+        .await
+        .expect("custom mint quote");
+
+    let response_quote_id = response.quote().clone();
+    let (seen_quote_id, seen_pubkey) = processor
+        .last_incoming()
+        .expect("processor must have received the incoming payment options");
+
+    assert_eq!(
+        seen_quote_id, response_quote_id,
+        "the quote_id passed to create_incoming_payment_request must equal the quote_id surfaced to the wallet",
+    );
+    assert_eq!(
+        seen_pubkey,
+        Some(pubkey),
+        "the NUT-20 pubkey passed to create_incoming_payment_request must equal the one the wallet supplied",
     );
 }
 

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -2319,11 +2319,18 @@ struct CustomPaymentProcessor {
     /// Captures the quote_id seen by `get_payment_quote` so tests can assert
     /// the mint propagates it correctly.
     last_quote_id: std::sync::Mutex<Option<cdk_common::QuoteId>>,
+    /// Captures the (quote_id, pubkey) seen by `create_incoming_payment_request`
+    /// so tests can assert the mint propagates them correctly.
+    last_incoming: std::sync::Mutex<Option<(cdk_common::QuoteId, Option<cashu::PublicKey>)>>,
 }
 
 impl CustomPaymentProcessor {
     fn last_quote_id(&self) -> Option<cdk_common::QuoteId> {
         self.last_quote_id.lock().expect("poisoned").clone()
+    }
+
+    fn last_incoming(&self) -> Option<(cdk_common::QuoteId, Option<cashu::PublicKey>)> {
+        self.last_incoming.lock().expect("poisoned").clone()
     }
 }
 
@@ -2343,9 +2350,26 @@ impl MintPayment for CustomPaymentProcessor {
 
     async fn create_incoming_payment_request(
         &self,
-        _options: cdk_common::payment::IncomingPaymentOptions,
+        options: cdk_common::payment::IncomingPaymentOptions,
     ) -> Result<cdk_common::payment::CreateIncomingPaymentResponse, Self::Err> {
-        Err(cdk_common::payment::Error::UnsupportedPaymentOption)
+        match options {
+            cdk_common::payment::IncomingPaymentOptions::Custom(custom) => {
+                // Capture the mint-supplied quote_id and NUT-20 pubkey so the
+                // regression test can assert both are propagated.
+                *self.last_incoming.lock().expect("poisoned") =
+                    Some((custom.quote_id.clone(), custom.pubkey));
+
+                Ok(cdk_common::payment::CreateIncomingPaymentResponse {
+                    request_lookup_id: PaymentIdentifier::CustomId(
+                        "custom-incoming-lookup-id".to_string(),
+                    ),
+                    request: "custom-incoming-request".to_string(),
+                    expiry: custom.unix_expiry,
+                    extra_json: None,
+                })
+            }
+            _ => Err(cdk_common::payment::Error::UnsupportedPaymentOption),
+        }
     }
 
     async fn get_payment_quote(
@@ -2562,6 +2586,73 @@ async fn test_custom_melt_quote_id_propagates_to_payment_processor() {
     assert_eq!(
         seen_by_processor, response_quote_id,
         "the quote_id passed to get_payment_quote must equal the quote_id surfaced to the wallet",
+    );
+}
+
+#[tokio::test]
+async fn test_custom_mint_quote_id_and_pubkey_propagate_to_payment_processor() {
+    setup_tracing();
+
+    let localstore = Arc::new(cdk_sqlite::mint::memory::empty().await.expect("memory db"));
+    let processor = Arc::new(CustomPaymentProcessor::default());
+
+    let mut mint_builder = cdk::mint::MintBuilder::new(localstore.clone());
+    let mnemonic = Mnemonic::generate(12).expect("mnemonic");
+    mint_builder
+        .add_payment_processor(
+            CurrencyUnit::Sat,
+            PaymentMethod::Custom("test-custom".to_string()),
+            cdk::mint::MintMeltLimits::new(1, 10_000),
+            processor.clone(),
+        )
+        .await
+        .expect("custom payment processor");
+
+    mint_builder = mint_builder
+        .with_name("mint quote-id propagation test".to_string())
+        .with_description("mint quote-id propagation test".to_string())
+        .with_urls(vec!["https://example-mint".to_string()])
+        .with_limits(2000, 2000);
+
+    let mint = mint_builder
+        .build_with_seed(localstore.clone(), &mnemonic.to_seed_normalized(""))
+        .await
+        .expect("mint build");
+
+    mint.set_quote_ttl(QuoteTTL::new(10_000, 10_000))
+        .await
+        .expect("quote ttl");
+
+    let secret_key = SecretKey::generate();
+    let pubkey = secret_key.public_key();
+
+    let response = mint
+        .get_mint_quote(cdk::mint::MintQuoteRequest::Custom {
+            method: PaymentMethod::Custom("test-custom".to_string()),
+            request: cdk::nuts::MintQuoteCustomRequest {
+                amount: Some(Amount::from(21)),
+                unit: CurrencyUnit::Sat,
+                description: None,
+                pubkey: Some(pubkey),
+                extra: serde_json::Value::Null,
+            },
+        })
+        .await
+        .expect("custom mint quote");
+
+    let response_quote_id = response.quote().clone();
+    let (seen_quote_id, seen_pubkey) = processor
+        .last_incoming()
+        .expect("processor must have received the incoming payment options");
+
+    assert_eq!(
+        seen_quote_id, response_quote_id,
+        "the quote_id passed to create_incoming_payment_request must equal the quote_id surfaced to the wallet",
+    );
+    assert_eq!(
+        seen_pubkey,
+        Some(pubkey),
+        "the NUT-20 pubkey passed to create_incoming_payment_request must equal the one the wallet supplied",
     );
 }
 

--- a/crates/cdk-payment-processor/src/proto/client.rs
+++ b/crates/cdk-payment-processor/src/proto/client.rs
@@ -186,6 +186,8 @@ impl MintPayment for PaymentProcessorClient {
                         amount: opts.amount.map(Into::into),
                         unix_expiry: opts.unix_expiry,
                         extra_json: opts.extra_json.clone(),
+                        quote_id: opts.quote_id.to_string(),
+                        pubkey: opts.pubkey.map(|p| p.to_hex()),
                     },
                 )),
             },

--- a/crates/cdk-payment-processor/src/proto/client.rs
+++ b/crates/cdk-payment-processor/src/proto/client.rs
@@ -185,7 +185,7 @@ impl MintPayment for PaymentProcessorClient {
                         description: opts.description,
                         amount: opts.amount.map(Into::into),
                         unix_expiry: opts.unix_expiry,
-                        extra_json: opts.extra_json.clone(),
+                        extra_json: opts.extra_json,
                         quote_id: opts.quote_id.to_string(),
                         pubkey: opts.pubkey.map(|p| p.to_hex()),
                     },

--- a/crates/cdk-payment-processor/src/proto/payment_processor.proto
+++ b/crates/cdk-payment-processor/src/proto/payment_processor.proto
@@ -56,6 +56,14 @@ message CustomIncomingPaymentOptions {
   // Extra payment-method-specific fields as JSON string
   // These fields are flattened into the JSON representation on the client side
   optional string extra_json = 4;
+  // (field 5 is left free for the in-flight method-name addition, PR #2275)
+  // The mint's quote_id for this mint quote. Required. Custom backends that
+  // need a mint-side correlation key at quote-creation time should key their
+  // records on this value, as the onchain backend does.
+  string quote_id = 6;
+  // NUT-20 locking pubkey of the quote (hex), present when the wallet
+  // requested a locked quote.
+  optional string pubkey = 7;
 }
 message Bolt12IncomingPaymentOptions {
   optional string description = 1;

--- a/crates/cdk-payment-processor/src/proto/server.rs
+++ b/crates/cdk-payment-processor/src/proto/server.rs
@@ -239,12 +239,10 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
                 let quote_id = parse_quote_id(&opts.quote_id)?;
                 let pubkey = opts
                     .pubkey
-                    .map(|p| {
-                        PublicKey::from_str(&p).map_err(|_| {
-                            Status::invalid_argument("Invalid pubkey in Custom options")
-                        })
-                    })
-                    .transpose()?;
+                    .as_deref()
+                    .map(PublicKey::from_str)
+                    .transpose()
+                    .map_err(|_| Status::invalid_argument("Invalid pubkey in Custom options"))?;
                 IncomingPaymentOptions::Custom(Box::new(
                     cdk_common::payment::CustomIncomingPaymentOptions {
                         method: "".to_string(),

--- a/crates/cdk-payment-processor/src/proto/server.rs
+++ b/crates/cdk-payment-processor/src/proto/server.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use cdk_common::grpc::create_version_check_interceptor;
 use cdk_common::payment::{IncomingPaymentOptions, MintPayment};
-use cdk_common::{CurrencyUnit, QuoteId};
+use cdk_common::{CurrencyUnit, PublicKey, QuoteId};
 use futures::{Stream, StreamExt};
 use lightning::offers::offer::Offer;
 use tokio::sync::{mpsc, Notify};
@@ -231,6 +231,20 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
                     ),
                     None => None,
                 };
+                if opts.quote_id.is_empty() {
+                    return Err(Status::invalid_argument(
+                        "Missing quote_id in Custom options",
+                    ));
+                }
+                let quote_id = parse_quote_id(&opts.quote_id)?;
+                let pubkey = opts
+                    .pubkey
+                    .map(|p| {
+                        PublicKey::from_str(&p).map_err(|_| {
+                            Status::invalid_argument("Invalid pubkey in Custom options")
+                        })
+                    })
+                    .transpose()?;
                 IncomingPaymentOptions::Custom(Box::new(
                     cdk_common::payment::CustomIncomingPaymentOptions {
                         method: "".to_string(),
@@ -238,6 +252,8 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
                         amount,
                         unix_expiry: opts.unix_expiry,
                         extra_json: opts.extra_json,
+                        quote_id,
+                        pubkey,
                     },
                 ))
             }

--- a/crates/cdk/src/mint/issue/mod.rs
+++ b/crates/cdk/src/mint/issue/mod.rs
@@ -315,6 +315,8 @@ impl Mint {
                         amount: request.amount.map(|a| a.with_unit(unit.clone())),
                         unix_expiry: Some(quote_expiry),
                         extra_json,
+                        quote_id: quote_id.clone(),
+                        pubkey,
                     };
 
                     IncomingPaymentOptions::Custom(Box::new(custom_options))


### PR DESCRIPTION
### Description

Adds the mint's `quote_id` (required) and the quote's NUT-20 locking `pubkey` (optional) to `CustomIncomingPaymentOptions`, so custom payment-method backends learn both at quote-creation time.

This completes the asymmetry closed for melt by #1973 and for onchain by #1870: custom incoming quotes are the only quote-creating path where the backend receives no mint-side identifier. A backend whose rail is keyed by the quote id the wallet displays (e.g. person-present settlement) has nothing to correlate on — reading it from wallet-supplied `extra_json` is spoofable — and no backend can currently see whether a quote is NUT-20-locked, so a locked-quotes-only policy is unenforceable. Both values are already in scope at the call site; the change mirrors the `Onchain` arm.

`PAYMENT_PROCESSOR_PROTOCOL_VERSION` is bumped 3.0.0 → 4.0.0 since the field is required, per the #1973 convention. Existing backends are unaffected; a regression test asserts both values match what the wallet sees.

-----

### Notes to the reviewers

* Proto fields are appended as 6/7, leaving field 5 free for the in-flight method-name addition in #2275 so the two compose without renumbering. Whichever lands second needs a trivial rebase (both touch `CustomIncomingPaymentOptions`).
* The server rejects an empty `quote_id` explicitly, since `QuoteId::from_str` accepts `""` as a base64 id.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

- Payment processor protocol version 3.0.0 → 4.0.0.

#### ADDED

- cdk-common: `quote_id` and NUT-20 `pubkey` on `CustomIncomingPaymentOptions`, populated by the mint and carried over the payment processor proto.

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
