### PR TITLE
feat(wallet): derive deterministic NUT-20 quote keys

### DIFF
--- a/crates/cashu/src/nuts/nut20.rs
+++ b/crates/cashu/src/nuts/nut20.rs
@@ -2,7 +2,9 @@
 
 use std::str::FromStr;
 
+use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv};
 use bitcoin::secp256k1::schnorr::Signature;
+use bitcoin::Network;
 use thiserror::Error;
 
 use super::{BlindedMessage, MintRequest, PublicKey, SecretKey};
@@ -19,9 +21,32 @@ pub enum Error {
     /// Nut01 error
     #[error(transparent)]
     NUT01(#[from] crate::nuts::nut01::Error),
+    /// BIP32 derivation error
+    #[error(transparent)]
+    Bip32(#[from] bitcoin::bip32::Error),
 }
 
 const MINT_QUOTE_SIG_DOMAIN_TAG: &[u8] = b"Cashu_MintQuoteSig_v1";
+const QUOTE_LOCKING_PURPOSE: u32 = 129_373;
+const QUOTE_LOCKING_ACCOUNT: u32 = 20;
+
+/// Derive a deterministic NUT-20 quote-locking key from a wallet seed.
+///
+/// Keys use the BIP32 path `m/129373'/20'/0'/0'/{counter}`, where `counter`
+/// is a non-hardened child index independent from all other wallet counters.
+pub fn derive_quote_locking_key(seed: &[u8; 64], counter: u32) -> Result<SecretKey, Error> {
+    let path = DerivationPath::from(vec![
+        ChildNumber::from_hardened_idx(QUOTE_LOCKING_PURPOSE)?,
+        ChildNumber::from_hardened_idx(QUOTE_LOCKING_ACCOUNT)?,
+        ChildNumber::from_hardened_idx(0)?,
+        ChildNumber::from_hardened_idx(0)?,
+        ChildNumber::from_normal_idx(counter)?,
+    ]);
+    let xpriv = Xpriv::new_master(Network::Bitcoin, seed)?;
+    let derived_key = xpriv.derive_priv(&crate::SECP256K1, &path)?.private_key;
+
+    Ok(derived_key.into())
+}
 
 fn amount_to_minimal_bytes(amount: crate::Amount) -> Vec<u8> {
     let value = u64::from(amount);
@@ -141,8 +166,38 @@ where
 
 #[cfg(test)]
 mod tests {
+    use bip39::Mnemonic;
 
     use super::*;
+
+    #[test]
+    fn quote_locking_key_derivation_matches_test_vectors() {
+        let mnemonic = Mnemonic::from_str(
+            "half depart obvious quality work element tank gorilla view sugar picture humble",
+        )
+        .expect("valid mnemonic");
+        let seed = mnemonic.to_seed_normalized("");
+        let expected = [
+            "03062837166e56114b59a4d1fd3a5a812bf7aadc1dde758428cf943d80acd41539",
+            "02b47d9d41725f5ce6f08c874835cef25376cb1e95f6cb073fef52ca8fd986cf15",
+            "029acbd3a46fd75bc05ba0226d0b4d909b2fb6e96c80544a094a1a3567737e44d3",
+            "0373e4a42fbe0a4e18aadb57cf500b655f2446b4071ee579121d2ed8905bcc49c2",
+            "02b8709bfce17c10f1864f5218844533ae60930d52089669b317d8b5f474eec071",
+        ];
+
+        for (counter, expected_pubkey) in expected.into_iter().enumerate() {
+            let secret_key = derive_quote_locking_key(&seed, counter as u32)
+                .expect("test vector key should derive");
+            assert_eq!(secret_key.public_key().to_hex(), expected_pubkey);
+        }
+    }
+
+    #[test]
+    fn quote_locking_key_derivation_rejects_hardened_counter() {
+        let seed = [0; 64];
+
+        assert!(derive_quote_locking_key(&seed, 1 << 31).is_err());
+    }
 
     #[test]
     fn amount_encoding_is_minimal_big_endian() {

--- a/crates/cdk-common/src/database/wallet/mod.rs
+++ b/crates/cdk-common/src/database/wallet/mod.rs
@@ -115,6 +115,9 @@ where
     /// Atomically increment Keyset counter and return new value
     async fn increment_keyset_counter(&self, keyset_id: &Id, count: u32) -> Result<u32, Err>;
 
+    /// Atomically increment a namespaced derivation counter and return its new value.
+    async fn increment_derivation_counter(&self, namespace: &str, count: u32) -> Result<u32, Err>;
+
     /// Add Mint to storage
     async fn add_mint(&self, mint_url: MintUrl, mint_info: Option<MintInfo>) -> Result<(), Err>;
 

--- a/crates/cdk-common/src/database/wallet/test/mod.rs
+++ b/crates/cdk-common/src/database/wallet/test/mod.rs
@@ -839,6 +839,70 @@ where
     assert_eq!(counter1, 5);
 }
 
+/// Test incrementing a derivation counter.
+pub async fn increment_derivation_counter<DB>(db: DB)
+where
+    DB: Database<crate::database::Error>,
+{
+    let counter1 = db.increment_derivation_counter("test", 1).await.unwrap();
+    assert_eq!(counter1, 1);
+
+    let counter2 = db.increment_derivation_counter("test", 4).await.unwrap();
+    assert_eq!(counter2, 5);
+}
+
+/// Test that derivation namespaces and NUT-13 keyset counters are independent.
+pub async fn derivation_counters_are_independent<DB>(db: DB)
+where
+    DB: Database<crate::database::Error>,
+{
+    let keyset_id = test_keyset_id();
+
+    db.increment_keyset_counter(&keyset_id, 7).await.unwrap();
+    db.increment_derivation_counter("first", 3).await.unwrap();
+    db.increment_derivation_counter("second", 5).await.unwrap();
+
+    assert_eq!(db.increment_keyset_counter(&keyset_id, 0).await.unwrap(), 7);
+    assert_eq!(
+        db.increment_derivation_counter("first", 0).await.unwrap(),
+        3
+    );
+    assert_eq!(
+        db.increment_derivation_counter("second", 0).await.unwrap(),
+        5
+    );
+}
+
+/// Test that concurrent derivation counter reservations return unique indexes.
+pub async fn derivation_counter_is_atomic<DB>(db: DB)
+where
+    DB: Database<crate::database::Error> + Sync,
+{
+    let (a, b, c, d, e, f, g, h) = tokio::join!(
+        db.increment_derivation_counter("test", 1),
+        db.increment_derivation_counter("test", 1),
+        db.increment_derivation_counter("test", 1),
+        db.increment_derivation_counter("test", 1),
+        db.increment_derivation_counter("test", 1),
+        db.increment_derivation_counter("test", 1),
+        db.increment_derivation_counter("test", 1),
+        db.increment_derivation_counter("test", 1),
+    );
+    let mut counters = vec![
+        a.unwrap(),
+        b.unwrap(),
+        c.unwrap(),
+        d.unwrap(),
+        e.unwrap(),
+        f.unwrap(),
+        g.unwrap(),
+        h.unwrap(),
+    ];
+    counters.sort_unstable();
+
+    assert_eq!(counters, (1..=8).collect::<Vec<_>>());
+}
+
 // =============================================================================
 // Transaction Tests
 // =============================================================================
@@ -1688,6 +1752,9 @@ macro_rules! wallet_db_test {
             get_balance_by_state,
             increment_keyset_counter,
             keyset_counter_isolation,
+            increment_derivation_counter,
+            derivation_counters_are_independent,
+            derivation_counter_is_atomic,
             add_and_get_transaction,
             update_transaction_status,
             same_proofs_in_different_sagas,

--- a/crates/cdk-ffi/src/database.rs
+++ b/crates/cdk-ffi/src/database.rs
@@ -169,6 +169,13 @@ pub trait WalletDatabase: Send + Sync {
     /// Atomically increment Keyset counter and return new value
     async fn increment_keyset_counter(&self, keyset_id: Id, count: u32) -> Result<u32, FfiError>;
 
+    /// Atomically increment a namespaced derivation counter and return its new value.
+    async fn increment_derivation_counter(
+        &self,
+        namespace: String,
+        count: u32,
+    ) -> Result<u32, FfiError>;
+
     /// Add Mint to storage
     async fn add_mint(
         &self,
@@ -810,6 +817,17 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         let ffi_id = (*keyset_id).into();
         self.ffi_db
             .increment_keyset_counter(ffi_id, count)
+            .await
+            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+    }
+
+    async fn increment_derivation_counter(
+        &self,
+        namespace: &str,
+        count: u32,
+    ) -> Result<u32, cdk::cdk_database::Error> {
+        self.ffi_db
+            .increment_derivation_counter(namespace.to_owned(), count)
             .await
             .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
     }
@@ -1575,6 +1593,17 @@ where
             .map_err(FfiError::internal)
     }
 
+    async fn increment_derivation_counter(
+        &self,
+        namespace: String,
+        count: u32,
+    ) -> Result<u32, FfiError> {
+        self.inner
+            .increment_derivation_counter(&namespace, count)
+            .await
+            .map_err(FfiError::internal)
+    }
+
     async fn add_mint(
         &self,
         mint_url: MintUrl,
@@ -1989,6 +2018,16 @@ macro_rules! impl_ffi_wallet_database {
                 count: u32,
             ) -> Result<u32, FfiError> {
                 self.inner.increment_keyset_counter(keyset_id, count).await
+            }
+
+            async fn increment_derivation_counter(
+                &self,
+                namespace: String,
+                count: u32,
+            ) -> Result<u32, FfiError> {
+                self.inner
+                    .increment_derivation_counter(namespace, count)
+                    .await
             }
 
             async fn add_mint(

--- a/crates/cdk-ffi/tests/test_transactions.py
+++ b/crates/cdk-ffi/tests/test_transactions.py
@@ -237,6 +237,35 @@ async def test_wallet_proofs_by_ys_empty_errors():
             os.unlink(db_path)
 
 
+async def test_wallet_derivation_counter():
+    """Test namespaced derivation counter operations"""
+    print("\n=== Test: Wallet Derivation Counter ===")
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        db_path = tmp.name
+
+    try:
+        backend = cdk_ffi.WalletDbBackend.SQLITE(path=db_path)
+        db = cdk_ffi.create_wallet_db(backend)
+
+        counter1 = await db.increment_derivation_counter("nut20_quote", 1)
+        counter2 = await db.increment_derivation_counter("nut20_quote", 5)
+        counter3 = await db.increment_derivation_counter("nut20_quote", 0)
+        p2pk_counter = await db.increment_derivation_counter("p2pk", 2)
+
+        print(f"✓ Derivation counter after +1: {counter1}")
+        assert counter1 == 1, f"Expected counter 1, got {counter1}"
+        assert counter2 == 6, f"Expected counter 6, got {counter2}"
+        assert counter3 == 6, f"Expected current counter 6, got {counter3}"
+        assert p2pk_counter == 2, f"Expected independent counter 2, got {p2pk_counter}"
+
+        print("✓ Test passed: namespaced derivation counters work")
+
+    finally:
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+
 async def test_wallet_proofs_by_ys():
     """Test retrieving proofs by Y values from the database"""
     print("\n=== Test: Wallet Get Proofs by Y Values ===")
@@ -327,6 +356,7 @@ async def main():
         ("Wallet Mint Management", test_wallet_mint_management),
         ("Wallet Keyset Management", test_wallet_keyset_management),
         ("Wallet Keyset Counter", test_wallet_keyset_counter),
+        ("Wallet Derivation Counter", test_wallet_derivation_counter),
         ("Wallet Quote Operations", test_wallet_quotes),
         ("Wallet Get Proofs by Y Values (Empty Errors)", test_wallet_proofs_by_ys_empty_errors),
         ("Wallet Get Proofs by Y Values", test_wallet_proofs_by_ys),

--- a/crates/cdk-redb/src/wallet/mod.rs
+++ b/crates/cdk-redb/src/wallet/mod.rs
@@ -46,6 +46,7 @@ const MINT_KEYS_TABLE: TableDefinition<&str, &str> = TableDefinition::new("mint_
 const PROOFS_TABLE: TableDefinition<&[u8], &str> = TableDefinition::new("proofs");
 const CONFIG_TABLE: TableDefinition<&str, &str> = TableDefinition::new("config");
 const KEYSET_COUNTER: TableDefinition<&str, u32> = TableDefinition::new("keyset_counter");
+const DERIVATION_COUNTER: TableDefinition<&str, u32> = TableDefinition::new("derivation_counter");
 // <Transaction_id, Transaction>
 const TRANSACTIONS_TABLE: TableDefinition<&[u8], &str> = TableDefinition::new("transactions");
 // <Saga_id, WalletSaga>
@@ -714,6 +715,34 @@ impl WalletDatabase<database::Error> for WalletRedbDatabase {
             new_counter
         };
         write_txn.commit().map_err(Error::from)?;
+        Ok(new_counter)
+    }
+
+    #[instrument(skip(self))]
+    async fn increment_derivation_counter(
+        &self,
+        namespace: &str,
+        count: u32,
+    ) -> Result<u32, database::Error> {
+        let write_txn = self.db.begin_write().map_err(Error::from)?;
+        let new_counter = {
+            let mut table = write_txn
+                .open_table(DERIVATION_COUNTER)
+                .map_err(Error::from)?;
+            let current_counter = table
+                .get(namespace)
+                .map_err(Error::from)?
+                .map(|value| value.value())
+                .unwrap_or_default();
+            let new_counter = current_counter
+                .checked_add(count)
+                .ok_or(database::Error::AmountOverflow)?;
+
+            table.insert(namespace, new_counter).map_err(Error::from)?;
+            new_counter
+        };
+        write_txn.commit().map_err(Error::from)?;
+
         Ok(new_counter)
     }
 

--- a/crates/cdk-sql-common/src/wallet/migrations/postgres/20260810000000_derivation_counter.sql
+++ b/crates/cdk-sql-common/src/wallet/migrations/postgres/20260810000000_derivation_counter.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS derivation_counter (
+    namespace TEXT PRIMARY KEY,
+    counter BIGINT NOT NULL DEFAULT 0 CHECK (counter >= 0)
+);

--- a/crates/cdk-sql-common/src/wallet/migrations/sqlite/20260810000000_derivation_counter.sql
+++ b/crates/cdk-sql-common/src/wallet/migrations/sqlite/20260810000000_derivation_counter.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS derivation_counter (
+    namespace TEXT PRIMARY KEY,
+    counter INTEGER NOT NULL DEFAULT 0 CHECK (counter >= 0)
+);

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -1020,6 +1020,38 @@ where
         Ok(new_counter)
     }
 
+    #[instrument(skip(self))]
+    async fn increment_derivation_counter(
+        &self,
+        namespace: &str,
+        count: u32,
+    ) -> Result<u32, database::Error> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
+
+        let new_counter = query(
+            r#"
+            INSERT INTO derivation_counter (namespace, counter)
+            VALUES (:namespace, :count)
+            ON CONFLICT(namespace) DO UPDATE SET
+                counter = derivation_counter.counter + :count
+            RETURNING counter
+            "#,
+        )?
+        .bind("namespace", namespace.to_owned())
+        .bind("count", count)
+        .pluck(&*conn)
+        .await?
+        .map(|n| Ok::<_, Error>(column_as_number!(n)))
+        .transpose()?
+        .ok_or_else(|| Error::Internal("Derivation counter update returned no value".to_owned()))?;
+
+        Ok(new_counter)
+    }
+
     #[instrument(skip(self, mint_info))]
     async fn add_mint(
         &self,

--- a/crates/cdk-supabase/migrations/supabase/migrations/20260810000000_add_derivation_counter.sql
+++ b/crates/cdk-supabase/migrations/supabase/migrations/20260810000000_add_derivation_counter.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS derivation_counter (
+    wallet_id TEXT NOT NULL DEFAULT public.get_current_wallet_id(),
+    namespace TEXT NOT NULL,
+    counter BIGINT NOT NULL DEFAULT 0 CHECK (counter >= 0),
+    PRIMARY KEY (wallet_id, namespace)
+);
+
+ALTER TABLE derivation_counter ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users access own derivation counters" ON derivation_counter
+    FOR ALL USING (wallet_id = public.get_current_wallet_id());
+
+GRANT ALL ON derivation_counter TO authenticated;
+
+CREATE OR REPLACE FUNCTION increment_derivation_counter(
+    p_namespace TEXT,
+    p_increment BIGINT DEFAULT 1
+)
+RETURNS BIGINT
+LANGUAGE sql
+SECURITY DEFINER
+AS $body$
+    INSERT INTO derivation_counter (wallet_id, namespace, counter)
+    VALUES (public.get_current_wallet_id(), p_namespace, p_increment)
+    ON CONFLICT (wallet_id, namespace)
+    DO UPDATE SET counter = derivation_counter.counter + p_increment
+    RETURNING counter
+$body$;
+
+INSERT INTO schema_info (key, value) VALUES ('schema_version', '9')
+ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;

--- a/crates/cdk-supabase/src/wallet.rs
+++ b/crates/cdk-supabase/src/wallet.rs
@@ -214,7 +214,7 @@ impl SupabaseWalletDatabase {
     /// This must match the latest `schema_version` value set in the migration files.
     /// When adding new migrations, update this constant and set the same value
     /// in the new migration's `INSERT INTO schema_info` statement.
-    pub const REQUIRED_SCHEMA_VERSION: u32 = 8;
+    pub const REQUIRED_SCHEMA_VERSION: u32 = 9;
 
     /// Get the full database schema SQL
     ///
@@ -1539,6 +1539,48 @@ impl Database<DatabaseError> for SupabaseWalletDatabase {
 
         Err(DatabaseError::Internal(format!(
             "increment_keyset_counter RPC failed: HTTP {}. Ensure migrations have been run.",
+            status
+        )))
+    }
+
+    async fn increment_derivation_counter(
+        &self,
+        namespace: &str,
+        count: u32,
+    ) -> Result<u32, DatabaseError> {
+        let rpc_body = serde_json::json!({
+            "p_namespace": namespace,
+            "p_increment": count
+        });
+        let url = self.join_url("rest/v1/rpc/increment_derivation_counter")?;
+        let auth_bearer = self.get_auth_bearer().await;
+
+        let res = self
+            .client
+            .post(url)
+            .header("apikey", &self.api_key)
+            .header("Authorization", format!("Bearer {}", auth_bearer))
+            .header("Content-Type", "application/json")
+            .header("Prefer", "return=representation")
+            .json(&rpc_body)
+            .send()
+            .await
+            .map_err(Error::Reqwest)?;
+        let status = res.status();
+        let text = res.text().await.map_err(Error::Reqwest)?;
+
+        if status.is_success() {
+            let new_counter: i64 = serde_json::from_str(&text).map_err(|err| {
+                DatabaseError::Internal(format!(
+                    "Failed to parse derivation counter response: {}",
+                    err
+                ))
+            })?;
+            return u32::try_from(new_counter).map_err(|_| DatabaseError::AmountOverflow);
+        }
+
+        Err(DatabaseError::Internal(format!(
+            "increment_derivation_counter RPC failed: HTTP {}. Ensure migrations have been run.",
             status
         )))
     }
@@ -3196,6 +3238,8 @@ mod tests {
         assert!(schema_sql.contains("CREATE TABLE IF NOT EXISTS schema_info"));
         assert!(schema_sql.contains("CREATE TABLE IF NOT EXISTS p2pk_signing_key"));
         assert!(schema_sql.contains("CREATE TABLE IF NOT EXISTS wallet_encryption_metadata"));
+        assert!(schema_sql.contains("CREATE TABLE IF NOT EXISTS derivation_counter"));
+        assert!(schema_sql.contains("CREATE OR REPLACE FUNCTION increment_derivation_counter"));
         assert_eq!(
             versions.last().copied(),
             Some(SupabaseWalletDatabase::REQUIRED_SCHEMA_VERSION)

--- a/crates/cdk/src/wallet/issue/mod.rs
+++ b/crates/cdk/src/wallet/issue/mod.rs
@@ -14,7 +14,7 @@ use crate::amount::SplitTarget;
 use crate::nuts::{BatchCheckMintQuoteRequest, Proofs, SecretKey, SpendingConditions};
 use crate::util::unix_time;
 use crate::wallet::recovery::RecoveryAction;
-use crate::wallet::{MintQuote, MintQuoteState};
+use crate::wallet::{DerivationCounterNamespace, MintQuote, MintQuoteState};
 use crate::{Amount, Error, Wallet};
 
 pub(crate) fn apply_mint_quote_response(
@@ -149,6 +149,16 @@ fn mint_quote_response_amount(response: &MintQuoteResponse<String>) -> Option<Am
 }
 
 impl Wallet {
+    async fn next_mint_quote_signing_key(&self) -> Result<SecretKey, Error> {
+        let counter = self
+            .reserve_derivation_index(DerivationCounterNamespace::Nut20Quote, 0)
+            .await?;
+
+        Ok(crate::nuts::nut20::derive_quote_locking_key(
+            &self.seed, counter,
+        )?)
+    }
+
     /// Resolve the NUT-20 signing key for a mint quote
     ///
     /// Returns the quote's stored key if present. NpubCash quotes do not
@@ -228,7 +238,7 @@ impl Wallet {
 
         self.keysets(Default::default()).await?;
 
-        let secret_key = SecretKey::generate();
+        let secret_key = self.next_mint_quote_signing_key().await?;
 
         let request = match &method {
             PaymentMethod::Known(KnownMethod::Bolt11) => {
@@ -709,10 +719,64 @@ impl Wallet {
 mod tests {
     use std::str::FromStr;
 
+    use bip39::Mnemonic;
     use cdk_common::mint_url::MintUrl;
     use cdk_common::nuts::CurrencyUnit;
 
     use super::*;
+
+    #[tokio::test]
+    async fn mint_quote_signing_keys_follow_nut20_counter_across_wallet_instances() {
+        let mnemonic = Mnemonic::from_str(
+            "half depart obvious quality work element tank gorilla view sugar picture humble",
+        )
+        .expect("valid mnemonic");
+        let seed = mnemonic.to_seed_normalized("");
+        let db = crate::wallet::test_utils::create_test_db().await;
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            db.clone(),
+            seed,
+            None,
+        )
+        .expect("wallet should build");
+
+        let first = wallet
+            .next_mint_quote_signing_key()
+            .await
+            .expect("first key should derive");
+        let second = wallet
+            .next_mint_quote_signing_key()
+            .await
+            .expect("second key should derive");
+
+        let restarted_wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            db,
+            seed,
+            None,
+        )
+        .expect("wallet should rebuild");
+        let third = restarted_wallet
+            .next_mint_quote_signing_key()
+            .await
+            .expect("third key should derive");
+
+        assert_eq!(
+            first.public_key().to_hex(),
+            "03062837166e56114b59a4d1fd3a5a812bf7aadc1dde758428cf943d80acd41539"
+        );
+        assert_eq!(
+            second.public_key().to_hex(),
+            "02b47d9d41725f5ce6f08c874835cef25376cb1e95f6cb073fef52ca8fd986cf15"
+        );
+        assert_eq!(
+            third.public_key().to_hex(),
+            "029acbd3a46fd75bc05ba0226d0b4d909b2fb6e96c80544a094a1a3567737e44d3"
+        );
+    }
 
     #[test]
     fn local_onchain_mint_quote_amount_is_not_stored() {

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -110,6 +110,21 @@ pub use wallet_repository::{TokenData, WalletConfig, WalletRepository, WalletRep
 
 use crate::nuts::nut00::ProofsMethods;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum DerivationCounterNamespace {
+    P2pk,
+    Nut20Quote,
+}
+
+impl DerivationCounterNamespace {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::P2pk => "p2pk",
+            Self::Nut20Quote => "nut20_quote",
+        }
+    }
+}
+
 /// CDK Wallet
 ///
 /// The CDK [`Wallet`] is a high level cashu wallet.
@@ -1009,31 +1024,59 @@ impl Wallet {
 
     /// generates and stores public key in database
     pub async fn generate_public_key(&self) -> Result<PublicKey, Error> {
-        let public_keys = self.localstore.list_p2pk_keys().await?;
-
-        let mut last_derivation_index = 0;
-
-        for public_key in public_keys {
-            if public_key.derivation_index >= last_derivation_index {
-                last_derivation_index = public_key.derivation_index + 1;
-            }
-        }
+        let minimum_index = match self.localstore.latest_p2pk().await? {
+            Some(key) => key.derivation_index.checked_add(1).ok_or_else(|| {
+                Error::Custom("P2PK derivation index has been exhausted".to_owned())
+            })?,
+            None => 0,
+        };
+        let derivation_index = self
+            .reserve_derivation_index(DerivationCounterNamespace::P2pk, minimum_index)
+            .await?;
 
         let derivation_path = DerivationPath::from(vec![
             ChildNumber::from_hardened_idx(P2PK_PURPOSE)?,
             ChildNumber::from_hardened_idx(P2PK_ACCOUNT)?,
             ChildNumber::from_hardened_idx(0)?,
             ChildNumber::from_hardened_idx(0)?,
-            ChildNumber::from_normal_idx(last_derivation_index)?,
+            ChildNumber::from_normal_idx(derivation_index)?,
         ]);
 
         let pubkey = p2pk::generate_public_key(&derivation_path, &self.seed).await?;
 
         self.localstore
-            .add_p2pk_key(&pubkey, derivation_path, last_derivation_index)
+            .add_p2pk_key(&pubkey, derivation_path, derivation_index)
             .await?;
 
         Ok(pubkey)
+    }
+
+    pub(crate) async fn reserve_derivation_index(
+        &self,
+        namespace: DerivationCounterNamespace,
+        minimum_index: u32,
+    ) -> Result<u32, Error> {
+        let namespace = namespace.as_str();
+        let current_counter = self
+            .localstore
+            .increment_derivation_counter(namespace, 0)
+            .await?;
+        let catch_up = minimum_index.saturating_sub(current_counter);
+        let reservation_count = catch_up.checked_add(1).ok_or_else(|| {
+            Error::Custom(format!(
+                "Derivation counter namespace `{namespace}` has been exhausted"
+            ))
+        })?;
+        let next_counter = self
+            .localstore
+            .increment_derivation_counter(namespace, reservation_count)
+            .await?;
+
+        next_counter.checked_sub(1).ok_or_else(|| {
+            Error::Custom(format!(
+                "Derivation counter namespace `{namespace}` did not advance after reservation"
+            ))
+        })
     }
 
     /// gets public key by it's hex value

--- a/crates/cdk/src/wallet/p2pk.rs
+++ b/crates/cdk/src/wallet/p2pk.rs
@@ -29,12 +29,15 @@ pub async fn generate_public_key(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::str::FromStr;
 
     use bip39::Mnemonic;
     use bitcoin::bip32::{ChildNumber, DerivationPath};
+    use cdk_common::nuts::{CurrencyUnit, SecretKey};
 
     use super::*;
+    use crate::Wallet;
 
     #[tokio::test]
     async fn nut13_test_vector() {
@@ -123,5 +126,59 @@ mod tests {
         assert_eq!(derivation_path_2.to_string(), "129373'/10'/0'/0'/2");
         assert_eq!(derivation_path_1.to_string(), "129373'/10'/0'/0'/1");
         assert_eq!(derivation_path_0.to_string(), "129373'/10'/0'/0'/0");
+    }
+
+    #[tokio::test]
+    async fn p2pk_generation_reserves_unique_indexes_after_existing_keys() {
+        let seed = [42; 64];
+        let db = crate::wallet::test_utils::create_test_db().await;
+        let existing_path = DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(P2PK_PURPOSE).expect("valid purpose"),
+            ChildNumber::from_hardened_idx(P2PK_ACCOUNT).expect("valid account"),
+            ChildNumber::from_hardened_idx(0).expect("valid branch"),
+            ChildNumber::from_hardened_idx(0).expect("valid branch"),
+            ChildNumber::from_normal_idx(5).expect("valid index"),
+        ]);
+        db.add_p2pk_key(&SecretKey::generate().public_key(), existing_path, 5)
+            .await
+            .expect("existing key should be stored");
+        let wallet = Wallet::new(
+            "https://mint.example.com",
+            CurrencyUnit::Sat,
+            db.clone(),
+            seed,
+            None,
+        )
+        .expect("wallet should build");
+
+        let (a, b, c, d, e, f, g, h) = tokio::join!(
+            wallet.generate_public_key(),
+            wallet.generate_public_key(),
+            wallet.generate_public_key(),
+            wallet.generate_public_key(),
+            wallet.generate_public_key(),
+            wallet.generate_public_key(),
+            wallet.generate_public_key(),
+            wallet.generate_public_key(),
+        );
+        let public_keys = [a, b, c, d, e, f, g, h]
+            .into_iter()
+            .collect::<Result<HashSet<_>, _>>()
+            .expect("keys should derive");
+        assert_eq!(public_keys.len(), 8);
+
+        let mut indexes = db
+            .list_p2pk_keys()
+            .await
+            .expect("keys should load")
+            .into_iter()
+            .filter_map(|key| {
+                public_keys
+                    .contains(&key.pubkey)
+                    .then_some(key.derivation_index)
+            })
+            .collect::<Vec<_>>();
+        indexes.sort_unstable();
+        assert_eq!(indexes, (6..14).collect::<Vec<_>>());
     }
 }


### PR DESCRIPTION
Derive quote-locking keys from the wallet seed using the NUT-20 BIP32 path, and reserve each derivation index with an independent persistent counter.

Implement atomic counter storage across SQL, Redb, Supabase, and FFI database adapters, with derivation, persistence, and concurrency coverage.
closes: https://github.com/cashubtc/cdk/issues/2204
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
