### PR TITLE
fix(mint): persist pending melt recovery handoffs

### DIFF
--- a/crates/cdk-common/src/mint.rs
+++ b/crates/cdk-common/src/mint.rs
@@ -164,6 +164,8 @@ pub enum MeltSagaState {
     SetupComplete,
     /// Payment attempted to Lightning network (may or may not have succeeded)
     PaymentAttempted,
+    /// Backend acknowledged an in-flight payment and recovery may poll it
+    PaymentPending,
     /// TX1 committed (proofs Spent, quote Paid) - change signing + cleanup pending
     Finalizing,
 }
@@ -173,6 +175,7 @@ impl fmt::Display for MeltSagaState {
         match self {
             MeltSagaState::SetupComplete => write!(f, "setup_complete"),
             MeltSagaState::PaymentAttempted => write!(f, "payment_attempted"),
+            MeltSagaState::PaymentPending => write!(f, "payment_pending"),
             MeltSagaState::Finalizing => write!(f, "finalizing"),
         }
     }
@@ -185,6 +188,7 @@ impl FromStr for MeltSagaState {
         match value.as_str() {
             "setup_complete" => Ok(MeltSagaState::SetupComplete),
             "payment_attempted" => Ok(MeltSagaState::PaymentAttempted),
+            "payment_pending" => Ok(MeltSagaState::PaymentPending),
             "finalizing" => Ok(MeltSagaState::Finalizing),
             _ => Err(Error::Custom(format!("Invalid melt saga state: {}", value))),
         }
@@ -225,6 +229,7 @@ impl SagaStateEnum {
             SagaStateEnum::Melt(state) => match state {
                 MeltSagaState::SetupComplete => "setup_complete",
                 MeltSagaState::PaymentAttempted => "payment_attempted",
+                MeltSagaState::PaymentPending => "payment_pending",
                 MeltSagaState::Finalizing => "finalizing",
             },
         }

--- a/crates/cdk/src/mint/melt/melt_saga/mod.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/mod.rs
@@ -84,7 +84,14 @@ mod tests;
 /// - Compensation is NOT executed (would cause fund loss)
 /// - Startup check will verify payment status with LN backend
 /// - If payment succeeded: finalize is retried
-/// - If payment failed: compensation runs
+/// - If payment explicitly failed: compensation runs
+/// - If payment is merely unpaid: proofs stay pending because dispatch may
+///   have happened before the backend acknowledged it
+///
+/// **After backend acknowledgement (PaymentPending state):**
+/// - Recovery polls the durable payment lookup id
+/// - If payment succeeded: finalize is retried
+/// - If payment failed or is unpaid: compensation runs
 ///
 /// This two-phase approach prevents fund loss where the mint pays the LN invoice
 /// but returns the proofs to the user.
@@ -93,7 +100,8 @@ mod tests;
 ///
 /// Unlike swap, melt must handle uncertain payment states:
 /// - **Paid**: Proceed to finalize
-/// - **Failed/Unpaid**: Compensate and return error
+/// - **Failed**: Compensate and return error
+/// - **Unpaid**: Compensate only after a durable `PaymentPending` handoff
 /// - **Pending/Unknown**: Proofs remain pending, saga cannot complete
 ///   (leave proofs pending for startup check to resolve)
 ///
@@ -101,7 +109,8 @@ mod tests;
 ///
 /// The saga persists its state for crash recovery:
 /// - **SetupComplete**: Payment was never attempted → safe to compensate
-/// - **PaymentAttempted**: Payment may have succeeded → must check LN backend
+/// - **PaymentAttempted**: Dispatch is ambiguous → only Paid/Failed is terminal
+/// - **PaymentPending**: Backend acknowledged the attempt → poll until terminal
 ///
 /// On startup, the recovery process checks the persisted saga state and takes
 /// appropriate action to either finalize (if payment succeeded) or compensate
@@ -630,7 +639,7 @@ impl MeltSaga<SetupComplete> {
                             "Lightning payment for quote {} unknown.",
                             self.state_data.quote.id
                         );
-                        self.persist_pending_payment_lookup_id(&response.payment_lookup_id)
+                        self.persist_payment_handoff(&response.payment_lookup_id, false)
                             .await;
                         return Ok(PaymentOutcome::Pending {
                             #[cfg(feature = "prometheus")]
@@ -642,7 +651,7 @@ impl MeltSaga<SetupComplete> {
                             "LN payment pending, proofs remain pending for quote: {}",
                             self.state_data.quote.id
                         );
-                        self.persist_pending_payment_lookup_id(&response.payment_lookup_id)
+                        self.persist_payment_handoff(&response.payment_lookup_id, true)
                             .await;
                         return Ok(PaymentOutcome::Pending {
                             #[cfg(feature = "prometheus")]
@@ -833,8 +842,10 @@ impl MeltSaga<SetupComplete> {
         Ok(check_response)
     }
 
-    /// Persists the backend's payment lookup id on the quote before the saga
-    /// parks the payment as pending.
+    /// Persists the backend's payment lookup id before parking the payment.
+    /// When the backend explicitly reports `Pending`, this also advances the
+    /// saga to `PaymentPending`. An `Unknown` response leaves the saga at
+    /// `PaymentAttempted` because dispatch remains ambiguous.
     ///
     /// For bolt12 melts the quote is created with `request_lookup_id: None`
     /// (no invoice exists until `make_payment`), so the id returned by the
@@ -848,18 +859,20 @@ impl MeltSaga<SetupComplete> {
     /// Best-effort: a database failure here is logged loudly but does not
     /// change the outcome — the payment is still pending and the in-process
     /// state is no worse than before.
-    async fn persist_pending_payment_lookup_id(
+    async fn persist_payment_handoff(
         &self,
         payment_lookup_id: &cdk_common::payment::PaymentIdentifier,
+        backend_acknowledged: bool,
     ) {
         let quote_id = &self.state_data.quote.id;
 
-        if self.state_data.quote.request_lookup_id.as_ref() == Some(payment_lookup_id) {
-            return;
-        }
-
         let result: Result<(), Error> = async {
             let mut tx = self.db.begin_transaction().await?;
+
+            let mut saga = tx
+                .get_saga_for_update(&self.operation_id)
+                .await?
+                .ok_or(Error::Internal)?;
 
             let mut quote = tx
                 .get_melt_quote(quote_id)
@@ -877,6 +890,14 @@ impl MeltSaga<SetupComplete> {
                     .await?;
             }
 
+            if backend_acknowledged {
+                tx.update_acquired_saga(
+                    &mut saga,
+                    SagaStateEnum::Melt(MeltSagaState::PaymentPending),
+                )
+                .await?;
+            }
+
             tx.commit().await?;
             Ok(())
         }
@@ -884,9 +905,9 @@ impl MeltSaga<SetupComplete> {
 
         if let Err(err) = result {
             tracing::error!(
-                "Failed to persist payment lookup id {} for pending melt quote {}: {}. \
-                 The pending payment cannot be polled from the database until a lookup id \
-                 is recorded; recovery may require manual intervention.",
+                "Failed to persist payment recovery handoff for lookup id {} and melt quote {}: {}. \
+                 The saga remains PaymentAttempted and recovery will fail closed; \
+                 manual intervention may be required.",
                 payment_lookup_id,
                 quote_id,
                 err

--- a/crates/cdk/src/mint/melt/melt_saga/tests.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/tests.rs
@@ -1784,7 +1784,12 @@ async fn test_payment_error_with_pending_check_does_not_compensate() {
     let outcome = payment_saga.make_payment(decision).await.unwrap();
 
     assert!(matches!(outcome, PaymentOutcome::Pending { .. }));
-    assert_saga_exists(&mint, &operation_id).await;
+    let pending_saga = assert_saga_exists(&mint, &operation_id).await;
+    assert_eq!(
+        pending_saga.state,
+        SagaStateEnum::Melt(MeltSagaState::PaymentPending),
+        "a backend Pending response should create a durable handoff"
+    );
     assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
 
     mint.recover_from_incomplete_melt_sagas()
@@ -2937,7 +2942,12 @@ async fn test_unknown_follow_up_after_payment_error_keeps_proofs_pending() {
     // recoverable and the proofs must stay reserved until the backend reports
     // a terminal state.
     assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
-    assert_saga_exists(&mint, &operation_id).await;
+    let pending_saga = assert_saga_exists(&mint, &operation_id).await;
+    assert_eq!(
+        pending_saga.state,
+        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted),
+        "a backend Unknown response must leave dispatch marked ambiguous"
+    );
 
     let stored_quote = mint
         .localstore

--- a/crates/cdk/src/mint/saga_recovery.rs
+++ b/crates/cdk/src/mint/saga_recovery.rs
@@ -127,7 +127,16 @@ pub(crate) async fn process_melt_saga_outcome(
                     )
                     .await;
                 }
-                MeltQuoteState::Pending | MeltQuoteState::Unknown => {
+                MeltQuoteState::Pending => {
+                    persist_payment_pending_handoff(saga, quote, &fresh_response, db).await?;
+                    tracing::info!(
+                        "Fresh payment status for melt quote {} is Pending; recorded durable handoff (saga {})",
+                        quote.id,
+                        saga.operation_id
+                    );
+                    return Ok(());
+                }
+                MeltQuoteState::Unknown => {
                     tracing::info!(
                         "Fresh payment status for melt quote {} is {}; leaving pending (saga {})",
                         quote.id,
@@ -137,6 +146,24 @@ pub(crate) async fn process_melt_saga_outcome(
                     return Ok(());
                 }
                 MeltQuoteState::Unpaid | MeltQuoteState::Failed => {}
+            }
+
+            if fresh_response.status == MeltQuoteState::Unpaid
+                && matches!(
+                    &saga.state,
+                    SagaStateEnum::Melt(MeltSagaState::PaymentAttempted)
+                )
+            {
+                // The process may have crashed after dispatch but before the
+                // backend returned a durable acknowledgement. Some backends
+                // report Unpaid when that attempt cannot yet be found, so only
+                // an explicit Failed result is safe to compensate here.
+                tracing::warn!(
+                    "Melt quote {} is Unpaid but saga {} has only PaymentAttempted; leaving pending because dispatch remains ambiguous",
+                    quote.id,
+                    saga.operation_id
+                );
+                return Ok(());
             }
 
             tracing::info!(
@@ -184,7 +211,16 @@ pub(crate) async fn process_melt_saga_outcome(
 
             Ok(())
         }
-        MeltQuoteState::Pending | MeltQuoteState::Unknown => {
+        MeltQuoteState::Pending => {
+            persist_payment_pending_handoff(saga, quote, payment_response, db).await?;
+            tracing::debug!(
+                "Melt quote {} (saga {}) payment remains Pending; durable handoff recorded",
+                quote.id,
+                saga.operation_id
+            );
+            Ok(())
+        }
+        MeltQuoteState::Unknown => {
             tracing::debug!(
                 "Melt quote {} (saga {}) payment status still {}, skipping action",
                 quote.id,
@@ -194,6 +230,55 @@ pub(crate) async fn process_melt_saga_outcome(
             Ok(())
         }
     }
+}
+
+/// Records that the backend recognizes an in-flight payment. Unlike the
+/// write-ahead `PaymentAttempted` marker, `PaymentPending` makes a later
+/// `Unpaid` observation safe to compensate.
+async fn persist_payment_pending_handoff(
+    saga: &Saga,
+    quote: &mut MeltQuote,
+    payment_response: &MakePaymentResponse,
+    db: &cdk_common::database::DynMintDatabase,
+) -> Result<(), Error> {
+    if !matches!(
+        &saga.state,
+        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted)
+    ) {
+        return Ok(());
+    }
+
+    let mut tx = db.begin_transaction().await?;
+    let Some(mut current_saga) = tx.get_saga_for_update(&saga.operation_id).await? else {
+        tx.rollback().await?;
+        return Ok(());
+    };
+
+    if current_saga.state != SagaStateEnum::Melt(MeltSagaState::PaymentAttempted) {
+        tx.rollback().await?;
+        return Ok(());
+    }
+
+    let mut current_quote = tx
+        .get_melt_quote(&quote.id)
+        .await?
+        .ok_or(Error::UnknownQuote)?;
+    if current_quote.request_lookup_id.as_ref() != Some(&payment_response.payment_lookup_id) {
+        tx.update_melt_quote_request_lookup_id(
+            &mut current_quote,
+            &payment_response.payment_lookup_id,
+        )
+        .await?;
+    }
+    tx.update_acquired_saga(
+        &mut current_saga,
+        SagaStateEnum::Melt(MeltSagaState::PaymentPending),
+    )
+    .await?;
+    tx.commit().await?;
+
+    quote.request_lookup_id = Some(payment_response.payment_lookup_id.clone());
+    Ok(())
 }
 
 /// Persists the paid outcome as a durable `Finalizing` handoff, then runs the
@@ -477,6 +562,116 @@ mod tests {
             .unwrap()
             .expect("quote should still exist after rollback");
         assert_eq!(recovered_quote.state, MeltQuoteState::Unpaid);
+    }
+
+    #[tokio::test]
+    async fn test_unpaid_only_compensates_after_pending_handoff() {
+        async fn run_case(state: MeltSagaState, should_compensate: bool) {
+            let fake_description = FakeInvoiceDescription {
+                pay_invoice_state: MeltQuoteState::Unpaid,
+                check_payment_state: MeltQuoteState::Unpaid,
+                pay_err: false,
+                check_err: false,
+            };
+            let amount_msats: u64 = Amount::from(9_000).into();
+            let invoice = create_fake_invoice(
+                amount_msats,
+                serde_json::to_string(&fake_description).unwrap(),
+            );
+            let payment_states = std::collections::HashMap::from([(
+                invoice.payment_hash().to_string(),
+                (
+                    MeltQuoteState::Unpaid,
+                    Amount::from(9_000).with_unit(CurrencyUnit::Sat),
+                ),
+            )]);
+            let mint = create_test_mint_with_payment_states(payment_states)
+                .await
+                .unwrap();
+            let request = cdk_common::melt::MeltQuoteRequest::Bolt11(MeltQuoteBolt11Request {
+                request: invoice,
+                unit: CurrencyUnit::Sat,
+                options: None,
+            });
+            let quote_response = mint.get_melt_quote(request).await.unwrap();
+            let quote = mint
+                .localstore
+                .get_melt_quote(quote_response.quote().unwrap())
+                .await
+                .unwrap()
+                .expect("quote should exist");
+            let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+            let input_ys = proofs.ys().unwrap();
+            let melt_request = create_test_melt_request(&proofs, &quote);
+            let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+            let saga = MeltSaga::new(
+                std::sync::Arc::new(mint.clone()),
+                mint.localstore(),
+                mint.pubsub_manager(),
+            );
+            let setup_saga = saga
+                .setup_melt(
+                    &melt_request,
+                    verification,
+                    PaymentMethod::Known(KnownMethod::Bolt11),
+                )
+                .await
+                .unwrap();
+            let operation_id = assert_single_melt_saga_operation_id(&mint).await;
+            drop(setup_saga);
+
+            let mut tx = mint.localstore.begin_transaction().await.unwrap();
+            let mut acquired_saga = tx
+                .get_saga_for_update(&operation_id)
+                .await
+                .unwrap()
+                .expect("saga should exist");
+            tx.update_acquired_saga(&mut acquired_saga, SagaStateEnum::Melt(state))
+                .await
+                .unwrap();
+            tx.commit().await.unwrap();
+
+            let saga = assert_saga_exists(&mint, &operation_id).await;
+            let mut quote = mint
+                .localstore
+                .get_melt_quote(&quote.id)
+                .await
+                .unwrap()
+                .expect("quote should exist");
+            let payment_response = MakePaymentResponse {
+                payment_lookup_id: quote
+                    .request_lookup_id
+                    .clone()
+                    .expect("bolt11 quote should have a lookup id"),
+                payment_proof: None,
+                status: MeltQuoteState::Unpaid,
+                total_spent: quote.amount(),
+            };
+
+            process_melt_saga_outcome(
+                &saga,
+                &mut quote,
+                &payment_response,
+                &mint.localstore,
+                &mint.pubsub_manager,
+                &mint,
+            )
+            .await
+            .unwrap();
+
+            if should_compensate {
+                assert_saga_not_exists(&mint, &operation_id).await;
+                assert_proofs_state(&mint, &input_ys, None).await;
+                assert_eq!(quote.state, MeltQuoteState::Unpaid);
+            } else {
+                assert_saga_exists(&mint, &operation_id).await;
+                assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+                assert_eq!(quote.state, MeltQuoteState::Pending);
+            }
+        }
+
+        run_case(MeltSagaState::PaymentAttempted, false).await;
+        run_case(MeltSagaState::PaymentPending, true).await;
     }
 
     #[tokio::test]

--- a/crates/cdk/src/mint/start_up_check.rs
+++ b/crates/cdk/src/mint/start_up_check.rs
@@ -394,8 +394,8 @@ impl Mint {
     /// - **Finalize**: If payment was confirmed as PAID on the LN backend, the
     ///   saga already reached `Finalizing`, or the melt settled internally
     /// - **Compensate**: If the saga is `SetupComplete` (payment never
-    ///   attempted) or the LN backend confirms UNPAID/FAILED for a payment
-    ///   that was attempted
+    ///   attempted), the backend explicitly confirms FAILED, or it confirms
+    ///   UNPAID after the saga durably reached `PaymentPending`
     /// - **Skip**: If payment is PENDING/UNKNOWN, or its status cannot be
     ///   verified (e.g. `PaymentAttempted` without a lookup id — left pending
     ///   for manual intervention rather than risking a premature refund)
@@ -560,7 +560,7 @@ impl Mint {
 
             // Check saga state to determine if payment was attempted
             // SetupComplete means setup transaction committed but payment NOT yet attempted
-            // PaymentAttempted means payment was attempted - must check LN backend
+            // PaymentAttempted/PaymentPending means payment was attempted - must check LN backend
             let should_compensate = match &saga.state {
                 cdk_common::mint::SagaStateEnum::Melt(state) => {
                     match state {
@@ -639,11 +639,13 @@ impl Mint {
                             );
                             continue;
                         }
-                        cdk_common::mint::MeltSagaState::PaymentAttempted => {
+                        cdk_common::mint::MeltSagaState::PaymentAttempted
+                        | cdk_common::mint::MeltSagaState::PaymentPending => {
                             // Payment was attempted - check for internal settlement first, then LN backend
                             tracing::info!(
-                                "Saga {} in PaymentAttempted state - checking for internal or external payment",
-                                saga.operation_id
+                                "Saga {} in {} state - checking for internal or external payment",
+                                saga.operation_id,
+                                state
                             );
 
                             // Check if this was an internal settlement by looking for a mint quote


### PR DESCRIPTION
### What changed

- Add a durable `PaymentPending` melt saga state.
- Persist the backend lookup identifier together with the pending handoff.
- Keep `PaymentAttempted + Unpaid` pending because dispatch may not yet be
  visible to the backend.
- Allow `Unpaid` compensation only after the backend has acknowledged the
  payment through `PaymentPending`.
- Record pending acknowledgements discovered by live processing or restart
  recovery.
- Add focused state-transition and compensation regression tests.

### Why

`PaymentAttempted` proves only that dispatch may have started. A backend can
temporarily return `Unpaid` before it recognizes that request, so recovery
cannot safely return proofs from that observation alone.

`PaymentPending` records the backend acknowledgement that makes a later
terminal `Unpaid` result safe to compensate, without adding an idempotency key
or periodic polling.

### Stack

This is PR 3 of 3. Merge in this order:

1. [#2337 — acquired saga mutations](https://github.com/cashubtc/cdk/pull/2337)
2. [#2338 — core melt recovery hardening](https://github.com/cashubtc/cdk/pull/2338)
3. [#2339 — durable pending-payment handoffs](https://github.com/cashubtc/cdk/pull/2339) (this PR)

This PR targets the branch from #2338 so its diff contains only the durable
handoff layer. After #2338 merges, retarget this PR to `main`.

### Validation

- `cargo test -p cdk --lib` — 604 tests
- `cargo test -p cdk-common --lib` — 130 tests
- `cargo test -p cdk-sqlite --lib` — 138 tests
- `cargo clippy -p cdk -p cdk-common -p cdk-sqlite --all-targets -- -D warnings`
