### PR TITLE
fix(nut17)!: harden WebSocket notification handling

### DIFF
--- a/crates/cashu/src/nuts/nut17/ws.rs
+++ b/crates/cashu/src/nuts/nut17/ws.rs
@@ -8,21 +8,14 @@ use super::{NotificationPayload, Params};
 /// JSON RPC version
 pub const JSON_RPC_VERSION: &str = "2.0";
 
-/// The response to a subscription request
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// The result returned after a subscription or unsubscription request.
+///
+/// NUT-17 uses the same result shape for both methods. Clients that need to
+/// distinguish them must correlate the response's JSON-RPC request ID with the
+/// request they sent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound = "I: Serialize + DeserializeOwned")]
-pub struct WsSubscribeResponse<I> {
-    /// Status
-    pub status: String,
-    /// Subscription ID
-    #[serde(rename = "subId")]
-    pub sub_id: I,
-}
-
-/// The response to an unsubscription request
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound = "I: Serialize + DeserializeOwned")]
-pub struct WsUnsubscribeResponse<I> {
+pub struct WsResponseResult<I> {
     /// Status
     pub status: String,
     /// Subscription ID
@@ -67,29 +60,6 @@ pub struct RawNotificationInner<I> {
 
     /// The raw notification payload
     pub payload: serde_json::Value,
-}
-
-/// Responses from the web socket server
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound = "I: Serialize + DeserializeOwned")]
-#[serde(untagged)]
-pub enum WsResponseResult<I> {
-    /// A response to a subscription request
-    Subscribe(WsSubscribeResponse<I>),
-    /// Unsubscribe
-    Unsubscribe(WsUnsubscribeResponse<I>),
-}
-
-impl<I> From<WsSubscribeResponse<I>> for WsResponseResult<I> {
-    fn from(response: WsSubscribeResponse<I>) -> Self {
-        WsResponseResult::Subscribe(response)
-    }
-}
-
-impl<I> From<WsUnsubscribeResponse<I>> for WsResponseResult<I> {
-    fn from(response: WsUnsubscribeResponse<I>) -> Self {
-        WsResponseResult::Unsubscribe(response)
-    }
 }
 
 /// The request to unsubscribe
@@ -231,7 +201,37 @@ impl<I> From<(usize, Result<WsResponseResult<I>, WsErrorBody>)> for WsMessageOrR
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
+
+    #[test]
+    fn response_result_uses_shared_nut17_acknowledgement_shape() {
+        let encoded = json!({
+            "jsonrpc": "2.0",
+            "result": {
+                "status": "OK",
+                "subId": "sub-id"
+            },
+            "id": 7
+        });
+
+        let decoded: WsResponse<String> =
+            serde_json::from_value(encoded.clone()).expect("NUT-17 response");
+
+        assert_eq!(decoded.id, 7);
+        assert_eq!(
+            decoded.result,
+            WsResponseResult {
+                status: "OK".to_string(),
+                sub_id: "sub-id".to_string(),
+            }
+        );
+        assert_eq!(
+            serde_json::to_value(decoded).expect("serialized NUT-17 response"),
+            encoded
+        );
+    }
 
     #[test]
     fn raw_ws_message_deserializes_notification_payload_as_json() {

--- a/crates/cdk-axum/src/ws/subscribe.rs
+++ b/crates/cdk-axum/src/ws/subscribe.rs
@@ -1,5 +1,5 @@
 use cdk::subscription::Params;
-use cdk::ws::{WsResponseResult, WsSubscribeResponse};
+use cdk::ws::WsResponseResult;
 
 use super::{WsContext, WsError, MAX_FILTERS_PER_SUBSCRIPTION, MAX_SUBSCRIPTIONS_PER_CONNECTION};
 
@@ -51,9 +51,8 @@ pub(crate) async fn handle(
             }
         }),
     );
-    Ok(WsSubscribeResponse {
+    Ok(WsResponseResult {
         status: "OK".to_string(),
         sub_id,
-    }
-    .into())
+    })
 }

--- a/crates/cdk-axum/src/ws/unsubscribe.rs
+++ b/crates/cdk-axum/src/ws/unsubscribe.rs
@@ -1,4 +1,4 @@
-use cdk::ws::{WsResponseResult, WsUnsubscribeRequest, WsUnsubscribeResponse};
+use cdk::ws::{WsResponseResult, WsUnsubscribeRequest};
 
 use super::{WsContext, WsError};
 
@@ -8,11 +8,10 @@ pub(crate) async fn handle(
 ) -> Result<WsResponseResult, WsError> {
     if let Some(handle) = context.subscriptions.remove(&req.sub_id) {
         handle.abort();
-        Ok(WsUnsubscribeResponse {
+        Ok(WsResponseResult {
             status: "OK".to_string(),
             sub_id: req.sub_id,
-        }
-        .into())
+        })
     } else {
         Err(WsError::InvalidParams)
     }

--- a/crates/cdk-common/src/ws.rs
+++ b/crates/cdk-common/src/ws.rs
@@ -20,14 +20,8 @@ pub type WsUnsubscribeRequest = nut17::ws::WsUnsubscribeRequest<SubId>;
 /// Notification message sent over websocket
 pub type WsNotification = nut17::ws::WsNotification<SubId>;
 
-/// Response to a subscription request
-pub type WsSubscribeResponse = nut17::ws::WsSubscribeResponse<SubId>;
-
 /// Result part of a websocket response
 pub type WsResponseResult = nut17::ws::WsResponseResult<SubId>;
-
-/// Response to an unsubscribe request
-pub type WsUnsubscribeResponse = nut17::ws::WsUnsubscribeResponse<SubId>;
 
 /// Generic websocket request
 pub type WsRequest = nut17::ws::WsRequest<SubId>;

--- a/crates/cdk/src/wallet/subscription.rs
+++ b/crates/cdk/src/wallet/subscription.rs
@@ -202,7 +202,7 @@ impl SubscriptionClient {
             .ok()
     }
 
-    fn get_unsub_request(&self, sub_id: String) -> Option<String> {
+    fn get_unsub_request(&self, sub_id: String) -> Option<(usize, String)> {
         let request: WsRequest<_> = (
             WsMethodRequest::Unsubscribe(WsUnsubscribeRequest { sub_id }),
             self.req_id
@@ -210,22 +210,13 @@ impl SubscriptionClient {
         )
             .into();
 
-        match serde_json::to_string(&request) {
-            Ok(json) => Some(json),
-            Err(err) => {
+        serde_json::to_string(&request)
+            .inspect_err(|err| {
                 tracing::error!("Could not serialize unsubscribe message: {:?}", err);
-                None
-            }
-        }
+            })
+            .map(|json| (request.id, json))
+            .ok()
     }
-}
-
-fn decode_notification_payload(
-    kind: &Kind,
-    payload: serde_json::Value,
-) -> Result<NotificationPayload, PubsubError> {
-    deserialize_payload_for_kind::<String, serde_json::Error>(kind, payload)
-        .map_err(|err| PubsubError::ParsingError(err.to_string()))
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -234,7 +225,7 @@ impl Transport for SubscriptionClient {
     type Spec = MintSubTopics;
 
     fn new_name(&self) -> <Self::Spec as Spec>::SubscriptionId {
-        Uuid::new_v4().to_string()
+        new_subscription_id()
     }
 
     async fn stream(
@@ -476,6 +467,10 @@ impl Transport for SubscriptionClient {
     }
 }
 
+fn new_subscription_id() -> String {
+    Uuid::now_v7().to_string()
+}
+
 async fn stream_client(
     client: &SubscriptionClient,
     mut ctrl: mpsc::Receiver<StreamCtrl<MintSubTopics>>,
@@ -483,6 +478,7 @@ async fn stream_client(
     reply_to: InternalRelay<MintSubTopics>,
 ) -> Result<(), PubsubError> {
     let mut sub_id_to_kind = HashMap::new();
+    let mut pending_requests = HashMap::new();
 
     let mut url = client
         .mint_url
@@ -541,14 +537,15 @@ async fn stream_client(
 
     for (name, index) in topics {
         let kind = SubscriptionClient::subscription_kind(&index);
-        let (_, req) = if let Some(req) = client.get_sub_request(name.clone(), index) {
+        let (request_id, req) = if let Some(req) = client.get_sub_request(name.clone(), index) {
             req
         } else {
             continue;
         };
 
-        sub_id_to_kind.insert(name, kind);
+        sub_id_to_kind.insert(name.clone(), kind);
         sender.send(req).await.map_err(map_ws_error)?;
+        pending_requests.insert(request_id, PendingRequest::Subscribe { sub_id: name });
     }
 
     loop {
@@ -557,22 +554,30 @@ async fn stream_client(
                 match msg {
                     StreamCtrl::Subscribe(msg) => {
                         let kind = SubscriptionClient::subscription_kind(&msg.1);
-                        let (_, req) = if let Some(req) = client.get_sub_request(msg.0.clone(), msg.1) {
+                        let (request_id, req) = if let Some(req) = client.get_sub_request(msg.0.clone(), msg.1) {
                             req
                         } else {
                             continue;
                         };
-                        sub_id_to_kind.insert(msg.0, kind);
+                        sub_id_to_kind.insert(msg.0.clone(), kind);
                         sender.send(req).await.map_err(map_ws_error)?;
+                        pending_requests.insert(
+                            request_id,
+                            PendingRequest::Subscribe { sub_id: msg.0 },
+                        );
                     }
                     StreamCtrl::Unsubscribe(msg) => {
                         sub_id_to_kind.remove(&msg);
-                        let req = if let Some(req) = client.get_unsub_request(msg) {
+                        let (request_id, req) = if let Some(req) = client.get_unsub_request(msg.clone()) {
                             req
                         } else {
                             continue;
                         };
                         sender.send(req).await.map_err(map_ws_error)?;
+                        pending_requests.insert(
+                            request_id,
+                            PendingRequest::Unsubscribe { sub_id: msg },
+                        );
                     }
                     StreamCtrl::Stop => {
                         if let Err(err) = sender.close().await {
@@ -612,21 +617,97 @@ async fn stream_client(
                             continue;
                         };
 
-                        let payload = decode_notification_payload(
+                        if let Some(payload) = decode_notification_payload_for_stream(
                             kind,
+                            &payload.params.sub_id,
                             payload.params.payload.clone(),
-                        )?;
-                        reply_to.send(payload);
+                        ) {
+                            reply_to.send(payload);
+                        }
                     }
                     RawWsMessageOrResponse::Response(response) => {
-                        tracing::debug!("Received response from server: {:?}", response);
+                        let Some(request) = pending_requests.remove(&response.id) else {
+                            tracing::warn!(
+                                "Received websocket response for unknown request id {}",
+                                response.id
+                            );
+                            continue;
+                        };
+
+                        if response.result.sub_id != request.sub_id() {
+                            tracing::warn!(
+                                "Received {} response for subId {}, expected {}",
+                                request.method(),
+                                response.result.sub_id,
+                                request.sub_id()
+                            );
+                            continue;
+                        }
+
+                        tracing::debug!(
+                            "Received {} response from server for subId {} with status {}",
+                            request.method(),
+                            response.result.sub_id,
+                            response.result.status
+                        );
                     }
                     RawWsMessageOrResponse::ErrorResponse(error) => {
-                        tracing::debug!("Received an error from server: {:?}", error);
+                        match pending_requests.remove(&error.id) {
+                            Some(request) => tracing::debug!(
+                                "Received an error from server for {} request and subId {}: {}",
+                                request.method(),
+                                request.sub_id(),
+                                error.error.message
+                            ),
+                            None => tracing::debug!(
+                                "Received an error from server for unknown request id {}: {}",
+                                error.id,
+                                error.error.message
+                            ),
+                        }
                         return Err(PubsubError::InternalStr(error.error.message));
                     }
                 }
             }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PendingRequest {
+    Subscribe { sub_id: String },
+    Unsubscribe { sub_id: String },
+}
+
+impl PendingRequest {
+    fn method(&self) -> &'static str {
+        match self {
+            Self::Subscribe { .. } => "subscribe",
+            Self::Unsubscribe { .. } => "unsubscribe",
+        }
+    }
+
+    fn sub_id(&self) -> &str {
+        match self {
+            Self::Subscribe { sub_id } | Self::Unsubscribe { sub_id } => sub_id,
+        }
+    }
+}
+
+fn decode_notification_payload_for_stream(
+    kind: &Kind,
+    sub_id: &str,
+    payload: serde_json::Value,
+) -> Option<NotificationPayload> {
+    match deserialize_payload_for_kind::<String, serde_json::Error>(kind, payload) {
+        Ok(payload) => Some(payload),
+        Err(err) => {
+            tracing::warn!(
+                "Dropping unsupported websocket notification for subId {}: {}",
+                sub_id,
+                err
+            );
+            None
         }
     }
 }
@@ -644,6 +725,36 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn nut17_subscription_ids_use_uuid_v7() {
+        let id = Uuid::parse_str(&new_subscription_id()).expect("valid subscription UUID");
+
+        assert_eq!(id.get_version_num(), 7);
+    }
+
+    #[test]
+    fn unsupported_notification_does_not_block_the_next_notification() {
+        let unsupported = json!({
+            "Y": "02194603ffa062682c4f10e2dfe8f53e17d5d0329db51c8d3935cc74a4c0e0d4cb",
+            "state": "FUTURE_STATE",
+            "witness": null
+        });
+        let supported = json!({
+            "Y": "02194603ffa062682c4f10e2dfe8f53e17d5d0329db51c8d3935cc74a4c0e0d4cb",
+            "state": "UNSPENT",
+            "witness": null
+        });
+
+        assert!(
+            decode_notification_payload_for_stream(&Kind::ProofState, "sub-id", unsupported)
+                .is_none()
+        );
+        assert!(matches!(
+            decode_notification_payload_for_stream(&Kind::ProofState, "sub-id", supported),
+            Some(NotificationPayload::ProofState(_))
+        ));
+    }
 
     #[test]
     fn transient_websocket_failure_keeps_streaming_enabled() {
@@ -674,7 +785,9 @@ mod tests {
             "witness": null
         });
 
-        let decoded = decode_notification_payload(&Kind::ProofState, payload).unwrap();
+        let decoded =
+            deserialize_payload_for_kind::<String, serde_json::Error>(&Kind::ProofState, payload)
+                .unwrap();
 
         assert!(matches!(decoded, NotificationPayload::ProofState(_)));
     }
@@ -699,10 +812,16 @@ mod tests {
             "payment_proof": "abc"
         });
 
-        let mint_decoded =
-            decode_notification_payload(&Kind::Bolt11MintQuote, mint_payload).unwrap();
-        let melt_decoded =
-            decode_notification_payload(&Kind::Bolt11MeltQuote, melt_payload).unwrap();
+        let mint_decoded = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::Bolt11MintQuote,
+            mint_payload,
+        )
+        .unwrap();
+        let melt_decoded = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::Bolt11MeltQuote,
+            melt_payload,
+        )
+        .unwrap();
 
         assert!(matches!(
             mint_decoded,
@@ -737,10 +856,16 @@ mod tests {
             "unit": "sat"
         });
 
-        let mint_decoded =
-            decode_notification_payload(&Kind::Bolt12MintQuote, mint_payload).unwrap();
-        let melt_decoded =
-            decode_notification_payload(&Kind::Bolt12MeltQuote, melt_payload).unwrap();
+        let mint_decoded = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::Bolt12MintQuote,
+            mint_payload,
+        )
+        .unwrap();
+        let melt_decoded = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::Bolt12MeltQuote,
+            melt_payload,
+        )
+        .unwrap();
 
         assert!(matches!(
             mint_decoded,
@@ -767,7 +892,11 @@ mod tests {
             "state": "future-extension"
         });
 
-        let decoded = decode_notification_payload(&Kind::OnchainMintQuote, payload).unwrap();
+        let decoded = deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::OnchainMintQuote,
+            payload,
+        )
+        .unwrap();
 
         assert!(matches!(
             decoded,
@@ -804,8 +933,12 @@ mod tests {
             "extra_field": "value"
         });
 
-        let mint_decoded = decode_notification_payload(&mint_kind, mint_payload).unwrap();
-        let melt_decoded = decode_notification_payload(&melt_kind, melt_payload).unwrap();
+        let mint_decoded =
+            deserialize_payload_for_kind::<String, serde_json::Error>(&mint_kind, mint_payload)
+                .unwrap();
+        let melt_decoded =
+            deserialize_payload_for_kind::<String, serde_json::Error>(&melt_kind, melt_payload)
+                .unwrap();
 
         assert!(matches!(
             mint_decoded,
@@ -821,10 +954,11 @@ mod tests {
 
     #[test]
     fn decode_unknown_custom_kind_errors() {
-        let err = decode_notification_payload(&Kind::Custom("foo_status".to_string()), json!({}))
-            .unwrap_err();
-
-        assert!(matches!(err, PubsubError::ParsingError(_)));
+        assert!(deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::Custom("foo_status".to_string()),
+            json!({}),
+        )
+        .is_err());
     }
 
     #[test]
@@ -835,8 +969,10 @@ mod tests {
             "witness": null
         });
 
-        let err = decode_notification_payload(&Kind::Bolt12MintQuote, payload).unwrap_err();
-
-        assert!(matches!(err, PubsubError::ParsingError(_)));
+        assert!(deserialize_payload_for_kind::<String, serde_json::Error>(
+            &Kind::Bolt12MintQuote,
+            payload,
+        )
+        .is_err());
     }
 }


### PR DESCRIPTION
Keep WebSocket streams alive when a notification contains an unsupported or malformed nested value. Correlate shared subscribe and unsubscribe acknowledgements through JSON-RPC request IDs and generate UUID v7 subscription IDs.

BREAKING CHANGE: WsResponseResult is now the shared acknowledgement struct rather than an enum with indistinguishable subscribe and unsubscribe variants.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
