### PR TITLE
ci(nix): split core library checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -428,6 +428,9 @@
               );
               doCheck = false;
               installPhaseCommand = "mkdir -p $out";
+              # These outputs are success markers; no later derivation consumes
+              # their target directories.
+              doInstallCargoArtifacts = false;
             }
           );
 
@@ -743,11 +746,14 @@
         # These run both clippy and unit tests in a single derivation
         # ========================================
         clippyAndTestChecks = {
-          "core-lib" = [
+          "core-cashu" = [
             "-p cashu"
             "-p cashu --no-default-features"
             "-p cashu --no-default-features --features wallet"
             "-p cashu --no-default-features --features mint"
+          ];
+
+          "core-common-http" = [
             "-p cdk-http-client"
             "-p cdk-http-client --no-default-features --features reqwest"
             "-p cdk-common"
@@ -758,13 +764,22 @@
             "-p cdk-common -p cdk-http-client --no-default-features --features cdk-common/wallet,cdk-common/http,cdk-http-client/reqwest"
             "-p cdk-common -p cdk-http-client --no-default-features --features cdk-common/mint,cdk-common/http,cdk-http-client/bitreq"
             "-p cdk-common -p cdk-http-client --no-default-features --features cdk-common/mint,cdk-common/http,cdk-http-client/reqwest"
+          ];
+
+          "core-sdk-baseline" = [
             "-p cdk -p cdk-http-client"
             "-p cdk --no-default-features"
+          ];
+
+          "core-sdk-wallet" = [
             "-p cdk --no-default-features --features bip353"
             "-p cdk -p cdk-http-client --no-default-features --features cdk/wallet,cdk-http-client/bitreq"
             "-p cdk -p cdk-http-client --no-default-features --features cdk/wallet,cdk-http-client/reqwest"
             "-p cdk -p cdk-http-client --no-default-features --features cdk/wallet,cdk/tor,cdk-http-client/bitreq"
             "-p cdk -p cdk-http-client --no-default-features --features cdk/wallet,cdk/npubcash,cdk-http-client/reqwest"
+          ];
+
+          "core-sdk-mint" = [
             "-p cdk -p cdk-http-client --no-default-features --features cdk/mint,cdk-http-client/bitreq"
             "-p cdk -p cdk-http-client --no-default-features --features cdk/mint,cdk-http-client/reqwest"
           ];
@@ -782,7 +797,6 @@
           ];
 
           "lightning-and-api" = [
-            "-p cdk-http-client"
             "-p cdk-axum"
             "-p cdk-axum --no-default-features"
             "-p cdk-axum --no-default-features --features redis"


### PR DESCRIPTION
Run the 23 core feature configurations in five feature-family derivations so CI can execute them in parallel.

Keep check outputs as small success markers instead of archiving unused Cargo target directories, and remove duplicate HTTP client coverage.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
