### PR TITLE
feat(cdk-mint-rpc): expose BDK wallet information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,7 @@ name = "cdk-mint-rpc"
 version = "0.17.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bip39",
  "cdk",
  "cdk-common",

--- a/crates/cdk-bdk/src/lib.rs
+++ b/crates/cdk-bdk/src/lib.rs
@@ -53,6 +53,11 @@ pub mod storage;
 pub(crate) mod sync;
 pub mod types;
 pub(crate) mod util;
+pub mod wallet_info;
+
+pub use crate::wallet_info::{
+    WalletAddress, WalletBalance, WalletKeychain, WalletPage, WalletTransaction,
+};
 
 /// Wrapper struct that combines wallet and database to prevent deadlocks
 pub(crate) struct WalletWithDb {
@@ -842,7 +847,7 @@ mod tests {
     };
     use bdk_wallet::keys::bip39::Mnemonic;
     use cdk_common::common::FeeReserve;
-    use cdk_common::payment::MintPayment;
+    use cdk_common::payment::{MintPayment, OnchainIncomingPaymentOptions};
     use futures::StreamExt;
 
     use super::*;
@@ -924,32 +929,188 @@ mod tests {
         Ok((backend, tmp))
     }
 
-    async fn fund_backend_wallet(backend: &CdkBdk, amount_sat: u64) {
+    #[tokio::test]
+    async fn wallet_info_lists_revealed_addresses_without_revealing_more() {
+        let (backend, _tmp) = build_test_instance_with_tempdir(1).await;
+
+        let initial_addresses = backend
+            .wallet_addresses(0, 100)
+            .await
+            .expect("list initial addresses");
+        assert_eq!(initial_addresses.total, 0);
+
+        backend
+            .create_incoming_payment_request(IncomingPaymentOptions::Onchain(
+                OnchainIncomingPaymentOptions {
+                    quote_id: cdk_common::QuoteId::new(),
+                },
+            ))
+            .await
+            .expect("create on-chain request");
+
+        let addresses = backend
+            .wallet_addresses(0, 100)
+            .await
+            .expect("list revealed addresses");
+        assert_eq!(addresses.total, 1);
+        assert_eq!(addresses.items.len(), 1);
+        assert_eq!(addresses.items[0].keychain, WalletKeychain::External);
+        assert_eq!(addresses.items[0].derivation_index, 0);
+        assert!(!addresses.items[0].used);
+        assert_eq!(addresses.items[0].balance_sat, 0);
+
+        let balance = backend.wallet_balance().await;
+        assert_eq!(balance.total_sat, 0);
+        assert_eq!(
+            backend
+                .wallet_transactions(0, 20)
+                .await
+                .expect("list transactions")
+                .total,
+            0
+        );
+
+        let addresses_again = backend
+            .wallet_addresses(0, 100)
+            .await
+            .expect("list revealed addresses again");
+        assert_eq!(addresses_again.total, 1);
+    }
+
+    #[tokio::test]
+    async fn wallet_info_paginates_revealed_addresses_across_keychains() {
+        let (backend, _tmp) = build_test_instance_with_tempdir(1).await;
+
+        {
+            let mut wallet_with_db = backend.wallet_with_db.lock().await;
+            let _ = wallet_with_db
+                .wallet
+                .reveal_addresses_to(KeychainKind::External, 1)
+                .count();
+            let _ = wallet_with_db
+                .wallet
+                .reveal_addresses_to(KeychainKind::Internal, 1)
+                .count();
+            wallet_with_db
+                .persist()
+                .expect("persist revealed addresses");
+        }
+
+        let page = backend
+            .wallet_addresses(1, 2)
+            .await
+            .expect("list paginated addresses");
+
+        assert_eq!(page.total, 4);
+        assert_eq!(page.items.len(), 2);
+        assert_eq!(page.items[0].keychain, WalletKeychain::External);
+        assert_eq!(page.items[0].derivation_index, 1);
+        assert_eq!(page.items[1].keychain, WalletKeychain::Internal);
+        assert_eq!(page.items[1].derivation_index, 0);
+    }
+
+    async fn fund_backend_wallet_transactions(backend: &CdkBdk, amounts_sat: &[u64]) -> Vec<Txid> {
         let mut wallet_with_db = backend.wallet_with_db.lock().await;
         let funding_script = wallet_with_db
             .wallet
             .reveal_next_address(KeychainKind::External)
             .address
             .script_pubkey();
-        let funding_tx = Transaction {
-            version: transaction::Version::TWO,
-            lock_time: absolute::LockTime::ZERO,
-            input: vec![TxIn {
-                previous_output: OutPoint::new(Txid::all_zeros(), 0),
-                script_sig: Default::default(),
-                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-                witness: Witness::new(),
-            }],
-            output: vec![TxOut {
-                value: bdk_wallet::bitcoin::Amount::from_sat(amount_sat),
-                script_pubkey: funding_script,
-            }],
-        };
+        let funding_transactions = amounts_sat
+            .iter()
+            .enumerate()
+            .map(|(index, amount_sat)| Transaction {
+                version: transaction::Version::TWO,
+                lock_time: absolute::LockTime::ZERO,
+                input: vec![TxIn {
+                    previous_output: OutPoint::new(
+                        Txid::all_zeros(),
+                        u32::try_from(index).expect("test transaction index fits in u32"),
+                    ),
+                    script_sig: Default::default(),
+                    sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                    witness: Witness::new(),
+                }],
+                output: vec![TxOut {
+                    value: bdk_wallet::bitcoin::Amount::from_sat(*amount_sat),
+                    script_pubkey: funding_script.clone(),
+                }],
+            })
+            .collect::<Vec<_>>();
+        let txids = funding_transactions
+            .iter()
+            .map(Transaction::compute_txid)
+            .collect();
 
         wallet_with_db
             .wallet
-            .apply_unconfirmed_txs([(funding_tx, 0)]);
+            .apply_unconfirmed_txs(funding_transactions.into_iter().map(|tx| (tx, 0)));
         wallet_with_db.persist().expect("persist funded wallet");
+
+        txids
+    }
+
+    async fn fund_backend_wallet(backend: &CdkBdk, amount_sat: u64) {
+        fund_backend_wallet_transactions(backend, &[amount_sat]).await;
+    }
+
+    #[tokio::test]
+    async fn wallet_info_reports_unconfirmed_funding() {
+        let (backend, _tmp) = build_test_instance_with_tempdir(1).await;
+        fund_backend_wallet(&backend, 42_000).await;
+
+        let balance = backend.wallet_balance().await;
+        assert_eq!(balance.untrusted_pending_sat, 42_000);
+        assert_eq!(balance.total_sat, 42_000);
+
+        let transactions = backend
+            .wallet_transactions(0, 20)
+            .await
+            .expect("list transactions");
+        assert_eq!(transactions.total, 1);
+        assert_eq!(transactions.items[0].received_sat, 42_000);
+        assert_eq!(transactions.items[0].sent_sat, 0);
+        assert_eq!(transactions.items[0].balance_delta_sat, 42_000);
+        assert_eq!(transactions.items[0].confirmation_height, None);
+        assert_eq!(transactions.items[0].first_seen, Some(0));
+
+        let addresses = backend
+            .wallet_addresses(0, 20)
+            .await
+            .expect("list addresses");
+        assert_eq!(addresses.total, 1);
+        assert!(addresses.items[0].used);
+        assert_eq!(addresses.items[0].balance_sat, 42_000);
+        assert_eq!(addresses.items[0].confirmed_balance_sat, 0);
+
+        let empty_page = backend
+            .wallet_transactions(0, 0)
+            .await
+            .expect("list empty transaction page");
+        assert_eq!(empty_page.total, 1);
+        assert!(empty_page.items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn wallet_info_uses_txid_to_order_equal_chain_positions() {
+        let (backend, _tmp) = build_test_instance_with_tempdir(1).await;
+        let mut expected_txids =
+            fund_backend_wallet_transactions(&backend, &[21_000, 42_000]).await;
+        expected_txids.sort_by(|left, right| right.cmp(left));
+
+        let first_page = backend
+            .wallet_transactions(0, 1)
+            .await
+            .expect("list first transaction page");
+        let second_page = backend
+            .wallet_transactions(1, 1)
+            .await
+            .expect("list second transaction page");
+
+        assert_eq!(first_page.total, 2);
+        assert_eq!(second_page.total, 2);
+        assert_eq!(first_page.items[0].txid, expected_txids[0].to_string());
+        assert_eq!(second_page.items[0].txid, expected_txids[1].to_string());
     }
 
     #[tokio::test]

--- a/crates/cdk-bdk/src/wallet_info.rs
+++ b/crates/cdk-bdk/src/wallet_info.rs
@@ -1,0 +1,234 @@
+//! Read-only wallet information for operator interfaces.
+
+use std::collections::HashMap;
+
+use bdk_wallet::bitcoin::Address;
+use bdk_wallet::chain::ChainPosition;
+use bdk_wallet::KeychainKind;
+
+use crate::{CdkBdk, Error};
+
+/// BDK wallet balance split by confirmation status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalletBalance {
+    /// Bitcoin network used by the wallet.
+    pub network: String,
+    /// Height of the wallet's latest local chain checkpoint.
+    pub synced_height: u32,
+    /// Confirmed, spendable balance in satoshis.
+    pub confirmed_sat: u64,
+    /// Unconfirmed wallet-created outputs in satoshis.
+    pub trusted_pending_sat: u64,
+    /// Unconfirmed externally-created outputs in satoshis.
+    pub untrusted_pending_sat: u64,
+    /// Immature coinbase outputs in satoshis.
+    pub immature_sat: u64,
+    /// Confirmed plus trusted-pending balance in satoshis.
+    pub trusted_spendable_sat: u64,
+    /// Total wallet balance in satoshis.
+    pub total_sat: u64,
+}
+
+/// A transaction relevant to the BDK wallet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalletTransaction {
+    /// Transaction ID.
+    pub txid: String,
+    /// Value received by wallet scripts in satoshis.
+    pub received_sat: u64,
+    /// Value spent from wallet inputs in satoshis.
+    pub sent_sat: u64,
+    /// Transaction fee in satoshis, when all previous outputs are known.
+    pub fee_sat: Option<u64>,
+    /// Net effect on the wallet balance in satoshis.
+    pub balance_delta_sat: i64,
+    /// Confirmation block height, when confirmed.
+    pub confirmation_height: Option<u32>,
+    /// Confirmation block timestamp, when confirmed.
+    pub confirmation_time: Option<u64>,
+    /// First-seen timestamp, when known for an unconfirmed transaction.
+    pub first_seen: Option<u64>,
+}
+
+/// BDK keychain containing a revealed address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WalletKeychain {
+    /// Address intended for incoming payments.
+    External,
+    /// Internal change address.
+    Internal,
+}
+
+/// An address revealed by the BDK wallet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalletAddress {
+    /// Bitcoin address.
+    pub address: String,
+    /// Descriptor keychain.
+    pub keychain: WalletKeychain,
+    /// Child derivation index.
+    pub derivation_index: u32,
+    /// Whether the address has appeared in a wallet transaction.
+    pub used: bool,
+    /// Total current unspent balance in satoshis.
+    pub balance_sat: u64,
+    /// Confirmed current unspent balance in satoshis.
+    pub confirmed_balance_sat: u64,
+}
+
+/// A page of wallet records and the total number available.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalletPage<T> {
+    /// Records in this page.
+    pub items: Vec<T>,
+    /// Total records before pagination.
+    pub total: u64,
+}
+
+impl CdkBdk {
+    /// Returns the wallet balance split by confirmation status.
+    pub async fn wallet_balance(&self) -> WalletBalance {
+        let wallet_with_db = self.wallet_with_db.lock().await;
+        let balance = wallet_with_db.wallet.balance();
+
+        WalletBalance {
+            network: self.network.to_string(),
+            synced_height: wallet_with_db.wallet.latest_checkpoint().height(),
+            confirmed_sat: balance.confirmed.to_sat(),
+            trusted_pending_sat: balance.trusted_pending.to_sat(),
+            untrusted_pending_sat: balance.untrusted_pending.to_sat(),
+            immature_sat: balance.immature.to_sat(),
+            trusted_spendable_sat: balance.trusted_spendable().to_sat(),
+            total_sat: balance.total().to_sat(),
+        }
+    }
+
+    /// Returns relevant wallet transactions, newest first.
+    pub async fn wallet_transactions(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<WalletPage<WalletTransaction>, Error> {
+        let wallet_with_db = self.wallet_with_db.lock().await;
+        let wallet = &wallet_with_db.wallet;
+        let transactions = wallet.transactions_sort_by(|left, right| {
+            right
+                .chain_position
+                .cmp(&left.chain_position)
+                .then_with(|| right.tx_node.txid.cmp(&left.tx_node.txid))
+        });
+        let total = u64::try_from(transactions.len())
+            .map_err(|_| Error::Wallet("Transaction count exceeds u64".to_string()))?;
+
+        let items = transactions
+            .into_iter()
+            .skip(offset)
+            .take(limit)
+            .map(|transaction| {
+                let tx = &transaction.tx_node.tx;
+                let (sent, received) = wallet.sent_and_received(tx);
+                let received_sat = received.to_sat();
+                let sent_sat = sent.to_sat();
+                let received_signed = i64::try_from(received_sat)
+                    .map_err(|_| Error::Wallet("Received value exceeds i64".to_string()))?;
+                let sent_signed = i64::try_from(sent_sat)
+                    .map_err(|_| Error::Wallet("Sent value exceeds i64".to_string()))?;
+
+                let (confirmation_height, confirmation_time, first_seen) =
+                    match transaction.chain_position {
+                        ChainPosition::Confirmed { anchor, .. } => (
+                            Some(anchor.block_id.height),
+                            Some(anchor.confirmation_time),
+                            None,
+                        ),
+                        ChainPosition::Unconfirmed { first_seen, .. } => (None, None, first_seen),
+                    };
+
+                Ok(WalletTransaction {
+                    txid: transaction.tx_node.txid.to_string(),
+                    received_sat,
+                    sent_sat,
+                    fee_sat: wallet.calculate_fee(tx).ok().map(|fee| fee.to_sat()),
+                    balance_delta_sat: received_signed - sent_signed,
+                    confirmation_height,
+                    confirmation_time,
+                    first_seen,
+                })
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+
+        Ok(WalletPage { items, total })
+    }
+
+    /// Returns revealed external and internal addresses in derivation order.
+    pub async fn wallet_addresses(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<WalletPage<WalletAddress>, Error> {
+        let wallet_with_db = self.wallet_with_db.lock().await;
+        let wallet = &wallet_with_db.wallet;
+        let mut balances = HashMap::<(KeychainKind, u32), (u64, u64)>::new();
+
+        for output in wallet.list_unspent() {
+            let entry = balances
+                .entry((output.keychain, output.derivation_index))
+                .or_default();
+            entry.0 = entry
+                .0
+                .checked_add(output.txout.value.to_sat())
+                .ok_or_else(|| Error::Wallet("Address balance overflow".to_string()))?;
+            if output.chain_position.is_confirmed() {
+                entry.1 = entry
+                    .1
+                    .checked_add(output.txout.value.to_sat())
+                    .ok_or_else(|| Error::Wallet("Address balance overflow".to_string()))?;
+            }
+        }
+
+        let keychains = [
+            (KeychainKind::External, WalletKeychain::External),
+            (KeychainKind::Internal, WalletKeychain::Internal),
+        ];
+        let total = keychains.iter().try_fold(0_u64, |total, (keychain, _)| {
+            let keychain_total =
+                u64::try_from(wallet.spk_index().revealed_keychain_spks(*keychain).count())
+                    .map_err(|_| Error::Wallet("Address count exceeds u64".to_string()))?;
+            total
+                .checked_add(keychain_total)
+                .ok_or_else(|| Error::Wallet("Address count exceeds u64".to_string()))
+        })?;
+
+        let items = keychains
+            .into_iter()
+            .flat_map(|(keychain, wallet_keychain)| {
+                wallet.spk_index().revealed_keychain_spks(keychain).map(
+                    move |(derivation_index, script)| {
+                        (keychain, wallet_keychain, derivation_index, script)
+                    },
+                )
+            })
+            .skip(offset)
+            .take(limit)
+            .map(|(keychain, wallet_keychain, derivation_index, script)| {
+                let address = Address::from_script(&script, self.network)
+                    .map_err(|err| Error::Wallet(err.to_string()))?;
+                let (balance_sat, confirmed_balance_sat) = balances
+                    .get(&(keychain, derivation_index))
+                    .copied()
+                    .unwrap_or_default();
+
+                Ok(WalletAddress {
+                    address: address.to_string(),
+                    keychain: wallet_keychain,
+                    derivation_index,
+                    used: wallet.spk_index().is_used(keychain, derivation_index),
+                    balance_sat,
+                    confirmed_balance_sat,
+                })
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+
+        Ok(WalletPage { items, total })
+    }
+}

--- a/crates/cdk-mint-rpc/Cargo.toml
+++ b/crates/cdk-mint-rpc/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/bin/mint_rpc_cli.rs"
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 cdk = { workspace = true, features = [
     "mint",
 ] }

--- a/crates/cdk-mint-rpc/build.rs
+++ b/crates/cdk-mint-rpc/build.rs
@@ -18,6 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "src/proto/cdk-mint-rpc.proto",
                 "src/proto/keyset.proto",
                 "src/proto/quote.proto",
+                "src/proto/wallet.proto",
             ],
             &["src/proto"],
         )?;

--- a/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
+++ b/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
@@ -8,6 +8,7 @@ use cdk_mint_rpc::cdk_mint_client::CdkMintClient;
 use cdk_mint_rpc::keyset::keyset_service_client::KeysetServiceClient;
 use cdk_mint_rpc::mint_rpc_cli::subcommands;
 use cdk_mint_rpc::quote::quote_service_client::QuoteServiceClient;
+use cdk_mint_rpc::wallet::wallet_service_client::WalletServiceClient;
 use cdk_mint_rpc::GetInfoRequest;
 use clap::{Parser, Subcommand};
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
@@ -107,6 +108,12 @@ enum Commands {
     UpdateMintQuoteState(subcommands::UpdateMintQuoteStateCommand),
     /// Rotate next keyset
     RotateNextKeyset(subcommands::RotateNextKeysetCommand),
+    /// Get the BDK on-chain wallet balance
+    GetWalletBalance,
+    /// List BDK on-chain wallet transactions
+    ListWalletTransactions(subcommands::WalletPaginationCommand),
+    /// List addresses revealed by the BDK on-chain wallet
+    ListWalletAddresses(subcommands::WalletPaginationCommand),
 }
 
 #[tokio::main]
@@ -160,6 +167,8 @@ async fn main() -> Result<()> {
     let interceptor =
         VersionInterceptor::new(VERSION_HEADER, cdk_common::MINT_RPC_PROTOCOL_VERSION);
     let mut client = CdkMintClient::with_interceptor(channel.clone(), interceptor.clone());
+    let mut wallet_client =
+        WalletServiceClient::with_interceptor(channel.clone(), interceptor.clone());
 
     match cli.command {
         Commands::GetInfo => {
@@ -246,6 +255,15 @@ async fn main() -> Result<()> {
         Commands::RotateNextKeyset(sub_command_args) => {
             let mut keyset_client = KeysetServiceClient::with_interceptor(channel, interceptor);
             subcommands::rotate_next_keyset(&mut keyset_client, &sub_command_args).await?;
+        }
+        Commands::GetWalletBalance => {
+            subcommands::get_wallet_balance(&mut wallet_client).await?;
+        }
+        Commands::ListWalletTransactions(args) => {
+            subcommands::list_wallet_transactions(&mut wallet_client, &args).await?;
+        }
+        Commands::ListWalletAddresses(args) => {
+            subcommands::list_wallet_addresses(&mut wallet_client, &args).await?;
         }
     }
 

--- a/crates/cdk-mint-rpc/src/lib.rs
+++ b/crates/cdk-mint-rpc/src/lib.rs
@@ -2,9 +2,15 @@
 
 pub mod proto;
 
+mod wallet_info;
+
 pub mod mint_rpc_cli;
 
 pub use proto::*;
+pub use wallet_info::{
+    DynWalletInfoProvider, WalletAddressPage, WalletInfoError, WalletInfoProvider,
+    WalletTransactionPage,
+};
 
 /// Type alias for the CdkMintClient that works with any tower service
 pub type CdkMintClient<S> = cdk_mint_client::CdkMintClient<S>;
@@ -27,6 +33,14 @@ pub type InterceptedKeysetServiceClient = keyset::keyset_service_client::KeysetS
 
 /// Type alias for QuoteServiceClient with the version header interceptor over a Channel
 pub type InterceptedQuoteServiceClient = quote::quote_service_client::QuoteServiceClient<
+    tonic::codegen::InterceptedService<
+        tonic::transport::Channel,
+        cdk_common::grpc::VersionInterceptor,
+    >,
+>;
+
+/// Type alias for WalletServiceClient with the version header interceptor over a Channel
+pub type InterceptedWalletServiceClient = wallet::wallet_service_client::WalletServiceClient<
     tonic::codegen::InterceptedService<
         tonic::transport::Channel,
         cdk_common::grpc::VersionInterceptor,

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
@@ -26,6 +26,8 @@ mod update_tos_url;
 mod update_ttl;
 /// Module for managing mint URLs
 mod update_urls;
+/// Module for inspecting the mint's BDK on-chain wallet.
+mod wallet;
 
 pub use rotate_next_keyset::{rotate_next_keyset, RotateNextKeysetCommand};
 pub use update_contact::{add_contact, remove_contact, AddContactCommand, RemoveContactCommand};
@@ -40,3 +42,6 @@ pub use update_short_description::{update_short_description, UpdateShortDescript
 pub use update_tos_url::{update_tos_url, UpdateTosUrlCommand};
 pub use update_ttl::{get_quote_ttl, update_quote_ttl, UpdateQuoteTtlCommand};
 pub use update_urls::{add_url, remove_url, AddUrlCommand, RemoveUrlCommand};
+pub use wallet::{
+    get_wallet_balance, list_wallet_addresses, list_wallet_transactions, WalletPaginationCommand,
+};

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/wallet.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/wallet.rs
@@ -1,0 +1,117 @@
+use anyhow::Result;
+use clap::Args;
+use tonic::Request;
+
+use crate::wallet::{GetBalanceRequest, ListAddressesRequest, ListTransactionsRequest};
+use crate::InterceptedWalletServiceClient;
+
+/// Pagination arguments for wallet list commands.
+#[derive(Debug, Args)]
+pub struct WalletPaginationCommand {
+    /// Maximum records to return; zero uses the server default.
+    #[arg(long, default_value_t = 0)]
+    limit: u32,
+    /// Records to skip.
+    #[arg(long, default_value_t = 0)]
+    offset: u32,
+}
+
+/// Prints the BDK on-chain wallet balance.
+pub async fn get_wallet_balance(client: &mut InterceptedWalletServiceClient) -> Result<()> {
+    let balance = client
+        .get_balance(Request::new(GetBalanceRequest {}))
+        .await?
+        .into_inner();
+
+    println!("network:                {}", balance.network);
+    println!("synced height:          {}", balance.synced_height);
+    println!("confirmed:              {} sat", balance.confirmed_sat);
+    println!(
+        "trusted pending:        {} sat",
+        balance.trusted_pending_sat
+    );
+    println!(
+        "untrusted pending:      {} sat",
+        balance.untrusted_pending_sat
+    );
+    println!("immature:               {} sat", balance.immature_sat);
+    println!(
+        "trusted spendable:      {} sat",
+        balance.trusted_spendable_sat
+    );
+    println!("total:                  {} sat", balance.total_sat);
+
+    Ok(())
+}
+
+/// Prints a page of BDK on-chain wallet transactions.
+pub async fn list_wallet_transactions(
+    client: &mut InterceptedWalletServiceClient,
+    command: &WalletPaginationCommand,
+) -> Result<()> {
+    let response = client
+        .list_transactions(Request::new(ListTransactionsRequest {
+            limit: command.limit,
+            offset: command.offset,
+        }))
+        .await?
+        .into_inner();
+
+    println!("total: {}", response.total);
+    for transaction in response.transactions {
+        println!(
+            "txid: {}, received: {} sat, sent: {} sat, fee: {}, delta: {} sat, height: {}, confirmation_time: {}, first_seen: {}",
+            transaction.txid,
+            transaction.received_sat,
+            transaction.sent_sat,
+            transaction
+                .fee_sat
+                .map(|fee| format!("{fee} sat"))
+                .unwrap_or_else(|| "unknown".to_string()),
+            transaction.balance_delta_sat,
+            transaction
+                .confirmation_height
+                .map(|height| height.to_string())
+                .unwrap_or_else(|| "unconfirmed".to_string()),
+            transaction
+                .confirmation_time
+                .map(|timestamp| timestamp.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+            transaction
+                .first_seen
+                .map(|timestamp| timestamp.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+        );
+    }
+
+    Ok(())
+}
+
+/// Prints a page of addresses revealed by the BDK on-chain wallet.
+pub async fn list_wallet_addresses(
+    client: &mut InterceptedWalletServiceClient,
+    command: &WalletPaginationCommand,
+) -> Result<()> {
+    let response = client
+        .list_addresses(Request::new(ListAddressesRequest {
+            limit: command.limit,
+            offset: command.offset,
+        }))
+        .await?
+        .into_inner();
+
+    println!("total: {}", response.total);
+    for address in response.addresses {
+        println!(
+            "address: {}, keychain: {}, index: {}, used: {}, balance: {} sat, confirmed: {} sat",
+            address.address,
+            address.keychain().as_str_name(),
+            address.derivation_index,
+            address.used,
+            address.balance_sat,
+            address.confirmed_balance_sat,
+        );
+    }
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/proto/mod.rs
+++ b/crates/cdk-mint-rpc/src/proto/mod.rs
@@ -12,6 +12,11 @@ pub mod quote {
     tonic::include_proto!("cdk_mint_quote_v1");
 }
 
+/// On-chain wallet information service
+pub mod wallet {
+    tonic::include_proto!("cdk_mint_wallet_v1");
+}
+
 mod server;
 
 /// Protocol version for gRPC Mint RPC communication

--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -21,6 +21,7 @@ use tonic::{Request, Response, Status};
 use crate::cdk_mint_server::{CdkMint, CdkMintServer};
 use crate::keyset::keyset_service_server::{KeysetService, KeysetServiceServer};
 use crate::quote::quote_service_server::{QuoteService, QuoteServiceServer};
+use crate::wallet::wallet_service_server::{WalletService, WalletServiceServer};
 use crate::{
     ContactInfo, GetInfoRequest, GetInfoResponse, GetQuoteTtlRequest, GetQuoteTtlResponse,
     RotateNextKeysetRequest, RotateNextKeysetResponse, UpdateContactRequest,
@@ -28,6 +29,12 @@ use crate::{
     UpdateNut04QuoteRequest, UpdateNut04Request, UpdateNut05Request, UpdateQuoteTtlRequest,
     UpdateResponse, UpdateTosUrlRequest, UpdateUrlRequest,
 };
+use crate::{DynWalletInfoProvider, WalletAddressPage, WalletTransactionPage};
+
+const DEFAULT_TRANSACTION_LIMIT: u32 = 20;
+const MAX_TRANSACTION_LIMIT: u32 = 100;
+const DEFAULT_ADDRESS_LIMIT: u32 = 100;
+const MAX_ADDRESS_LIMIT: u32 = 1_000;
 
 /// Error
 #[derive(Debug, Error)]
@@ -68,6 +75,7 @@ pub struct MintRPCServer {
     socket_addr: SocketAddr,
     mint: Arc<Mint>,
     mutation_guard: Option<Arc<dyn MintMutationGuard>>,
+    wallet_info_provider: Option<DynWalletInfoProvider>,
     shutdown: Arc<Notify>,
     handle: Option<Arc<JoinHandle<Result<(), Error>>>>,
 }
@@ -84,6 +92,7 @@ impl MintRPCServer {
             socket_addr: format!("{addr}:{port}").parse()?,
             mint,
             mutation_guard: None,
+            wallet_info_provider: None,
             shutdown: Arc::new(Notify::new()),
             handle: None,
         })
@@ -106,6 +115,12 @@ impl MintRPCServer {
             }
             MintMutationGuardError::Internal(message) => Status::internal(message),
         })
+    }
+
+    /// Configures the read-only on-chain wallet information provider.
+    pub fn with_wallet_info_provider(mut self, provider: DynWalletInfoProvider) -> Self {
+        self.wallet_info_provider = Some(provider);
+        self
     }
 
     /// Starts the RPC server
@@ -200,6 +215,13 @@ impl MintRPCServer {
                             cdk_common::MINT_RPC_PROTOCOL_VERSION,
                         ),
                     ))
+                    .add_service(WalletServiceServer::with_interceptor(
+                        self.clone(),
+                        create_version_check_interceptor(
+                            cdk_common::grpc::VERSION_HEADER,
+                            cdk_common::MINT_RPC_PROTOCOL_VERSION,
+                        ),
+                    ))
             }
             None => {
                 tracing::warn!("No valid TLS configuration found, starting insecure server");
@@ -219,6 +241,13 @@ impl MintRPCServer {
                         ),
                     ))
                     .add_service(QuoteServiceServer::with_interceptor(
+                        self.clone(),
+                        create_version_check_interceptor(
+                            cdk_common::grpc::VERSION_HEADER,
+                            cdk_common::MINT_RPC_PROTOCOL_VERSION,
+                        ),
+                    ))
+                    .add_service(WalletServiceServer::with_interceptor(
                         self.clone(),
                         create_version_check_interceptor(
                             cdk_common::grpc::VERSION_HEADER,
@@ -384,6 +413,12 @@ impl MintRPCServer {
             .await
             .map_err(|_| Status::invalid_argument("Could not find quote".to_string()))?
             .ok_or(Status::invalid_argument("Could not find quote".to_string()))
+    }
+
+    fn wallet_info_provider(&self) -> Result<&DynWalletInfoProvider, Status> {
+        self.wallet_info_provider.as_ref().ok_or_else(|| {
+            Status::failed_precondition("No on-chain wallet information provider is configured")
+        })
     }
 }
 
@@ -1073,6 +1108,84 @@ impl QuoteService for MintRPCServer {
     }
 }
 
+#[tonic::async_trait]
+impl WalletService for MintRPCServer {
+    /// Gets the on-chain wallet balance.
+    async fn get_balance(
+        &self,
+        _request: Request<crate::wallet::GetBalanceRequest>,
+    ) -> Result<Response<crate::wallet::GetBalanceResponse>, Status> {
+        let balance = self
+            .wallet_info_provider()?
+            .get_balance()
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
+
+        Ok(Response::new(balance))
+    }
+
+    /// Lists on-chain wallet transactions.
+    async fn list_transactions(
+        &self,
+        request: Request<crate::wallet::ListTransactionsRequest>,
+    ) -> Result<Response<crate::wallet::ListTransactionsResponse>, Status> {
+        let request = request.into_inner();
+        let limit = page_limit(
+            request.limit,
+            DEFAULT_TRANSACTION_LIMIT,
+            MAX_TRANSACTION_LIMIT,
+        )?;
+
+        let WalletTransactionPage {
+            transactions,
+            total,
+        } = self
+            .wallet_info_provider()?
+            .list_transactions(request.offset as usize, limit)
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
+
+        Ok(Response::new(crate::wallet::ListTransactionsResponse {
+            transactions,
+            total,
+        }))
+    }
+
+    /// Lists addresses revealed by the on-chain wallet.
+    async fn list_addresses(
+        &self,
+        request: Request<crate::wallet::ListAddressesRequest>,
+    ) -> Result<Response<crate::wallet::ListAddressesResponse>, Status> {
+        let request = request.into_inner();
+        let limit = page_limit(request.limit, DEFAULT_ADDRESS_LIMIT, MAX_ADDRESS_LIMIT)?;
+
+        let WalletAddressPage { addresses, total } = self
+            .wallet_info_provider()?
+            .list_addresses(request.offset as usize, limit)
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
+
+        Ok(Response::new(crate::wallet::ListAddressesResponse {
+            addresses,
+            total,
+        }))
+    }
+}
+
+fn page_limit(requested: u32, default: u32, maximum: u32) -> Result<usize, Status> {
+    let limit = match requested {
+        0 => default,
+        requested if requested <= maximum => requested,
+        requested => {
+            return Err(Status::invalid_argument(format!(
+                "Requested page size {requested} exceeds maximum {maximum}"
+            )));
+        }
+    };
+
+    Ok(limit as usize)
+}
+
 impl From<MintQuoteState> for crate::quote::MintQuoteState {
     fn from(state: MintQuoteState) -> Self {
         match state {
@@ -1101,6 +1214,54 @@ mod tests {
     use super::*;
     use crate::cdk_mint_server::CdkMint;
     use crate::{GetInfoRequest, UpdateTosUrlRequest};
+
+    struct TestWalletInfoProvider;
+
+    #[async_trait::async_trait]
+    impl crate::WalletInfoProvider for TestWalletInfoProvider {
+        async fn get_balance(
+            &self,
+        ) -> Result<crate::wallet::GetBalanceResponse, crate::WalletInfoError> {
+            Ok(crate::wallet::GetBalanceResponse {
+                confirmed_sat: 21,
+                trusted_pending_sat: 2,
+                untrusted_pending_sat: 3,
+                immature_sat: 4,
+                trusted_spendable_sat: 23,
+                total_sat: 30,
+                network: "regtest".to_string(),
+                synced_height: 123,
+            })
+        }
+
+        async fn list_transactions(
+            &self,
+            offset: usize,
+            limit: usize,
+        ) -> Result<crate::WalletTransactionPage, crate::WalletInfoError> {
+            Ok(crate::WalletTransactionPage {
+                transactions: vec![crate::wallet::WalletTransaction {
+                    txid: format!("{offset}:{limit}"),
+                    ..Default::default()
+                }],
+                total: 7,
+            })
+        }
+
+        async fn list_addresses(
+            &self,
+            offset: usize,
+            limit: usize,
+        ) -> Result<crate::WalletAddressPage, crate::WalletInfoError> {
+            Ok(crate::WalletAddressPage {
+                addresses: vec![crate::wallet::WalletAddress {
+                    address: format!("{offset}:{limit}"),
+                    ..Default::default()
+                }],
+                total: 9,
+            })
+        }
+    }
 
     /// A well-formed quote id that no test mint has issued
     const UNKNOWN_QUOTE_ID: &str = "019820ab-cdef-7000-8000-000000000000";
@@ -1163,6 +1324,7 @@ mod tests {
             socket_addr: "127.0.0.1:0".parse().unwrap(),
             mint: Arc::new(mint),
             mutation_guard: None,
+            wallet_info_provider: None,
             shutdown: Arc::new(Notify::new()),
             handle: None,
         }
@@ -1178,6 +1340,65 @@ mod tests {
                 "configuration restart pending".to_owned(),
             ))
         }
+    }
+
+    #[tokio::test]
+    async fn wallet_service_requires_a_configured_provider() {
+        let server = create_test_rpc_server().await;
+
+        let error = server
+            .get_balance(Request::new(crate::wallet::GetBalanceRequest {}))
+            .await
+            .expect_err("wallet provider should be required");
+
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    }
+
+    #[tokio::test]
+    async fn wallet_service_returns_provider_data_and_applies_page_defaults() {
+        let server = create_test_rpc_server()
+            .await
+            .with_wallet_info_provider(Arc::new(TestWalletInfoProvider));
+
+        let balance = server
+            .get_balance(Request::new(crate::wallet::GetBalanceRequest {}))
+            .await
+            .expect("get balance")
+            .into_inner();
+        assert_eq!(balance.confirmed_sat, 21);
+        assert_eq!(balance.total_sat, 30);
+        assert_eq!(balance.network, "regtest");
+        assert_eq!(balance.synced_height, 123);
+
+        let transactions = server
+            .list_transactions(Request::new(crate::wallet::ListTransactionsRequest {
+                limit: 0,
+                offset: 2,
+            }))
+            .await
+            .expect("list transactions")
+            .into_inner();
+        assert_eq!(transactions.total, 7);
+        assert_eq!(transactions.transactions[0].txid, "2:20");
+
+        let addresses = server
+            .list_addresses(Request::new(crate::wallet::ListAddressesRequest {
+                limit: 3,
+                offset: 4,
+            }))
+            .await
+            .expect("list addresses")
+            .into_inner();
+        assert_eq!(addresses.total, 9);
+        assert_eq!(addresses.addresses[0].address, "4:3");
+    }
+
+    #[test]
+    fn wallet_service_rejects_oversized_pages() {
+        let error = page_limit(101, DEFAULT_TRANSACTION_LIMIT, MAX_TRANSACTION_LIMIT)
+            .expect_err("oversized page should fail");
+
+        assert_eq!(error.code(), tonic::Code::InvalidArgument);
     }
 
     #[tokio::test]

--- a/crates/cdk-mint-rpc/src/proto/wallet.proto
+++ b/crates/cdk-mint-rpc/src/proto/wallet.proto
@@ -1,0 +1,105 @@
+syntax = "proto3";
+
+package cdk_mint_wallet_v1;
+
+// Read-only information about the mint's on-chain wallet.
+service WalletService {
+    // Returns the wallet balance split by confirmation status.
+    rpc GetBalance(GetBalanceRequest) returns (GetBalanceResponse) {}
+    // Returns wallet transactions, newest first.
+    rpc ListTransactions(ListTransactionsRequest) returns (ListTransactionsResponse) {}
+    // Returns addresses that the wallet has revealed, in derivation order.
+    rpc ListAddresses(ListAddressesRequest) returns (ListAddressesResponse) {}
+}
+
+message GetBalanceRequest {
+}
+
+message GetBalanceResponse {
+    // Confirmed, spendable balance.
+    uint64 confirmed_sat = 1;
+    // Unconfirmed outputs created by a wallet transaction.
+    uint64 trusted_pending_sat = 2;
+    // Unconfirmed outputs received from an external wallet.
+    uint64 untrusted_pending_sat = 3;
+    // Confirmed coinbase outputs that are not mature yet.
+    uint64 immature_sat = 4;
+    // Confirmed plus trusted-pending balance.
+    uint64 trusted_spendable_sat = 5;
+    // All value currently visible to the wallet.
+    uint64 total_sat = 6;
+    // Bitcoin network used by the wallet, e.g. "bitcoin" or "regtest".
+    string network = 7;
+    // Height of the wallet's latest local chain checkpoint.
+    uint32 synced_height = 8;
+}
+
+message ListTransactionsRequest {
+    // Number of transactions to return. Zero uses the server default. The
+    // server rejects values above its maximum.
+    uint32 limit = 1;
+    // Number of transactions to skip from the newest transaction.
+    uint32 offset = 2;
+}
+
+message WalletTransaction {
+    // Transaction ID in display encoding.
+    string txid = 1;
+    // Value sent to wallet scripts, including change.
+    uint64 received_sat = 2;
+    // Value consumed from wallet inputs.
+    uint64 sent_sat = 3;
+    // Transaction fee when all previous outputs are known.
+    optional uint64 fee_sat = 4;
+    // Net effect on the wallet balance.
+    sint64 balance_delta_sat = 5;
+    // Confirmation block height, when confirmed.
+    optional uint32 confirmation_height = 6;
+    // Confirmation block timestamp, when confirmed.
+    optional uint64 confirmation_time = 7;
+    // First-seen timestamp, when known for an unconfirmed transaction.
+    optional uint64 first_seen = 8;
+}
+
+message ListTransactionsResponse {
+    // Requested page of transactions.
+    repeated WalletTransaction transactions = 1;
+    // Total relevant transactions before pagination.
+    uint64 total = 2;
+}
+
+message ListAddressesRequest {
+    // Number of addresses to return. Zero uses the server default. The server
+    // rejects values above its maximum.
+    uint32 limit = 1;
+    // Number of addresses to skip.
+    uint32 offset = 2;
+}
+
+enum KeychainKind {
+    KEYCHAIN_KIND_UNSPECIFIED = 0;
+    KEYCHAIN_KIND_EXTERNAL = 1;
+    KEYCHAIN_KIND_INTERNAL = 2;
+}
+
+message WalletAddress {
+    // Bitcoin address in network-specific display encoding.
+    string address = 1;
+    // Descriptor keychain containing the address.
+    KeychainKind keychain = 2;
+    // Child derivation index.
+    uint32 derivation_index = 3;
+    // Whether the address has appeared in a wallet transaction.
+    bool used = 4;
+    // Total current unspent balance assigned to this address.
+    uint64 balance_sat = 5;
+    // Confirmed current unspent balance assigned to this address.
+    uint64 confirmed_balance_sat = 6;
+}
+
+message ListAddressesResponse {
+    // Requested page of revealed addresses.
+    repeated WalletAddress addresses = 1;
+    // Total revealed addresses before pagination.
+    uint64 total = 2;
+}

--- a/crates/cdk-mint-rpc/src/wallet_info.rs
+++ b/crates/cdk-mint-rpc/src/wallet_info.rs
@@ -1,0 +1,66 @@
+//! Read-only on-chain wallet information provider.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use crate::wallet::{GetBalanceResponse, WalletAddress, WalletTransaction};
+
+/// Error returned while reading the configured on-chain wallet.
+#[derive(Debug, Error)]
+#[error("{message}")]
+pub struct WalletInfoError {
+    message: String,
+}
+
+impl WalletInfoError {
+    /// Creates an error from a backend-provided message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+/// A page of wallet transactions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalletTransactionPage {
+    /// Transactions in newest-first order.
+    pub transactions: Vec<WalletTransaction>,
+    /// Total transactions before pagination.
+    pub total: u64,
+}
+
+/// A page of revealed wallet addresses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalletAddressPage {
+    /// Revealed addresses in derivation order.
+    pub addresses: Vec<WalletAddress>,
+    /// Total revealed addresses before pagination.
+    pub total: u64,
+}
+
+/// Supplies read-only information for the management wallet service.
+#[async_trait]
+pub trait WalletInfoProvider {
+    /// Returns the wallet balance.
+    async fn get_balance(&self) -> Result<GetBalanceResponse, WalletInfoError>;
+
+    /// Returns a page of wallet transactions.
+    async fn list_transactions(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<WalletTransactionPage, WalletInfoError>;
+
+    /// Returns a page of revealed wallet addresses.
+    async fn list_addresses(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<WalletAddressPage, WalletInfoError>;
+}
+
+/// Dynamically dispatched wallet information provider.
+pub type DynWalletInfoProvider = Arc<dyn WalletInfoProvider + Send + Sync>;

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -202,6 +202,113 @@ impl cdk_mint_rpc::MintMutationGuard for ConfigurationMutationGuard {
     }
 }
 
+#[cfg(all(feature = "management-rpc", feature = "bdk"))]
+type ConfiguredWalletInfoProvider = Option<cdk_mint_rpc::DynWalletInfoProvider>;
+#[cfg(not(all(feature = "management-rpc", feature = "bdk")))]
+type ConfiguredWalletInfoProvider = ();
+
+#[cfg(all(feature = "management-rpc", feature = "bdk"))]
+#[derive(Clone)]
+struct BdkWalletInfoProvider {
+    bdk: Arc<cdk_bdk::CdkBdk>,
+}
+
+#[cfg(all(feature = "management-rpc", feature = "bdk"))]
+#[async_trait::async_trait]
+impl cdk_mint_rpc::WalletInfoProvider for BdkWalletInfoProvider {
+    async fn get_balance(
+        &self,
+    ) -> std::result::Result<cdk_mint_rpc::wallet::GetBalanceResponse, cdk_mint_rpc::WalletInfoError>
+    {
+        let balance = self.bdk.wallet_balance().await;
+
+        Ok(cdk_mint_rpc::wallet::GetBalanceResponse {
+            confirmed_sat: balance.confirmed_sat,
+            trusted_pending_sat: balance.trusted_pending_sat,
+            untrusted_pending_sat: balance.untrusted_pending_sat,
+            immature_sat: balance.immature_sat,
+            trusted_spendable_sat: balance.trusted_spendable_sat,
+            total_sat: balance.total_sat,
+            network: balance.network,
+            synced_height: balance.synced_height,
+        })
+    }
+
+    async fn list_transactions(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> std::result::Result<cdk_mint_rpc::WalletTransactionPage, cdk_mint_rpc::WalletInfoError>
+    {
+        let page = self
+            .bdk
+            .wallet_transactions(offset, limit)
+            .await
+            .map_err(|err| cdk_mint_rpc::WalletInfoError::new(err.to_string()))?;
+
+        Ok(cdk_mint_rpc::WalletTransactionPage {
+            transactions: page
+                .items
+                .into_iter()
+                .map(|transaction| cdk_mint_rpc::wallet::WalletTransaction {
+                    txid: transaction.txid,
+                    received_sat: transaction.received_sat,
+                    sent_sat: transaction.sent_sat,
+                    fee_sat: transaction.fee_sat,
+                    balance_delta_sat: transaction.balance_delta_sat,
+                    confirmation_height: transaction.confirmation_height,
+                    confirmation_time: transaction.confirmation_time,
+                    first_seen: transaction.first_seen,
+                })
+                .collect(),
+            total: page.total,
+        })
+    }
+
+    async fn list_addresses(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> std::result::Result<cdk_mint_rpc::WalletAddressPage, cdk_mint_rpc::WalletInfoError> {
+        let page = self
+            .bdk
+            .wallet_addresses(offset, limit)
+            .await
+            .map_err(|err| cdk_mint_rpc::WalletInfoError::new(err.to_string()))?;
+
+        Ok(cdk_mint_rpc::WalletAddressPage {
+            addresses: page
+                .items
+                .into_iter()
+                .map(|address| cdk_mint_rpc::wallet::WalletAddress {
+                    address: address.address,
+                    keychain: match address.keychain {
+                        cdk_bdk::WalletKeychain::External => {
+                            cdk_mint_rpc::wallet::KeychainKind::External.into()
+                        }
+                        cdk_bdk::WalletKeychain::Internal => {
+                            cdk_mint_rpc::wallet::KeychainKind::Internal.into()
+                        }
+                    },
+                    derivation_index: address.derivation_index,
+                    used: address.used,
+                    balance_sat: address.balance_sat,
+                    confirmed_balance_sat: address.confirmed_balance_sat,
+                })
+                .collect(),
+            total: page.total,
+        })
+    }
+}
+
+#[cfg(all(feature = "management-rpc", feature = "bdk"))]
+fn no_wallet_info_provider() -> ConfiguredWalletInfoProvider {
+    None
+}
+
+#[cfg(not(all(feature = "management-rpc", feature = "bdk")))]
+fn no_wallet_info_provider() -> ConfiguredWalletInfoProvider {}
+
 fn extract_supported_payment_methods(mint_info: &cdk::nuts::MintInfo) -> Vec<String> {
     let mut seen = HashSet::new();
     mint_info
@@ -875,13 +982,13 @@ async fn setup_sqlite_database(
  * Configures a `MintBuilder` instance with provided settings and initializes
  * routers for the configured payment backends.
  */
-async fn configure_mint_builder(
+async fn configure_mint_builder_with_wallet_info(
     settings: &config::Settings,
     mint_builder: MintBuilder,
     runtime: Option<std::sync::Arc<tokio::runtime::Runtime>>,
     work_dir: &Path,
     kv_store: Option<Arc<dyn KVStore<Err = cdk::cdk_database::Error> + Send + Sync>>,
-) -> Result<MintBuilder> {
+) -> Result<(MintBuilder, ConfiguredWalletInfoProvider)> {
     settings
         .validate_backend_pairing()
         .map_err(anyhow::Error::msg)?;
@@ -922,8 +1029,14 @@ async fn configure_mint_builder(
     .await?;
 
     // Configure onchain backend
-    let mint_builder =
-        configure_onchain_backend(settings, mint_builder, runtime, work_dir, kv_store).await?;
+    let (mint_builder, wallet_info_provider) = configure_onchain_backend_with_wallet_info(
+        settings,
+        mint_builder,
+        runtime,
+        work_dir,
+        kv_store,
+    )
+    .await?;
 
     // Extract configured payment methods from mint_builder
     let mint_info = mint_builder.current_mint_info();
@@ -951,7 +1064,28 @@ async fn configure_mint_builder(
         bail!("At least one payment backend must be configured");
     }
 
-    Ok(mint_builder)
+    Ok((mint_builder, wallet_info_provider))
+}
+
+#[cfg(test)]
+async fn configure_mint_builder(
+    settings: &config::Settings,
+    mint_builder: MintBuilder,
+    runtime: Option<std::sync::Arc<tokio::runtime::Runtime>>,
+    work_dir: &Path,
+    kv_store: Option<Arc<dyn KVStore<Err = cdk::cdk_database::Error> + Send + Sync>>,
+) -> Result<MintBuilder> {
+    Ok(
+        configure_mint_builder_with_wallet_info(
+            settings,
+            mint_builder,
+            runtime,
+            work_dir,
+            kv_store,
+        )
+        .await?
+        .0,
+    )
 }
 
 /// Configures basic mint information (name, contact info, descriptions, etc.)
@@ -1243,16 +1377,21 @@ fn configure_fake_wallet_keyset_rotations_once(
 }
 
 /// Configures Onchain backend based on the specified backend type
-async fn configure_onchain_backend(
+async fn configure_onchain_backend_with_wallet_info(
     settings: &config::Settings,
     #[cfg_attr(not(feature = "bdk"), allow(unused_mut))] mut mint_builder: MintBuilder,
     _runtime: Option<std::sync::Arc<tokio::runtime::Runtime>>,
     _work_dir: &Path,
     _kv_store: Option<Arc<dyn KVStore<Err = cdk::cdk_database::Error> + Send + Sync>>,
-) -> Result<MintBuilder> {
+) -> Result<(MintBuilder, ConfiguredWalletInfoProvider)> {
     use config::OnchainBackend;
     #[cfg(feature = "bdk")]
     use setup::OnchainBackendSetup;
+
+    #[cfg(all(feature = "management-rpc", feature = "bdk"))]
+    let mut wallet_info_provider = no_wallet_info_provider();
+    #[cfg(not(all(feature = "management-rpc", feature = "bdk")))]
+    let wallet_info_provider = no_wallet_info_provider();
 
     if let Some(onchain_settings) = &settings.onchain {
         match onchain_settings.onchain_backend {
@@ -1278,6 +1417,13 @@ async fn configure_onchain_backend(
                     )
                     .await?;
                 let bdk = Arc::new(bdk);
+
+                #[cfg(feature = "management-rpc")]
+                {
+                    wallet_info_provider = Some(Arc::new(BdkWalletInfoProvider {
+                        bdk: Arc::clone(&bdk),
+                    }));
+                }
 
                 mint_builder = configure_backend_for_unit(
                     settings,
@@ -1340,7 +1486,26 @@ async fn configure_onchain_backend(
         }
     }
 
-    Ok(mint_builder)
+    Ok((mint_builder, wallet_info_provider))
+}
+
+#[cfg(test)]
+async fn configure_onchain_backend(
+    settings: &config::Settings,
+    mint_builder: MintBuilder,
+    runtime: Option<std::sync::Arc<tokio::runtime::Runtime>>,
+    work_dir: &Path,
+    kv_store: Option<Arc<dyn KVStore<Err = cdk::cdk_database::Error> + Send + Sync>>,
+) -> Result<MintBuilder> {
+    Ok(configure_onchain_backend_with_wallet_info(
+        settings,
+        mint_builder,
+        runtime,
+        work_dir,
+        kv_store,
+    )
+    .await?
+    .0)
 }
 
 /// Helper function to configure a mint builder with a payment backend for a specific currency unit
@@ -1810,10 +1975,12 @@ struct RunningMintd {
 impl PreparedMintd {
     /// Builds every resource and performs all database reconciliation
     /// without starting tasks or binding listeners.
+    #[allow(clippy::too_many_arguments)]
     async fn prepare(
         mint: Arc<cdk::mint::Mint>,
         settings: &config::Settings,
         _work_dir: &Path,
+        _wallet_info_provider: ConfiguredWalletInfoProvider,
         mint_builder_info: cdk::nuts::MintInfo,
         routers: Vec<Router>,
         auth_localstore: Option<cdk_common::database::DynMintAuthDatabase>,
@@ -1843,6 +2010,10 @@ impl PreparedMintd {
                             mint_rpc.with_mutation_guard(Arc::new(ConfigurationMutationGuard {
                                 service: activation.service.clone(),
                             }));
+                    }
+                    #[cfg(feature = "bdk")]
+                    if let Some(provider) = _wallet_info_provider.clone() {
+                        mint_rpc = mint_rpc.with_wallet_info_provider(provider);
                     }
 
                     let tls_dir = rpc_settings.tls_dir.unwrap_or(_work_dir.join("tls"));
@@ -2266,6 +2437,7 @@ async fn start_services_with_shutdown(
     mint: Arc<cdk::mint::Mint>,
     settings: &config::Settings,
     work_dir: &Path,
+    wallet_info_provider: ConfiguredWalletInfoProvider,
     mint_builder_info: cdk::nuts::MintInfo,
     shutdown_signal: impl std::future::Future<Output = ()> + Send + 'static,
     routers: Vec<Router>,
@@ -2276,6 +2448,7 @@ async fn start_services_with_shutdown(
         mint,
         settings,
         work_dir,
+        wallet_info_provider,
         mint_builder_info,
         routers,
         auth_localstore,
@@ -2415,8 +2588,14 @@ async fn run_mintd_with_database_and_shutdown(
         }
     };
 
-    let mint_builder =
-        configure_mint_builder(settings, maybe_mint_builder, runtime, work_dir, Some(kv)).await?;
+    let (mint_builder, wallet_info_provider) = configure_mint_builder_with_wallet_info(
+        settings,
+        maybe_mint_builder,
+        runtime,
+        work_dir,
+        Some(kv),
+    )
+    .await?;
     let (mint_builder, auth_localstore) =
         setup_authentication(settings, work_dir, mint_builder, db_password).await?;
 
@@ -2438,6 +2617,7 @@ async fn run_mintd_with_database_and_shutdown(
         mint.clone(),
         settings,
         work_dir,
+        wallet_info_provider,
         config_mint_info,
         shutdown_signal,
         routers,
@@ -3439,6 +3619,65 @@ backend = "fakewallet"
             err.to_string().contains("fakewallet") && err.to_string().contains("bdk"),
             "error should mention backend pairing validation: {err}"
         );
+    }
+
+    #[cfg(all(feature = "management-rpc", feature = "bdk", feature = "sqlite"))]
+    #[tokio::test]
+    async fn bdk_onchain_exposes_wallet_info_provider() {
+        use cdk::mint::MintBuilder;
+        use cdk_sqlite::mint::memory;
+
+        use crate::config::{Bdk, Onchain, OnchainBackend};
+
+        let work_dir = test_utils::unique_temp_path("cdk_mintd_wallet_info_provider");
+        let settings = config::Settings {
+            onchain: Some(Onchain {
+                onchain_backend: OnchainBackend::Bdk,
+                ..Default::default()
+            }),
+            bdk: Some(Bdk {
+                network: Some("regtest".to_string()),
+                chain_source_type: Some("esplora".to_string()),
+                esplora_url: Some("http://127.0.0.1:1".to_string()),
+                mnemonic: Some(
+                    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+                        .to_string(),
+                ),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let localstore = Arc::new(memory::empty().await.expect("in-memory database"));
+        let builder = MintBuilder::new(localstore.clone());
+        let (builder, provider) = configure_onchain_backend_with_wallet_info(
+            &settings,
+            builder,
+            None,
+            &work_dir,
+            Some(localstore),
+        )
+        .await
+        .expect("configure BDK backend");
+
+        assert!(builder
+            .current_mint_info()
+            .nuts
+            .nut04
+            .methods
+            .iter()
+            .any(|method| method.method == PaymentMethod::Known(KnownMethod::Onchain)));
+
+        let balance = provider
+            .expect("wallet info provider")
+            .get_balance()
+            .await
+            .expect("get wallet balance");
+        assert_eq!(balance.network, "regtest");
+        assert_eq!(balance.total_sat, 0);
+
+        drop(builder);
+        let _ = std::fs::remove_dir_all(work_dir);
     }
 
     #[cfg(all(feature = "fakewallet", feature = "sqlite"))]


### PR DESCRIPTION
Add a read-only WalletService for balance, paginated transaction history, and revealed address balances. Keep BDK inspection behind a dedicated provider instead of extending MintPayment, and wire it through mintd only when BDK is configured.

Add matching mint CLI commands and tests for pagination, provider availability, wallet accounting, and mintd wiring.

@orangeshyguy21 

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
