### PR TITLE
feat(mint): advertise the maximum request array length

### DIFF
--- a/crates/cashu/src/nuts/nut06.rs
+++ b/crates/cashu/src/nuts/nut06.rs
@@ -107,6 +107,9 @@ pub struct MintInfo {
     /// terms of url service of the mint
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tos_url: Option<String>,
+    /// max length the mint accepts for any array in a request
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_array_length: Option<u64>,
 }
 
 impl MintInfo {
@@ -217,6 +220,14 @@ impl MintInfo {
     {
         Self {
             tos_url: Some(tos_url.into()),
+            ..self
+        }
+    }
+
+    /// Set max_array_length
+    pub fn max_array_length(self, max_array_length: u64) -> Self {
+        Self {
+            max_array_length: Some(max_array_length),
             ..self
         }
     }
@@ -753,7 +764,8 @@ mod tests {
             .icon_url("https://example.com/icon.png")
             .motd("hello")
             .time(123_u64)
-            .tos_url("https://example.com/tos");
+            .tos_url("https://example.com/tos")
+            .max_array_length(1000);
 
         assert_eq!(info.name.as_deref(), Some("Test mint"));
         assert_eq!(info.pubkey, Some(pubkey));
@@ -772,6 +784,7 @@ mod tests {
         assert_eq!(info.motd.as_deref(), Some("hello"));
         assert_eq!(info.time, Some(123));
         assert_eq!(info.tos_url.as_deref(), Some("https://example.com/tos"));
+        assert_eq!(info.max_array_length, Some(1000));
     }
 
     #[test]

--- a/crates/cdk-ffi/src/types/mint.rs
+++ b/crates/cdk-ffi/src/types/mint.rs
@@ -637,6 +637,8 @@ pub struct MintInfo {
     pub time: Option<u64>,
     /// terms of url service of the mint
     pub tos_url: Option<String>,
+    /// max length the mint accepts for any array in a request
+    pub max_array_length: Option<u64>,
 }
 
 impl From<cdk::nuts::MintInfo> for MintInfo {
@@ -656,6 +658,7 @@ impl From<cdk::nuts::MintInfo> for MintInfo {
             motd: info.motd,
             time: info.time,
             tos_url: info.tos_url,
+            max_array_length: info.max_array_length,
         }
     }
 }
@@ -679,6 +682,7 @@ impl TryFrom<MintInfo> for cdk::nuts::MintInfo {
             motd: info.motd,
             time: info.time,
             tos_url: info.tos_url,
+            max_array_length: info.max_array_length,
         })
     }
 }
@@ -1107,6 +1111,7 @@ mod tests {
             motd: None,
             time: None,
             tos_url: None,
+            max_array_length: None,
         };
 
         let result = cdk::nuts::MintInfo::try_from(ffi_mint_info);

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -1092,6 +1092,8 @@ where
                     motd,
                     time,
                     tos_url,
+                    // Not persisted: a runtime hint the mint recomputes, refreshed with /v1/info.
+                    max_array_length: _,
                 } = mint_info;
 
                 (
@@ -2029,6 +2031,7 @@ fn sql_row_to_mint_info(row: Vec<Column>) -> Result<MintInfo, Error> {
         motd: column_as_nullable_string!(motd),
         time: column_as_nullable_number!(mint_time).map(|t| t),
         tos_url: column_as_nullable_string!(tos_url),
+        max_array_length: None,
     })
 }
 

--- a/crates/cdk-supabase/src/wallet.rs
+++ b/crates/cdk-supabase/src/wallet.rs
@@ -2503,6 +2503,8 @@ impl TryInto<MintInfo> for MintTable {
             motd: self.motd,
             time: self.mint_time.map(|t| t as u64),
             tos_url: self.tos_url,
+            // Not persisted: a runtime hint the mint recomputes, refreshed with /v1/info.
+            max_array_length: None,
         })
     }
 }

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -749,7 +749,7 @@ impl Mint {
 
         let mint_info: MintInfo = serde_json::from_slice(&mint_info)?;
 
-        let mint_info = if let Some(auth_db) = self.auth_localstore.as_ref() {
+        let mut mint_info = if let Some(auth_db) = self.auth_localstore.as_ref() {
             let mut mint_info = mint_info;
             let auth_endpoints = auth_db.get_auth_for_endpoints().await?;
 
@@ -781,6 +781,11 @@ impl Mint {
         } else {
             mint_info
         };
+
+        // Derived from the running limits rather than stored config, so it cannot drift from what
+        // the endpoints actually enforce. One figure for both, so a wallet respecting it trips
+        // neither cap.
+        mint_info.max_array_length = Some(self.max_inputs.min(self.max_outputs) as u64);
 
         Ok(mint_info)
     }


### PR DESCRIPTION
Implements cashubtc/nuts#425.

Adds the optional [NUT-06](https://github.com/cashubtc/nuts/blob/main/06.md) `max_array_length` to `/v1/info` so wallets can size their batches up front instead of discovering the cap by getting an error partway through a request.

`Mint::mint_info` serves the lower of `max_inputs` and `max_outputs`, so a wallet that respects the figure trips neither. It is derived at read time rather than stored in the config, so it cannot drift from what `check_state`, `restore` and `verification` actually enforce.

