### PR TITLE
feat(cdk-ldk-node): persist BOLT12 quote ID payment lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,7 @@ dependencies = [
  "axum",
  "bip39",
  "cdk-common",
+ "cdk-sqlite",
  "futures",
  "ldk-node",
  "maud",

--- a/crates/cdk-integration-tests/src/bin/start_regtest.rs
+++ b/crates/cdk-integration-tests/src/bin/start_regtest.rs
@@ -69,6 +69,7 @@ async fn main() -> Result<()> {
             addr: [127, 0, 0, 1],
             port: 8092,
         }],
+        std::sync::Arc::new(cdk_sqlite::mint::memory::empty().await?),
     );
     let cdk_ldk = node_builder.build()?;
 

--- a/crates/cdk-integration-tests/src/bin/start_regtest_mints.rs
+++ b/crates/cdk-integration-tests/src/bin/start_regtest_mints.rs
@@ -733,6 +733,7 @@ fn main() -> Result<()> {
                 addr: [127, 0, 0, 1],
                 port: ldk_node_p2p_port,
             }],
+            std::sync::Arc::new(cdk_sqlite::mint::memory::empty().await?),
         )
         .with_seed(test_mnemonic.clone());
         let cdk_ldk = match node_builder.build() {
@@ -766,6 +767,7 @@ fn main() -> Result<()> {
                         addr: [127, 0, 0, 1],
                         port: ldk_node_p2p_port,
                     }],
+                    std::sync::Arc::new(cdk_sqlite::mint::memory::empty().await?),
                 )
                 .with_seed(test_mnemonic);
 

--- a/crates/cdk-ldk-node/Cargo.toml
+++ b/crates/cdk-ldk-node/Cargo.toml
@@ -32,5 +32,8 @@ serde_urlencoded = "0.7"
 bip39.workspace = true
 web-time.workspace = true
 
+[dev-dependencies]
+cdk-sqlite.workspace = true
+
 [lints]
 workspace = true

--- a/crates/cdk-ldk-node/src/error.rs
+++ b/crates/cdk-ldk-node/src/error.rs
@@ -29,6 +29,14 @@ pub enum Error {
     #[error("Invalid payment ID length")]
     InvalidPaymentIdLength,
 
+    /// Invalid quote id
+    #[error("Invalid quote id")]
+    InvalidQuoteId,
+
+    /// Database error
+    #[error("Database error: {0}")]
+    Database(String),
+
     /// Unknown invoice amount
     #[error("Unknown invoice amount")]
     UnknownInvoiceAmount,

--- a/crates/cdk-ldk-node/src/lib.rs
+++ b/crates/cdk-ldk-node/src/lib.rs
@@ -11,10 +11,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bip39::Mnemonic;
 use cdk_common::common::FeeReserve;
+use cdk_common::database::DynKVStore;
 use cdk_common::payment::{self, *};
 use cdk_common::redact::url_for_logs;
 use cdk_common::util::{hex, unix_time};
-use cdk_common::{Amount, CurrencyUnit, MeltOptions, MeltQuoteState};
+use cdk_common::{Amount, CurrencyUnit, MeltOptions, MeltQuoteState, QuoteId};
 use futures::{Stream, StreamExt};
 use ldk_node::bitcoin::hashes::Hash;
 use ldk_node::bitcoin::Network;
@@ -37,6 +38,59 @@ mod error;
 mod log;
 mod web;
 
+/// Primary KV namespace for the ldk-node backend's durable bookkeeping
+const LDK_KV_PRIMARY_NAMESPACE: &str = "cdk_ldk_node_lightning_backend";
+/// Secondary KV namespace holding the bolt12 melt quote id -> payment id
+/// mapping used to resolve `PaymentIdentifier::QuoteId` lookups
+const LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE: &str = "bolt12_outgoing_payments";
+
+/// Result of looking up the payment id recorded for a bolt12 melt quote
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Bolt12QuotePaymentIdLookup {
+    /// A payment id was recorded: the payment was dispatched and is tracked
+    Found(PaymentId),
+    /// The dispatch sentinel is present: `send` was started but no payment id
+    /// was recorded (crash during dispatch, or dispatch errored before the
+    /// sentinel could be cleaned up). The payment state is indeterminate.
+    Dispatching,
+    /// No record exists: the payment was never dispatched
+    Missing,
+    /// A record exists but cannot be parsed
+    Malformed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Bolt12QuotePaymentIdResolution {
+    PaymentId(PaymentId),
+    Status(MeltQuoteState),
+}
+
+impl Bolt12QuotePaymentIdLookup {
+    fn resolve(self) -> Bolt12QuotePaymentIdResolution {
+        match self {
+            Self::Found(payment_id) => Bolt12QuotePaymentIdResolution::PaymentId(payment_id),
+            // Dispatch was attempted but no payment id was recorded. Pending
+            // prevents the live melt saga from compensating an indeterminate
+            // payment after a dispatch-ambiguous error.
+            Self::Dispatching => Bolt12QuotePaymentIdResolution::Status(MeltQuoteState::Pending),
+            // Without the pre-dispatch sentinel, the payment was never sent.
+            Self::Missing => Bolt12QuotePaymentIdResolution::Status(MeltQuoteState::Unpaid),
+            // Corrupt bookkeeping cannot establish any payment state.
+            Self::Malformed => Bolt12QuotePaymentIdResolution::Status(MeltQuoteState::Unknown),
+        }
+    }
+}
+
+/// Whether an LDK BOLT12 send error can occur after dispatch was accepted.
+///
+/// In `ldk-node` 0.7, [`ldk_node::NodeError::PersistenceFailed`] can be returned
+/// while persisting the payment record after `ChannelManager::pay_for_offer`
+/// accepted the payment. All other errors returned by the BOLT12 send methods
+/// occur before dispatch or after `pay_for_offer` rejected the attempt.
+fn bolt12_send_error_has_ambiguous_dispatch(err: &ldk_node::NodeError) -> bool {
+    matches!(err, ldk_node::NodeError::PersistenceFailed)
+}
+
 /// CDK Lightning backend using LDK Node
 ///
 /// Provides Lightning Network functionality for CDK with support for Cashu operations.
@@ -45,6 +99,7 @@ mod web;
 pub struct CdkLdkNode {
     inner: Arc<Node>,
     fee_reserve: FeeReserve,
+    kv_store: DynKVStore,
     wait_invoice_cancel_token: CancellationToken,
     wait_invoice_is_active: Arc<AtomicBool>,
     sender: tokio::sync::broadcast::Sender<WaitPaymentResponse>,
@@ -146,7 +201,6 @@ impl fmt::Debug for GossipSource {
     }
 }
 /// A builder for an [`CdkLdkNode`] instance.
-#[derive(Debug)]
 pub struct CdkLdkNodeBuilder {
     network: Network,
     chain_source: ChainSource,
@@ -154,9 +208,25 @@ pub struct CdkLdkNodeBuilder {
     log_dir_path: Option<String>,
     storage_dir_path: String,
     fee_reserve: FeeReserve,
+    kv_store: DynKVStore,
     listening_addresses: Vec<SocketAddress>,
     seed: Option<Mnemonic>,
     announcement_addresses: Option<Vec<SocketAddress>>,
+}
+
+impl std::fmt::Debug for CdkLdkNodeBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CdkLdkNodeBuilder")
+            .field("network", &self.network)
+            .field("chain_source", &self.chain_source)
+            .field("gossip_source", &self.gossip_source)
+            .field("log_dir_path", &self.log_dir_path)
+            .field("storage_dir_path", &self.storage_dir_path)
+            .field("fee_reserve", &self.fee_reserve)
+            .field("listening_addresses", &self.listening_addresses)
+            .field("announcement_addresses", &self.announcement_addresses)
+            .finish_non_exhaustive()
+    }
 }
 
 impl CdkLdkNodeBuilder {
@@ -168,6 +238,7 @@ impl CdkLdkNodeBuilder {
         storage_dir_path: String,
         fee_reserve: FeeReserve,
         listening_addresses: Vec<SocketAddress>,
+        kv_store: DynKVStore,
     ) -> Self {
         Self {
             network,
@@ -175,6 +246,7 @@ impl CdkLdkNodeBuilder {
             gossip_source,
             storage_dir_path,
             fee_reserve,
+            kv_store,
             listening_addresses,
             seed: None,
             announcement_addresses: None,
@@ -270,6 +342,7 @@ impl CdkLdkNodeBuilder {
         Ok(CdkLdkNode {
             inner: node.into(),
             fee_reserve: self.fee_reserve,
+            kv_store: self.kv_store,
             wait_invoice_cancel_token: CancellationToken::new(),
             wait_invoice_is_active: Arc::new(AtomicBool::new(false)),
             sender,
@@ -295,6 +368,18 @@ impl CdkLdkNode {
     /// the system to automatically assign an available port
     pub fn default_web_addr() -> SocketAddr {
         SocketAddr::from(([127, 0, 0, 1], 8091))
+    }
+
+    /// Best-effort removal of the pre-dispatch sentinel after a send that did
+    /// not dispatch. If removal fails the sentinel remains and the payment
+    /// resolves as `Pending`, keeping the melt proofs reserved.
+    async fn cleanup_bolt12_dispatch_sentinel(&self, quote_id: &QuoteId) {
+        if let Err(err) = delete_bolt12_quote_payment_id(&self.kv_store, quote_id).await {
+            tracing::warn!(
+                "Could not remove BOLT12 dispatch sentinel for quote {quote_id}: {err}. \
+                 The payment will remain Pending."
+            );
+        }
     }
 
     fn make_payment_response_from_details(
@@ -819,7 +904,9 @@ impl MintPayment for CdkLdkNode {
                 };
 
                 Ok(PaymentQuoteResponse {
-                    request_lookup_id: None,
+                    request_lookup_id: Some(PaymentIdentifier::QuoteId(
+                        bolt12_options.quote_id.clone(),
+                    )),
                     amount,
                     fee: Amount::new(fee, unit.clone()),
                     state: MeltQuoteState::Unpaid,
@@ -930,6 +1017,8 @@ impl MintPayment for CdkLdkNode {
             }
             OutgoingPaymentOptions::Bolt12(bolt12_options) => {
                 let offer = bolt12_options.offer;
+                let quote_id = bolt12_options.quote_id.clone();
+                let quote_payment_identifier = PaymentIdentifier::QuoteId(quote_id.clone());
 
                 let send_params = match bolt12_options
                     .max_fee_amount
@@ -949,25 +1038,65 @@ impl MintPayment for CdkLdkNode {
                     }
                 };
 
+                // Write the pre-dispatch sentinel before attempting the send so
+                // a crash during dispatch is distinguishable from "never
+                // dispatched" (mirrors cdk-cln's pre-dispatch bolt12 quote
+                // mapping). The payment must not be attempted unless this
+                // marker is durable.
+                write_bolt12_quote_payment_id(&self.kv_store, &quote_id, None).await?;
+
                 let payment_id = match bolt12_options.melt_options {
-                    Some(MeltOptions::Amountless { amountless }) => self
-                        .inner
-                        .bolt12_payment()
-                        .send_using_amount(
+                    Some(MeltOptions::Amountless { amountless }) => {
+                        self.inner.bolt12_payment().send_using_amount(
                             &offer,
                             amountless.amount_msat.into(),
                             None,
                             None,
                             send_params,
                         )
-                        .map_err(Error::LdkNode)?,
+                    }
                     None => self
                         .inner
                         .bolt12_payment()
-                        .send(&offer, None, None, send_params)
-                        .map_err(Error::LdkNode)?,
-                    _ => return Err(payment::Error::UnsupportedPaymentOption),
+                        .send(&offer, None, None, send_params),
+                    _ => {
+                        self.cleanup_bolt12_dispatch_sentinel(&quote_id).await;
+                        return Err(payment::Error::UnsupportedPaymentOption);
+                    }
                 };
+
+                let payment_id = match payment_id {
+                    Ok(payment_id) => payment_id,
+                    Err(err) => {
+                        match bolt12_send_error_has_ambiguous_dispatch(&err) {
+                            true => {
+                                tracing::warn!(
+                                    quote_id = %quote_id,
+                                    "LDK payment persistence failed after BOLT12 send; retaining \
+                                     the dispatch sentinel because the payment may have been dispatched"
+                                );
+                            }
+                            false => {
+                                self.cleanup_bolt12_dispatch_sentinel(&quote_id).await;
+                            }
+                        }
+                        return Err(Error::LdkNode(err).into());
+                    }
+                };
+
+                // Record the payment id so QuoteId lookups resolve to the
+                // dispatched payment. Best-effort: if this write fails the
+                // sentinel remains and the payment resolves as Pending, keeping
+                // the melt proofs reserved.
+                if let Err(err) =
+                    write_bolt12_quote_payment_id(&self.kv_store, &quote_id, Some(&payment_id))
+                        .await
+                {
+                    tracing::error!(
+                        "Could not record BOLT12 payment id for quote {quote_id}: {err}. \
+                         The payment will remain Pending until manual intervention."
+                    );
+                }
 
                 // Check payment status for up to 10 seconds
                 let start = std::time::Instant::now();
@@ -1006,7 +1135,7 @@ impl MintPayment for CdkLdkNode {
 
                 Self::make_payment_response_from_details(
                     unit,
-                    PaymentIdentifier::PaymentId(payment_id.0),
+                    quote_payment_identifier,
                     &payment_details,
                 )
             }
@@ -1163,6 +1292,24 @@ impl MintPayment for CdkLdkNode {
                 }))
             }
             PaymentIdentifier::PaymentId(id) => self.inner.payment(&PaymentId(*id)),
+            PaymentIdentifier::QuoteId(quote_id) => {
+                match read_bolt12_quote_payment_id(&self.kv_store, quote_id)
+                    .await?
+                    .resolve()
+                {
+                    Bolt12QuotePaymentIdResolution::PaymentId(payment_id) => {
+                        self.inner.payment(&payment_id)
+                    }
+                    Bolt12QuotePaymentIdResolution::Status(status) => {
+                        return Ok(MakePaymentResponse {
+                            payment_lookup_id: request_lookup_id.clone(),
+                            payment_proof: None,
+                            status,
+                            total_spent: Amount::new(0, CurrencyUnit::Msat),
+                        });
+                    }
+                }
+            }
             _ => {
                 return Ok(MakePaymentResponse {
                     payment_lookup_id: request_lookup_id.clone(),
@@ -1192,6 +1339,125 @@ impl Drop for CdkLdkNode {
         self.wait_invoice_cancel_token.cancel();
         tracing::debug!("Cancelled wait_invoice token in drop");
     }
+}
+
+/// KV key for the bolt12 melt quote id -> payment id mapping
+fn bolt12_quote_payment_id_key(quote_id: &QuoteId) -> Result<String, Error> {
+    match quote_id {
+        QuoteId::UUID(uuid) => Ok(uuid.to_string()),
+        QuoteId::BASE64(_) => Err(Error::InvalidQuoteId),
+    }
+}
+
+/// Records the bolt12 melt quote id -> payment id mapping.
+///
+/// `payment_id` of `None` writes the pre-dispatch sentinel: it marks that
+/// `send` is about to be attempted so a crash during dispatch is
+/// distinguishable from "never dispatched" (mirrors cdk-cln's pre-dispatch
+/// bolt12 quote mapping).
+async fn write_bolt12_quote_payment_id(
+    kv_store: &DynKVStore,
+    quote_id: &QuoteId,
+    payment_id: Option<&PaymentId>,
+) -> Result<(), Error> {
+    let key = bolt12_quote_payment_id_key(quote_id)?;
+    let value = payment_id.map(|id| hex::encode(id.0)).unwrap_or_default();
+    let mut tx = kv_store
+        .begin_transaction()
+        .await
+        .map_err(|e| Error::Database(e.to_string()))?;
+
+    tx.kv_write(
+        LDK_KV_PRIMARY_NAMESPACE,
+        LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+        &key,
+        value.as_bytes(),
+    )
+    .await
+    .map_err(|e| Error::Database(e.to_string()))?;
+    tx.commit()
+        .await
+        .map_err(|e| Error::Database(e.to_string()))?;
+
+    Ok(())
+}
+
+/// Reads the bolt12 melt quote id -> payment id mapping
+async fn read_bolt12_quote_payment_id(
+    kv_store: &DynKVStore,
+    quote_id: &QuoteId,
+) -> Result<Bolt12QuotePaymentIdLookup, Error> {
+    let key = bolt12_quote_payment_id_key(quote_id)?;
+    let Some(stored) = kv_store
+        .kv_read(
+            LDK_KV_PRIMARY_NAMESPACE,
+            LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+            &key,
+        )
+        .await
+        .map_err(|e| Error::Database(e.to_string()))?
+    else {
+        return Ok(Bolt12QuotePaymentIdLookup::Missing);
+    };
+
+    if stored.is_empty() {
+        return Ok(Bolt12QuotePaymentIdLookup::Dispatching);
+    }
+
+    let payment_id_hex = match String::from_utf8(stored) {
+        Ok(payment_id_hex) => payment_id_hex,
+        Err(err) => {
+            tracing::warn!(
+                "LDK: invalid UTF-8 in BOLT12 payment id mapping for quote {quote_id}: {err}"
+            );
+            return Ok(Bolt12QuotePaymentIdLookup::Malformed);
+        }
+    };
+
+    let payment_id_bytes = match hex::decode(&payment_id_hex) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            tracing::warn!(
+                "LDK: invalid hex in BOLT12 payment id mapping for quote {quote_id}: {err}"
+            );
+            return Ok(Bolt12QuotePaymentIdLookup::Malformed);
+        }
+    };
+
+    let payment_id: [u8; 32] = match payment_id_bytes.try_into() {
+        Ok(payment_id) => payment_id,
+        Err(_) => {
+            tracing::warn!("LDK: invalid payment id length in BOLT12 mapping for quote {quote_id}");
+            return Ok(Bolt12QuotePaymentIdLookup::Malformed);
+        }
+    };
+
+    Ok(Bolt12QuotePaymentIdLookup::Found(PaymentId(payment_id)))
+}
+
+/// Removes the bolt12 melt quote id -> payment id mapping
+async fn delete_bolt12_quote_payment_id(
+    kv_store: &DynKVStore,
+    quote_id: &QuoteId,
+) -> Result<(), Error> {
+    let key = bolt12_quote_payment_id_key(quote_id)?;
+    let mut tx = kv_store
+        .begin_transaction()
+        .await
+        .map_err(|e| Error::Database(e.to_string()))?;
+
+    tx.kv_remove(
+        LDK_KV_PRIMARY_NAMESPACE,
+        LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+        &key,
+    )
+    .await
+    .map_err(|e| Error::Database(e.to_string()))?;
+    tx.commit()
+        .await
+        .map_err(|e| Error::Database(e.to_string()))?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1353,5 +1619,132 @@ mod tests {
 
         assert_eq!(selected.id, PaymentId([2; 32]));
         assert_eq!(selected.status, PaymentStatus::Failed);
+    }
+
+    #[test]
+    fn bolt12_persistence_failure_has_ambiguous_dispatch() {
+        assert!(bolt12_send_error_has_ambiguous_dispatch(
+            &ldk_node::NodeError::PersistenceFailed
+        ));
+
+        for not_dispatched in [
+            ldk_node::NodeError::NotRunning,
+            ldk_node::NodeError::UnsupportedCurrency,
+            ldk_node::NodeError::InvalidOffer,
+            ldk_node::NodeError::InvalidAmount,
+            ldk_node::NodeError::DuplicatePayment,
+            ldk_node::NodeError::InvoiceRequestCreationFailed,
+            ldk_node::NodeError::PaymentSendingFailed,
+        ] {
+            assert!(
+                !bolt12_send_error_has_ambiguous_dispatch(&not_dispatched),
+                "{not_dispatched} must be treated as not dispatched"
+            );
+        }
+    }
+
+    #[test]
+    fn bolt12_quote_payment_id_lookup_resolution_is_safe() {
+        assert_eq!(
+            Bolt12QuotePaymentIdLookup::Dispatching.resolve(),
+            Bolt12QuotePaymentIdResolution::Status(MeltQuoteState::Pending),
+            "an indeterminate dispatch must keep melt proofs reserved"
+        );
+        assert_eq!(
+            Bolt12QuotePaymentIdLookup::Missing.resolve(),
+            Bolt12QuotePaymentIdResolution::Status(MeltQuoteState::Unpaid),
+            "a missing sentinel means the payment was never dispatched"
+        );
+        assert_eq!(
+            Bolt12QuotePaymentIdLookup::Malformed.resolve(),
+            Bolt12QuotePaymentIdResolution::Status(MeltQuoteState::Unknown),
+            "corrupt bookkeeping must remain indeterminate"
+        );
+    }
+
+    async fn test_kv_store() -> DynKVStore {
+        std::sync::Arc::new(cdk_sqlite::mint::memory::empty().await.unwrap())
+    }
+
+    /// The mapping must resolve Missing before any dispatch, Found after the
+    /// payment id is recorded, and Dispatching (indeterminate) while only the
+    /// pre-dispatch sentinel exists.
+    #[tokio::test]
+    async fn bolt12_quote_payment_id_mapping_lifecycle() {
+        let kv_store = test_kv_store().await;
+        let quote_id = QuoteId::new();
+
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .unwrap(),
+            Bolt12QuotePaymentIdLookup::Missing,
+            "no record must resolve as never dispatched"
+        );
+
+        // Pre-dispatch sentinel
+        write_bolt12_quote_payment_id(&kv_store, &quote_id, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .unwrap(),
+            Bolt12QuotePaymentIdLookup::Dispatching,
+            "sentinel must resolve as indeterminate, never terminal"
+        );
+
+        // Record the payment id
+        let payment_id = PaymentId([7; 32]);
+        write_bolt12_quote_payment_id(&kv_store, &quote_id, Some(&payment_id))
+            .await
+            .unwrap();
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .unwrap(),
+            Bolt12QuotePaymentIdLookup::Found(payment_id)
+        );
+
+        // Removal returns to Missing (failed dispatch cleanup)
+        delete_bolt12_quote_payment_id(&kv_store, &quote_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .unwrap(),
+            Bolt12QuotePaymentIdLookup::Missing
+        );
+    }
+
+    /// A corrupted mapping must resolve as indeterminate (`Malformed`), never
+    /// as a terminal state that could trigger compensation.
+    #[tokio::test]
+    async fn bolt12_quote_payment_id_mapping_malformed_is_indeterminate() {
+        let kv_store = test_kv_store().await;
+        let quote_id = QuoteId::new();
+        let key = bolt12_quote_payment_id_key(&quote_id).unwrap();
+
+        for corrupt in ["not-hex", "0102", "zz"] {
+            let mut tx = kv_store.begin_transaction().await.unwrap();
+            tx.kv_write(
+                LDK_KV_PRIMARY_NAMESPACE,
+                LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+                &key,
+                corrupt.as_bytes(),
+            )
+            .await
+            .unwrap();
+            tx.commit().await.unwrap();
+
+            assert_eq!(
+                read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                    .await
+                    .unwrap(),
+                Bolt12QuotePaymentIdLookup::Malformed,
+                "corrupt value {corrupt} must be indeterminate"
+            );
+        }
     }
 }

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -1182,7 +1182,7 @@ async fn configure_lightning_backend(
                         ln_entry.unit.clone(),
                         _runtime.clone(),
                         work_dir,
-                        None,
+                        _kv_store.clone(),
                     )
                     .await?;
 

--- a/crates/cdk-mintd/src/setup.rs
+++ b/crates/cdk-mintd/src/setup.rs
@@ -425,7 +425,7 @@ impl LnBackendSetup for config::LdkNode {
         _unit: CurrencyUnit,
         _runtime: Option<std::sync::Arc<tokio::runtime::Runtime>>,
         work_dir: &Path,
-        _kv_store: Option<Arc<dyn KVStore<Err = cdk::cdk_database::Error> + Send + Sync>>,
+        kv_store: Option<Arc<dyn KVStore<Err = cdk::cdk_database::Error> + Send + Sync>>,
     ) -> anyhow::Result<cdk_ldk_node::CdkLdkNode> {
         use std::net::SocketAddr;
 
@@ -521,6 +521,8 @@ impl LnBackendSetup for config::LdkNode {
             .map(|addrs| addrs.iter().filter_map(|addr| addr.parse().ok()).collect())
             .unwrap_or_default();
 
+        let kv_store = kv_store.ok_or_else(|| anyhow::anyhow!("LdkNode needs a KV store"))?;
+
         let mut ldk_node_builder = cdk_ldk_node::CdkLdkNodeBuilder::new(
             network,
             chain_source,
@@ -528,6 +530,7 @@ impl LnBackendSetup for config::LdkNode {
             storage_dir_path,
             fee_reserve,
             listen_address,
+            kv_store,
         );
 
         // Only set seed if provided

--- a/crates/cdk/src/mint/melt/melt_saga/tests.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/tests.rs
@@ -23,6 +23,7 @@ use cdk_common::util::unix_time;
 use cdk_common::{
     Amount, CurrencyUnit, MintQuoteBolt11Request, PaymentMethod, ProofsMethods, State,
 };
+use cdk_fake_wallet::{create_fake_invoice, FakeInvoiceDescription};
 
 use crate::mint::melt::melt_saga::{MeltSaga, PaymentOutcome};
 use crate::mint::melt::shared::{finalize_melt_quote, rollback_melt_quote};
@@ -1730,6 +1731,68 @@ async fn test_saga_deleted_after_payment_failure() {
     );
 
     // SUCCESS: Saga properly deleted after direct payment failure!
+}
+
+/// A payment error followed by a Pending backend check must keep proofs reserved.
+///
+/// Dispatch-ambiguous backends use Pending to prevent the live error path from
+/// converting an indeterminate payment to Failed and compensating it.
+#[tokio::test]
+async fn test_payment_error_with_pending_check_does_not_compensate() {
+    let mint = create_test_mint().await.unwrap();
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+    let quote = create_test_melt_quote_with_description(
+        &mint,
+        Amount::from(9_000),
+        FakeInvoiceDescription {
+            pay_invoice_state: MeltQuoteState::Unknown,
+            check_payment_state: MeltQuoteState::Pending,
+            pay_err: true,
+            check_err: false,
+        },
+    )
+    .await;
+    let melt_request = create_test_melt_request(&proofs, &quote);
+    let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+    let saga = MeltSaga::new(
+        std::sync::Arc::new(mint.clone()),
+        mint.localstore(),
+        mint.pubsub_manager(),
+    );
+    let setup_saga = saga
+        .setup_melt(
+            &melt_request,
+            verification,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+        )
+        .await
+        .unwrap();
+    let operation_id = setup_saga.operation_id;
+    let (payment_saga, decision) = setup_saga
+        .attempt_internal_settlement(&melt_request)
+        .await
+        .unwrap();
+
+    let outcome = payment_saga.make_payment(decision).await.unwrap();
+
+    assert!(matches!(outcome, PaymentOutcome::Pending { .. }));
+    assert_saga_exists(&mint, &operation_id).await;
+    assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+
+    mint.recover_from_incomplete_melt_sagas()
+        .await
+        .expect("recovery should leave an indeterminate dispatch pending");
+
+    assert_saga_exists(&mint, &operation_id).await;
+    assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+    let stored_quote = mint
+        .localstore
+        .get_melt_quote(&quote.id)
+        .await
+        .unwrap()
+        .expect("quote should remain persisted");
+    assert_eq!(stored_quote.state, MeltQuoteState::Pending);
 }
 
 // ============================================================================
@@ -3466,19 +3529,24 @@ async fn create_test_melt_quote(
     mint: &crate::mint::Mint,
     amount: Amount,
 ) -> cdk_common::mint::MeltQuote {
-    use cdk_common::melt::MeltQuoteRequest;
-    use cdk_common::nuts::MeltQuoteBolt11Request;
-    use cdk_common::CurrencyUnit;
-    use cdk_fake_wallet::{create_fake_invoice, FakeInvoiceDescription};
+    create_test_melt_quote_with_description(
+        mint,
+        amount,
+        FakeInvoiceDescription {
+            pay_invoice_state: MeltQuoteState::Paid,
+            check_payment_state: MeltQuoteState::Paid,
+            pay_err: false,
+            check_err: false,
+        },
+    )
+    .await
+}
 
-    // Create fake invoice description (controls payment behavior)
-    let fake_description = FakeInvoiceDescription {
-        pay_invoice_state: MeltQuoteState::Paid, // Payment will succeed
-        check_payment_state: MeltQuoteState::Paid, // Check will show paid
-        pay_err: false,                          // No payment error
-        check_err: false,                        // No check error
-    };
-
+async fn create_test_melt_quote_with_description(
+    mint: &crate::mint::Mint,
+    amount: Amount,
+    fake_description: FakeInvoiceDescription,
+) -> cdk_common::mint::MeltQuote {
     // Create valid bolt11 invoice (amount in millisats)
     // Amount is already in millisats, just convert to u64
     let amount_msats: u64 = amount.into();


### PR DESCRIPTION
### What changed

- Return the melt quote ID as the BOLT12 payment lookup identifier.
- Persist a pre-dispatch sentinel before sending and replace it with the LDK payment ID after dispatch.
- Resolve quote-ID lookups to `Unpaid`, `Unknown`, or the recorded LDK payment state without treating indeterminate dispatch as failure.
- Wire the mint KV store into the LDK backend and regtest setup.

### Why

LDK BOLT12 melt quotes previously had no durable mapping from the mint quote ID to LDK's payment ID. After a crash, a `PaymentAttempted` saga could not determine whether the payment had been dispatched, so it could not be recovered safely.

### Dependency

This PR is based on `main`, but it depends semantically on #2306 preserving `Unknown` as an indeterminate payment state. It should remain draft until #2306 merges, then be rebased onto the updated `main`.

### Validation

- `cargo fmt --all -- --check`
- `cargo test -p cdk-ldk-node` (16 passed)