### PR TITLE
fix(wallet): drop the unused mint_quote created_time column

### DIFF
--- a/crates/cdk-sql-common/src/wallet/migrations/postgres/20260810000000_drop_mint_quote_created_time.sql
+++ b/crates/cdk-sql-common/src/wallet/migrations/postgres/20260810000000_drop_mint_quote_created_time.sql
@@ -1,0 +1,3 @@
+-- Drop the unused created_time column from mint_quote: added for ordering queries
+-- that were never implemented, it has never been written or read.
+ALTER TABLE mint_quote DROP COLUMN created_time;

--- a/crates/cdk-sql-common/src/wallet/migrations/sqlite/20260810000000_drop_mint_quote_created_time.sql
+++ b/crates/cdk-sql-common/src/wallet/migrations/sqlite/20260810000000_drop_mint_quote_created_time.sql
@@ -1,0 +1,3 @@
+-- Drop the unused created_time column from mint_quote: added for ordering queries
+-- that were never implemented, it has never been written or read.
+ALTER TABLE mint_quote DROP COLUMN created_time;


### PR DESCRIPTION
  Removes the wallet database's `mint_quote.created_time` column. It was added
  for ordering queries that were never implemented: no code path has ever
  written it (every row in every wallet holds the schema default of `0`) and no
  query reads it. The public `MintQuote` struct never carried the field. 

  Deleting it now is lossless — the column contains no information — and it
  restores schema parity with the backends that never gained the column.
  Age- and staleness-based queries already have populated columns to key on
  (`expiry`, `updated_at`); if creation-time ordering ever becomes a real
  feature, the column can return together with its write path and readers in
  one coherent change.
 
  Two migration files (sqlite + postgres); every fresh test database exercises
  the full migration chain (the original ADD followed by this DROP), verified
  on sqlite and live postgres.

  Closes #2316