### PR TITLE
Add advisory locks to the mint transaction traits

### DIFF
--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -123,6 +123,26 @@ pub struct LockedMeltQuotes {
     pub all_related: Vec<Acquired<MeltQuote>>,
 }
 
+/// The advisory lock serializing every keyset transaction, which is what makes
+/// a rotation and a peer's reload mutually exclusive. The backend takes it as
+/// the transaction begins, so callers never reach for it themselves.
+///
+/// One global key rather than per-unit: rotations are rare, and a single key
+/// keeps the keyset reads a signatory does during reload consistent with each
+/// other without per-unit lock bookkeeping.
+pub const KEYSETS_LOCK: &str = "cdk:keysets";
+
+/// The advisory lock covering a quote, mint or melt alike: quote ids are unique
+/// across both, so they share one namespace.
+fn quote_lock(quote_id: &QuoteId) -> String {
+    format!("cdk:quote:{quote_id}")
+}
+
+/// The advisory lock covering a single proof, keyed by its `Y`.
+fn proof_lock(y: &PublicKey) -> String {
+    format!("cdk:proof:{y}")
+}
+
 /// KeysDatabaseWriter
 #[async_trait]
 pub trait KeysDatabaseTransaction<'a, Error>: DbTransactionFinalizer<Err = Error> {
@@ -667,6 +687,28 @@ pub trait CompletedOperationsDatabase {
 }
 
 /// Base database writer
+///
+/// # Advisory locks
+///
+/// Row locks ([`Acquired`]) only protect rows that already exist. The advisory
+/// locks below cover what they cannot: serializing operations whose rows are not
+/// inserted yet (proofs entering a swap or melt), and giving every caller one
+/// agreed acquisition order so overlapping operations queue instead of
+/// deadlocking on each other's row locks. A lock is released when the
+/// transaction ends, so it cannot outlive the operation that took it.
+///
+/// Two ordering rules, both of which exist to keep the locks from causing the
+/// deadlocks they are meant to prevent:
+///
+/// 1. Take every advisory lock a transaction needs before its first row lock. A
+///    transaction that row-locks a quote and then reaches for that quote's
+///    advisory lock deadlocks against one doing the reverse. A caller that only
+///    learns which rows it needs by reading them (a quote looked up by payment
+///    identifier, say) therefore takes no advisory lock at all, and relies on
+///    its row locks.
+/// 2. Take quote locks before proof locks. [`lock_quotes`](Self::lock_quotes)
+///    and [`lock_proofs`](Self::lock_proofs) sort within each group.
+#[async_trait]
 pub trait Transaction<Error>:
     DbTransactionFinalizer<Err = Error>
     + QuotesTransaction<Err = Error>
@@ -676,6 +718,45 @@ pub trait Transaction<Error>:
     + SagaTransaction<Err = Error>
     + CompletedOperationsTransaction<Err = Error>
 {
+    /// Take the exclusive advisory locks named by `keys`, waiting for whichever
+    /// transactions hold them. A key this transaction already holds is a no-op.
+    ///
+    /// Keys are opaque namespaced strings, `cdk:<domain>:<id>`; only equality
+    /// matters, so two callers that build the same string exclude each other.
+    /// Prefer [`lock_quotes`](Self::lock_quotes) and
+    /// [`lock_proofs`](Self::lock_proofs), which build the keys and order them.
+    ///
+    /// The whole batch is one call so a backend can take it in a single round
+    /// trip, which is what keeps a melt or swap with many proofs from paying a
+    /// round trip per proof. Callers hand the keys over already sorted, and an
+    /// implementation must acquire them in that order: agreeing on the order is
+    /// what leaves two overlapping batches queueing instead of deadlocking.
+    async fn advisory_locks(&mut self, keys: &[String]) -> Result<(), Error>;
+
+    /// Take the advisory locks for a set of quotes.
+    ///
+    /// Sorting is the point: a batch mint naming the same quotes as another, in
+    /// a different order, would otherwise deadlock on the row locks it takes
+    /// later.
+    async fn lock_quotes(&mut self, quote_ids: &[QuoteId]) -> Result<(), Error> {
+        let mut keys = quote_ids.iter().map(quote_lock).collect::<Vec<_>>();
+        keys.sort();
+        keys.dedup();
+
+        self.advisory_locks(&keys).await
+    }
+
+    /// Take the advisory locks for a set of proofs. See
+    /// [`lock_quotes`](Self::lock_quotes) for why the order is fixed; two
+    /// operations spending overlapping proofs deadlock inserting them if they
+    /// disagree on it.
+    async fn lock_proofs(&mut self, ys: &[PublicKey]) -> Result<(), Error> {
+        let mut keys = ys.iter().map(proof_lock).collect::<Vec<_>>();
+        keys.sort();
+        keys.dedup();
+
+        self.advisory_locks(&keys).await
+    }
 }
 
 /// Mint Database trait

--- a/crates/cdk-integration-tests/tests/signatory_rotation.rs
+++ b/crates/cdk-integration-tests/tests/signatory_rotation.rs
@@ -4,9 +4,8 @@
 //! lock, drive concurrent rotations of the same unit through separate
 //! Postgres connection pools pointing at one schema. Nothing in-process
 //! serializes them: the only guard is the global keyset advisory lock
-//! (`pg_advisory_xact_lock(hashtext('cdk:keysets'))`) taken when each keyset
-//! transaction begins. The test asserts every rotation still gets a unique
-//! keyset id and path index.
+//! (`cdk:keysets`) taken when each keyset transaction begins. The test asserts
+//! every rotation still gets a unique keyset id and path index.
 //!
 //! Requires Postgres. Set `CDK_MINTD_DATABASE_URL` (or `PG_DB_URL`) to a
 //! reachable server (see `docker-compose.postgres.yaml`). With neither set the

--- a/crates/cdk-postgres/src/lib.rs
+++ b/crates/cdk-postgres/src/lib.rs
@@ -427,6 +427,97 @@ mod test {
 
     mint_db_test!(provide_mint_db);
 
+    /// Postgres-only: SQLite serializes writers already, so it has no second
+    /// concurrent transaction to exclude and nothing to assert here. The
+    /// one-key batch is the shape every keyset transaction takes.
+    #[tokio::test]
+    async fn advisory_lock_excludes_concurrent_transaction() {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use cdk_common::database::MintDatabase;
+
+        let test_id = format!("test_advisory_lock_{}", uuid::Uuid::new_v4());
+        let db = Arc::new(provide_mint_db(test_id).await);
+        // Advisory locks are database-wide, not schema-scoped, so the key has to
+        // be unique or concurrent test runs would block each other.
+        let key = vec![format!("cdk:test:{}", uuid::Uuid::new_v4())];
+
+        let mut holder = MintDatabase::begin_transaction(&*db).await.expect("tx");
+        holder.advisory_locks(&key).await.expect("lock");
+
+        let waiter = tokio::spawn({
+            let db = db.clone();
+            let key = key.clone();
+            async move {
+                let mut tx = MintDatabase::begin_transaction(&*db).await.expect("tx");
+                tx.advisory_locks(&key).await.expect("lock");
+                tx.commit().await.expect("commit");
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            !waiter.is_finished(),
+            "second transaction took a lock the first still holds"
+        );
+
+        holder.commit().await.expect("commit");
+
+        tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("lock still held after the holder committed")
+            .expect("waiter task");
+    }
+
+    /// The batched form takes every key in one statement, so it also needs the
+    /// exclusion the per-key form gives.
+    #[tokio::test]
+    async fn advisory_locks_batch_excludes_concurrent_transaction() {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use cdk_common::database::MintDatabase;
+
+        let test_id = format!("test_advisory_locks_batch_{}", uuid::Uuid::new_v4());
+        let db = Arc::new(provide_mint_db(test_id).await);
+        let run = uuid::Uuid::new_v4();
+        let mut keys = (0..4)
+            .map(|i| format!("cdk:test:{run}:{i}"))
+            .collect::<Vec<_>>();
+        keys.sort();
+
+        let mut holder = MintDatabase::begin_transaction(&*db).await.expect("tx");
+        holder.advisory_locks(&keys).await.expect("lock");
+
+        // Only the last key overlaps, which is enough to block the whole batch.
+        let waiter = tokio::spawn({
+            let db = db.clone();
+            let overlapping = vec![
+                format!("cdk:test:{}:{}", uuid::Uuid::new_v4(), 0),
+                keys[keys.len() - 1].clone(),
+            ];
+            async move {
+                let mut tx = MintDatabase::begin_transaction(&*db).await.expect("tx");
+                tx.advisory_locks(&overlapping).await.expect("lock");
+                tx.commit().await.expect("commit");
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            !waiter.is_finished(),
+            "second transaction took a lock the first still holds"
+        );
+
+        holder.commit().await.expect("commit");
+
+        tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("lock still held after the holder committed")
+            .expect("waiter task");
+    }
+
     #[tokio::test]
     async fn kvstore_compare_and_swap() {
         let test_id = format!("test_kvstore_compare_and_swap_{}", uuid::Uuid::new_v4());

--- a/crates/cdk-sql-common/src/mint/keys.rs
+++ b/crates/cdk-sql-common/src/mint/keys.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use bitcoin::bip32::DerivationPath;
 use cdk_common::common::IssuerVersion;
+use cdk_common::database::mint::KEYSETS_LOCK;
 use cdk_common::database::{Error, MintKeyDatabaseTransaction, MintKeysDatabase};
 use cdk_common::mint::MintKeySetInfo;
 use cdk_common::{CurrencyUnit, Id};
@@ -264,26 +265,6 @@ impl<RM> SQLTransaction<RM>
 where
     RM: DatabasePool + 'static,
 {
-    /// Take the global keyset advisory lock, held until the transaction commits,
-    /// so every keyset transaction (rotation, reload, boot reactivation)
-    /// serializes across processes. This removes torn reads and index races
-    /// without per-unit lock bookkeeping.
-    ///
-    /// No-op on backends that already serialize writers (SQLite's
-    /// `BEGIN IMMEDIATE`). Postgres runs at `START TRANSACTION` isolation, which
-    /// does not serialize concurrent reads, so it takes an explicit,
-    /// non-standard lock. Dispatched by driver name, the same way migrations
-    /// are.
-    async fn lock_keysets(&self) -> Result<(), Error> {
-        if RM::Connection::name() == "postgres" {
-            query(r#"SELECT pg_advisory_xact_lock(hashtext('cdk:keysets'))"#)?
-                .execute(&self.inner)
-                .await?;
-        }
-
-        Ok(())
-    }
-
     /// Bump the persisted keyset epoch so any keyset change (insert or
     /// active-pointer reassignment) is observable by peers, which reload when
     /// the epoch they loaded no longer matches.
@@ -319,7 +300,7 @@ where
     async fn begin_transaction<'a>(
         &'a self,
     ) -> Result<Box<dyn MintKeyDatabaseTransaction<'a, Error> + Send + Sync + 'a>, Error> {
-        let tx = SQLTransaction {
+        let mut tx = SQLTransaction {
             inner: ConnectionWithTransaction::new(
                 self.pool
                     .get()
@@ -332,7 +313,7 @@ where
         // Serialize every keyset transaction on one global advisory lock, held
         // to commit. All keyset reads and writes then see a consistent snapshot
         // without per-unit locking or torn-read retries.
-        tx.lock_keysets().await?;
+        tx.take_advisory_locks(&[KEYSETS_LOCK.to_owned()]).await?;
 
         Ok(Box::new(tx))
     }

--- a/crates/cdk-sql-common/src/mint/mod.rs
+++ b/crates/cdk-sql-common/src/mint/mod.rs
@@ -17,6 +17,7 @@ use cdk_common::database::{self, DbTransactionFinalizer, Error, MintDatabase};
 use crate::common::migrate;
 use crate::database::{ConnectionWithTransaction, DatabaseExecutor};
 use crate::pool::{DatabasePool, Pool, PooledResource};
+use crate::stmt::query;
 
 mod auth;
 mod completed_operations;
@@ -80,8 +81,58 @@ where
     }
 }
 
+impl<RM> SQLTransaction<RM>
+where
+    RM: DatabasePool + 'static,
+{
+    /// Take a whole batch of advisory locks in one statement, so a melt or swap
+    /// with many proofs does not pay a round trip per key.
+    ///
+    /// Only Postgres needs any of this. It runs the transaction at read
+    /// committed, where concurrent transactions interleave freely; SQLite
+    /// already serializes writers with `BEGIN IMMEDIATE`, so there is nothing
+    /// left to exclude. Dispatched by driver name, the same way migrations are.
+    ///
+    /// The `ORDER BY` is what preserves the caller's acquisition order: the sort
+    /// feeds the rows to `pg_advisory_xact_lock` in key order, so two batches
+    /// that overlap take the shared keys in the same order and queue rather than
+    /// deadlock. Callers already hand the keys over sorted; this keeps the plan
+    /// from being the one place that could disagree.
+    ///
+    /// Keys are hashed with `hashtextextended` rather than `hashtext`: a
+    /// collision only costs two unrelated operations a needless wait, but the
+    /// wider space makes it vanishingly rare across per-quote and per-proof
+    /// keys.
+    pub(crate) async fn take_advisory_locks(&mut self, keys: &[String]) -> Result<(), Error> {
+        if keys.is_empty() || RM::Connection::name() != "postgres" {
+            return Ok(());
+        }
+
+        query(
+            r#"
+            SELECT pg_advisory_xact_lock(hashtextextended(key, 0))
+            FROM (
+                SELECT key FROM unnest(ARRAY[:keys]::TEXT[]) AS t(key) ORDER BY key
+            ) sorted
+            "#,
+        )?
+        .bind_vec("keys", keys.to_vec())?
+        .execute(&self.inner)
+        .await?;
+
+        Ok(())
+    }
+}
+
 #[async_trait]
-impl<RM> database::MintTransaction<Error> for SQLTransaction<RM> where RM: DatabasePool + 'static {}
+impl<RM> database::MintTransaction<Error> for SQLTransaction<RM>
+where
+    RM: DatabasePool + 'static,
+{
+    async fn advisory_locks(&mut self, keys: &[String]) -> Result<(), Error> {
+        self.take_advisory_locks(keys).await
+    }
+}
 
 #[async_trait]
 impl<RM> DbTransactionFinalizer for SQLTransaction<RM>

--- a/crates/cdk/src/mint/issue/mod.rs
+++ b/crates/cdk/src/mint/issue/mod.rs
@@ -906,6 +906,11 @@ impl Mint {
             // Phase 5: Atomic database transaction
             let mut tx = self.localstore.begin_transaction().await?;
 
+            // Lock every quote in the request before the row locks below. A batch
+            // naming the same quotes in a different order would otherwise deadlock
+            // against this one.
+            tx.lock_quotes(&quote_ids).await?;
+
             // Acquire every quote row in one ordered query before taking any other
             // locks. The database returns the quotes in request order, while locking
             // them by ID, so reversed batch requests cannot deadlock each other.

--- a/crates/cdk/src/mint/melt/melt_saga/mod.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/mod.rs
@@ -215,7 +215,25 @@ impl MeltSaga<Initial> {
         // and HTLC (including SIGALL)
         melt_request.verify_spending_conditions()?;
 
+        let input_ys = melt_request.inputs().ys()?;
+
         let mut tx = self.db.begin_transaction().await?;
+
+        // Lock the quote and the inputs up front, before any row lock is taken
+        // below, so concurrent melts of the same quote or of overlapping proofs
+        // queue rather than deadlock.
+        if let Err(err) = tx
+            .lock_quotes(std::slice::from_ref(melt_request.quote_id()))
+            .await
+        {
+            tx.rollback().await?;
+            return Err(err.into());
+        }
+
+        if let Err(err) = tx.lock_proofs(&input_ys).await {
+            tx.rollback().await?;
+            return Err(err.into());
+        }
 
         let mut quote =
             match shared::load_melt_quotes_exclusively(&mut tx, melt_request.quote()).await {
@@ -258,8 +276,6 @@ impl MeltSaga<Initial> {
                 err => Error::Database(err),
             });
         }
-
-        let input_ys = melt_request.inputs().ys()?;
 
         let mut proofs = tx.get_proofs(&input_ys).await?;
 

--- a/crates/cdk/src/mint/melt/shared.rs
+++ b/crates/cdk/src/mint/melt/shared.rs
@@ -145,6 +145,12 @@ pub async fn rollback_melt_quote(
 
     let mut tx = db.begin_transaction().await?;
 
+    // Same lock order as the setup this undoes, and taken before any row lock,
+    // so a rollback racing another operation over these proofs waits instead of
+    // deadlocking.
+    tx.lock_quotes(std::slice::from_ref(quote_id)).await?;
+    tx.lock_proofs(input_ys).await?;
+
     // Acquire quote locks before touching the saga, melt-request,
     // blinded-signature, or proof rows. Finalization uses the same order.
     let locked_quotes = tx.lock_melt_quote_and_related(quote_id).await?;
@@ -726,6 +732,10 @@ pub async fn finalize_melt_quote(
     };
 
     let mut tx = db.begin_transaction().await?;
+
+    // Advisory lock before the row lock below, so the saga's finalize and the
+    // startup recovery's finalize for the same quote serialize.
+    tx.lock_quotes(std::slice::from_ref(&quote.id)).await?;
 
     // Acquire lock on the quote for safe state update
 

--- a/crates/cdk/src/mint/swap/swap_saga/mod.rs
+++ b/crates/cdk/src/mint/swap/swap_saga/mod.rs
@@ -179,7 +179,20 @@ impl<'a> SwapSaga<'a, Initial> {
             None, // payment_method (not applicable for swap)
         );
 
+        let ys = match input_proofs.ys() {
+            Ok(ys) => ys,
+            Err(err) => return Err(Error::NUT00(err)),
+        };
+
         let mut tx = self.db.begin_transaction().await?;
+
+        // Lock the inputs before touching them. Without it two swaps sharing
+        // proofs, listed in different orders, deadlock against each other
+        // inserting them below.
+        if let Err(err) = tx.lock_proofs(&ys).await {
+            tx.rollback().await?;
+            return Err(err.into());
+        }
 
         // Add input proofs to DB
         let mut new_proofs = match tx
@@ -195,11 +208,6 @@ impl<'a> SwapSaga<'a, Initial> {
                     _ => Error::Database(err),
                 });
             }
-        };
-
-        let ys = match input_proofs.ys() {
-            Ok(ys) => ys,
-            Err(err) => return Err(Error::NUT00(err)),
         };
 
         if let Err(err) = Mint::update_proofs_state(&mut tx, &mut new_proofs, State::Pending).await


### PR DESCRIPTION

### Description

Fixes #2332

Row locks only protect rows that already exist, so operations racing over rows they are about to insert had nothing serializing them. Two swaps sharing proofs, or two batch mints naming the same quotes in a different order, could deadlock against each other.

Transactions can now take a named advisory lock, held until the transaction ends. Melt, mint and swap take theirs before any row lock, quotes before proofs, each group sorted. The keyset lock that was hand-rolled in the SQL keys module goes through the same path.

Postgres backs this with pg_advisory_xact_lock; SQLite is a no-op, since BEGIN IMMEDIATE already serializes writers.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
