### PR TITLE
fix(wallet): read the mint info pubkey as the bytes the store writes

### DIFF
--- a/crates/cdk-common/src/database/wallet/test/mod.rs
+++ b/crates/cdk-common/src/database/wallet/test/mod.rs
@@ -181,7 +181,14 @@ where
     DB: Database<crate::database::Error>,
 {
     let mint_url = test_mint_url();
-    let mint_info = MintInfo::default();
+    let pubkey = crate::nuts::PublicKey::from_hex(
+        "02836c831cfff541ba17fbca32dd0f6a54d06305893cbcb2af0d7143e66a609147",
+    )
+    .unwrap();
+    let mint_info = MintInfo {
+        pubkey: Some(pubkey),
+        ..MintInfo::default()
+    };
 
     // Add mint
     db.add_mint(mint_url.clone(), Some(mint_info.clone()))
@@ -190,7 +197,12 @@ where
 
     // Get mint
     let retrieved = db.get_mint(mint_url.clone()).await.unwrap();
-    assert!(retrieved.is_some());
+    let retrieved = retrieved.expect("mint info should be stored");
+    assert_eq!(
+        retrieved.pubkey,
+        Some(pubkey),
+        "the stored pubkey must survive the database round trip"
+    );
 
     // Get all mints
     let mints = db.get_mints().await.unwrap();

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -2015,8 +2015,8 @@ fn sql_row_to_mint_info(row: Vec<Column>) -> Result<MintInfo, Error> {
 
     Ok(MintInfo {
         name: column_as_nullable_string!(&name),
-        pubkey: column_as_nullable_string!(&pubkey, |v| serde_json::from_str(v).ok(), |v| {
-            serde_json::from_slice(v).ok()
+        pubkey: column_as_nullable_string!(&pubkey, |_| None, |v| {
+            cdk_common::nuts::PublicKey::from_slice(v).ok()
         }),
         version: column_as_nullable_string!(&version).and_then(|v| serde_json::from_str(&v).ok()),
         description: column_as_nullable_string!(description),


### PR DESCRIPTION
  The wallet's `mint` table pubkey column has only ever been written as raw
  compressed bytes — `add_mint` has bound `to_bytes()` since before
  `cdk-sql-common` existed, matching every other key-material column and the
  postgres schema's own `BYTEA` declaration. The reader only attempted JSON
  parses and swallowed the failure, so no stored row has ever round-tripped:
  fresh wallets work from the in-memory fetch, and the first process restart
  serves mint info with the pubkey silently gone.

  Standardize the reader on the one encoding that exists: parse the raw bytes,
  nothing else. The generic `add_and_get_mint` suite test previously
  round-tripped `MintInfo::default()` and asserted only existence (which is how
  this survived); it now stores a pubkey and asserts it reads back intact, so
  every backend running the shared suite inherits the regression net — verified
  against sqlite, redb, and live postgres.
  
  Closes #2317
