### PR TITLE
fix(wallet): preserve proofs after ambiguous mint failures

### DIFF
--- a/crates/cdk-common/src/database/wallet/mod.rs
+++ b/crates/cdk-common/src/database/wallet/mod.rs
@@ -177,7 +177,11 @@ where
         operation_id: &uuid::Uuid,
     ) -> Result<(), Err>;
 
-    /// Release proofs reserved by an operation
+    /// Release proofs reserved by an operation.
+    ///
+    /// Only proofs owned by `operation_id` in [`State::Reserved`] or
+    /// [`State::Pending`] may be changed to [`State::Unspent`]. Implementations
+    /// must preserve spent proofs and proofs owned by another operation.
     async fn release_proofs(&self, operation_id: &uuid::Uuid) -> Result<(), Err>;
 
     /// Get proofs reserved by an operation

--- a/crates/cdk-common/src/database/wallet/test/mod.rs
+++ b/crates/cdk-common/src/database/wallet/test/mod.rs
@@ -1448,6 +1448,34 @@ where
     assert!(reserved.is_empty());
 }
 
+/// Test that releasing an operation never resurrects proofs already marked spent.
+pub async fn release_proofs_preserves_spent<DB>(db: DB)
+where
+    DB: Database<crate::database::Error>,
+{
+    let mint_url = test_mint_url();
+    let keyset_id = test_keyset_id();
+    let proof_info = test_proof_info(keyset_id, 100, mint_url);
+    let proof_y = proof_info.y;
+
+    db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+    let operation_id = uuid::Uuid::new_v4();
+    db.reserve_proofs(vec![proof_y], &operation_id)
+        .await
+        .unwrap();
+    db.update_proofs_state(vec![proof_y], State::Spent)
+        .await
+        .unwrap();
+
+    db.release_proofs(&operation_id).await.unwrap();
+
+    let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].state, State::Spent);
+    assert_eq!(stored[0].used_by_operation, Some(operation_id));
+}
+
 /// Test getting proofs reserved by an operation
 pub async fn get_reserved_proofs<DB>(db: DB)
 where
@@ -1615,6 +1643,7 @@ macro_rules! wallet_db_test {
             get_incomplete_sagas,
             reserve_proofs,
             release_proofs,
+            release_proofs_preserves_spent,
             get_reserved_proofs,
             reserve_proofs_already_reserved,
             reserve_proofs_is_atomic

--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -583,7 +583,6 @@ mod tests {
     fn test_is_definitive_failure() {
         // Test definitive failures
         assert!(Error::AmountOverflow.is_definitive_failure());
-        assert!(Error::TokenAlreadySpent.is_definitive_failure());
         assert!(Error::MintingDisabled.is_definitive_failure());
         assert!(Error::MaxInputsExceeded { actual: 2, max: 1 }.is_definitive_failure());
         assert!(Error::MaxOutputsExceeded { actual: 2, max: 1 }.is_definitive_failure());
@@ -599,6 +598,8 @@ mod tests {
         assert!(!Error::Timeout.is_definitive_failure());
         assert!(!Error::Internal.is_definitive_failure());
         assert!(!Error::ConcurrentUpdate.is_definitive_failure());
+        assert!(!Error::BlindedMessageAlreadySigned.is_definitive_failure());
+        assert!(!Error::TokenAlreadySpent.is_definitive_failure());
 
         // Test HTTP server errors (5xx)
         assert!(
@@ -685,7 +686,6 @@ impl Error {
             | Self::PaidQuote
             | Self::MeltingDisabled
             | Self::UnknownKeySet
-            | Self::BlindedMessageAlreadySigned
             | Self::InactiveKeyset
             | Self::ExpiredKeyset
             | Self::TransactionUnbalanced(_, _, _)
@@ -698,7 +698,6 @@ impl Error {
             | Self::MultipleUnits
             | Self::UnitMismatch
             | Self::SigAllUsedInMelt
-            | Self::TokenAlreadySpent
             | Self::P2PKConditionsNotMet(_)
             | Self::DuplicateSignatureError
             | Self::LocktimeNotProvided

--- a/crates/cdk-ffi/src/database.rs
+++ b/crates/cdk-ffi/src/database.rs
@@ -234,7 +234,11 @@ pub trait WalletDatabase: Send + Sync {
         operation_id: String,
     ) -> Result<(), FfiError>;
 
-    /// Release proofs reserved by an operation
+    /// Release live proofs reserved by an operation.
+    ///
+    /// Implementations must only change Reserved or Pending proofs owned by
+    /// `operation_id`; Spent proofs and proofs owned by another operation must
+    /// be preserved.
     async fn release_proofs(&self, operation_id: String) -> Result<(), FfiError>;
 
     /// Get proofs reserved by an operation

--- a/crates/cdk-redb/src/wallet/mod.rs
+++ b/crates/cdk-redb/src/wallet/mod.rs
@@ -1182,7 +1182,9 @@ impl WalletDatabase<database::Error> for WalletRedbDatabase {
 
             // Now update proofs that match the operation_id
             for (y_bytes, mut proof) in all_proofs {
-                if proof.used_by_operation == Some(*operation_id) {
+                if proof.used_by_operation == Some(*operation_id)
+                    && matches!(proof.state, State::Reserved | State::Pending)
+                {
                     proof.state = State::Unspent;
                     proof.used_by_operation = None;
 

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -1615,6 +1615,7 @@ where
             UPDATE proof
             SET state = 'UNSPENT', used_by_operation = NULL
             WHERE used_by_operation = :operation_id
+              AND state IN ('RESERVED', 'PENDING')
             "#,
         )?
         .bind("operation_id", operation_id.to_string())

--- a/crates/cdk-supabase/src/wallet.rs
+++ b/crates/cdk-supabase/src/wallet.rs
@@ -2034,14 +2034,17 @@ impl Database<DatabaseError> for SupabaseWalletDatabase {
     async fn release_proofs(&self, operation_id: &uuid::Uuid) -> Result<(), DatabaseError> {
         let op_id_str = operation_id.to_string();
 
-        // Update all proofs reserved by this operation back to Unspent
+        // Release only live reservations owned by this operation. In
+        // particular, never resurrect a proof already finalized as Spent.
         let update = serde_json::json!({
             "state": State::Unspent.to_string(),
             "used_by_operation": null,
         });
         let path = format!(
-            "rest/v1/proof?used_by_operation=eq.{}",
-            url_encode(&op_id_str)
+            "rest/v1/proof?used_by_operation=eq.{}&state=in.({},{})",
+            url_encode(&op_id_str),
+            url_encode(&State::Reserved.to_string()),
+            url_encode(&State::Pending.to_string())
         );
         let (status, response_text) = self.patch_request(&path, &update).await?;
 

--- a/crates/cdk/src/wallet/melt/mod.rs
+++ b/crates/cdk/src/wallet/melt/mod.rs
@@ -2680,6 +2680,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_reconcile_stale_failure_preserves_spent_proof() {
+        let (db, proof_y, operation_id, mock_client, pending) = pending_bolt11_melt(false).await;
+        let quote_id = pending.saga.quote().id.clone();
+
+        db.update_proofs_state(vec![proof_y], State::Spent)
+            .await
+            .unwrap();
+        mock_client.set_melt_quote_status_response(Ok(bolt11_status(
+            &quote_id,
+            MeltQuoteState::Failed,
+            None,
+        )));
+
+        assert!(matches!(
+            pending
+                .reconcile_non_paid_status(MeltQuoteState::Failed)
+                .await,
+            WaitStep::Terminal(Err(Error::PaymentFailed))
+        ));
+
+        let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        assert_eq!(stored[0].state, State::Spent);
+        assert_eq!(stored[0].used_by_operation, Some(operation_id));
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_stale_failure_preserves_newer_proof_owner() {
+        let (db, proof_y, _operation_id, mock_client, pending) = pending_bolt11_melt(false).await;
+        let quote_id = pending.saga.quote().id.clone();
+        let newer_operation_id = uuid::Uuid::new_v4();
+
+        let mut stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        stored[0].state = State::Reserved;
+        stored[0].used_by_operation = Some(newer_operation_id);
+        db.update_proofs(stored, vec![]).await.unwrap();
+
+        mock_client.set_melt_quote_status_response(Ok(bolt11_status(
+            &quote_id,
+            MeltQuoteState::Failed,
+            None,
+        )));
+
+        assert!(matches!(
+            pending
+                .reconcile_non_paid_status(MeltQuoteState::Failed)
+                .await,
+            WaitStep::Terminal(Err(Error::PaymentFailed))
+        ));
+
+        let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        assert_eq!(stored[0].state, State::Reserved);
+        assert_eq!(stored[0].used_by_operation, Some(newer_operation_id));
+    }
+
+    #[tokio::test]
     async fn test_reconcile_non_paid_status_http_failed_with_proof_keeps_waiting() {
         let (db, proof_y, operation_id, mock_client, pending) = pending_bolt11_melt(false).await;
         let quote_id = pending.saga.quote().id.clone();

--- a/crates/cdk/src/wallet/melt/saga/compensation.rs
+++ b/crates/cdk/src/wallet/melt/saga/compensation.rs
@@ -111,14 +111,14 @@ mod tests {
         let mint_url = test_mint_url();
         let keyset_id = test_keyset_id();
 
-        // Create and store proof in Reserved state
-        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Reserved);
-        let proof_y = proof_info.y;
-        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
-
         let saga = test_melt_saga(mint_url);
         let saga_id = saga.id;
         db.add_saga(saga).await.unwrap();
+
+        let mut proof_info = test_proof_info(keyset_id, 100, test_mint_url(), State::Reserved);
+        proof_info.used_by_operation = Some(saga_id);
+        let proof_y = proof_info.y;
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
 
         let compensation = RevertProofReservation {
             localstore: db.clone(),
@@ -144,13 +144,12 @@ mod tests {
         let mint_url = test_mint_url();
         let keyset_id = test_keyset_id();
 
-        // Create and store proof
-        let proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Reserved);
-        let proof_y = proof_info.y;
-        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
-
         // Use a saga_id that doesn't exist
         let saga_id = uuid::Uuid::new_v4();
+        let mut proof_info = test_proof_info(keyset_id, 100, mint_url, State::Reserved);
+        proof_info.used_by_operation = Some(saga_id);
+        let proof_y = proof_info.y;
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
 
         let compensation = RevertProofReservation {
             localstore: db.clone(),
@@ -158,12 +157,12 @@ mod tests {
             saga_id,
         };
 
-        // Should succeed even though saga doesn't exist
+        // A stale compensation should no-op without its persisted saga.
         compensation.execute().await.unwrap();
 
-        // Proof should be Unspent
+        // Proof should remain reserved.
         let proofs = db
-            .get_proofs(None, None, Some(vec![State::Unspent]), None)
+            .get_proofs(None, None, Some(vec![State::Reserved]), None)
             .await
             .unwrap();
         assert_eq!(proofs.len(), 1);
@@ -216,14 +215,20 @@ mod tests {
     // =========================================================================
 
     #[tokio::test]
-    async fn test_compensation_only_affects_specified_proofs() {
+    async fn test_compensation_only_affects_owning_operation() {
         let db = create_test_db().await;
         let mint_url = test_mint_url();
         let keyset_id = test_keyset_id();
 
-        // Create two proofs, both Reserved
-        let proof_info_1 = test_proof_info(keyset_id, 100, mint_url.clone(), State::Reserved);
-        let proof_info_2 = test_proof_info(keyset_id, 200, mint_url.clone(), State::Reserved);
+        let saga = test_melt_saga(mint_url.clone());
+        let saga_id = saga.id;
+        db.add_saga(saga).await.unwrap();
+
+        // Create two reserved proofs owned by different operations.
+        let mut proof_info_1 = test_proof_info(keyset_id, 100, mint_url.clone(), State::Reserved);
+        proof_info_1.used_by_operation = Some(saga_id);
+        let mut proof_info_2 = test_proof_info(keyset_id, 200, mint_url, State::Reserved);
+        proof_info_2.used_by_operation = Some(uuid::Uuid::new_v4());
 
         let proof_y_1 = proof_info_1.y;
         let proof_y_2 = proof_info_2.y;
@@ -232,11 +237,6 @@ mod tests {
             .await
             .unwrap();
 
-        let saga = test_melt_saga(mint_url);
-        let saga_id = saga.id;
-        db.add_saga(saga).await.unwrap();
-
-        // Only revert the first proof
         let compensation = RevertProofReservation {
             localstore: db.clone(),
             proof_ys: vec![proof_y_1],

--- a/crates/cdk/src/wallet/melt/saga/mod.rs
+++ b/crates/cdk/src/wallet/melt/saga/mod.rs
@@ -1212,21 +1212,18 @@ impl<'a> MeltSaga<'a, MeltRequested> {
     /// Handle failed payment - release proofs and clean up.
     async fn handle_failure(&self) {
         let operation_id = self.state_data.operation_id;
-        let final_proofs = &self.state_data.final_proofs;
 
-        if let Ok(all_ys) = final_proofs.ys() {
-            let _ = self
-                .wallet
-                .localstore
-                .update_proofs_state(all_ys, State::Unspent)
-                .await;
-        }
-        let _ = self
+        if let Err(e) = self
             .wallet
-            .localstore
-            .release_melt_quote(&operation_id)
-            .await;
-        let _ = self.wallet.localstore.delete_saga(&operation_id).await;
+            .claim_and_compensate_melt(&operation_id, &[MeltSagaState::MeltRequested])
+            .await
+        {
+            tracing::error!(
+                "Failed to compensate melt operation {} after failure: {}",
+                operation_id,
+                e
+            );
+        }
     }
 }
 
@@ -1271,24 +1268,21 @@ impl<'a> MeltSaga<'a, PaymentPending> {
             final_proofs.total_amount().unwrap_or(Amount::ZERO)
         );
 
-        if let Ok(all_ys) = final_proofs.ys() {
-            if let Err(e) = self
-                .wallet
-                .localstore
-                .update_proofs_state(all_ys, State::Unspent)
-                .await
-            {
-                tracing::error!("Failed to restore proofs for failed melt: {}", e);
-            } else {
-                tracing::info!("Successfully restored proofs to Unspent");
-            }
-        }
-        let _ = self
+        match self
             .wallet
-            .localstore
-            .release_melt_quote(&operation_id)
-            .await;
-        let _ = self.wallet.localstore.delete_saga(&operation_id).await;
+            .claim_and_compensate_melt(
+                &operation_id,
+                &[MeltSagaState::MeltRequested, MeltSagaState::PaymentPending],
+            )
+            .await
+        {
+            Ok(true) => tracing::info!("Successfully restored owned proofs to Unspent"),
+            Ok(false) => tracing::info!(
+                "Skipped stale failure cleanup for melt operation {}",
+                operation_id
+            ),
+            Err(e) => tracing::error!("Failed to restore proofs for failed melt: {}", e),
+        }
     }
 }
 

--- a/crates/cdk/src/wallet/melt/saga/resume.rs
+++ b/crates/cdk/src/wallet/melt/saga/resume.rs
@@ -6,7 +6,7 @@
 
 use cdk_common::wallet::{
     MeltOperationData, MeltSagaState, OperationData, Transaction, TransactionDirection,
-    TransactionId, WalletSaga,
+    TransactionId, WalletSaga, WalletSagaState,
 };
 use cdk_common::{Amount, MeltQuoteState};
 use tracing::instrument;
@@ -36,6 +36,14 @@ impl Wallet {
         &self,
         saga: &WalletSaga,
     ) -> Result<Option<FinalizedMelt>, Error> {
+        // Callers enumerate sagas and then await while processing them. Always
+        // reload this operation so a stale snapshot cannot compensate a saga
+        // that another task has advanced or completed.
+        let saga = match self.localstore.get_saga(&saga.id).await? {
+            Some(saga) => saga,
+            None => return Ok(None),
+        };
+
         let state = match &saga.state {
             cdk_common::wallet::WalletSagaState::Melt(s) => s,
             _ => {
@@ -64,7 +72,12 @@ impl Wallet {
                     "Melt saga {} in ProofsReserved state - compensating",
                     saga.id
                 );
-                self.compensate_melt(&saga.id).await?;
+                if !self
+                    .claim_and_compensate_melt(&saga.id, &[MeltSagaState::ProofsReserved])
+                    .await?
+                {
+                    return Ok(None);
+                }
                 Ok(Some(FinalizedMelt::new(
                     data.quote_id.clone(),
                     MeltQuoteState::Unpaid,
@@ -121,7 +134,15 @@ impl Wallet {
                     }
                     // Payment failed - compensate and return FinalizedMelt with failed state
                     tracing::info!("Melt saga {} - payment failed, compensating", saga_id);
-                    self.compensate_melt(saga_id).await?;
+                    if !self
+                        .claim_and_compensate_melt(
+                            saga_id,
+                            &[MeltSagaState::MeltRequested, MeltSagaState::PaymentPending],
+                        )
+                        .await?
+                    {
+                        return Ok(None);
+                    }
                     Ok(Some(FinalizedMelt::new(
                         data.quote_id.clone(),
                         quote_status.state(),
@@ -416,6 +437,40 @@ impl Wallet {
 
         Ok(())
     }
+
+    /// Claim a persisted melt saga before compensating it.
+    ///
+    /// The no-op state update is an optimistic-locking claim. A stale caller
+    /// loses the claim if another task advanced the saga after it was read.
+    pub(super) async fn claim_and_compensate_melt(
+        &self,
+        saga_id: &uuid::Uuid,
+        expected_states: &[MeltSagaState],
+    ) -> Result<bool, Error> {
+        let mut saga = match self.localstore.get_saga(saga_id).await? {
+            Some(saga) => saga,
+            None => return Ok(false),
+        };
+
+        if saga.mint_url != self.mint_url || saga.unit != self.unit {
+            return Ok(false);
+        }
+
+        let WalletSagaState::Melt(current_state) = saga.state else {
+            return Ok(false);
+        };
+        if !expected_states.contains(&current_state) {
+            return Ok(false);
+        }
+
+        saga.update_state(WalletSagaState::Melt(current_state));
+        if !self.localstore.update_saga(saga).await? {
+            return Ok(false);
+        }
+
+        self.compensate_melt(saga_id).await?;
+        Ok(true)
+    }
 }
 
 #[cfg(test)]
@@ -529,6 +584,70 @@ mod tests {
 
         // Saga should be deleted
         assert!(db.get_saga(&saga_id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_recover_melt_reloads_stale_proofs_reserved_snapshot() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let keyset_id = test_keyset_id();
+        let saga_id = uuid::Uuid::new_v4();
+        let quote_id = format!("test_melt_quote_{}", uuid::Uuid::new_v4());
+
+        let mut proof_info = test_proof_info(keyset_id, 100, mint_url.clone(), State::Pending);
+        proof_info.used_by_operation = Some(saga_id);
+        let proof_y = proof_info.y;
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
+
+        let stale_saga = WalletSaga::new(
+            saga_id,
+            WalletSagaState::Melt(MeltSagaState::ProofsReserved),
+            Amount::from(100),
+            mint_url,
+            CurrencyUnit::Sat,
+            OperationData::Melt(MeltOperationData {
+                quote_id: quote_id.clone(),
+                amount: Amount::from(100),
+                fee_reserve: Amount::from(10),
+                counter_start: None,
+                counter_end: None,
+                change_amount: None,
+                metadata: HashMap::new(),
+                final_proof_ys: Some(vec![proof_y]),
+                change_blinded_messages: None,
+            }),
+        );
+        db.add_saga(stale_saga.clone()).await.unwrap();
+
+        let mut advanced_saga = stale_saga.clone();
+        advanced_saga.update_state(WalletSagaState::Melt(MeltSagaState::MeltRequested));
+        assert!(db.update_saga(advanced_saga).await.unwrap());
+
+        let mock_client = Arc::new(MockMintConnector::new());
+        mock_client.set_melt_quote_status_response(Ok(MeltQuoteBolt11Response {
+            quote: quote_id,
+            state: MeltQuoteState::Pending,
+            expiry: 9999999999,
+            fee_reserve: Amount::from(10),
+            amount: Amount::from(100),
+            request: Some("lnbc100...".to_string()),
+            payment_preimage: None,
+            change: None,
+            unit: Some(CurrencyUnit::Sat),
+            method: PaymentMethod::BOLT11,
+        }));
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+
+        let result = wallet.resume_melt_saga(&stale_saga).await.unwrap();
+        assert!(result.is_none());
+
+        let stored = db.get_proofs_by_ys(vec![proof_y]).await.unwrap();
+        assert_eq!(stored[0].state, State::Pending);
+        assert_eq!(stored[0].used_by_operation, Some(saga_id));
+        assert!(matches!(
+            db.get_saga(&saga_id).await.unwrap().map(|saga| saga.state),
+            Some(WalletSagaState::Melt(MeltSagaState::MeltRequested))
+        ));
     }
 
     #[tokio::test]

--- a/crates/cdk/src/wallet/saga/mod.rs
+++ b/crates/cdk/src/wallet/saga/mod.rs
@@ -21,7 +21,7 @@ use async_trait::async_trait;
 use cdk_common::database::{self, WalletDatabase};
 use tracing::instrument;
 
-use crate::nuts::{PublicKey, State};
+use crate::nuts::PublicKey;
 use crate::Error;
 
 /// Trait for compensating actions in the saga pattern.
@@ -100,33 +100,26 @@ impl CompensatingAction for RevertProofReservation {
             self.proof_ys.len()
         );
 
-        // Fetch current states to avoid reverting proofs that were already spent
-        // (e.g. by a successful internal swap that occurred before a crash)
-        let current_proofs = if self.proof_ys.is_empty() {
-            vec![]
-        } else {
-            self.localstore
-                .get_proofs_by_ys(self.proof_ys.clone())
-                .await
-                .map_err(Error::Database)?
-        };
-
-        let mut proofs_to_revert: Vec<_> = current_proofs
-            .into_iter()
-            .filter(|p| p.state == State::Reserved || p.state == State::Pending)
-            .collect();
-
-        for proof in proofs_to_revert.iter_mut() {
-            proof.state = State::Unspent;
-            proof.used_by_operation = None;
+        // A missing saga means this compensation is stale or was already
+        // completed. Never mutate proofs from a stale in-memory action.
+        if self
+            .localstore
+            .get_saga(&self.saga_id)
+            .await
+            .map_err(Error::Database)?
+            .is_none()
+        {
+            return Ok(());
         }
 
-        if !proofs_to_revert.is_empty() {
-            self.localstore
-                .update_proofs(proofs_to_revert, vec![])
-                .await
-                .map_err(Error::Database)?;
-        }
+        // The database performs the ownership and live-state checks in the
+        // same write that releases the proofs. This prevents a stale
+        // compensation from overwriting a Spent proof or a reservation owned
+        // by a newer operation between a read and a write.
+        self.localstore
+            .release_proofs(&self.saga_id)
+            .await
+            .map_err(Error::Database)?;
 
         if let Err(e) = self.localstore.delete_saga(&self.saga_id).await {
             tracing::warn!(
@@ -224,6 +217,9 @@ pub mod test_utils {
 }
 
 #[cfg(test)]
+use crate::nuts::State;
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -237,14 +233,19 @@ mod tests {
         let mint_url = test_utils::test_mint_url();
         let keyset_id = test_utils::test_keyset_id();
 
-        let proof_info =
-            test_utils::test_proof_info(keyset_id, 100, mint_url.clone(), State::Reserved);
-        let proof_y = proof_info.y;
-        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
-
         let saga = test_utils::test_simple_saga(mint_url);
         let saga_id = saga.id;
         db.add_saga(saga).await.unwrap();
+
+        let mut proof_info = test_utils::test_proof_info(
+            keyset_id,
+            100,
+            test_utils::test_mint_url(),
+            State::Reserved,
+        );
+        proof_info.used_by_operation = Some(saga_id);
+        let proof_y = proof_info.y;
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
 
         let compensation = RevertProofReservation {
             localstore: db.clone(),
@@ -270,13 +271,13 @@ mod tests {
         let mint_url = test_utils::test_mint_url();
         let keyset_id = test_utils::test_keyset_id();
 
-        let proof_info =
+        let mut proof_info =
             test_utils::test_proof_info(keyset_id, 100, mint_url.clone(), State::Reserved);
-        let proof_y = proof_info.y;
-        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
-
         // Use a saga_id that doesn't exist
         let saga_id = uuid::Uuid::new_v4();
+        proof_info.used_by_operation = Some(saga_id);
+        let proof_y = proof_info.y;
+        db.update_proofs(vec![proof_info], vec![]).await.unwrap();
 
         let compensation = RevertProofReservation {
             localstore: db.clone(),
@@ -284,39 +285,40 @@ mod tests {
             saga_id,
         };
 
-        // Should succeed even without saga
+        // A stale compensation should no-op without its persisted saga.
         compensation.execute().await.unwrap();
 
-        // Proof should be Unspent
+        // Proof should remain reserved.
         let proofs = db
-            .get_proofs(None, None, Some(vec![State::Unspent]), None)
+            .get_proofs(None, None, Some(vec![State::Reserved]), None)
             .await
             .unwrap();
         assert_eq!(proofs.len(), 1);
     }
 
     #[tokio::test]
-    async fn test_revert_proof_reservation_only_affects_specified_proofs() {
+    async fn test_revert_proof_reservation_only_affects_owning_operation() {
         let db = test_utils::create_test_db().await;
         let mint_url = test_utils::test_mint_url();
         let keyset_id = test_utils::test_keyset_id();
 
-        // Create two reserved proofs
-        let proof_info_1 =
+        let saga = test_utils::test_simple_saga(mint_url.clone());
+        let saga_id = saga.id;
+        db.add_saga(saga).await.unwrap();
+
+        // Create two reserved proofs owned by different operations.
+        let mut proof_info_1 =
             test_utils::test_proof_info(keyset_id, 100, mint_url.clone(), State::Reserved);
-        let proof_info_2 =
+        proof_info_1.used_by_operation = Some(saga_id);
+        let mut proof_info_2 =
             test_utils::test_proof_info(keyset_id, 200, mint_url.clone(), State::Reserved);
+        proof_info_2.used_by_operation = Some(uuid::Uuid::new_v4());
         let proof_y_1 = proof_info_1.y;
         let proof_y_2 = proof_info_2.y;
         db.update_proofs(vec![proof_info_1, proof_info_2], vec![])
             .await
             .unwrap();
 
-        let saga = test_utils::test_simple_saga(mint_url);
-        let saga_id = saga.id;
-        db.add_saga(saga).await.unwrap();
-
-        // Only revert the first proof
         let compensation = RevertProofReservation {
             localstore: db.clone(),
             proof_ys: vec![proof_y_1],

--- a/crates/cdk/src/wallet/swap/mod.rs
+++ b/crates/cdk/src/wallet/swap/mod.rs
@@ -376,6 +376,7 @@ mod tests {
         .unwrap();
         let pi2 =
             ProofInfo::new(proof2.clone(), mint_url, State::Unspent, CurrencyUnit::Sat).unwrap();
+        let proof_ys = vec![pi1.y, pi2.y];
         db.update_proofs(vec![pi1, pi2], vec![]).await.unwrap();
 
         // Rotate keysets on the mock: A becomes inactive, B becomes active
@@ -428,6 +429,53 @@ mod tests {
                 .all(|o| o.keyset_id == keyset_b_id),
             "second swap attempt should target keyset B"
         );
+
+        let stored = db.get_proofs_by_ys(proof_ys).await.unwrap();
+        assert!(stored.iter().all(|proof| proof.state == State::Reserved));
+        assert!(stored.iter().all(|proof| proof.used_by_operation.is_some()));
+    }
+
+    #[tokio::test]
+    async fn swap_already_signed_error_keeps_inputs_reserved() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        db.add_mint(mint_url.clone(), None).await.unwrap();
+
+        let mock = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock.clone()).await;
+        wallet.keysets(KeysetLoadPolicy::Refresh).await.unwrap();
+
+        let proof1 = test_proof(test_keyset_id(), 1);
+        let proof2 = test_proof(test_keyset_id(), 2);
+        let pi1 = ProofInfo::new(
+            proof1.clone(),
+            mint_url.clone(),
+            State::Unspent,
+            CurrencyUnit::Sat,
+        )
+        .unwrap();
+        let pi2 =
+            ProofInfo::new(proof2.clone(), mint_url, State::Unspent, CurrencyUnit::Sat).unwrap();
+        let proof_ys = vec![pi1.y, pi2.y];
+        db.update_proofs(vec![pi1, pi2], vec![]).await.unwrap();
+
+        mock.set_post_swap_response(Err(Error::BlindedMessageAlreadySigned));
+
+        let result = wallet
+            .swap(
+                None,
+                SplitTarget::default(),
+                vec![proof1, proof2],
+                None,
+                false,
+                false,
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::BlindedMessageAlreadySigned)));
+        let stored = db.get_proofs_by_ys(proof_ys).await.unwrap();
+        assert!(stored.iter().all(|proof| proof.state == State::Reserved));
+        assert!(stored.iter().all(|proof| proof.used_by_operation.is_some()));
     }
 
     /// When the mint returns InactiveKeyset but the active keyset hasn't


### PR DESCRIPTION
Treat already-signed and already-spent responses as indeterminate so replayed swaps do not release inputs the mint may have already consumed.

Reload and claim persisted melt sagas before compensation. Release proofs only when they are owned by that operation and remain reserved or pending. This prevents stale recovery from resurrecting spent proofs or clobbering a newer reservation.

Add regression coverage for replay errors, stale snapshots, concurrent finalization, and database release semantics.

found by project loupe

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
