### PR TITLE
Pace requests by destination host, not by wallet

### DIFF
--- a/crates/cdk-common/src/rate_limit.rs
+++ b/crates/cdk-common/src/rate_limit.rs
@@ -1,14 +1,20 @@
 //! Client-side request rate limiting for the wallet.
 //!
-//! The wallet paces its outbound HTTP requests to a mint so it stays under the
-//! mint's server-side request cap without the caller having to think about it.
-//! Pacing uses the Generic Cell Rate Algorithm (GCRA): the bucket tracks a
-//! single theoretical arrival time (TAT) rather than a refilling token count.
+//! The wallet paces its outbound HTTP requests so it stays under a server's
+//! request cap without the caller having to think about it. Pacing uses the
+//! Generic Cell Rate Algorithm (GCRA): the bucket tracks a single theoretical
+//! arrival time (TAT) rather than a refilling token count.
 //!
-//! The budget is persisted per mint host in the wallet key-value store, so a
-//! wallet that is built, used, and dropped hands its remaining budget to the
-//! next wallet built for the same mint instead of starting full and bursting
-//! again.
+//! A cap is a property of the host being called, not of the wallet doing the
+//! calling, so budgets are keyed by the *destination* host of each request (see
+//! [`RateLimiterManager`](crate::rate_limit::RateLimiterManager)). A wallet's
+//! transport also carries requests that have
+//! nothing to do with its mint (LNURL services, OIDC providers), and those must
+//! not draw down the mint's budget.
+//!
+//! The budget is persisted per host in the wallet key-value store, so a wallet
+//! that is built, used, and dropped hands its remaining budget to the next
+//! wallet talking to the same host instead of starting full and bursting again.
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -24,11 +30,13 @@ use url::Url;
 use web_time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::database::{self, WalletDatabase, KVSTORE_NAMESPACE_KEY_MAX_LEN};
-use crate::mint_url::MintUrl;
 use crate::{AuthToken, HttpError, RawResponse};
 
 /// Namespace under which per-host rate-limit budgets are stored.
 const KV_NAMESPACE: &str = "rate_limiter";
+
+/// Database handle used to persist budgets.
+type BudgetDb = Arc<dyn WalletDatabase<database::Error> + Send + Sync>;
 
 /// Configuration for a [`TokenBucket`].
 ///
@@ -91,10 +99,10 @@ trait BudgetStore: std::fmt::Debug + Send + Sync {
     async fn store(&self, value: &[u8]) -> bool;
 }
 
-/// [`BudgetStore`] backed by the wallet key-value store, keyed by mint host.
+/// [`BudgetStore`] backed by the wallet key-value store, keyed by host.
 #[derive(Debug)]
 struct KvBudgetStore {
-    db: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
+    db: BudgetDb,
     key: String,
 }
 
@@ -182,17 +190,17 @@ impl TokenBucket {
         Self::build(config, None)
     }
 
-    /// Create a bucket that persists its budget for `mint_url` in `store`.
+    /// Create a bucket whose budget is persisted under `key`, or held only in
+    /// memory when `db` is `None`.
     ///
-    /// If a host cannot be derived from `mint_url`, the bucket still paces
-    /// requests in memory but persists nothing.
-    pub fn for_mint(
-        config: RateLimitConfig,
-        mint_url: &MintUrl,
-        db: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
-    ) -> Self {
-        let persistence = origin_key(mint_url)
-            .map(|key| Arc::new(KvBudgetStore { db, key }) as Arc<dyn BudgetStore>);
+    /// `key` is an [`origin_key`], already sanitized to the KV alphabet.
+    fn persisted(config: RateLimitConfig, key: &str, db: Option<BudgetDb>) -> Self {
+        let persistence = db.map(|db| {
+            Arc::new(KvBudgetStore {
+                db,
+                key: key.to_string(),
+            }) as Arc<dyn BudgetStore>
+        });
         Self::build(config, persistence)
     }
 
@@ -457,78 +465,119 @@ impl TokenBucket {
     }
 }
 
-/// Hands out one shared [`TokenBucket`] per mint origin.
+/// Pacing settings a manager applies to the buckets it hands out. Shared across
+/// clones so a runtime change reaches every one of them.
+#[derive(Debug, Clone, Copy)]
+struct ManagerSettings {
+    config: RateLimitConfig,
+    enabled: bool,
+}
+
+/// Hands out one shared [`TokenBucket`] per destination origin.
 ///
-/// A mint origin is the sanitized host plus non-default port (see
-/// [`origin_key`]), so every currency-unit wallet at one mint host draws down a
-/// single budget and a single persistence writer instead of each getting a full
-/// burst. Cloning the manager shares the same per-origin map and config through
-/// `Arc`s, so cloned managers keep handing out the same live budgets.
+/// An origin is the sanitized host plus non-default port (see [`origin_key`]).
+/// Every request to one host draws down a single budget and feeds a single
+/// persistence writer, no matter which wallet, currency unit, or client issued
+/// it. That also keeps a wallet's non-mint traffic (LNURL, OIDC) off its mint's
+/// budget. Cloning the manager shares the same per-origin map and settings
+/// through `Arc`s, so cloned managers keep handing out the same live budgets.
 #[derive(Clone)]
 pub struct RateLimiterManager {
-    config: RateLimitConfig,
-    db: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
-    /// One bucket per origin. An entry is evicted lazily (during
-    /// [`Self::bucket_for`]) once its budget is fully recovered and no live
-    /// wallet still holds it, so the map is bounded by the origins with active
-    /// or recently-active wallets. Eviction is a behavioral no-op: a recovered
-    /// bucket is equivalent to a fresh one, and the persisted budget survives a
-    /// re-add.
+    settings: Arc<Mutex<ManagerSettings>>,
+    /// `None` keeps every bucket in memory only, for callers with no wallet
+    /// database to persist through.
+    db: Option<BudgetDb>,
+    /// One bucket per origin. An entry is evicted lazily (when
+    /// [`Self::bucket_for`] has to create one) once its budget is fully
+    /// recovered and nothing else still holds it, so the map is bounded by the
+    /// origins with active or recently-active traffic. Eviction is a behavioral
+    /// no-op: a recovered bucket is equivalent to a fresh one, and the persisted
+    /// budget survives a re-add.
     buckets: Arc<Mutex<HashMap<String, TokenBucket>>>,
 }
 
 impl std::fmt::Debug for RateLimiterManager {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RateLimiterManager")
-            .field("config", &self.config)
+            .field("settings", &*lock(&self.settings))
             .finish_non_exhaustive()
     }
 }
 
 impl RateLimiterManager {
     /// Create a manager that hands out buckets configured with `config` and
-    /// persisted through `db`.
-    pub fn new(
-        config: RateLimitConfig,
-        db: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
-    ) -> Self {
+    /// persisted through `db`, or held in memory only when `db` is `None`.
+    pub fn new(config: RateLimitConfig, db: Option<BudgetDb>) -> Self {
         Self {
-            config,
+            settings: Arc::new(Mutex::new(ManagerSettings {
+                config,
+                enabled: true,
+            })),
             db,
             buckets: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    /// Get or create the shared bucket for `mint_url`'s origin, returning a
-    /// clone that draws down the same budget.
+    /// Get or create the shared bucket for `url`'s origin, returning a clone
+    /// that draws down the same budget.
     ///
-    /// The first call for an origin builds one persisted bucket (via
-    /// [`TokenBucket::for_mint`], so the KV budget and its single background
-    /// writer are shared); later calls for the same origin clone it. A host-less
-    /// URL falls back to keying on the full URL string, so it still gets one
-    /// stable in-memory bucket, though `for_mint` persists nothing for it.
+    /// The first call for an origin builds one bucket, so the KV budget and its
+    /// single background writer are shared; later calls for the same origin
+    /// clone it. A host-less URL has no valid KV key, so it falls back to keying
+    /// on the full URL string and paces in memory without persisting.
     ///
-    /// Each call first evicts any other origin whose bucket is fully recovered
-    /// and held only by the map (no live wallet), bounding the map over time.
-    pub fn bucket_for(&self, mint_url: &MintUrl) -> TokenBucket {
-        let key = origin_key(mint_url).unwrap_or_else(|| mint_url.to_string());
+    /// Runs on every request, so a hit is a hash lookup and a clone. Only a miss
+    /// pays for the eviction sweep, which drops origins whose budget has fully
+    /// recovered and that nothing else still holds: a recovered bucket is
+    /// equivalent to a fresh one, so rebuilding it later is free. A bucket
+    /// someone still shares (`handle_count > 1`) is kept so co-active callers
+    /// never split into independent budgets.
+    pub fn bucket_for(&self, url: &Url) -> TokenBucket {
+        let origin = origin_key(url);
+        let key = origin.clone().unwrap_or_else(|| url.to_string());
         let mut buckets = lock(&self.buckets);
-        // Drop origins with no live wallet whose budget has fully recovered: a
-        // recovered bucket is equivalent to a fresh one, so rebuilding it later
-        // is free. Keep the requested key and any bucket a wallet still shares
-        // (handle_count > 1) so co-active wallets never split into independent
-        // budgets.
-        buckets.retain(|k, bucket| {
-            k == &key || bucket.handle_count() > 1 || !bucket.is_fully_recovered()
-        });
-        buckets
-            .entry(key)
-            .or_insert_with(|| TokenBucket::for_mint(self.config, mint_url, self.db.clone()))
-            .clone()
+        if let Some(bucket) = buckets.get(&key) {
+            return bucket.clone();
+        }
+        buckets.retain(|_, bucket| bucket.handle_count() > 1 || !bucket.is_fully_recovered());
+
+        let db = match origin {
+            Some(_) => self.db.clone(),
+            None => None,
+        };
+        let settings = *lock(&self.settings);
+        let bucket = TokenBucket::persisted(settings.config, &key, db);
+        bucket.set_enabled(settings.enabled);
+        buckets.insert(key, bucket.clone());
+        bucket
     }
 
-    /// Number of mint origins currently tracked. Exposed for diagnostics and to
-    /// let tests observe eviction.
+    /// Replace the pacing configuration for every origin: the buckets already
+    /// handed out and any created later.
+    ///
+    /// Like [`TokenBucket::set_config`] this also re-enables pacing.
+    pub fn set_config(&self, config: RateLimitConfig) {
+        {
+            let mut settings = lock(&self.settings);
+            settings.config = config;
+            settings.enabled = true;
+        }
+        for bucket in lock(&self.buckets).values() {
+            bucket.set_config(config);
+        }
+    }
+
+    /// Enable or disable pacing for every origin: the buckets already handed out
+    /// and any created later.
+    pub fn set_enabled(&self, enabled: bool) {
+        lock(&self.settings).enabled = enabled;
+        for bucket in lock(&self.buckets).values() {
+            bucket.set_enabled(enabled);
+        }
+    }
+
+    /// Number of origins currently tracked. Exposed for diagnostics and to let
+    /// tests observe eviction.
     pub fn origin_count(&self) -> usize {
         lock(&self.buckets).len()
     }
@@ -608,20 +657,20 @@ fn tat_to_unix_millis(arrival_time: Instant) -> u64 {
         .unwrap_or(0)
 }
 
-/// Derive a mint's rate-limit origin identity from its host and non-default
-/// port, sanitized to the KV alphabet (disallowed characters become `_`,
-/// truncated to the max length). Returns `None` when the URL has no host.
+/// Derive a rate-limit origin identity from a URL's host and non-default port,
+/// sanitized to the KV alphabet (disallowed characters become `_`, truncated to
+/// the max length). Returns `None` when the URL has no host.
 ///
 /// This is the identity used both to key the persisted budget in the KV store
-/// and to share one live in-memory [`TokenBucket`] across wallets (see
-/// [`RateLimiterManager`]). `Url::parse` normalizes a scheme-default port away,
-/// so `:443` and an implicit default map to one origin: one mint host is one
-/// budget. Sanitizing can collide two distinct hosts onto one key; that only
-/// makes them share a budget, never leak between them.
-pub fn origin_key(mint_url: &MintUrl) -> Option<String> {
-    let parsed = Url::parse(&mint_url.to_string()).ok()?;
-    let host = parsed.host_str()?;
-    let authority = match parsed.port() {
+/// and to share one live in-memory [`TokenBucket`] (see [`RateLimiterManager`]).
+/// The scheme is deliberately excluded, so `http://` and `https://` on one host
+/// share a budget: it is one server enforcing one cap. `Url::parse` normalizes a
+/// scheme-default port away, so `:443` and an implicit default map to one origin
+/// too. Sanitizing can collide two distinct hosts onto one key; that only makes
+/// them share a budget, never leak between them.
+pub fn origin_key(url: &Url) -> Option<String> {
+    let host = url.host_str()?;
+    let authority = match url.port() {
         Some(port) => format!("{host}:{port}"),
         None => host.to_string(),
     };
@@ -655,26 +704,35 @@ async fn sleep(duration: Duration) {
     gloo_timers::future::TimeoutFuture::new(duration.as_millis() as u32).await;
 }
 
-/// A [`Transport`] decorator that paces HTTP requests through a [`TokenBucket`].
+/// A [`Transport`] decorator that paces each HTTP request through the bucket for
+/// the host it is addressed to.
+///
+/// The bucket is resolved per request rather than fixed at construction, so a
+/// transport built for a mint does not spend that mint's budget on a call to an
+/// unrelated host (an LNURL service, an OIDC provider) and does not pace that
+/// host by the mint's budget either.
 ///
 /// Only the HTTP request methods are throttled; `ws_connect`, `with_proxy`, and
 /// `resolve_dns_txt` pass straight through to the inner transport.
 #[derive(Debug, Clone)]
 pub struct RateLimitedTransport<T> {
     inner: T,
-    bucket: TokenBucket,
+    limiter: RateLimiterManager,
 }
 
 impl<T> RateLimitedTransport<T> {
-    /// Wrap `inner` with a (possibly shared) `bucket`.
-    pub fn with_bucket(inner: T, bucket: TokenBucket) -> Self {
-        Self { inner, bucket }
+    /// Wrap `inner` with a (possibly shared) `limiter`.
+    pub fn with_manager(inner: T, limiter: RateLimiterManager) -> Self {
+        Self { inner, limiter }
     }
 }
 
 impl<T: Default> Default for RateLimitedTransport<T> {
     fn default() -> Self {
-        Self::with_bucket(T::default(), TokenBucket::new(RateLimitConfig::default()))
+        Self::with_manager(
+            T::default(),
+            RateLimiterManager::new(RateLimitConfig::default(), None),
+        )
     }
 }
 
@@ -714,7 +772,8 @@ impl<T: Transport> Transport for RateLimitedTransport<T> {
     where
         R: DeserializeOwned,
     {
-        self.bucket.acquire(self.inner.http_get(url, auth)).await
+        let bucket = self.limiter.bucket_for(&url);
+        bucket.acquire(self.inner.http_get(url, auth)).await
     }
 
     async fn http_get_raw(
@@ -722,9 +781,8 @@ impl<T: Transport> Transport for RateLimitedTransport<T> {
         url: Url,
         auth: Option<AuthToken>,
     ) -> Result<RawResponse, HttpError> {
-        self.bucket
-            .acquire(self.inner.http_get_raw(url, auth))
-            .await
+        let bucket = self.limiter.bucket_for(&url);
+        bucket.acquire(self.inner.http_get_raw(url, auth)).await
     }
 
     async fn http_post<P, R>(
@@ -737,7 +795,8 @@ impl<T: Transport> Transport for RateLimitedTransport<T> {
         P: Serialize + Send + Sync,
         R: DeserializeOwned,
     {
-        self.bucket
+        let bucket = self.limiter.bucket_for(&url);
+        bucket
             .acquire(self.inner.http_post(url, auth_token, payload))
             .await
     }
@@ -751,7 +810,8 @@ impl<T: Transport> Transport for RateLimitedTransport<T> {
     where
         P: Serialize + Send + Sync,
     {
-        self.bucket
+        let bucket = self.limiter.bucket_for(&url);
+        bucket
             .acquire(self.inner.http_post_form_raw(url, auth_token, payload))
             .await
     }
@@ -759,7 +819,6 @@ impl<T: Transport> Transport for RateLimitedTransport<T> {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use std::str::FromStr;
     use std::time::Instant as StdInstant;
 
     use super::*;
@@ -997,10 +1056,13 @@ mod tests {
             .expect("flush must not hang on a failing store");
     }
 
+    fn parse(url: &str) -> Url {
+        Url::parse(url).expect("valid url")
+    }
+
     #[test]
     fn kv_key_is_sanitized() {
-        let url = MintUrl::from_str("https://mint.example.com:3338").unwrap();
-        let key = origin_key(&url).expect("host present");
+        let key = origin_key(&parse("https://mint.example.com:3338")).expect("host present");
         assert!(!key.contains('.'));
         assert!(!key.contains(':'));
         assert!(key
@@ -1012,14 +1074,84 @@ mod tests {
     fn kv_key_ignores_default_port() {
         // `Url::parse` normalizes a scheme-default port away, so an explicit
         // `:443` and an implicit default map to one budget for the same host.
-        let implicit = origin_key(&MintUrl::from_str("https://mint.example.com").unwrap());
-        let explicit = origin_key(&MintUrl::from_str("https://mint.example.com:443").unwrap());
+        let implicit = origin_key(&parse("https://mint.example.com"));
+        let explicit = origin_key(&parse("https://mint.example.com:443"));
         assert_eq!(implicit, explicit);
         assert_eq!(implicit.as_deref(), Some("mint_example_com"));
 
         // A non-default port still yields a distinct budget.
-        let other = origin_key(&MintUrl::from_str("https://mint.example.com:8443").unwrap());
+        let other = origin_key(&parse("https://mint.example.com:8443"));
         assert_ne!(implicit, other);
+    }
+
+    #[test]
+    fn kv_key_ignores_scheme_and_path() {
+        // One host is one server enforcing one cap, whatever the scheme, and
+        // whatever path a request targets.
+        let plain = origin_key(&parse("http://mint.example.com/v1/keys"));
+        let secure = origin_key(&parse("https://mint.example.com/other/mint"));
+        assert_eq!(plain, secure);
+    }
+
+    #[tokio::test]
+    async fn manager_paces_each_origin_independently() {
+        let manager = RateLimiterManager::new(config(1, 300), None);
+        let mint = manager.bucket_for(&parse("https://mint.example.com/v1/mint"));
+        // A different path at the same host resolves to the same budget.
+        let same_host = manager.bucket_for(&parse("https://mint.example.com/v1/melt"));
+        // An unrelated host (an LNURL service, say) gets its own.
+        let lnurl = manager.bucket_for(&parse("https://pay.example.org/.well-known/lnurlp/alice"));
+
+        assert!(mint.try_acquire().await);
+        assert!(!same_host.try_acquire().await, "same host shares a budget");
+        assert!(lnurl.try_acquire().await, "another host is independent");
+    }
+
+    #[tokio::test]
+    async fn manager_toggles_reach_existing_and_future_buckets() {
+        let manager = RateLimiterManager::new(config(1, 60), None);
+        let existing = manager.bucket_for(&parse("https://mint.example.com"));
+        assert!(existing.try_acquire().await);
+        assert!(!existing.try_acquire().await);
+
+        manager.set_enabled(false);
+        assert!(existing.try_acquire().await, "existing bucket is disabled");
+        let later = manager.bucket_for(&parse("https://pay.example.org"));
+        for _ in 0..5 {
+            assert!(later.try_acquire().await, "new bucket inherits disabled");
+        }
+
+        // set_config re-enables pacing everywhere. The existing bucket keeps the
+        // debt it had before being disabled, so it is paced again immediately.
+        manager.set_config(config(1, 60));
+        assert!(!existing.try_acquire().await, "existing bucket paces again");
+        let newest = manager.bucket_for(&parse("https://third.example.net"));
+        assert!(newest.try_acquire().await);
+        assert!(!newest.try_acquire().await, "new bucket inherits config");
+    }
+
+    #[tokio::test]
+    async fn manager_evicts_only_recovered_unheld_origins() {
+        let manager = RateLimiterManager::new(config(1, 60), None);
+        // Held by the test, so it survives an eviction sweep even once
+        // recovered.
+        let held = manager.bucket_for(&parse("https://held.example.com"));
+        // Dropped immediately and never used, so it is fully recovered and
+        // unheld: the next miss sweeps it away.
+        manager.bucket_for(&parse("https://stale.example.com"));
+        assert_eq!(manager.origin_count(), 2);
+
+        manager.bucket_for(&parse("https://fresh.example.com"));
+        assert_eq!(manager.origin_count(), 2, "stale origin was evicted");
+        // The held origin kept its drawn-down budget rather than being rebuilt.
+        assert!(held.try_acquire().await);
+        assert!(!held.try_acquire().await);
+        assert!(
+            !manager
+                .bucket_for(&parse("https://held.example.com"))
+                .try_acquire()
+                .await
+        );
     }
 
     // Timing tests use a 200ms emission interval (refill 300/min) so the pace
@@ -1227,7 +1359,10 @@ mod tests {
         // capacity 2, emission ~200ms: two calls burst, the third is paced.
         let inner = CountingTransport::default();
         let counter = inner.clone();
-        let transport = RateLimitedTransport::with_bucket(inner, TokenBucket::new(config(2, 300)));
+        let transport = RateLimitedTransport::with_manager(
+            inner,
+            RateLimiterManager::new(config(2, 300), None),
+        );
 
         let start = StdInstant::now();
         let _ = transport.http_get_raw(url(), None).await;
@@ -1249,12 +1384,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn transport_paces_by_destination_host() {
+        // The whole point of resolving per request: a transport built for a mint
+        // must not spend the mint's budget on an LNURL or OIDC host.
+        let transport = RateLimitedTransport::with_manager(
+            CountingTransport::default(),
+            RateLimiterManager::new(config(1, 300), None),
+        );
+        let mint = parse("https://mint.example.com/v1/keys");
+        let lnurl = parse("https://pay.example.org/.well-known/lnurlp/alice");
+
+        // Drain the mint's single burst slot.
+        let _ = transport.http_get_raw(mint.clone(), None).await;
+
+        // The unrelated host still has its own full burst.
+        let start = StdInstant::now();
+        let _ = transport.http_get_raw(lnurl, None).await;
+        assert!(
+            start.elapsed() < Duration::from_millis(100),
+            "another host must not be paced by the mint's budget"
+        );
+
+        // The mint's own budget is still drawn down.
+        let start = StdInstant::now();
+        let _ = transport.http_get_raw(mint, None).await;
+        assert!(
+            start.elapsed() >= Duration::from_millis(150),
+            "the mint's own budget is still enforced"
+        );
+    }
+
+    #[tokio::test]
     async fn transport_passes_proxy_through_unthrottled() {
         let inner = CountingTransport::default();
         let flag = inner.proxied.clone();
         let counter = inner.clone();
-        let mut transport =
-            RateLimitedTransport::with_bucket(inner, TokenBucket::new(config(1, 300)));
+        let mut transport = RateLimitedTransport::with_manager(
+            inner,
+            RateLimiterManager::new(config(1, 300), None),
+        );
 
         transport.with_proxy(url(), None, false).expect("proxy set");
         // with_proxy reached the inner transport and consumed no rate-limit slot.
@@ -1263,15 +1431,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transports_sharing_a_bucket_share_the_budget() {
-        let bucket = TokenBucket::new(config(1, 300));
-        let a = RateLimitedTransport::with_bucket(CountingTransport::default(), bucket.clone());
-        let b = RateLimitedTransport::with_bucket(CountingTransport::default(), bucket.clone());
+    async fn transports_sharing_a_manager_share_the_budget() {
+        let manager = RateLimiterManager::new(config(1, 300), None);
+        let a = RateLimitedTransport::with_manager(CountingTransport::default(), manager.clone());
+        let b = RateLimitedTransport::with_manager(CountingTransport::default(), manager.clone());
 
         // Drain the single burst slot through transport A.
         let _ = a.http_get_raw(url(), None).await;
 
-        // Transport B, sharing the same bucket, must now wait.
+        // Transport B, sharing the same manager and so the same per-host bucket,
+        // must now wait.
         let start = StdInstant::now();
         let _ = b.http_get_raw(url(), None).await;
         assert!(

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -120,8 +120,11 @@ impl Wallet {
     ///
     /// A new wallet is built with the default limiter enabled. Use this to
     /// disable it, restore the default, or set a custom burst and refill. It
-    /// takes effect immediately on the live wallet and is shared by the main and
-    /// blind-auth clients.
+    /// takes effect immediately and covers every host the wallet's limiter
+    /// paces, so it reaches the main and blind-auth clients as well as any
+    /// third-party host their transport reaches. For a wallet built through a
+    /// wallet repository the limiter is shared, so the change is
+    /// repository-wide.
     ///
     /// Returns an error if a `Custom` value has a zero field.
     pub fn set_rate_limit(&self, rate_limit: RateLimit) -> Result<(), FfiError> {

--- a/crates/cdk/src/wallet/builder.rs
+++ b/crates/cdk/src/wallet/builder.rs
@@ -15,20 +15,21 @@ use crate::wallet::mint_connector::transport::{Async, RateLimitedTransport};
 use crate::wallet::mint_connector::{RateLimitedAuthHttpClient, RateLimitedHttpClient};
 use crate::wallet::mint_metadata_cache::MintMetadataCache;
 use crate::wallet::{
-    AuthHttpClient, HttpClient, MintConnector, RateLimitConfig, SubscriptionManager, TokenBucket,
-    Wallet,
+    AuthHttpClient, HttpClient, MintConnector, RateLimitConfig, RateLimiterManager,
+    SubscriptionManager, Wallet,
 };
 
 /// Builder for creating a new [`Wallet`]
 ///
-/// Rate limiting: unless a bucket is injected with
-/// [`WalletBuilder::with_rate_limit_bucket`], `build()` constructs the wallet's
-/// own [`TokenBucket`] for the mint. Two wallets built independently for the
-/// same mint therefore do not share a live in-memory budget, only the persisted
-/// per-host budget in the KV store. To share one live budget across wallets
-/// (for example every currency unit at one mint), build them through a
+/// Rate limiting: unless a limiter is injected with
+/// [`WalletBuilder::with_rate_limiter`], `build()` constructs the wallet's own
+/// [`RateLimiterManager`]. Budgets are keyed by the host each request is
+/// addressed to, so the wallet's mint, an LNURL service, and an OIDC provider
+/// each pace separately. Two wallets built independently do not share a live
+/// in-memory budget, only the persisted per-host budget in the KV store. To
+/// share one live budget, build them through a
 /// [`WalletRepository`](crate::wallet::WalletRepository), which injects one
-/// shared bucket per mint origin.
+/// manager into every wallet it creates.
 pub struct WalletBuilder {
     mint_url: Option<MintUrl>,
     unit: Option<CurrencyUnit>,
@@ -43,7 +44,7 @@ pub struct WalletBuilder {
     metadata_cache: Option<Arc<MintMetadataCache>>,
     metadata_caches: HashMap<MintUrl, Arc<MintMetadataCache>>,
     rate_limit: Option<RateLimitConfig>,
-    rate_limit_bucket: Option<TokenBucket>,
+    rate_limiter: Option<RateLimiterManager>,
     auth_cat: Option<String>,
 }
 
@@ -73,7 +74,7 @@ impl Default for WalletBuilder {
             metadata_cache: None,
             metadata_caches: HashMap::new(),
             rate_limit: Some(RateLimitConfig::default()),
-            rate_limit_bucket: None,
+            rate_limiter: None,
             auth_cat: None,
         }
     }
@@ -204,28 +205,28 @@ impl WalletBuilder {
     ///
     /// Rate limiting is enabled by default with [`RateLimitConfig::default`].
     /// This config is only used when `build()` constructs the wallet's own
-    /// bucket; a bucket injected with [`Self::with_rate_limit_bucket`] carries
-    /// its own config and overrides this, regardless of call order.
+    /// limiter; a limiter injected with [`Self::with_rate_limiter`] carries its
+    /// own config and overrides this, regardless of call order.
     pub fn with_rate_limiting_config(mut self, config: RateLimitConfig) -> Self {
         self.rate_limit = Some(config);
         self
     }
 
-    /// Use a pre-built, possibly shared [`TokenBucket`] for pacing.
+    /// Use a pre-built, possibly shared [`RateLimiterManager`] for pacing.
     ///
-    /// An injected bucket takes precedence over
+    /// An injected limiter takes precedence over
     /// [`Self::with_rate_limiting_config`]: `build()` uses it verbatim instead of
-    /// constructing a per-wallet bucket, so several wallets can share one live
-    /// in-memory budget. [`Self::without_rate_limiting`] still clears it.
-    pub fn with_rate_limit_bucket(mut self, bucket: TokenBucket) -> Self {
-        self.rate_limit_bucket = Some(bucket);
+    /// constructing a per-wallet one, so several wallets can share one live set
+    /// of per-host budgets. [`Self::without_rate_limiting`] still clears it.
+    pub fn with_rate_limiter(mut self, limiter: RateLimiterManager) -> Self {
+        self.rate_limiter = Some(limiter);
         self
     }
 
     /// Disable client-side rate limiting.
     pub fn without_rate_limiting(mut self) -> Self {
         self.rate_limit = None;
-        self.rate_limit_bucket = None;
+        self.rate_limiter = None;
         self
     }
 
@@ -281,29 +282,33 @@ impl WalletBuilder {
         metadata_cache.set_ttl(self.metadata_cache_ttl);
 
         // A single rate-limited transport, shared by the main client and the
-        // blind-auth client so both draw down one persisted budget and reuse one
-        // connection pool. An injected bucket (e.g. one shared across every unit
-        // at a mint by WalletRepository) wins over building a per-wallet one.
-        let rate_limit_bucket = match self.rate_limit_bucket.take() {
-            Some(bucket) => Some(bucket),
+        // blind-auth client so both draw down one persisted budget per host and
+        // reuse one connection pool. An injected limiter (e.g. the one
+        // WalletRepository shares across all its wallets) wins over building a
+        // per-wallet one.
+        let rate_limiter = match self.rate_limiter.take() {
+            Some(limiter) => Some(limiter),
             None => self
                 .rate_limit
                 .take()
-                .map(|config| TokenBucket::for_mint(config, &mint_url, localstore.clone())),
+                .map(|config| RateLimiterManager::new(config, Some(localstore.clone()))),
         };
-        let shared_transport = rate_limit_bucket
-            .clone()
-            .map(|bucket| Arc::new(RateLimitedTransport::with_bucket(Async::default(), bucket)));
+        let shared_transport = rate_limiter.clone().map(|limiter| {
+            Arc::new(RateLimitedTransport::with_manager(
+                Async::default(),
+                limiter,
+            ))
+        });
 
-        // The bucket only paces traffic through a client the wallet itself
+        // The limiter only paces traffic through a client the wallet itself
         // builds around `shared_transport`: the main client (unless a custom one
         // replaces it) and the blind-auth client (only on the CAT path). If a
-        // custom client is supplied and there is no CAT, the bucket is wired to
+        // custom client is supplied and there is no CAT, the limiter is wired to
         // nothing, so keep it off the wallet rather than exposing runtime setters
-        // that mutate a disconnected bucket.
+        // that mutate a disconnected limiter.
         let has_custom_client = self.client.is_some();
         let has_auth_cat = self.auth_cat.is_some();
-        let bucket_is_wired = rate_limit_bucket.is_some() && (!has_custom_client || has_auth_cat);
+        let limiter_is_wired = rate_limiter.is_some() && (!has_custom_client || has_auth_cat);
 
         // The auth wallet comes either from a CAT set on the builder (built here
         // so it can share the transport) or from a pre-built wallet supplied
@@ -358,11 +363,7 @@ impl WalletBuilder {
             seed,
             client: client.clone(),
             subscription: SubscriptionManager::new(client, self.use_http_subscription),
-            rate_limit: if bucket_is_wired {
-                rate_limit_bucket
-            } else {
-                None
-            },
+            rate_limiter: if limiter_is_wired { rate_limiter } else { None },
         })
     }
 }
@@ -447,19 +448,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn default_build_keeps_the_rate_limit_bucket() {
-        // No custom client: the bucket paces the main client, so it is retained
+    async fn default_build_keeps_the_rate_limiter() {
+        // No custom client: the limiter paces the main client, so it is retained
         // and the runtime setters have something to act on.
         let wallet = base_builder().await.build().unwrap();
-        assert!(wallet.rate_limit.is_some());
+        assert!(wallet.rate_limiter.is_some());
     }
 
     #[tokio::test]
-    async fn custom_client_drops_the_rate_limit_bucket() {
+    async fn custom_client_drops_the_rate_limiter() {
         // A custom client replaces the wallet's rate-limited transport and there
-        // is no CAT, so the bucket is wired to nothing. The wallet must not keep
+        // is no CAT, so the limiter is wired to nothing. The wallet must not keep
         // it, otherwise the runtime setters would silently mutate a disconnected
-        // bucket that never touches the main client's traffic.
+        // limiter that never touches the main client's traffic.
         use crate::wallet::test_utils::MockMintConnector;
 
         let wallet = base_builder()
@@ -467,12 +468,12 @@ mod tests {
             .shared_client(Arc::new(MockMintConnector::new()))
             .build()
             .unwrap();
-        assert!(wallet.rate_limit.is_none());
+        assert!(wallet.rate_limiter.is_none());
     }
 
     #[tokio::test]
-    async fn custom_client_with_auth_cat_keeps_bucket_for_auth() {
-        // With a custom main client but a CAT, the bucket still paces the
+    async fn custom_client_with_auth_cat_keeps_limiter_for_auth() {
+        // With a custom main client but a CAT, the limiter still paces the
         // blind-auth client the wallet builds, so it is retained: the setters
         // then reconfigure the auth client's pacing.
         use crate::wallet::test_utils::MockMintConnector;
@@ -484,6 +485,6 @@ mod tests {
             .unwrap()
             .build()
             .unwrap();
-        assert!(wallet.rate_limit.is_some());
+        assert!(wallet.rate_limiter.is_some());
     }
 }

--- a/crates/cdk/src/wallet/mint_connector/transport.rs
+++ b/crates/cdk/src/wallet/mint_connector/transport.rs
@@ -15,15 +15,14 @@ pub use cdk_http_client::{Async, Transport};
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod persistence_tests {
     use std::num::NonZeroU32;
-    use std::str::FromStr;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
     use cdk_common::database;
+    use url::Url;
 
     use super::{RateLimitConfig, RateLimiterManager, TokenBucket};
     use crate::cdk_database::WalletDatabase;
-    use crate::mint_url::MintUrl;
 
     fn config(capacity: u32, refill_per_minute: u32) -> RateLimitConfig {
         RateLimitConfig::new(
@@ -32,19 +31,26 @@ mod persistence_tests {
         )
     }
 
+    fn parse(url: &str) -> Url {
+        Url::parse(url).expect("valid url")
+    }
+
+    async fn store() -> Arc<dyn WalletDatabase<database::Error> + Send + Sync> {
+        Arc::new(
+            cdk_sqlite::wallet::memory::empty()
+                .await
+                .expect("in-memory wallet database"),
+        )
+    }
+
     #[tokio::test]
     async fn manager_shares_one_bucket_per_origin() {
-        let store: Arc<dyn WalletDatabase<database::Error> + Send + Sync> =
-            Arc::new(cdk_sqlite::wallet::memory::empty().await.unwrap());
         // capacity 2 so two try_acquires exhaust one origin's shared burst.
-        let manager = RateLimiterManager::new(config(2, 300), store);
+        let manager = RateLimiterManager::new(config(2, 300), Some(store().await));
 
-        // Two URLs of the same origin (default port collapses to no port) must
-        // resolve to one shared bucket.
-        let implicit = MintUrl::from_str("https://mint.example.com").unwrap();
-        let explicit = MintUrl::from_str("https://mint.example.com:443").unwrap();
-        let a = manager.bucket_for(&implicit);
-        let b = manager.bucket_for(&explicit);
+        // Same host, different port spelling and different path: one bucket.
+        let a = manager.bucket_for(&parse("https://mint.example.com/v1/keys"));
+        let b = manager.bucket_for(&parse("https://mint.example.com:443/v1/swap"));
 
         assert!(a.try_acquire().await);
         assert!(b.try_acquire().await);
@@ -53,62 +59,50 @@ mod persistence_tests {
         assert!(!b.try_acquire().await, "shared origin budget is drained");
 
         // A different origin keeps its own budget.
-        let other = manager.bucket_for(&MintUrl::from_str("https://other.example.com").unwrap());
+        let other = manager.bucket_for(&parse("https://other.example.com"));
         assert!(other.try_acquire().await, "distinct origin is independent");
     }
 
     #[tokio::test]
     async fn manager_evicts_recovered_unreferenced_bucket() {
-        let store: Arc<dyn WalletDatabase<database::Error> + Send + Sync> =
-            Arc::new(cdk_sqlite::wallet::memory::empty().await.unwrap());
-        let manager = RateLimiterManager::new(config(5, 300), store);
+        let manager = RateLimiterManager::new(config(5, 300), Some(store().await));
 
         // A fresh bucket is fully recovered. Dropping the handle leaves the map
         // as its only holder.
-        let a = MintUrl::from_str("https://a.example.com").unwrap();
-        drop(manager.bucket_for(&a));
+        drop(manager.bucket_for(&parse("https://a.example.com")));
         assert_eq!(manager.origin_count(), 1);
 
         // Creating a bucket for a different origin sweeps the recovered,
         // unreferenced A out, so only B remains.
-        let b = MintUrl::from_str("https://b.example.com").unwrap();
-        let _b = manager.bucket_for(&b);
+        let _b = manager.bucket_for(&parse("https://b.example.com"));
         assert_eq!(manager.origin_count(), 1);
     }
 
     #[tokio::test]
     async fn manager_retains_referenced_bucket() {
-        let store: Arc<dyn WalletDatabase<database::Error> + Send + Sync> =
-            Arc::new(cdk_sqlite::wallet::memory::empty().await.unwrap());
-        let manager = RateLimiterManager::new(config(5, 300), store);
+        let manager = RateLimiterManager::new(config(5, 300), Some(store().await));
 
         // Hold a live clone of A: even though A is fully recovered, a live
-        // holder must keep it so co-active wallets never split budgets.
-        let a = MintUrl::from_str("https://a.example.com").unwrap();
-        let _held = manager.bucket_for(&a);
+        // holder must keep it so co-active callers never split budgets.
+        let _held = manager.bucket_for(&parse("https://a.example.com"));
 
-        let b = MintUrl::from_str("https://b.example.com").unwrap();
-        let _b = manager.bucket_for(&b);
+        let _b = manager.bucket_for(&parse("https://b.example.com"));
         assert_eq!(manager.origin_count(), 2);
     }
 
     #[tokio::test]
     async fn manager_retains_unrecovered_bucket() {
-        let store: Arc<dyn WalletDatabase<database::Error> + Send + Sync> =
-            Arc::new(cdk_sqlite::wallet::memory::empty().await.unwrap());
-        let manager = RateLimiterManager::new(config(5, 300), store);
+        let manager = RateLimiterManager::new(config(5, 300), Some(store().await));
 
         // Drain A past its burst so it carries debt, then drop the handle: it is
         // unreferenced but not yet recovered, so it must be kept.
-        let a = MintUrl::from_str("https://a.example.com").unwrap();
-        let bucket_a = manager.bucket_for(&a);
+        let bucket_a = manager.bucket_for(&parse("https://a.example.com"));
         for _ in 0..5 {
             bucket_a.try_acquire().await;
         }
         drop(bucket_a);
 
-        let b = MintUrl::from_str("https://b.example.com").unwrap();
-        let _b = manager.bucket_for(&b);
+        let _b = manager.bucket_for(&parse("https://b.example.com"));
         assert_eq!(manager.origin_count(), 2);
     }
 
@@ -116,12 +110,11 @@ mod persistence_tests {
     async fn shared_bucket_survives_concurrent_writers() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
-        let store: Arc<dyn WalletDatabase<database::Error> + Send + Sync> =
-            Arc::new(cdk_sqlite::wallet::memory::empty().await.unwrap());
-        let url = MintUrl::from_str("https://concurrent.example.com").unwrap();
+        let store = store().await;
+        let url = parse("https://concurrent.example.com/v1/info");
         // capacity 5, emission ~200ms so the inherited budget paces measurably.
         let cfg = config(5, 300);
-        let manager = RateLimiterManager::new(cfg, store.clone());
+        let manager = RateLimiterManager::new(cfg, Some(store.clone()));
 
         // Two handles to the same origin, as two currency-unit wallets hold.
         let a = manager.bucket_for(&url);
@@ -151,13 +144,13 @@ mod persistence_tests {
             "concurrent handles share one burst, not one each"
         );
 
-        // The single writer persists the drained budget; a fresh instance over
+        // The single writer persists the drained budget; a fresh manager over
         // the same store inherits it (does not reset to full), proving no
         // concurrent writer overwrote it back to a staler value.
         a.flush().await;
         drop((a, b, manager));
 
-        let fresh = TokenBucket::for_mint(cfg, &url, store.clone());
+        let fresh = RateLimiterManager::new(cfg, Some(store)).bucket_for(&url);
         let start = Instant::now();
         fresh.acquire(async {}).await;
         fresh.acquire(async {}).await;
@@ -170,14 +163,14 @@ mod persistence_tests {
 
     #[tokio::test]
     async fn budget_persists_across_instances() {
-        let store: Arc<dyn WalletDatabase<database::Error> + Send + Sync> =
-            Arc::new(cdk_sqlite::wallet::memory::empty().await.unwrap());
-        let url = MintUrl::from_str("https://persist.example.com").unwrap();
+        let store = store().await;
+        // A path the mint would never use, to show the budget follows the host.
+        let url = parse("https://persist.example.com/.well-known/lnurlp/alice");
         // capacity 2, emission ~200ms so the pace signal clears scheduler noise.
         let cfg = config(2, 300);
 
         // Drain the first bucket's burst, flush it to the store, then drop it.
-        let first = TokenBucket::for_mint(cfg, &url, store.clone());
+        let first = RateLimiterManager::new(cfg, Some(store.clone())).bucket_for(&url);
         first.acquire(async {}).await;
         first.acquire(async {}).await;
         first.flush().await;
@@ -185,7 +178,7 @@ mod persistence_tests {
 
         // A second bucket for the same host inherits the drained budget: it is
         // at the burst edge, so two acquires take about one emission interval.
-        let second = TokenBucket::for_mint(cfg, &url, store.clone());
+        let second = RateLimiterManager::new(cfg, Some(store)).bucket_for(&url);
         let start = Instant::now();
         second.acquire(async {}).await;
         second.acquire(async {}).await;

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -143,14 +143,14 @@ pub struct Wallet {
     seed: [u8; 64],
     client: Arc<dyn MintConnector + Send + Sync>,
     subscription: SubscriptionManager,
-    /// Handle to the shared client-side rate limiter, when the wallet paces any
-    /// of the clients it builds.
+    /// Handle to the client-side rate limiter, when the wallet paces any of the
+    /// clients it builds.
     ///
     /// `None` when rate limiting was disabled, or when a custom client replaced
-    /// the transport and no rate-limited auth client remains. Cloning the bucket
-    /// shares one budget, so this reconfigures the same limiter the transport
-    /// paces through.
-    rate_limit: Option<TokenBucket>,
+    /// the transport and no rate-limited auth client remains. Cloning the manager
+    /// shares its per-host budgets, so this reconfigures the same limiter the
+    /// transport paces through.
+    rate_limiter: Option<RateLimiterManager>,
 }
 
 const ALPHANUMERIC: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -293,35 +293,35 @@ impl Wallet {
 
     /// Replace the client-side rate-limit configuration at runtime.
     ///
-    /// Affects the shared budget of every client the wallet paces: the main
-    /// client, and the blind-auth client when the wallet was built from a CAT. It
-    /// is a no-op when the wallet paces nothing, either because rate limiting was
-    /// disabled ([`WalletBuilder::without_rate_limiting`]) or because a custom
-    /// client ([`WalletBuilder::client`]/[`WalletBuilder::shared_client`])
+    /// Applies to every host the wallet's limiter paces, not only the mint: the
+    /// buckets already in use and any created later. That includes third-party
+    /// hosts the wallet's transport reaches, such as an LNURL service or an OIDC
+    /// provider.
+    ///
+    /// It is a no-op when the wallet paces nothing, either because rate limiting
+    /// was disabled ([`WalletBuilder::without_rate_limiting`]) or because a
+    /// custom client ([`WalletBuilder::client`]/[`WalletBuilder::shared_client`])
     /// replaced the main transport and no rate-limited auth client remains. With
     /// a custom main client plus a CAT it reconfigures only the blind-auth
     /// client's pacing.
     ///
-    /// When the wallet was built through a
-    /// [`WalletRepository`], its bucket is
-    /// shared with every other wallet at the same mint origin, so this
-    /// reconfigures the pacing for all of that origin's currency units at once.
+    /// When the wallet was built through a [`WalletRepository`], the limiter is
+    /// shared with every other wallet in that repository, so this reconfigures
+    /// pacing repository-wide.
     pub fn set_rate_limiting_config(&self, config: RateLimitConfig) {
-        if let Some(bucket) = &self.rate_limit {
-            bucket.set_config(config);
+        if let Some(limiter) = &self.rate_limiter {
+            limiter.set_config(config);
         }
     }
 
     /// Disable client-side rate limiting at runtime.
     ///
-    /// Affects the same clients as [`Wallet::set_rate_limiting_config`]: a no-op
-    /// when the wallet paces nothing, and with a custom main client plus a CAT it
-    /// disables only the blind-auth client's pacing. For a repository-built
-    /// wallet the bucket is shared, so this disables pacing for every currency
-    /// unit at that mint origin.
+    /// Has the same reach as [`Wallet::set_rate_limiting_config`]: every host the
+    /// wallet's limiter paces, repository-wide for a repository-built wallet, and
+    /// a no-op when the wallet paces nothing.
     pub fn disable_rate_limiting(&self) {
-        if let Some(bucket) = &self.rate_limit {
-            bucket.set_enabled(false);
+        if let Some(limiter) = &self.rate_limiter {
+            limiter.set_enabled(false);
         }
     }
 

--- a/crates/cdk/src/wallet/wallet_repository.rs
+++ b/crates/cdk/src/wallet/wallet_repository.rs
@@ -233,7 +233,10 @@ impl WalletRepositoryBuilder {
         let seed = self.seed.ok_or(Error::Custom("seed is required".into()))?;
 
         let wallet = WalletRepository {
-            rate_limiter: RateLimiterManager::new(RateLimitConfig::default(), localstore.clone()),
+            rate_limiter: RateLimiterManager::new(
+                RateLimitConfig::default(),
+                Some(localstore.clone()),
+            ),
             localstore,
             seed,
             wallets: Arc::new(RwLock::new(BTreeMap::new())),
@@ -298,10 +301,11 @@ fn validate_proxy_url(proxy_url: &url::Url) -> Result<(), Error> {
 /// access to individual Wallet instances. Each wallet is uniquely identified
 /// by the combination of mint URL and currency unit.
 ///
-/// Wallets that target the same mint origin (host + non-default port) share one
-/// live rate-limit budget through the repository's [`RateLimiterManager`],
-/// regardless of currency unit, so they pace one combined burst instead of each
-/// getting a full one.
+/// Every wallet shares the repository's [`RateLimiterManager`], which keys
+/// budgets by the host each request is addressed to. Wallets at one mint pace
+/// one combined burst regardless of currency unit, and traffic to a third-party
+/// host (an LNURL service, an OIDC provider) paces against that host's own
+/// budget rather than any mint's.
 #[derive(Clone)]
 pub struct WalletRepository {
     /// Storage backend
@@ -309,8 +313,8 @@ pub struct WalletRepository {
     seed: [u8; 64],
     /// Wallets indexed by (mint URL, currency unit)
     wallets: Arc<RwLock<BTreeMap<WalletKey, Wallet>>>,
-    /// Hands out one shared rate-limit budget per mint origin, so every wallet
-    /// at an origin paces one combined burst regardless of currency unit.
+    /// Hands out one shared rate-limit budget per destination host, injected
+    /// into every wallet this repository builds.
     rate_limiter: RateLimiterManager,
     /// Proxy configuration for HTTP clients (optional)
     proxy_config: Option<url::Url>,
@@ -616,10 +620,6 @@ impl WalletRepository {
         let metadata_cache_ttl = config.and_then(|c| c.metadata_cache_ttl);
         let configured_auth_connector = config.and_then(|c| c.auth_connector.clone());
 
-        // One shared budget per mint origin: every unit at this mint paces one
-        // combined burst instead of each wallet building its own bucket.
-        let rate_limit_bucket = self.rate_limiter.bucket_for(&mint_url);
-
         // Check if custom connector is provided in config
         if let Some(cfg) = config {
             if let Some(custom_connector) = &cfg.mint_connector {
@@ -630,7 +630,7 @@ impl WalletRepository {
                     .localstore(self.localstore.clone())
                     .seed(self.seed)
                     .target_proof_count(target_proof_count)
-                    .with_rate_limit_bucket(rate_limit_bucket.clone())
+                    .with_rate_limiter(self.rate_limiter.clone())
                     .shared_client(custom_connector.clone());
 
                 if let Some(auth_connector) = configured_auth_connector.clone() {
@@ -667,7 +667,7 @@ impl WalletRepository {
                 .localstore(self.localstore.clone())
                 .seed(self.seed)
                 .target_proof_count(target_proof_count)
-                .with_rate_limit_bucket(rate_limit_bucket.clone())
+                .with_rate_limiter(self.rate_limiter.clone())
                 .client(client)
                 .auth_connector(auth_connector);
 
@@ -699,7 +699,7 @@ impl WalletRepository {
                     .localstore(self.localstore.clone())
                     .seed(self.seed)
                     .target_proof_count(target_proof_count)
-                    .with_rate_limit_bucket(rate_limit_bucket.clone())
+                    .with_rate_limiter(self.rate_limiter.clone())
                     .client(client)
                     .auth_connector(auth_connector);
 
@@ -716,7 +716,7 @@ impl WalletRepository {
                     .localstore(self.localstore.clone())
                     .seed(self.seed)
                     .target_proof_count(target_proof_count)
-                    .with_rate_limit_bucket(rate_limit_bucket.clone());
+                    .with_rate_limiter(self.rate_limiter.clone());
 
                 if let Some(auth_connector) = configured_auth_connector.clone() {
                     builder = builder.auth_connector(auth_connector);
@@ -738,7 +738,7 @@ impl WalletRepository {
                     .localstore(self.localstore.clone())
                     .seed(self.seed)
                     .target_proof_count(target_proof_count)
-                    .with_rate_limit_bucket(rate_limit_bucket.clone());
+                    .with_rate_limiter(self.rate_limiter.clone());
 
                 if let Some(auth_connector) = configured_auth_connector.clone() {
                     builder = builder.auth_connector(auth_connector);
@@ -1346,6 +1346,15 @@ mod tests {
     // exceeds test wall-clock, so no slot is earned back mid-test.
     const DEFAULT_BURST: usize = 20;
 
+    /// Resolve the bucket a wallet's requests to `url` would draw from.
+    fn bucket_for(wallet: &Wallet, url: &str) -> crate::wallet::TokenBucket {
+        wallet
+            .rate_limiter
+            .clone()
+            .expect("default path retains its limiter")
+            .bucket_for(&url::Url::parse(url).expect("valid url"))
+    }
+
     #[tokio::test]
     async fn wallets_for_same_mint_share_one_rate_limit_budget() {
         let repo = create_test_repository().await;
@@ -1360,14 +1369,8 @@ mod tests {
             .await
             .expect("failed to create usd wallet");
 
-        let sat_bucket = sat
-            .rate_limit
-            .clone()
-            .expect("default path retains its bucket");
-        let usd_bucket = usd
-            .rate_limit
-            .clone()
-            .expect("default path retains its bucket");
+        let sat_bucket = bucket_for(&sat, "https://mint.example.com/v1/mint");
+        let usd_bucket = bucket_for(&usd, "https://mint.example.com/v1/melt");
 
         // Interleave across the two handles: sharing one budget means the two
         // together drain a single burst, not one each.
@@ -1408,8 +1411,8 @@ mod tests {
             .create_wallet(mint_b, CurrencyUnit::Sat, None)
             .await
             .expect("failed to create wallet b");
-        let bucket_a = wallet_a.rate_limit.clone().expect("bucket a");
-        let bucket_b = wallet_b.rate_limit.clone().expect("bucket b");
+        let bucket_a = bucket_for(&wallet_a, "https://mint-a.example.com/v1/info");
+        let bucket_b = bucket_for(&wallet_b, "https://mint-b.example.com/v1/info");
 
         for _ in 0..DEFAULT_BURST {
             assert!(bucket_a.try_acquire().await);
@@ -1421,6 +1424,53 @@ mod tests {
         assert!(
             bucket_b.try_acquire().await,
             "mint B has an untouched budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn third_party_hosts_pace_against_their_own_budget() {
+        // A wallet's transport also carries LNURL and OIDC traffic. That must
+        // neither spend the mint's budget nor be paced by it, and two wallets at
+        // different mints hitting one service must share that service's budget.
+        let repo = create_test_repository().await;
+        let wallet_a = repo
+            .create_wallet(
+                "https://mint-a.example.com".parse().unwrap(),
+                CurrencyUnit::Sat,
+                None,
+            )
+            .await
+            .expect("failed to create wallet a");
+        let wallet_b = repo
+            .create_wallet(
+                "https://mint-b.example.com".parse().unwrap(),
+                CurrencyUnit::Sat,
+                None,
+            )
+            .await
+            .expect("failed to create wallet b");
+
+        let mint_bucket = bucket_for(&wallet_a, "https://mint-a.example.com/v1/info");
+        let lnurl = "https://pay.example.org/.well-known/lnurlp/alice";
+        let lnurl_bucket = bucket_for(&wallet_a, lnurl);
+
+        // Spending the mint's whole burst leaves the LNURL host untouched.
+        for _ in 0..DEFAULT_BURST {
+            assert!(mint_bucket.try_acquire().await);
+        }
+        assert!(!mint_bucket.try_acquire().await);
+        assert!(
+            lnurl_bucket.try_acquire().await,
+            "the LNURL host keeps its own budget"
+        );
+
+        // Wallet B, a different mint entirely, draws from the same LNURL budget.
+        for _ in 0..(DEFAULT_BURST - 1) {
+            assert!(bucket_for(&wallet_b, lnurl).try_acquire().await);
+        }
+        assert!(
+            !bucket_for(&wallet_b, lnurl).try_acquire().await,
+            "the LNURL host's budget is shared across mints"
         );
     }
 
@@ -1438,8 +1488,8 @@ mod tests {
             .await
             .expect("failed to create usd wallet");
 
-        let sat_bucket = sat.rate_limit.clone().expect("bucket");
-        let usd_bucket = usd.rate_limit.clone().expect("bucket");
+        let sat_bucket = bucket_for(&sat, "https://mint.example.com/v1/mint");
+        let usd_bucket = bucket_for(&usd, "https://mint.example.com/v1/melt");
 
         // Drain the whole burst through the Sat handle; the Usd handle sees an
         // already-spent budget because they share one bucket.


### PR DESCRIPTION
### Description

Fixes #2313

RateLimitedTransport held one fixed bucket and paced every request through it, whatever the target. A wallet's transport also carries LNURL fetches and OIDC discovery, token, and JWKS calls, so those burned the mint's budget and were themselves paced by it. A request cap belongs to the host being called, not to the wallet doing the calling.

RateLimiterManager is now what gets injected into the wallet's HTTP clients, and the transport resolves a bucket from each request URL's origin. Wallets at one mint still share that mint's budget; a third-party host gets its own, shared by whoever calls it.

Runtime toggles move to the manager, so disabling rate limiting stops all pacing rather than just the mint's, and is repository-wide for a repository-built wallet. Persistence is unchanged in shape: every origin contacted keeps its budget under the same KV namespace.


<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
