### PR TITLE
remove shell entry banners

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -936,30 +936,12 @@
         pgShellHook = ''
           # PostgreSQL environment variables
           export CDK_MINTD_DATABASE_URL="postgresql://${postgresConf.pgUser}:${postgresConf.pgPassword}@localhost:${postgresConf.pgPort}/${postgresConf.pgDatabase}"
-
-          # Informational banner goes to stderr so it never corrupts the stdout of
-          # commands run via `nix develop --command ... > file` (e.g. CI schema dumps).
-          echo "" >&2
-          echo "PostgreSQL commands available:" >&2
-          echo "  start-postgres  - Initialize and start PostgreSQL" >&2
-          echo "  stop-postgres   - Stop PostgreSQL (run before exiting)" >&2
-          echo "  pg-status       - Check PostgreSQL status" >&2
-          echo "  pg-connect      - Connect to PostgreSQL with psql" >&2
-          echo "" >&2
         '';
 
         redisShellHook = ''
           # Redis environment variables (single-node defaults)
           export CDK_MINTD_CACHE_REDIS_URL="redis://127.0.0.1:6379"
           export CDK_MINTD_CACHE_REDIS_CLUSTER_NODES="redis://127.0.0.1:7001,redis://127.0.0.1:7002,redis://127.0.0.1:7003"
-
-          echo "" >&2
-          echo "Redis commands available:" >&2
-          echo "  start-redis-single   - Start a single-node Redis on port 6379" >&2
-          echo "  stop-redis-single    - Stop the single-node Redis" >&2
-          echo "  start-redis-cluster  - Start a 3-node Redis cluster on ports 7001-7003" >&2
-          echo "  stop-redis-cluster   - Stop the Redis cluster" >&2
-          echo "" >&2
         '';
 
         # PostgreSQL configuration


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
Every time you entered the nix dev shell, it printed a banner listing the PostgreSQL/Redis helper commands (start-postgres, pg-status, start-redis-single, etc). Gets old fast when you're in and out of the shell all day, so this just removes the banner. Commands still work fine, just no more spam.

Fixes #2292
-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->
small change, just deleted the `echo` lines in `pgShellHook` and `redisShellHook` in `flake.nix`. Nothing else touched.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED
- Dev shell no longer prints Postgres/Redis command banner on every entry.


#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
