### PR TITLE
Share one rate-limit budget per mint origin

### DIFF
--- a/crates/cdk-common/src/rate_limit.rs
+++ b/crates/cdk-common/src/rate_limit.rs
@@ -10,6 +10,7 @@
 //! next wallet built for the same mint instead of starting full and bursting
 //! again.
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex};
@@ -190,7 +191,7 @@ impl TokenBucket {
         mint_url: &MintUrl,
         db: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
     ) -> Self {
-        let persistence = kv_key_for(mint_url)
+        let persistence = origin_key(mint_url)
             .map(|key| Arc::new(KvBudgetStore { db, key }) as Arc<dyn BudgetStore>);
         Self::build(config, persistence)
     }
@@ -297,6 +298,23 @@ impl TokenBucket {
             }
             None => false,
         }
+    }
+
+    /// Whether the bucket carries no outstanding GCRA debt: its theoretical
+    /// arrival time is at or before now, so the full burst is available again
+    /// and it behaves identically to a freshly built bucket. Used to decide when
+    /// a shared bucket can be dropped and rebuilt on demand without changing
+    /// pacing behavior.
+    fn is_fully_recovered(&self) -> bool {
+        lock(&self.inner.state).arrival_time <= Instant::now()
+    }
+
+    /// Number of live handles sharing this bucket's budget. Meaningful because
+    /// the background writer owns only the store and channels, never
+    /// `Arc<TokenBucketInner>` (see `run_writer`), so this counts only
+    /// `TokenBucket` clones, not the writer task.
+    fn handle_count(&self) -> usize {
+        Arc::strong_count(&self.inner)
     }
 
     /// Advance the theoretical arrival time by one slot under the lock. Returns
@@ -439,6 +457,83 @@ impl TokenBucket {
     }
 }
 
+/// Hands out one shared [`TokenBucket`] per mint origin.
+///
+/// A mint origin is the sanitized host plus non-default port (see
+/// [`origin_key`]), so every currency-unit wallet at one mint host draws down a
+/// single budget and a single persistence writer instead of each getting a full
+/// burst. Cloning the manager shares the same per-origin map and config through
+/// `Arc`s, so cloned managers keep handing out the same live budgets.
+#[derive(Clone)]
+pub struct RateLimiterManager {
+    config: RateLimitConfig,
+    db: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
+    /// One bucket per origin. An entry is evicted lazily (during
+    /// [`Self::bucket_for`]) once its budget is fully recovered and no live
+    /// wallet still holds it, so the map is bounded by the origins with active
+    /// or recently-active wallets. Eviction is a behavioral no-op: a recovered
+    /// bucket is equivalent to a fresh one, and the persisted budget survives a
+    /// re-add.
+    buckets: Arc<Mutex<HashMap<String, TokenBucket>>>,
+}
+
+impl std::fmt::Debug for RateLimiterManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RateLimiterManager")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RateLimiterManager {
+    /// Create a manager that hands out buckets configured with `config` and
+    /// persisted through `db`.
+    pub fn new(
+        config: RateLimitConfig,
+        db: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
+    ) -> Self {
+        Self {
+            config,
+            db,
+            buckets: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Get or create the shared bucket for `mint_url`'s origin, returning a
+    /// clone that draws down the same budget.
+    ///
+    /// The first call for an origin builds one persisted bucket (via
+    /// [`TokenBucket::for_mint`], so the KV budget and its single background
+    /// writer are shared); later calls for the same origin clone it. A host-less
+    /// URL falls back to keying on the full URL string, so it still gets one
+    /// stable in-memory bucket, though `for_mint` persists nothing for it.
+    ///
+    /// Each call first evicts any other origin whose bucket is fully recovered
+    /// and held only by the map (no live wallet), bounding the map over time.
+    pub fn bucket_for(&self, mint_url: &MintUrl) -> TokenBucket {
+        let key = origin_key(mint_url).unwrap_or_else(|| mint_url.to_string());
+        let mut buckets = lock(&self.buckets);
+        // Drop origins with no live wallet whose budget has fully recovered: a
+        // recovered bucket is equivalent to a fresh one, so rebuilding it later
+        // is free. Keep the requested key and any bucket a wallet still shares
+        // (handle_count > 1) so co-active wallets never split into independent
+        // budgets.
+        buckets.retain(|k, bucket| {
+            k == &key || bucket.handle_count() > 1 || !bucket.is_fully_recovered()
+        });
+        buckets
+            .entry(key)
+            .or_insert_with(|| TokenBucket::for_mint(self.config, mint_url, self.db.clone()))
+            .clone()
+    }
+
+    /// Number of mint origins currently tracked. Exposed for diagnostics and to
+    /// let tests observe eviction.
+    pub fn origin_count(&self) -> usize {
+        lock(&self.buckets).len()
+    }
+}
+
 /// The single writer task for a persisted bucket: persist the latest cached
 /// value whenever it changes, coalescing intermediate updates. Persistence is
 /// best effort (`store` logs its own failures); `progress` reports the latest
@@ -513,15 +608,17 @@ fn tat_to_unix_millis(arrival_time: Instant) -> u64 {
         .unwrap_or(0)
 }
 
-/// Derive a KV key from a mint URL's host and non-default port, sanitized to
-/// the KV alphabet (disallowed characters become `_`, truncated to the max
-/// length). Returns `None` when the URL has no host.
+/// Derive a mint's rate-limit origin identity from its host and non-default
+/// port, sanitized to the KV alphabet (disallowed characters become `_`,
+/// truncated to the max length). Returns `None` when the URL has no host.
 ///
-/// `Url::parse` normalizes a scheme-default port away, so `:443` and an
-/// implicit default map to one budget: one mint host is one budget. Sanitizing
-/// can collide two distinct hosts onto one key; that only makes them share a
-/// budget, never leak between them.
-fn kv_key_for(mint_url: &MintUrl) -> Option<String> {
+/// This is the identity used both to key the persisted budget in the KV store
+/// and to share one live in-memory [`TokenBucket`] across wallets (see
+/// [`RateLimiterManager`]). `Url::parse` normalizes a scheme-default port away,
+/// so `:443` and an implicit default map to one origin: one mint host is one
+/// budget. Sanitizing can collide two distinct hosts onto one key; that only
+/// makes them share a budget, never leak between them.
+pub fn origin_key(mint_url: &MintUrl) -> Option<String> {
     let parsed = Url::parse(&mint_url.to_string()).ok()?;
     let host = parsed.host_str()?;
     let authority = match parsed.port() {
@@ -755,6 +852,56 @@ mod tests {
         }
     }
 
+    /// A [`BudgetStore`] that signals from its `Drop`. Because the writer task
+    /// owns a clone of the store `Arc` (never `Arc<TokenBucketInner>`), the store
+    /// is freed only after the task returns, so this fires exactly when the
+    /// writer terminates.
+    #[derive(Debug)]
+    struct DropSignalStore {
+        on_drop: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    }
+
+    #[async_trait]
+    impl BudgetStore for DropSignalStore {
+        async fn load(&self) -> Option<Vec<u8>> {
+            None
+        }
+        async fn store(&self, _value: &[u8]) -> bool {
+            true
+        }
+    }
+
+    impl Drop for DropSignalStore {
+        fn drop(&mut self) {
+            if let Some(tx) = lock(&self.on_drop).take() {
+                let _ = tx.send(());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn writer_task_terminates_when_last_handle_drops() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let store: Arc<dyn BudgetStore> = Arc::new(DropSignalStore {
+            on_drop: Mutex::new(Some(tx)),
+        });
+        let bucket = TokenBucket::with_store(config(5, 300), store);
+
+        // First acquire spawns the writer task, which holds one store Arc clone.
+        bucket.acquire(async {}).await;
+
+        // Dropping the only handle drops Inner, closing the writer's `desired`
+        // channel. The writer then does its final write, returns, and releases
+        // its store Arc, firing the drop signal. This is the lifecycle eviction
+        // relies on to reclaim writer tasks.
+        drop(bucket);
+
+        tokio::time::timeout(Duration::from_secs(2), rx)
+            .await
+            .expect("writer task should terminate and drop its store")
+            .expect("drop signal sender dropped without sending");
+    }
+
     #[tokio::test]
     async fn far_future_persisted_budget_heals_to_clamped_value() {
         // A persisted TAT an hour ahead is far beyond one burst window. The
@@ -853,7 +1000,7 @@ mod tests {
     #[test]
     fn kv_key_is_sanitized() {
         let url = MintUrl::from_str("https://mint.example.com:3338").unwrap();
-        let key = kv_key_for(&url).expect("host present");
+        let key = origin_key(&url).expect("host present");
         assert!(!key.contains('.'));
         assert!(!key.contains(':'));
         assert!(key
@@ -865,13 +1012,13 @@ mod tests {
     fn kv_key_ignores_default_port() {
         // `Url::parse` normalizes a scheme-default port away, so an explicit
         // `:443` and an implicit default map to one budget for the same host.
-        let implicit = kv_key_for(&MintUrl::from_str("https://mint.example.com").unwrap());
-        let explicit = kv_key_for(&MintUrl::from_str("https://mint.example.com:443").unwrap());
+        let implicit = origin_key(&MintUrl::from_str("https://mint.example.com").unwrap());
+        let explicit = origin_key(&MintUrl::from_str("https://mint.example.com:443").unwrap());
         assert_eq!(implicit, explicit);
         assert_eq!(implicit.as_deref(), Some("mint_example_com"));
 
         // A non-default port still yields a distinct budget.
-        let other = kv_key_for(&MintUrl::from_str("https://mint.example.com:8443").unwrap());
+        let other = origin_key(&MintUrl::from_str("https://mint.example.com:8443").unwrap());
         assert_ne!(implicit, other);
     }
 

--- a/crates/cdk/src/wallet/builder.rs
+++ b/crates/cdk/src/wallet/builder.rs
@@ -20,6 +20,15 @@ use crate::wallet::{
 };
 
 /// Builder for creating a new [`Wallet`]
+///
+/// Rate limiting: unless a bucket is injected with
+/// [`WalletBuilder::with_rate_limit_bucket`], `build()` constructs the wallet's
+/// own [`TokenBucket`] for the mint. Two wallets built independently for the
+/// same mint therefore do not share a live in-memory budget, only the persisted
+/// per-host budget in the KV store. To share one live budget across wallets
+/// (for example every currency unit at one mint), build them through a
+/// [`WalletRepository`](crate::wallet::WalletRepository), which injects one
+/// shared bucket per mint origin.
 pub struct WalletBuilder {
     mint_url: Option<MintUrl>,
     unit: Option<CurrencyUnit>,
@@ -34,6 +43,7 @@ pub struct WalletBuilder {
     metadata_cache: Option<Arc<MintMetadataCache>>,
     metadata_caches: HashMap<MintUrl, Arc<MintMetadataCache>>,
     rate_limit: Option<RateLimitConfig>,
+    rate_limit_bucket: Option<TokenBucket>,
     auth_cat: Option<String>,
 }
 
@@ -63,6 +73,7 @@ impl Default for WalletBuilder {
             metadata_cache: None,
             metadata_caches: HashMap::new(),
             rate_limit: Some(RateLimitConfig::default()),
+            rate_limit_bucket: None,
             auth_cat: None,
         }
     }
@@ -192,14 +203,29 @@ impl WalletBuilder {
     /// Set the rate-limiting configuration.
     ///
     /// Rate limiting is enabled by default with [`RateLimitConfig::default`].
+    /// This config is only used when `build()` constructs the wallet's own
+    /// bucket; a bucket injected with [`Self::with_rate_limit_bucket`] carries
+    /// its own config and overrides this, regardless of call order.
     pub fn with_rate_limiting_config(mut self, config: RateLimitConfig) -> Self {
         self.rate_limit = Some(config);
+        self
+    }
+
+    /// Use a pre-built, possibly shared [`TokenBucket`] for pacing.
+    ///
+    /// An injected bucket takes precedence over
+    /// [`Self::with_rate_limiting_config`]: `build()` uses it verbatim instead of
+    /// constructing a per-wallet bucket, so several wallets can share one live
+    /// in-memory budget. [`Self::without_rate_limiting`] still clears it.
+    pub fn with_rate_limit_bucket(mut self, bucket: TokenBucket) -> Self {
+        self.rate_limit_bucket = Some(bucket);
         self
     }
 
     /// Disable client-side rate limiting.
     pub fn without_rate_limiting(mut self) -> Self {
         self.rate_limit = None;
+        self.rate_limit_bucket = None;
         self
     }
 
@@ -256,11 +282,15 @@ impl WalletBuilder {
 
         // A single rate-limited transport, shared by the main client and the
         // blind-auth client so both draw down one persisted budget and reuse one
-        // connection pool.
-        let rate_limit_bucket = self
-            .rate_limit
-            .take()
-            .map(|config| TokenBucket::for_mint(config, &mint_url, localstore.clone()));
+        // connection pool. An injected bucket (e.g. one shared across every unit
+        // at a mint by WalletRepository) wins over building a per-wallet one.
+        let rate_limit_bucket = match self.rate_limit_bucket.take() {
+            Some(bucket) => Some(bucket),
+            None => self
+                .rate_limit
+                .take()
+                .map(|config| TokenBucket::for_mint(config, &mint_url, localstore.clone())),
+        };
         let shared_transport = rate_limit_bucket
             .clone()
             .map(|bucket| Arc::new(RateLimitedTransport::with_bucket(Async::default(), bucket)));

--- a/crates/cdk/src/wallet/mint_connector/mod.rs
+++ b/crates/cdk/src/wallet/mint_connector/mod.rs
@@ -24,7 +24,7 @@ pub mod http_client;
 pub mod transport;
 
 use transport::RateLimitedTransport;
-pub use transport::{RateLimitConfig, TokenBucket};
+pub use transport::{RateLimitConfig, RateLimiterManager, TokenBucket};
 
 /// Auth HTTP Client with async transport
 pub type AuthHttpClient = http_client::AuthHttpClient<transport::Async>;

--- a/crates/cdk/src/wallet/mint_connector/transport.rs
+++ b/crates/cdk/src/wallet/mint_connector/transport.rs
@@ -2,7 +2,9 @@
 
 // The rate limiter lives in cdk-common so the logic is shared; re-export it here
 // to keep the wallet's transport path stable.
-pub use cdk_common::rate_limit::{RateLimitConfig, RateLimitedTransport, TokenBucket};
+pub use cdk_common::rate_limit::{
+    RateLimitConfig, RateLimitedTransport, RateLimiterManager, TokenBucket,
+};
 #[cfg(all(feature = "tor", not(target_arch = "wasm32")))]
 pub use cdk_http_client::TorAsync;
 pub use cdk_http_client::{Async, Transport};
@@ -19,7 +21,7 @@ mod persistence_tests {
 
     use cdk_common::database;
 
-    use super::{RateLimitConfig, TokenBucket};
+    use super::{RateLimitConfig, RateLimiterManager, TokenBucket};
     use crate::cdk_database::WalletDatabase;
     use crate::mint_url::MintUrl;
 
@@ -28,6 +30,142 @@ mod persistence_tests {
             NonZeroU32::new(capacity).unwrap_or(NonZeroU32::MIN),
             NonZeroU32::new(refill_per_minute).unwrap_or(NonZeroU32::MIN),
         )
+    }
+
+    #[tokio::test]
+    async fn manager_shares_one_bucket_per_origin() {
+        let store: Arc<dyn WalletDatabase<database::Error> + Send + Sync> =
+            Arc::new(cdk_sqlite::wallet::memory::empty().await.unwrap());
+        // capacity 2 so two try_acquires exhaust one origin's shared burst.
+        let manager = RateLimiterManager::new(config(2, 300), store);
+
+        // Two URLs of the same origin (default port collapses to no port) must
+        // resolve to one shared bucket.
+        let implicit = MintUrl::from_str("https://mint.example.com").unwrap();
+        let explicit = MintUrl::from_str("https://mint.example.com:443").unwrap();
+        let a = manager.bucket_for(&implicit);
+        let b = manager.bucket_for(&explicit);
+
+        assert!(a.try_acquire().await);
+        assert!(b.try_acquire().await);
+        // The shared burst of 2 is now spent across both handles.
+        assert!(!a.try_acquire().await, "shared origin budget is drained");
+        assert!(!b.try_acquire().await, "shared origin budget is drained");
+
+        // A different origin keeps its own budget.
+        let other = manager.bucket_for(&MintUrl::from_str("https://other.example.com").unwrap());
+        assert!(other.try_acquire().await, "distinct origin is independent");
+    }
+
+    #[tokio::test]
+    async fn manager_evicts_recovered_unreferenced_bucket() {
+        let store: Arc<dyn WalletDatabase<database::Error> + Send + Sync> =
+            Arc::new(cdk_sqlite::wallet::memory::empty().await.unwrap());
+        let manager = RateLimiterManager::new(config(5, 300), store);
+
+        // A fresh bucket is fully recovered. Dropping the handle leaves the map
+        // as its only holder.
+        let a = MintUrl::from_str("https://a.example.com").unwrap();
+        drop(manager.bucket_for(&a));
+        assert_eq!(manager.origin_count(), 1);
+
+        // Creating a bucket for a different origin sweeps the recovered,
+        // unreferenced A out, so only B remains.
+        let b = MintUrl::from_str("https://b.example.com").unwrap();
+        let _b = manager.bucket_for(&b);
+        assert_eq!(manager.origin_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn manager_retains_referenced_bucket() {
+        let store: Arc<dyn WalletDatabase<database::Error> + Send + Sync> =
+            Arc::new(cdk_sqlite::wallet::memory::empty().await.unwrap());
+        let manager = RateLimiterManager::new(config(5, 300), store);
+
+        // Hold a live clone of A: even though A is fully recovered, a live
+        // holder must keep it so co-active wallets never split budgets.
+        let a = MintUrl::from_str("https://a.example.com").unwrap();
+        let _held = manager.bucket_for(&a);
+
+        let b = MintUrl::from_str("https://b.example.com").unwrap();
+        let _b = manager.bucket_for(&b);
+        assert_eq!(manager.origin_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn manager_retains_unrecovered_bucket() {
+        let store: Arc<dyn WalletDatabase<database::Error> + Send + Sync> =
+            Arc::new(cdk_sqlite::wallet::memory::empty().await.unwrap());
+        let manager = RateLimiterManager::new(config(5, 300), store);
+
+        // Drain A past its burst so it carries debt, then drop the handle: it is
+        // unreferenced but not yet recovered, so it must be kept.
+        let a = MintUrl::from_str("https://a.example.com").unwrap();
+        let bucket_a = manager.bucket_for(&a);
+        for _ in 0..5 {
+            bucket_a.try_acquire().await;
+        }
+        drop(bucket_a);
+
+        let b = MintUrl::from_str("https://b.example.com").unwrap();
+        let _b = manager.bucket_for(&b);
+        assert_eq!(manager.origin_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn shared_bucket_survives_concurrent_writers() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let store: Arc<dyn WalletDatabase<database::Error> + Send + Sync> =
+            Arc::new(cdk_sqlite::wallet::memory::empty().await.unwrap());
+        let url = MintUrl::from_str("https://concurrent.example.com").unwrap();
+        // capacity 5, emission ~200ms so the inherited budget paces measurably.
+        let cfg = config(5, 300);
+        let manager = RateLimiterManager::new(cfg, store.clone());
+
+        // Two handles to the same origin, as two currency-unit wallets hold.
+        let a = manager.bucket_for(&url);
+        let b = manager.bucket_for(&url);
+
+        // Hammer both handles concurrently. They share one budget and one
+        // writer, so the combined burst is exactly `capacity`, never twice it,
+        // no matter how the four tasks interleave.
+        let admitted = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+        for bucket in [a.clone(), b.clone(), a.clone(), b.clone()] {
+            let admitted = admitted.clone();
+            handles.push(tokio::spawn(async move {
+                for _ in 0..10 {
+                    if bucket.try_acquire().await {
+                        admitted.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            }));
+        }
+        for handle in handles {
+            handle.await.unwrap();
+        }
+        assert_eq!(
+            admitted.load(Ordering::SeqCst),
+            5,
+            "concurrent handles share one burst, not one each"
+        );
+
+        // The single writer persists the drained budget; a fresh instance over
+        // the same store inherits it (does not reset to full), proving no
+        // concurrent writer overwrote it back to a staler value.
+        a.flush().await;
+        drop((a, b, manager));
+
+        let fresh = TokenBucket::for_mint(cfg, &url, store.clone());
+        let start = Instant::now();
+        fresh.acquire(async {}).await;
+        fresh.acquire(async {}).await;
+        assert!(
+            start.elapsed() >= Duration::from_millis(150),
+            "inherited budget should pace, took {:?}",
+            start.elapsed()
+        );
     }
 
     #[tokio::test]

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -89,7 +89,7 @@ pub use melt::{MeltConfirmOptions, MeltOutcome, PendingMelt, PreparedMelt};
 pub use mint_connector::transport::Transport as HttpTransport;
 pub use mint_connector::{
     AuthHttpClient, HttpClient, LnurlPayInvoiceResponse, LnurlPayResponse, MintConnector,
-    RateLimitConfig, TokenBucket,
+    RateLimitConfig, RateLimiterManager, TokenBucket,
 };
 pub use mint_metadata_cache::MintMetadata;
 #[cfg(feature = "nostr")]
@@ -301,6 +301,11 @@ impl Wallet {
     /// replaced the main transport and no rate-limited auth client remains. With
     /// a custom main client plus a CAT it reconfigures only the blind-auth
     /// client's pacing.
+    ///
+    /// When the wallet was built through a
+    /// [`WalletRepository`], its bucket is
+    /// shared with every other wallet at the same mint origin, so this
+    /// reconfigures the pacing for all of that origin's currency units at once.
     pub fn set_rate_limiting_config(&self, config: RateLimitConfig) {
         if let Some(bucket) = &self.rate_limit {
             bucket.set_config(config);
@@ -311,7 +316,9 @@ impl Wallet {
     ///
     /// Affects the same clients as [`Wallet::set_rate_limiting_config`]: a no-op
     /// when the wallet paces nothing, and with a custom main client plus a CAT it
-    /// disables only the blind-auth client's pacing.
+    /// disables only the blind-auth client's pacing. For a repository-built
+    /// wallet the bucket is shared, so this disables pacing for every currency
+    /// unit at that mint origin.
     pub fn disable_rate_limiting(&self) {
         if let Some(bucket) = &self.rate_limit {
             bucket.set_enabled(false);

--- a/crates/cdk/src/wallet/wallet_repository.rs
+++ b/crates/cdk/src/wallet/wallet_repository.rs
@@ -16,7 +16,7 @@ use tracing::instrument;
 use zeroize::Zeroize;
 
 use super::builder::WalletBuilder;
-use super::{AuthMintConnector, Error, MintConnector};
+use super::{AuthMintConnector, Error, MintConnector, RateLimitConfig, RateLimiterManager};
 use crate::mint_url::MintUrl;
 use crate::nuts::CurrencyUnit;
 #[cfg(all(feature = "tor", not(target_arch = "wasm32")))]
@@ -233,6 +233,7 @@ impl WalletRepositoryBuilder {
         let seed = self.seed.ok_or(Error::Custom("seed is required".into()))?;
 
         let wallet = WalletRepository {
+            rate_limiter: RateLimiterManager::new(RateLimitConfig::default(), localstore.clone()),
             localstore,
             seed,
             wallets: Arc::new(RwLock::new(BTreeMap::new())),
@@ -296,6 +297,11 @@ fn validate_proxy_url(proxy_url: &url::Url) -> Result<(), Error> {
 /// Simple container that bootstraps wallets from database and provides
 /// access to individual Wallet instances. Each wallet is uniquely identified
 /// by the combination of mint URL and currency unit.
+///
+/// Wallets that target the same mint origin (host + non-default port) share one
+/// live rate-limit budget through the repository's [`RateLimiterManager`],
+/// regardless of currency unit, so they pace one combined burst instead of each
+/// getting a full one.
 #[derive(Clone)]
 pub struct WalletRepository {
     /// Storage backend
@@ -303,6 +309,9 @@ pub struct WalletRepository {
     seed: [u8; 64],
     /// Wallets indexed by (mint URL, currency unit)
     wallets: Arc<RwLock<BTreeMap<WalletKey, Wallet>>>,
+    /// Hands out one shared rate-limit budget per mint origin, so every wallet
+    /// at an origin paces one combined burst regardless of currency unit.
+    rate_limiter: RateLimiterManager,
     /// Proxy configuration for HTTP clients (optional)
     proxy_config: Option<url::Url>,
     /// Whether proxied HTTPS clients should accept invalid TLS certificates
@@ -485,6 +494,13 @@ impl WalletRepository {
     /// This only removes the wallet from the in-memory map. It does not remove
     /// the mint from the database. Use the database directly if you need to
     /// explicitly remove persisted mint data.
+    ///
+    /// The origin's shared rate-limit bucket stays in the
+    /// [`RateLimiterManager`] while any handle is live or its budget is still
+    /// recovering, so re-adding a wallet for the same origin inherits the same
+    /// live budget rather than starting full and bursting again. Once no wallet
+    /// holds it and its budget has fully recovered, a later wallet creation
+    /// evicts it; the persisted budget still survives a re-add.
     #[instrument(skip(self))]
     pub async fn remove_wallet(
         &self,
@@ -600,6 +616,10 @@ impl WalletRepository {
         let metadata_cache_ttl = config.and_then(|c| c.metadata_cache_ttl);
         let configured_auth_connector = config.and_then(|c| c.auth_connector.clone());
 
+        // One shared budget per mint origin: every unit at this mint paces one
+        // combined burst instead of each wallet building its own bucket.
+        let rate_limit_bucket = self.rate_limiter.bucket_for(&mint_url);
+
         // Check if custom connector is provided in config
         if let Some(cfg) = config {
             if let Some(custom_connector) = &cfg.mint_connector {
@@ -610,6 +630,7 @@ impl WalletRepository {
                     .localstore(self.localstore.clone())
                     .seed(self.seed)
                     .target_proof_count(target_proof_count)
+                    .with_rate_limit_bucket(rate_limit_bucket.clone())
                     .shared_client(custom_connector.clone());
 
                 if let Some(auth_connector) = configured_auth_connector.clone() {
@@ -646,6 +667,7 @@ impl WalletRepository {
                 .localstore(self.localstore.clone())
                 .seed(self.seed)
                 .target_proof_count(target_proof_count)
+                .with_rate_limit_bucket(rate_limit_bucket.clone())
                 .client(client)
                 .auth_connector(auth_connector);
 
@@ -677,6 +699,7 @@ impl WalletRepository {
                     .localstore(self.localstore.clone())
                     .seed(self.seed)
                     .target_proof_count(target_proof_count)
+                    .with_rate_limit_bucket(rate_limit_bucket.clone())
                     .client(client)
                     .auth_connector(auth_connector);
 
@@ -692,7 +715,8 @@ impl WalletRepository {
                     .unit(unit.clone())
                     .localstore(self.localstore.clone())
                     .seed(self.seed)
-                    .target_proof_count(target_proof_count);
+                    .target_proof_count(target_proof_count)
+                    .with_rate_limit_bucket(rate_limit_bucket.clone());
 
                 if let Some(auth_connector) = configured_auth_connector.clone() {
                     builder = builder.auth_connector(auth_connector);
@@ -713,7 +737,8 @@ impl WalletRepository {
                     .unit(unit.clone())
                     .localstore(self.localstore.clone())
                     .seed(self.seed)
-                    .target_proof_count(target_proof_count);
+                    .target_proof_count(target_proof_count)
+                    .with_rate_limit_bucket(rate_limit_bucket.clone());
 
                 if let Some(auth_connector) = configured_auth_connector.clone() {
                     builder = builder.auth_connector(auth_connector);
@@ -1314,5 +1339,116 @@ mod tests {
             .await
             .unwrap()
             .is_some());
+    }
+
+    // The default rate-limit config admits exactly `capacity` (20) immediate
+    // `try_acquire`s before pacing kicks in, and its burst tolerance (~57s) far
+    // exceeds test wall-clock, so no slot is earned back mid-test.
+    const DEFAULT_BURST: usize = 20;
+
+    #[tokio::test]
+    async fn wallets_for_same_mint_share_one_rate_limit_budget() {
+        let repo = create_test_repository().await;
+        let mint_url: MintUrl = "https://mint.example.com".parse().unwrap();
+
+        let sat = repo
+            .create_wallet(mint_url.clone(), CurrencyUnit::Sat, None)
+            .await
+            .expect("failed to create sat wallet");
+        let usd = repo
+            .create_wallet(mint_url.clone(), CurrencyUnit::Usd, None)
+            .await
+            .expect("failed to create usd wallet");
+
+        let sat_bucket = sat
+            .rate_limit
+            .clone()
+            .expect("default path retains its bucket");
+        let usd_bucket = usd
+            .rate_limit
+            .clone()
+            .expect("default path retains its bucket");
+
+        // Interleave across the two handles: sharing one budget means the two
+        // together drain a single burst, not one each.
+        let mut admitted = 0;
+        for _ in 0..DEFAULT_BURST {
+            if sat_bucket.try_acquire().await {
+                admitted += 1;
+            }
+            if usd_bucket.try_acquire().await {
+                admitted += 1;
+            }
+        }
+        assert_eq!(
+            admitted, DEFAULT_BURST,
+            "combined burst is one capacity, not two"
+        );
+        assert!(
+            !sat_bucket.try_acquire().await,
+            "shared budget already spent"
+        );
+        assert!(
+            !usd_bucket.try_acquire().await,
+            "shared budget already spent"
+        );
+    }
+
+    #[tokio::test]
+    async fn wallets_for_different_mints_have_independent_budgets() {
+        let repo = create_test_repository().await;
+        let mint_a: MintUrl = "https://mint-a.example.com".parse().unwrap();
+        let mint_b: MintUrl = "https://mint-b.example.com".parse().unwrap();
+
+        let wallet_a = repo
+            .create_wallet(mint_a, CurrencyUnit::Sat, None)
+            .await
+            .expect("failed to create wallet a");
+        let wallet_b = repo
+            .create_wallet(mint_b, CurrencyUnit::Sat, None)
+            .await
+            .expect("failed to create wallet b");
+        let bucket_a = wallet_a.rate_limit.clone().expect("bucket a");
+        let bucket_b = wallet_b.rate_limit.clone().expect("bucket b");
+
+        for _ in 0..DEFAULT_BURST {
+            assert!(bucket_a.try_acquire().await);
+        }
+        assert!(
+            !bucket_a.try_acquire().await,
+            "mint A's own burst is drained"
+        );
+        assert!(
+            bucket_b.try_acquire().await,
+            "mint B has an untouched budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_or_create_wallet_second_unit_shares_the_budget() {
+        let repo = create_test_repository().await;
+        let mint_url: MintUrl = "https://mint.example.com".parse().unwrap();
+
+        let sat = repo
+            .get_or_create_wallet(mint_url.clone(), CurrencyUnit::Sat, None)
+            .await
+            .expect("failed to create sat wallet");
+        let usd = repo
+            .get_or_create_wallet(mint_url.clone(), CurrencyUnit::Usd, None)
+            .await
+            .expect("failed to create usd wallet");
+
+        let sat_bucket = sat.rate_limit.clone().expect("bucket");
+        let usd_bucket = usd.rate_limit.clone().expect("bucket");
+
+        // Drain the whole burst through the Sat handle; the Usd handle sees an
+        // already-spent budget because they share one bucket.
+        for _ in 0..DEFAULT_BURST {
+            assert!(sat_bucket.try_acquire().await);
+        }
+        assert!(
+            !usd_bucket.try_acquire().await,
+            "shared budget already spent"
+        );
     }
 }


### PR DESCRIPTION


### Description

Fixes #2312

WalletRepository created a wallet per (mint, unit), and each wallet built its own TokenBucket. Wallets for different units at the same mint shared only the persisted KV key, not the live budget, so each could consume a full burst and their independent writer tasks overwrote one another.

Introduce a RateLimiterManager keyed by mint origin (host + non-default port) that owns one shared bucket per origin. WalletRepository holds one manager and injects the shared bucket into every WalletBuilder it builds, so all currency units at a mint pace one combined burst and a single writer persists the budget. Persistence is unchanged: the same origin still maps to the same KV key.

A wallet built directly through WalletBuilder still gets its own bucket unless one is injected, documented on the builder and the runtime setters.


-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
