### PR TITLE
Let callers choose request pacing when a wallet is built

### DIFF
--- a/bindings/dart/test/wallet_test.dart
+++ b/bindings/dart/test/wallet_test.dart
@@ -64,6 +64,71 @@ void main() {
     }
   });
 
+  Wallet rateLimitedWallet(RateLimit? rateLimit) => Wallet(
+    mintUrl: 'https://mint.example.com',
+    unit: SatCurrencyUnit(),
+    mnemonic: generateMnemonic(),
+    store: SqliteWalletStore(':memory:'),
+    config: WalletConfig(targetProofCount: null, rateLimit: rateLimit),
+  );
+
+  test('rate limit defaults to pacing', () {
+    // Omitting the field is the backwards-compatible spelling and must keep
+    // selecting the built-in default.
+    final omitted = Wallet(
+      mintUrl: 'https://mint.example.com',
+      unit: SatCurrencyUnit(),
+      mnemonic: generateMnemonic(),
+      store: SqliteWalletStore(':memory:'),
+      config: WalletConfig(targetProofCount: null),
+    );
+    try {
+      expect(omitted.isRateLimited(), isTrue);
+    } finally {
+      omitted.dispose();
+    }
+
+    final explicit = rateLimitedWallet(DefaultRateLimit());
+    try {
+      expect(explicit.isRateLimited(), isTrue);
+    } finally {
+      explicit.dispose();
+    }
+  });
+
+  test('rate limit can be disabled and re-enabled', () {
+    final wallet = rateLimitedWallet(DisabledRateLimit());
+    try {
+      expect(wallet.isRateLimited(), isFalse);
+      wallet.setRateLimit(rateLimit: DefaultRateLimit());
+      expect(wallet.isRateLimited(), isTrue);
+    } finally {
+      wallet.dispose();
+    }
+  });
+
+  test('custom rate limit paces the wallet', () {
+    final wallet = rateLimitedWallet(
+      CustomRateLimit(capacity: 5, refillPerMinute: 30),
+    );
+    try {
+      expect(wallet.isRateLimited(), isTrue);
+    } finally {
+      wallet.dispose();
+    }
+  });
+
+  test('zero rate limit values are rejected', () {
+    expect(
+      () => rateLimitedWallet(CustomRateLimit(capacity: 0, refillPerMinute: 30)),
+      throwsA(isA<FfiException>()),
+    );
+    expect(
+      () => rateLimitedWallet(CustomRateLimit(capacity: 5, refillPerMinute: 0)),
+      throwsA(isA<FfiException>()),
+    );
+  });
+
   test(
     'mint flow',
     () async {

--- a/bindings/go/cdk_test.go
+++ b/bindings/go/cdk_test.go
@@ -84,6 +84,89 @@ func TestInMemorySqliteConcurrentAccess(t *testing.T) {
 	}
 }
 
+func newRateLimitedWallet(rateLimit *RateLimit) (*Wallet, error) {
+	mnemonic, err := GenerateMnemonic()
+	if err != nil {
+		return nil, err
+	}
+	return NewWallet(
+		"https://mint.example.com",
+		CurrencyUnitSat{},
+		mnemonic,
+		WalletStoreSqlite{Path: ":memory:"},
+		WalletConfig{TargetProofCount: nil, RateLimit: rateLimit},
+	)
+}
+
+func TestRateLimitDefaultsToPacing(t *testing.T) {
+	// A nil rate limit is the backwards-compatible spelling and must keep
+	// selecting the built-in default.
+	omitted, err := newRateLimitedWallet(nil)
+	if err != nil {
+		t.Fatalf("NewWallet: %v", err)
+	}
+	defer omitted.Destroy()
+	if !omitted.IsRateLimited() {
+		t.Error("an omitted rate limit should pace by default")
+	}
+
+	var def RateLimit = RateLimitDefault{}
+	explicit, err := newRateLimitedWallet(&def)
+	if err != nil {
+		t.Fatalf("NewWallet: %v", err)
+	}
+	defer explicit.Destroy()
+	if !explicit.IsRateLimited() {
+		t.Error("Default should pace the wallet")
+	}
+}
+
+func TestRateLimitCanBeDisabledAndReEnabled(t *testing.T) {
+	var disabled RateLimit = RateLimitDisabled{}
+	w, err := newRateLimitedWallet(&disabled)
+	if err != nil {
+		t.Fatalf("NewWallet: %v", err)
+	}
+	defer w.Destroy()
+
+	if w.IsRateLimited() {
+		t.Error("Disabled should not pace")
+	}
+
+	if err := w.SetRateLimit(RateLimitDefault{}); err != nil {
+		t.Fatalf("SetRateLimit: %v", err)
+	}
+	if !w.IsRateLimited() {
+		t.Error("a wallet built disabled should be re-enablable")
+	}
+}
+
+func TestCustomRateLimitPaces(t *testing.T) {
+	var custom RateLimit = RateLimitCustom{Capacity: 5, RefillPerMinute: 30}
+	w, err := newRateLimitedWallet(&custom)
+	if err != nil {
+		t.Fatalf("NewWallet: %v", err)
+	}
+	defer w.Destroy()
+
+	if !w.IsRateLimited() {
+		t.Error("Custom should pace the wallet")
+	}
+}
+
+func TestZeroRateLimitValuesAreRejected(t *testing.T) {
+	for _, rl := range []RateLimit{
+		RateLimitCustom{Capacity: 0, RefillPerMinute: 30},
+		RateLimitCustom{Capacity: 5, RefillPerMinute: 0},
+	} {
+		rl := rl
+		if w, err := newRateLimitedWallet(&rl); err == nil {
+			w.Destroy()
+			t.Errorf("%v should be rejected", rl)
+		}
+	}
+}
+
 func TestMintFlow(t *testing.T) {
 	w := newTestWallet(t, tempDBPath(t))
 	defer w.Destroy()

--- a/bindings/kotlin/cdk-jvm/src/test/kotlin/org/cashudevkit/WalletTest.kt
+++ b/bindings/kotlin/cdk-jvm/src/test/kotlin/org/cashudevkit/WalletTest.kt
@@ -65,6 +65,71 @@ class WalletTest {
         }
     }
 
+    private fun rateLimitedWallet(rateLimit: RateLimit?): Wallet = Wallet(
+        mintUrl = "https://mint.example.com",
+        unit = CurrencyUnit.Sat,
+        mnemonic = generateMnemonic(),
+        store = WalletStore.Sqlite(path = ":memory:"),
+        config = WalletConfig(targetProofCount = null, rateLimit = rateLimit),
+    )
+
+    @Test
+    fun `rate limit defaults to pacing`() {
+        // Omitting the field is the backwards-compatible spelling and must keep
+        // selecting the built-in default.
+        val omitted = Wallet(
+            mintUrl = "https://mint.example.com",
+            unit = CurrencyUnit.Sat,
+            mnemonic = generateMnemonic(),
+            store = WalletStore.Sqlite(path = ":memory:"),
+            config = WalletConfig(targetProofCount = null),
+        )
+        try {
+            assertTrue(omitted.isRateLimited())
+        } finally {
+            omitted.close()
+        }
+
+        val explicit = rateLimitedWallet(RateLimit.Default)
+        try {
+            assertTrue(explicit.isRateLimited())
+        } finally {
+            explicit.close()
+        }
+    }
+
+    @Test
+    fun `rate limit can be disabled and re-enabled`() {
+        val disabled = rateLimitedWallet(RateLimit.Disabled)
+        try {
+            assertFalse(disabled.isRateLimited())
+            disabled.setRateLimit(RateLimit.Default)
+            assertTrue(disabled.isRateLimited())
+        } finally {
+            disabled.close()
+        }
+    }
+
+    @Test
+    fun `custom rate limit paces the wallet`() {
+        val custom = rateLimitedWallet(RateLimit.Custom(capacity = 5U, refillPerMinute = 30U))
+        try {
+            assertTrue(custom.isRateLimited())
+        } finally {
+            custom.close()
+        }
+    }
+
+    @Test
+    fun `zero rate limit values are rejected`() {
+        assertThrows(FfiException::class.java) {
+            rateLimitedWallet(RateLimit.Custom(capacity = 0U, refillPerMinute = 30U))
+        }
+        assertThrows(FfiException::class.java) {
+            rateLimitedWallet(RateLimit.Custom(capacity = 5U, refillPerMinute = 0U))
+        }
+    }
+
     @Test
     fun `mint flow`() = runBlocking {
         val quote = wallet.mintQuote(

--- a/bindings/swift/Tests/CdkTests.swift
+++ b/bindings/swift/Tests/CdkTests.swift
@@ -55,6 +55,58 @@ struct CdkTests {
         }
     }
 
+    private func rateLimitedWallet(_ rateLimit: RateLimit?) throws -> Wallet {
+        try Wallet(
+            mintUrl: "https://mint.example.com",
+            unit: .sat,
+            mnemonic: try generateMnemonic(),
+            store: .sqlite(path: ":memory:"),
+            config: WalletConfig(targetProofCount: nil, rateLimit: rateLimit)
+        )
+    }
+
+    @Test("Rate limit defaults to pacing")
+    func rateLimitDefaultsToPacing() throws {
+        // Omitting the field is the backwards-compatible spelling and must keep
+        // selecting the built-in default.
+        let omitted = try Wallet(
+            mintUrl: "https://mint.example.com",
+            unit: .sat,
+            mnemonic: try generateMnemonic(),
+            store: .sqlite(path: ":memory:"),
+            config: WalletConfig(targetProofCount: nil)
+        )
+        #expect(omitted.isRateLimited(), "An omitted rate limit should pace by default")
+
+        let explicit = try rateLimitedWallet(.default)
+        #expect(explicit.isRateLimited(), "Default should pace the wallet")
+    }
+
+    @Test("Rate limit can be disabled and re-enabled")
+    func rateLimitCanBeDisabledAndReEnabled() throws {
+        let wallet = try rateLimitedWallet(.disabled)
+        #expect(!wallet.isRateLimited(), "Disabled should not pace")
+
+        try wallet.setRateLimit(rateLimit: .default)
+        #expect(wallet.isRateLimited(), "A wallet built disabled should be re-enablable")
+    }
+
+    @Test("Custom rate limit paces the wallet")
+    func customRateLimitPaces() throws {
+        let wallet = try rateLimitedWallet(.custom(capacity: 5, refillPerMinute: 30))
+        #expect(wallet.isRateLimited(), "Custom should pace the wallet")
+    }
+
+    @Test("Zero rate limit values are rejected")
+    func zeroRateLimitValuesAreRejected() throws {
+        #expect(throws: (any Error).self) {
+            try rateLimitedWallet(.custom(capacity: 0, refillPerMinute: 30))
+        }
+        #expect(throws: (any Error).self) {
+            try rateLimitedWallet(.custom(capacity: 5, refillPerMinute: 0))
+        }
+    }
+
     @Test("Mint flow completes successfully")
     func mintFlow() async throws {
         let quote = try await wallet.mintQuote(

--- a/crates/cdk-common/src/rate_limit.rs
+++ b/crates/cdk-common/src/rate_limit.rs
@@ -587,6 +587,12 @@ impl RateLimiterManager {
         }
     }
 
+    /// Whether pacing is currently on. Reports the manager-wide toggle, which
+    /// every bucket created later inherits.
+    pub fn is_enabled(&self) -> bool {
+        lock(&self.settings).enabled
+    }
+
     /// Wait until every budget drawn down so far has been handed to the store.
     ///
     /// The shutdown barrier for a wallet lifecycle owner: without it, the final
@@ -1201,6 +1207,18 @@ mod tests {
         let newest = manager.bucket_for(&parse("https://third.example.net"));
         assert!(newest.try_acquire().await);
         assert!(!newest.try_acquire().await, "new bucket inherits config");
+    }
+
+    #[tokio::test]
+    async fn manager_reports_whether_pacing_is_on() {
+        let manager = RateLimiterManager::new(config(1, 60), None);
+        assert!(manager.is_enabled(), "a fresh manager paces");
+
+        manager.set_enabled(false);
+        assert!(!manager.is_enabled());
+
+        manager.set_config(config(2, 120));
+        assert!(manager.is_enabled(), "set_config re-enables pacing");
     }
 
     #[tokio::test]

--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -21,6 +21,8 @@ use crate::mint_url::MintUrl;
 use crate::nuts::{
     CurrencyUnit, Id, MeltQuoteState, MintQuoteState, SecretKey, SpendingConditions, State,
 };
+#[cfg(feature = "http")]
+use crate::rate_limit::RateLimitConfig;
 use crate::{Amount, Error};
 
 pub mod saga;
@@ -1187,6 +1189,29 @@ pub trait Wallet: Send + Sync {
     /// before requiring a refresh from the mint server.
     /// If `None`, cache never expires and is always used.
     fn set_metadata_cache_ttl(&self, ttl_secs: Option<u64>);
+
+    /// Configure client-side request pacing, or turn it off with `None`.
+    ///
+    /// Reaches every host the wallet paces, not only its mint, and is
+    /// repository-wide when the wallet came from a wallet repository, since
+    /// those share one limiter. `None` then `Some` is a reversible toggle.
+    #[cfg(feature = "http")]
+    fn set_rate_limiting_config(&self, config: Option<RateLimitConfig>);
+
+    /// Whether requests from this wallet are being paced right now.
+    ///
+    /// Also false when a custom transport left the limiter wired to nothing,
+    /// which is what silently makes [`Self::set_rate_limiting_config`] a no-op.
+    #[cfg(feature = "http")]
+    fn is_rate_limited(&self) -> bool;
+
+    /// Wait until the rate-limit budget drawn down so far has been persisted.
+    ///
+    /// Persistence is otherwise best effort, so a caller that rebuilds the
+    /// wallet or tears down the runtime without this barrier can lose the final
+    /// write and start the next wallet with a full burst.
+    #[cfg(feature = "http")]
+    async fn flush_rate_limits(&self);
 
     /// Subscribe to wallet events
     async fn subscribe(

--- a/crates/cdk-ffi/src/lib.rs
+++ b/crates/cdk-ffi/src/lib.rs
@@ -501,11 +501,13 @@ mod tests {
     fn test_wallet_config() {
         let config = WalletConfig {
             target_proof_count: None,
+            rate_limit: None,
         };
         assert!(config.target_proof_count.is_none());
 
         let config_with_values = WalletConfig {
             target_proof_count: Some(5),
+            rate_limit: None,
         };
         assert_eq!(config_with_values.target_proof_count, Some(5));
     }

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -67,16 +67,32 @@ impl Wallet {
             .map_err(|e| FfiError::internal(format!("Invalid mnemonic: {}", e)))?;
         let seed = m.to_seed_normalized("");
 
-        let wallet = CdkWalletBuilder::new()
+        let requested = config
+            .rate_limit
+            .as_ref()
+            .map(RateLimit::to_config)
+            .transpose()?;
+        let pace_with = requested.map(|config| config.unwrap_or_default());
+        let start_disabled = matches!(requested, Some(None));
+
+        let mut builder = CdkWalletBuilder::new()
             .mint_url(mint_url.parse().map_err(|e: cdk::mint_url::Error| {
                 FfiError::internal(format!("Invalid URL: {}", e))
             })?)
             .unit(unit.into())
             .localstore(localstore)
             .seed(seed)
-            .target_proof_count(config.target_proof_count.unwrap_or(3) as usize)
-            .build()
-            .map_err(FfiError::from)?;
+            .target_proof_count(config.target_proof_count.unwrap_or(3) as usize);
+
+        if let Some(config) = pace_with {
+            builder = builder.with_rate_limiting_config(config);
+        }
+
+        let wallet = builder.build().map_err(FfiError::from)?;
+
+        if start_disabled {
+            wallet.disable_rate_limiting();
+        }
 
         Ok(Self {
             inner: Arc::new(wallet),
@@ -118,35 +134,38 @@ impl Wallet {
 
     /// Change client-side request rate limiting on this wallet.
     ///
-    /// A new wallet is built with the default limiter enabled. Use this to
-    /// disable it, restore the default, or set a custom burst and refill. It
-    /// takes effect immediately and covers every host the wallet's limiter
-    /// paces, so it reaches the main and blind-auth clients as well as any
-    /// third-party host their transport reaches. For a wallet built through a
-    /// wallet repository the limiter is shared, so the change is
+    /// A new wallet starts with whatever `WalletConfig.rate_limit` selected. Use
+    /// this to disable pacing, restore the default, or set a custom burst and
+    /// refill. It takes effect immediately and covers every host the wallet's
+    /// limiter paces, so it reaches the main and blind-auth clients as well as
+    /// any third-party host their transport reaches. For a wallet built through
+    /// a wallet repository the limiter is shared, so the change is
     /// repository-wide.
     ///
     /// Returns an error if a `Custom` value has a zero field.
     pub fn set_rate_limit(&self, rate_limit: RateLimit) -> Result<(), FfiError> {
-        match rate_limit {
-            RateLimit::Default => self
-                .inner
-                .set_rate_limiting_config(RateLimitConfig::default()),
-            RateLimit::Disabled => self.inner.disable_rate_limiting(),
-            RateLimit::Custom {
-                capacity,
-                refill_per_minute,
-            } => {
-                let config =
-                    RateLimitConfig::try_new(capacity, refill_per_minute).ok_or_else(|| {
-                        FfiError::internal(
-                            "rate limit capacity and refill_per_minute must be non-zero",
-                        )
-                    })?;
-                self.inner.set_rate_limiting_config(config);
-            }
+        match rate_limit.to_config()? {
+            Some(config) => self.inner.set_rate_limiting_config(config),
+            None => self.inner.disable_rate_limiting(),
         }
         Ok(())
+    }
+
+    /// Whether this wallet's requests are being paced right now.
+    ///
+    /// Also false when the wallet paces nothing at all, which is the case
+    /// [`Wallet::set_rate_limit`] silently ignores.
+    pub fn is_rate_limited(&self) -> bool {
+        self.inner.is_rate_limited()
+    }
+
+    /// Wait until the rate-limit budget this wallet drew down has been stored.
+    ///
+    /// Await this before dropping the wallet on shutdown. Without it,
+    /// persistence is best effort and a rebuild can outrun the detached writer,
+    /// so the rebuilt wallet starts with a full burst against the mint's cap.
+    pub async fn flush_rate_limits(&self) {
+        self.inner.flush_rate_limits().await;
     }
 
     /// Get total balance
@@ -969,9 +988,10 @@ impl Wallet {
 
 /// Client-side request pacing for a wallet's mint traffic.
 ///
-/// A new wallet always starts with the built-in default pacing so it stays
-/// under a mint's per-minute request cap. Pass one of these to
-/// [`Wallet::set_rate_limit`] to change it on a live wallet.
+/// A wallet starts with whatever [`WalletConfig::rate_limit`] selected, which
+/// defaults to the built-in pacing so it stays under a mint's per-minute request
+/// cap. Pass one of these to [`Wallet::set_rate_limit`] to change it on a live
+/// wallet.
 ///
 /// # Example
 ///
@@ -1003,10 +1023,38 @@ pub enum RateLimit {
     },
 }
 
+impl RateLimit {
+    /// Translate into the native config, where `None` means pacing is off.
+    ///
+    /// The only place a zero-valued `Custom` is rejected, since the native
+    /// config's fields are non-zero by construction.
+    pub(crate) fn to_config(&self) -> Result<Option<RateLimitConfig>, FfiError> {
+        match self {
+            RateLimit::Default => Ok(Some(RateLimitConfig::default())),
+            RateLimit::Disabled => Ok(None),
+            RateLimit::Custom {
+                capacity,
+                refill_per_minute,
+            } => RateLimitConfig::try_new(*capacity, *refill_per_minute)
+                .map(Some)
+                .ok_or_else(|| {
+                    FfiError::internal("rate limit capacity and refill_per_minute must be non-zero")
+                }),
+        }
+    }
+}
+
 /// Configuration for creating wallets
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct WalletConfig {
     pub target_proof_count: Option<u32>,
+    /// Client-side request pacing to start with. Omit it to keep the built-in
+    /// default, which paces the wallet under a mint's per-minute request cap.
+    ///
+    /// `Disabled` builds the limiter but leaves it off, so a later
+    /// [`Wallet::set_rate_limit`] can turn pacing back on.
+    #[uniffi(default = None)]
+    pub rate_limit: Option<RateLimit>,
 }
 
 /// Generates a new random mnemonic phrase
@@ -1033,19 +1081,24 @@ mod tests {
     use crate::database::custom_wallet_store;
     use crate::sqlite::WalletSqliteDatabase;
 
-    fn test_wallet() -> Wallet {
+    const MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    fn wallet_with(rate_limit: Option<RateLimit>) -> Result<Wallet, FfiError> {
         let db = WalletSqliteDatabase::new_in_memory().expect("in-memory wallet db should open");
         Wallet::new(
             "https://mint.example.com".to_string(),
             CurrencyUnit::Sat,
-            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-                .to_string(),
+            MNEMONIC.to_string(),
             custom_wallet_store(db),
             WalletConfig {
                 target_proof_count: None,
+                rate_limit,
             },
         )
-        .expect("wallet should be created")
+    }
+
+    fn test_wallet() -> Wallet {
+        wallet_with(None).expect("wallet should be created")
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1098,5 +1151,104 @@ mod tests {
                 refill_per_minute: 0,
             })
             .is_err());
+    }
+
+    #[test]
+    fn to_config_maps_every_variant() {
+        assert_eq!(
+            RateLimit::Default.to_config().expect("default is valid"),
+            Some(RateLimitConfig::default())
+        );
+        assert_eq!(
+            RateLimit::Disabled.to_config().expect("disabled is valid"),
+            None
+        );
+        assert_eq!(
+            RateLimit::Custom {
+                capacity: 5,
+                refill_per_minute: 30,
+            }
+            .to_config()
+            .expect("non-zero custom is valid"),
+            RateLimitConfig::try_new(5, 30)
+        );
+        assert!(RateLimit::Custom {
+            capacity: 0,
+            refill_per_minute: 30,
+        }
+        .to_config()
+        .is_err());
+        assert!(RateLimit::Custom {
+            capacity: 5,
+            refill_per_minute: 0,
+        }
+        .to_config()
+        .is_err());
+    }
+
+    #[test]
+    fn wallet_config_selects_the_starting_rate_limit() {
+        for rate_limit in [
+            None,
+            Some(RateLimit::Default),
+            Some(RateLimit::Custom {
+                capacity: 5,
+                refill_per_minute: 30,
+            }),
+        ] {
+            let wallet = wallet_with(rate_limit).expect("wallet should be created");
+            assert!(wallet.is_rate_limited());
+        }
+    }
+
+    #[test]
+    fn wallet_config_disabled_is_reversible() {
+        let wallet = wallet_with(Some(RateLimit::Disabled)).expect("wallet should be created");
+        assert!(!wallet.is_rate_limited());
+
+        wallet
+            .set_rate_limit(RateLimit::Default)
+            .expect("default is always valid");
+        assert!(
+            wallet.is_rate_limited(),
+            "a wallet built disabled still has a limiter to turn back on"
+        );
+    }
+
+    #[test]
+    fn wallet_config_rejects_zero_custom() {
+        assert!(wallet_with(Some(RateLimit::Custom {
+            capacity: 0,
+            refill_per_minute: 30,
+        }))
+        .is_err());
+        assert!(wallet_with(Some(RateLimit::Custom {
+            capacity: 5,
+            refill_per_minute: 0,
+        }))
+        .is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_rate_limits_is_available_on_wallet_and_trait() {
+        let wallet = test_wallet();
+
+        wallet.flush_rate_limits().await;
+        <Wallet as WalletTrait>::flush_rate_limits(&wallet).await;
+    }
+
+    #[test]
+    fn rate_limiting_round_trips_through_the_trait() {
+        let wallet = test_wallet();
+        assert!(<Wallet as WalletTrait>::is_rate_limited(&wallet));
+
+        <Wallet as WalletTrait>::set_rate_limiting_config(&wallet, None);
+        assert!(!<Wallet as WalletTrait>::is_rate_limited(&wallet));
+
+        <Wallet as WalletTrait>::set_rate_limiting_config(
+            &wallet,
+            Some(RateLimitConfig::default()),
+        );
+        assert!(<Wallet as WalletTrait>::is_rate_limited(&wallet));
     }
 }

--- a/crates/cdk-ffi/src/wallet_repository.rs
+++ b/crates/cdk-ffi/src/wallet_repository.rs
@@ -10,6 +10,22 @@ use cdk::wallet::wallet_repository::{
 
 use crate::error::FfiError;
 use crate::types::*;
+use crate::wallet::RateLimit;
+
+/// Configuration for creating a wallet repository.
+///
+/// Rate limiting is a repository-wide setting: every wallet the repository
+/// hands out shares one limiter, so there is no per-wallet equivalent.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct WalletRepositoryConfig {
+    /// Proxy used by every mint operation. Omit for a direct connection.
+    #[uniffi(default = None)]
+    pub proxy_url: Option<String>,
+    /// Client-side request pacing to start with. Omit it to keep the built-in
+    /// default.
+    #[uniffi(default = None)]
+    pub rate_limit: Option<RateLimit>,
+}
 
 /// FFI-compatible WalletRepository
 #[derive(uniffi::Object)]
@@ -86,6 +102,61 @@ impl WalletRepository {
                 .proxy_url(proxy_url)
                 .build()
                 .await
+        })?;
+
+        Ok(Self {
+            inner: Arc::new(wallet),
+        })
+    }
+
+    /// Create a new WalletRepository with proxy and rate-limit configuration.
+    ///
+    /// Construction restores locally persisted wallet state without making
+    /// network requests to configured mints.
+    #[uniffi::constructor]
+    pub fn new_with_config(
+        mnemonic: String,
+        store: crate::database::WalletStore,
+        config: WalletRepositoryConfig,
+    ) -> Result<Self, FfiError> {
+        let db = crate::database::resolve_wallet_store(store)?;
+
+        let m = Mnemonic::parse(&mnemonic)
+            .map_err(|e| FfiError::internal(format!("Invalid mnemonic: {}", e)))?;
+        let seed = m.to_seed_normalized("");
+
+        let localstore = crate::database::create_cdk_database_from_ffi(db);
+
+        let proxy_url = config
+            .proxy_url
+            .as_deref()
+            .map(url::Url::parse)
+            .transpose()
+            .map_err(|e| FfiError::internal(format!("Invalid URL: {}", e)))?;
+
+        let rate_limit = config
+            .rate_limit
+            .as_ref()
+            .map(RateLimit::to_config)
+            .transpose()?;
+
+        let rt = crate::runtime::RuntimeGuard::new().map_err(FfiError::internal)?;
+        let wallet = rt.block_on(async move {
+            let mut builder = WalletRepositoryBuilder::new()
+                .localstore(localstore)
+                .seed(seed);
+
+            if let Some(proxy_url) = proxy_url {
+                builder = builder.proxy_url(proxy_url);
+            }
+
+            builder = match rate_limit {
+                Some(Some(config)) => builder.with_rate_limiting_config(config),
+                Some(None) => builder.with_rate_limiting_disabled(),
+                None => builder,
+            };
+
+            builder.build().await
         })?;
 
         Ok(Self {
@@ -216,6 +287,28 @@ impl WalletRepository {
     /// mint's rate cap.
     pub async fn flush_rate_limits(&self) {
         self.inner.flush_rate_limits().await;
+    }
+
+    /// Change client-side request rate limiting for every wallet here.
+    ///
+    /// Pacing is repository-wide because one limiter is shared, which is why
+    /// `create_wallet` and `get_or_create_wallet` take no rate limit: a
+    /// per-wallet value would silently reconfigure its siblings. Repository
+    /// construction makes no network requests, so calling this immediately
+    /// after `new` is equivalent to configuring it through `new_with_config`.
+    ///
+    /// Returns an error if a `Custom` value has a zero field.
+    pub fn set_rate_limit(&self, rate_limit: RateLimit) -> Result<(), FfiError> {
+        self.inner.set_rate_limiting_config(rate_limit.to_config()?);
+        Ok(())
+    }
+
+    /// Whether this repository is pacing requests right now.
+    ///
+    /// Wallets reached through a proxy or Tor are built with a custom client,
+    /// so they report false even while this is true.
+    pub fn is_rate_limited(&self) -> bool {
+        self.inner.is_rate_limited()
     }
 
     /// Check if mint is in wallet
@@ -359,6 +452,74 @@ mod tests {
 
     fn mint_url() -> MintUrl {
         MintUrl::new("https://mint.example.com".to_string()).expect("valid mint url")
+    }
+
+    fn repository_with(rate_limit: Option<RateLimit>) -> Result<WalletRepository, FfiError> {
+        let db = WalletSqliteDatabase::new_in_memory().expect("in-memory wallet db should open");
+        WalletRepository::new_with_config(
+            MNEMONIC.to_string(),
+            custom_wallet_store(db),
+            WalletRepositoryConfig {
+                proxy_url: None,
+                rate_limit,
+            },
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn new_with_config_selects_the_starting_rate_limit() {
+        for rate_limit in [
+            None,
+            Some(RateLimit::Default),
+            Some(RateLimit::Custom {
+                capacity: 5,
+                refill_per_minute: 30,
+            }),
+        ] {
+            let repo = repository_with(rate_limit).expect("repository should be created");
+            assert!(repo.is_rate_limited());
+        }
+
+        let disabled =
+            repository_with(Some(RateLimit::Disabled)).expect("repository should be created");
+        assert!(!disabled.is_rate_limited());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn new_with_config_rejects_zero_custom() {
+        assert!(repository_with(Some(RateLimit::Custom {
+            capacity: 0,
+            refill_per_minute: 30,
+        }))
+        .is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn set_rate_limit_reaches_wallets_it_handed_out() {
+        let repo = repository_with(Some(RateLimit::Disabled)).expect("repository created");
+        let wallet = repo
+            .get_or_create_wallet(mint_url(), CurrencyUnit::Sat, None)
+            .await
+            .expect("wallet should be created");
+        assert!(!wallet.is_rate_limited());
+
+        repo.set_rate_limit(RateLimit::Default)
+            .expect("default is always valid");
+        assert!(
+            wallet.is_rate_limited(),
+            "wallets share the repository limiter"
+        );
+
+        repo.set_rate_limit(RateLimit::Disabled)
+            .expect("disabled is always valid");
+        assert!(!wallet.is_rate_limited());
+
+        assert!(repo
+            .set_rate_limit(RateLimit::Custom {
+                capacity: 5,
+                refill_per_minute: 0,
+            })
+            .is_err());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/cdk-ffi/src/wallet_trait.rs
+++ b/crates/cdk-ffi/src/wallet_trait.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 #[cfg(all(feature = "bip353", not(target_arch = "wasm32")))]
 use cdk_common::bitcoin;
+use cdk_common::rate_limit::RateLimitConfig;
 use cdk_common::wallet::Wallet as WalletTraitDef;
 
 use crate::error::FfiError;
@@ -463,6 +464,18 @@ impl WalletTraitDef for Wallet {
     fn set_metadata_cache_ttl(&self, ttl_secs: Option<u64>) {
         let ttl = ttl_secs.map(std::time::Duration::from_secs);
         self.inner().set_metadata_cache_ttl(ttl);
+    }
+
+    fn set_rate_limiting_config(&self, config: Option<RateLimitConfig>) {
+        WalletTraitDef::set_rate_limiting_config(self.inner().as_ref(), config);
+    }
+
+    fn is_rate_limited(&self) -> bool {
+        WalletTraitDef::is_rate_limited(self.inner().as_ref())
+    }
+
+    async fn flush_rate_limits(&self) {
+        WalletTraitDef::flush_rate_limits(self.inner().as_ref()).await;
     }
 
     async fn subscribe(

--- a/crates/cdk-ffi/tests/test_rate_limit.py
+++ b/crates/cdk-ffi/tests/test_rate_limit.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""
+Test suite for CDK FFI client-side rate-limit configuration
+
+Covers the default, disabled, custom and invalid configurations on both a
+directly constructed wallet and a repository-provided one. Every test is
+offline: building a wallet or a repository makes no network request.
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+
+# Setup paths before importing cdk_ffi
+repo_root = Path(__file__).parent.parent.parent.parent
+bindings_path = repo_root / "target" / "bindings" / "python"
+lib_path = repo_root / "target" / "release"
+
+lib_file = "libcdk_ffi.dylib" if sys.platform == "darwin" else "libcdk_ffi.so"
+src_lib = lib_path / lib_file
+dst_lib = bindings_path / lib_file
+
+if src_lib.exists() and not dst_lib.exists():
+    shutil.copy2(src_lib, dst_lib)
+
+# Add target/bindings/python to path to load cdk_ffi module
+sys.path.insert(0, str(bindings_path))
+
+import cdk_ffi
+
+MINT_URL = "https://mint.example.com"
+
+
+# Helper functions
+
+def make_wallet(config):
+    """Build a wallet backed by a fresh in-memory SQLite store"""
+    return cdk_ffi.Wallet(
+        mint_url=MINT_URL,
+        unit=cdk_ffi.CurrencyUnit.SAT(),
+        mnemonic=cdk_ffi.generate_mnemonic(),
+        store=cdk_ffi.sqlite_wallet_store(":memory:"),
+        config=config,
+    )
+
+
+def make_repository(config):
+    """Build a wallet repository backed by a fresh in-memory SQLite store"""
+    return cdk_ffi.WalletRepository.new_with_config(
+        mnemonic=cdk_ffi.generate_mnemonic(),
+        store=cdk_ffi.sqlite_wallet_store(":memory:"),
+        config=config,
+    )
+
+
+# Wallet tests
+
+async def test_wallet_default_rate_limit():
+    """Omitting the field and asking for DEFAULT both pace the wallet"""
+    # Omitting rate_limit entirely is the backwards-compatible spelling: it must
+    # keep working and must select the built-in default.
+    omitted = make_wallet(cdk_ffi.WalletConfig(target_proof_count=None))
+    assert omitted.is_rate_limited(), "an omitted rate limit paces by default"
+
+    explicit = make_wallet(
+        cdk_ffi.WalletConfig(
+            target_proof_count=None,
+            rate_limit=cdk_ffi.RateLimit.DEFAULT(),
+        )
+    )
+    assert explicit.is_rate_limited(), "DEFAULT paces the wallet"
+
+
+async def test_wallet_disabled_rate_limit():
+    """DISABLED turns pacing off and can be turned back on"""
+    wallet = make_wallet(
+        cdk_ffi.WalletConfig(
+            target_proof_count=None,
+            rate_limit=cdk_ffi.RateLimit.DISABLED(),
+        )
+    )
+    assert not wallet.is_rate_limited(), "DISABLED does not pace"
+
+    wallet.set_rate_limit(cdk_ffi.RateLimit.DEFAULT())
+    assert wallet.is_rate_limited(), "a wallet built disabled can be re-enabled"
+
+
+async def test_wallet_custom_rate_limit():
+    """A non-zero CUSTOM burst and refill paces the wallet"""
+    wallet = make_wallet(
+        cdk_ffi.WalletConfig(
+            target_proof_count=None,
+            rate_limit=cdk_ffi.RateLimit.CUSTOM(capacity=5, refill_per_minute=30),
+        )
+    )
+    assert wallet.is_rate_limited(), "CUSTOM paces the wallet"
+
+
+async def test_wallet_invalid_rate_limit():
+    """A zero in either CUSTOM field is rejected at construction"""
+    for capacity, refill in [(0, 30), (5, 0), (0, 0)]:
+        try:
+            make_wallet(
+                cdk_ffi.WalletConfig(
+                    target_proof_count=None,
+                    rate_limit=cdk_ffi.RateLimit.CUSTOM(
+                        capacity=capacity,
+                        refill_per_minute=refill,
+                    ),
+                )
+            )
+        except Exception:
+            continue
+        raise AssertionError(
+            f"CUSTOM(capacity={capacity}, refill_per_minute={refill}) should be rejected"
+        )
+
+
+async def test_wallet_set_rate_limit_rejects_zero():
+    """The runtime setter rejects the same zero values"""
+    wallet = make_wallet(cdk_ffi.WalletConfig(target_proof_count=None))
+
+    try:
+        wallet.set_rate_limit(cdk_ffi.RateLimit.CUSTOM(capacity=0, refill_per_minute=30))
+    except Exception:
+        pass
+    else:
+        raise AssertionError("a zero capacity should be rejected")
+
+    assert wallet.is_rate_limited(), "a rejected change leaves pacing untouched"
+
+
+async def test_wallet_flush_rate_limits():
+    """Flushing an untouched wallet completes"""
+    wallet = make_wallet(cdk_ffi.WalletConfig(target_proof_count=None))
+    await wallet.flush_rate_limits()
+
+
+# Repository tests
+
+async def test_repository_default_rate_limit():
+    """Omitting the field and asking for DEFAULT both pace the repository"""
+    omitted = make_repository(cdk_ffi.WalletRepositoryConfig())
+    assert omitted.is_rate_limited(), "an omitted rate limit paces by default"
+
+    explicit = make_repository(
+        cdk_ffi.WalletRepositoryConfig(rate_limit=cdk_ffi.RateLimit.DEFAULT())
+    )
+    assert explicit.is_rate_limited(), "DEFAULT paces the repository"
+
+
+async def test_repository_disabled_rate_limit():
+    """DISABLED turns repository pacing off, and it reaches its wallets"""
+    repo = make_repository(
+        cdk_ffi.WalletRepositoryConfig(rate_limit=cdk_ffi.RateLimit.DISABLED())
+    )
+    assert not repo.is_rate_limited(), "DISABLED does not pace"
+
+    wallet = await repo.get_or_create_wallet(
+        cdk_ffi.MintUrl(url=MINT_URL), cdk_ffi.CurrencyUnit.SAT(), None
+    )
+    assert not wallet.is_rate_limited(), "a wallet inherits the repository setting"
+
+    repo.set_rate_limit(cdk_ffi.RateLimit.DEFAULT())
+    assert wallet.is_rate_limited(), "wallets share the repository limiter"
+
+
+async def test_repository_custom_rate_limit():
+    """A non-zero CUSTOM burst and refill paces the repository"""
+    repo = make_repository(
+        cdk_ffi.WalletRepositoryConfig(
+            rate_limit=cdk_ffi.RateLimit.CUSTOM(capacity=5, refill_per_minute=30)
+        )
+    )
+    assert repo.is_rate_limited(), "CUSTOM paces the repository"
+
+
+async def test_repository_invalid_rate_limit():
+    """A zero in either CUSTOM field is rejected, at construction and at runtime"""
+    try:
+        make_repository(
+            cdk_ffi.WalletRepositoryConfig(
+                rate_limit=cdk_ffi.RateLimit.CUSTOM(capacity=0, refill_per_minute=30)
+            )
+        )
+    except Exception:
+        pass
+    else:
+        raise AssertionError("a zero capacity should be rejected at construction")
+
+    repo = make_repository(cdk_ffi.WalletRepositoryConfig())
+    try:
+        repo.set_rate_limit(cdk_ffi.RateLimit.CUSTOM(capacity=5, refill_per_minute=0))
+    except Exception:
+        pass
+    else:
+        raise AssertionError("a zero refill should be rejected at runtime")
+
+
+async def test_repository_flush_rate_limits():
+    """Flushing an untouched repository completes"""
+    repo = make_repository(cdk_ffi.WalletRepositoryConfig())
+    await repo.flush_rate_limits()
+
+
+async def main():
+    """Run all rate-limit tests"""
+    print("Starting CDK FFI Rate Limit Tests")
+    print("=" * 60)
+
+    tests = [
+        # Directly constructed wallets
+        ("Wallet Default Rate Limit", test_wallet_default_rate_limit),
+        ("Wallet Disabled Rate Limit", test_wallet_disabled_rate_limit),
+        ("Wallet Custom Rate Limit", test_wallet_custom_rate_limit),
+        ("Wallet Invalid Rate Limit", test_wallet_invalid_rate_limit),
+        ("Wallet Set Rate Limit Rejects Zero", test_wallet_set_rate_limit_rejects_zero),
+        ("Wallet Flush Rate Limits", test_wallet_flush_rate_limits),
+        # Repository-provided wallets
+        ("Repository Default Rate Limit", test_repository_default_rate_limit),
+        ("Repository Disabled Rate Limit", test_repository_disabled_rate_limit),
+        ("Repository Custom Rate Limit", test_repository_custom_rate_limit),
+        ("Repository Invalid Rate Limit", test_repository_invalid_rate_limit),
+        ("Repository Flush Rate Limits", test_repository_flush_rate_limits),
+    ]
+
+    passed = 0
+    failed = 0
+
+    for test_name, test_func in tests:
+        try:
+            await test_func()
+            passed += 1
+        except Exception as e:
+            failed += 1
+            print(f"\n  Test failed: {test_name}")
+            print(f"  Error: {e}")
+            import traceback
+            traceback.print_exc()
+
+    print("\n" + "=" * 60)
+    print(f"Test Results: {passed} passed, {failed} failed")
+    print("=" * 60)
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    exit_code = asyncio.run(main())
+    sys.exit(exit_code)

--- a/crates/cdk-integration-tests/tests/ffi_minting_integration.rs
+++ b/crates/cdk-integration-tests/tests/ffi_minting_integration.rs
@@ -47,6 +47,7 @@ async fn create_test_ffi_wallet() -> FfiWallet {
     let mnemonic = Mnemonic::generate(12).unwrap().to_string();
     let config = WalletConfig {
         target_proof_count: Some(3),
+        rate_limit: None,
     };
 
     FfiWallet::new(
@@ -300,6 +301,7 @@ async fn test_ffi_minting_error_handling() {
     let mnemonic = Mnemonic::generate(12).unwrap().to_string();
     let config = WalletConfig {
         target_proof_count: Some(3),
+        rate_limit: None,
     };
 
     let invalid_wallet_result = FfiWallet::new(
@@ -355,6 +357,7 @@ async fn test_ffi_wallet_configuration() {
     for target_count in proof_counts {
         let config = WalletConfig {
             target_proof_count: Some(target_count),
+            rate_limit: None,
         };
 
         let wallet = FfiWallet::new(
@@ -379,6 +382,7 @@ async fn test_ffi_wallet_configuration() {
     // Test wallet restoration with same mnemonic
     let config = WalletConfig {
         target_proof_count: Some(3),
+        rate_limit: None,
     };
 
     let wallet1 = FfiWallet::new(

--- a/crates/cdk/src/wallet/builder.rs
+++ b/crates/cdk/src/wallet/builder.rs
@@ -224,6 +224,11 @@ impl WalletBuilder {
     }
 
     /// Disable client-side rate limiting.
+    ///
+    /// This drops the limiter entirely rather than turning it off, so the
+    /// runtime setters become permanent no-ops and [`Wallet::is_rate_limited`]
+    /// stays false. A caller who wants a reversible off switch builds with a
+    /// config and calls [`Wallet::disable_rate_limiting`] instead.
     pub fn without_rate_limiting(mut self) -> Self {
         self.rate_limit = None;
         self.rate_limiter = None;
@@ -453,6 +458,33 @@ mod tests {
         // and the runtime setters have something to act on.
         let wallet = base_builder().await.build().unwrap();
         assert!(wallet.rate_limiter.is_some());
+        assert!(wallet.is_rate_limited());
+    }
+
+    #[tokio::test]
+    async fn disabling_at_runtime_is_reversible() {
+        let wallet = base_builder().await.build().unwrap();
+
+        wallet.disable_rate_limiting();
+        assert!(!wallet.is_rate_limited());
+
+        wallet.set_rate_limiting_config(RateLimitConfig::default());
+        assert!(wallet.is_rate_limited());
+    }
+
+    #[tokio::test]
+    async fn without_rate_limiting_cannot_be_turned_back_on() {
+        // The limiter is never built, so the runtime setter has nothing to act
+        // on and the wallet stays unpaced forever.
+        let wallet = base_builder()
+            .await
+            .without_rate_limiting()
+            .build()
+            .unwrap();
+        assert!(!wallet.is_rate_limited());
+
+        wallet.set_rate_limiting_config(RateLimitConfig::default());
+        assert!(!wallet.is_rate_limited());
     }
 
     #[tokio::test]
@@ -469,6 +501,7 @@ mod tests {
             .build()
             .unwrap();
         assert!(wallet.rate_limiter.is_none());
+        assert!(!wallet.is_rate_limited());
     }
 
     #[tokio::test]

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -323,6 +323,9 @@ impl Wallet {
     /// When the wallet was built through a [`WalletRepository`], the limiter is
     /// shared with every other wallet in that repository, so this reconfigures
     /// pacing repository-wide.
+    ///
+    /// [`Wallet::is_rate_limited`] reports whether the call took effect, since
+    /// the no-op cases are otherwise silent.
     pub fn set_rate_limiting_config(&self, config: RateLimitConfig) {
         if let Some(limiter) = &self.rate_limiter {
             limiter.set_config(config);
@@ -338,6 +341,17 @@ impl Wallet {
         if let Some(limiter) = &self.rate_limiter {
             limiter.set_enabled(false);
         }
+    }
+
+    /// Whether this wallet's requests are being paced right now.
+    ///
+    /// False both when pacing was turned off and when the wallet paces nothing
+    /// at all, which is the case [`Wallet::set_rate_limiting_config`] silently
+    /// ignores.
+    pub fn is_rate_limited(&self) -> bool {
+        self.rate_limiter
+            .as_ref()
+            .is_some_and(RateLimiterManager::is_enabled)
     }
 
     /// Wait until the rate-limit budget this wallet has drawn down has been

--- a/crates/cdk/src/wallet/wallet_repository.rs
+++ b/crates/cdk/src/wallet/wallet_repository.rs
@@ -149,6 +149,7 @@ pub struct WalletRepositoryBuilder {
     seed: Option<[u8; 64]>,
     proxy_config: Option<url::Url>,
     danger_accept_invalid_certs: bool,
+    rate_limit: Option<RateLimitConfig>,
     #[cfg(all(feature = "tor", not(target_arch = "wasm32")))]
     use_tor: bool,
 }
@@ -163,6 +164,7 @@ impl std::fmt::Debug for WalletRepositoryBuilder {
                 "danger_accept_invalid_certs",
                 &self.danger_accept_invalid_certs,
             )
+            .field("rate_limit", &self.rate_limit)
             .finish()
     }
 }
@@ -181,6 +183,7 @@ impl WalletRepositoryBuilder {
             seed: None,
             proxy_config: None,
             danger_accept_invalid_certs: false,
+            rate_limit: Some(RateLimitConfig::default()),
             #[cfg(all(feature = "tor", not(target_arch = "wasm32")))]
             use_tor: false,
         }
@@ -223,6 +226,28 @@ impl WalletRepositoryBuilder {
         self
     }
 
+    /// Set the rate-limiting configuration shared by every wallet this
+    /// repository builds.
+    ///
+    /// Rate limiting is on by default with [`RateLimitConfig::default`].
+    pub fn with_rate_limiting_config(mut self, config: RateLimitConfig) -> Self {
+        self.rate_limit = Some(config);
+        self
+    }
+
+    /// Start with pacing turned off.
+    ///
+    /// The limiter is still built, so
+    /// [`WalletRepository::set_rate_limiting_config`] can turn pacing back on
+    /// later. That reversibility is why this is not named
+    /// `without_rate_limiting`: the repository has no equivalent of
+    /// [`WalletBuilder::without_rate_limiting`], which drops the limiter
+    /// outright, because one limiter is shared across every wallet here.
+    pub fn with_rate_limiting_disabled(mut self) -> Self {
+        self.rate_limit = None;
+        self
+    }
+
     /// Build the WalletRepository and load existing wallets from the database.
     ///
     /// This only uses persisted mint metadata and does not make network requests.
@@ -232,11 +257,14 @@ impl WalletRepositoryBuilder {
             .ok_or(Error::Custom("localstore is required".into()))?;
         let seed = self.seed.ok_or(Error::Custom("seed is required".into()))?;
 
+        let rate_limiter = RateLimiterManager::new(
+            self.rate_limit.unwrap_or_default(),
+            Some(localstore.clone()),
+        );
+        rate_limiter.set_enabled(self.rate_limit.is_some());
+
         let wallet = WalletRepository {
-            rate_limiter: RateLimiterManager::new(
-                RateLimitConfig::default(),
-                Some(localstore.clone()),
-            ),
+            rate_limiter,
             localstore,
             seed,
             wallets: Arc::new(RwLock::new(BTreeMap::new())),
@@ -306,6 +334,13 @@ fn validate_proxy_url(proxy_url: &url::Url) -> Result<(), Error> {
 /// one combined burst regardless of currency unit, and traffic to a third-party
 /// host (an LNURL service, an OIDC provider) paces against that host's own
 /// budget rather than any mint's.
+///
+/// Because that limiter is shared, pacing is configured for the repository as a
+/// whole, at build time through [`WalletRepositoryBuilder::with_rate_limiting_config`]
+/// or later through [`WalletRepository::set_rate_limiting_config`], never per
+/// wallet. Proxied and Tor wallets are built with a custom client, so their
+/// limiter is wired to nothing and they report
+/// [`Wallet::is_rate_limited`] as false whatever the repository is set to.
 #[derive(Clone)]
 pub struct WalletRepository {
     /// Storage backend
@@ -504,6 +539,28 @@ impl WalletRepository {
     /// detached writer.
     pub async fn flush_rate_limits(&self) {
         self.rate_limiter.flush().await;
+    }
+
+    /// Reconfigure pacing for every wallet in this repository, or turn it off
+    /// with `None`.
+    ///
+    /// Pacing is a repository-wide property because one limiter is shared, so
+    /// there is deliberately no per-wallet equivalent at creation time: it would
+    /// silently reconfigure sibling wallets.
+    pub fn set_rate_limiting_config(&self, config: Option<RateLimitConfig>) {
+        match config {
+            Some(config) => self.rate_limiter.set_config(config),
+            None => self.rate_limiter.set_enabled(false),
+        }
+    }
+
+    /// Whether this repository is pacing requests right now.
+    ///
+    /// Individual wallets can still report false while this is true: a proxied
+    /// or Tor wallet is built with a custom client, which leaves its limiter
+    /// wired to nothing.
+    pub fn is_rate_limited(&self) -> bool {
+        self.rate_limiter.is_enabled()
     }
 
     /// Remove a wallet from the in-memory repository
@@ -1575,6 +1632,70 @@ mod tests {
         assert!(unlimited.rate_limiter.is_none());
         unlimited.flush_rate_limits().await;
         create_test_repository().await.flush_rate_limits().await;
+    }
+
+    async fn repository_with_rate_limit(rate_limit: Option<RateLimitConfig>) -> WalletRepository {
+        let localstore: Arc<dyn WalletDatabase<database::Error> + Send + Sync> = Arc::new(
+            cdk_sqlite::wallet::memory::empty()
+                .await
+                .expect("Failed to create in-memory database"),
+        );
+        let builder = WalletRepositoryBuilder::new()
+            .localstore(localstore)
+            .seed([0u8; 64]);
+        let builder = match rate_limit {
+            Some(config) => builder.with_rate_limiting_config(config),
+            None => builder.with_rate_limiting_disabled(),
+        };
+        builder
+            .build()
+            .await
+            .expect("Failed to create WalletRepository")
+    }
+
+    #[tokio::test]
+    async fn repository_starts_with_the_configured_rate_limit() {
+        assert!(create_test_repository().await.is_rate_limited());
+        assert!(repository_with_rate_limit(RateLimitConfig::try_new(5, 30))
+            .await
+            .is_rate_limited());
+        assert!(!repository_with_rate_limit(None).await.is_rate_limited());
+    }
+
+    #[tokio::test]
+    async fn repository_rate_limit_reaches_wallets_it_already_handed_out() {
+        let repo = repository_with_rate_limit(None).await;
+        let mint_url: MintUrl = "https://mint.example.com".parse().unwrap();
+        let wallet = repo
+            .get_or_create_wallet(mint_url, CurrencyUnit::Sat, None)
+            .await
+            .expect("wallet should be created");
+        assert!(!wallet.is_rate_limited());
+
+        repo.set_rate_limiting_config(Some(RateLimitConfig::default()));
+        assert!(repo.is_rate_limited());
+        assert!(
+            wallet.is_rate_limited(),
+            "the wallet shares the repository's limiter"
+        );
+
+        repo.set_rate_limiting_config(None);
+        assert!(!wallet.is_rate_limited());
+    }
+
+    #[tokio::test]
+    async fn a_disabled_repository_admits_more_than_one_burst() {
+        let repo = repository_with_rate_limit(None).await;
+        let mint_url: MintUrl = "https://mint.example.com".parse().unwrap();
+        let wallet = repo
+            .get_or_create_wallet(mint_url, CurrencyUnit::Sat, None)
+            .await
+            .expect("wallet should be created");
+
+        let bucket = bucket_for(&wallet, "https://mint.example.com/v1/info");
+        for _ in 0..(DEFAULT_BURST + 5) {
+            assert!(bucket.try_acquire().await, "pacing is off");
+        }
     }
 
     #[tokio::test]

--- a/crates/cdk/src/wallet/wallet_trait.rs
+++ b/crates/cdk/src/wallet/wallet_trait.rs
@@ -11,6 +11,7 @@ use cdk_common::nuts::nut18::PaymentRequest;
 use cdk_common::nuts::{
     AuthProof, CurrencyUnit, Id, MeltOptions, MintInfo, PaymentMethod, Proofs, SpendingConditions,
 };
+use cdk_common::rate_limit::RateLimitConfig;
 use cdk_common::subscription::WalletParams;
 use cdk_common::wallet::{
     CrossMintTransferQuote, MeltQuote, MintQuote, ReceiveOptions, Restored, SendOptions,
@@ -386,6 +387,21 @@ impl WalletTrait for super::Wallet {
         self.set_metadata_cache_ttl(ttl);
     }
 
+    fn set_rate_limiting_config(&self, config: Option<RateLimitConfig>) {
+        match config {
+            Some(config) => self.set_rate_limiting_config(config),
+            None => self.disable_rate_limiting(),
+        }
+    }
+
+    fn is_rate_limited(&self) -> bool {
+        self.is_rate_limited()
+    }
+
+    async fn flush_rate_limits(&self) {
+        self.flush_rate_limits().await;
+    }
+
     #[instrument(skip(self, params))]
     async fn subscribe(&self, params: WalletParams) -> Result<ActiveSubscription, Self::Error> {
         self.subscribe(params).await
@@ -467,5 +483,44 @@ impl WalletTrait for super::Wallet {
     async fn get_signing_key(&self, pubkey: &PublicKey) -> Result<Option<SecretKey>, Self::Error> {
         let signing_key = self.get_signing_key(pubkey).await?;
         Ok(signing_key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use cdk_common::rate_limit::RateLimitConfig;
+
+    use super::*;
+    use crate::wallet::WalletBuilder;
+
+    async fn test_wallet() -> super::super::Wallet {
+        let store = Arc::new(cdk_sqlite::wallet::memory::empty().await.unwrap());
+        WalletBuilder::default()
+            .mint_url(MintUrl::from_str("https://mint.example.com").unwrap())
+            .unit(CurrencyUnit::Sat)
+            .localstore(store)
+            .seed([0u8; 64])
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn rate_limiting_round_trips_through_the_trait() {
+        let wallet = test_wallet().await;
+        assert!(WalletTrait::is_rate_limited(&wallet));
+
+        WalletTrait::set_rate_limiting_config(&wallet, None);
+        assert!(!WalletTrait::is_rate_limited(&wallet));
+
+        WalletTrait::set_rate_limiting_config(&wallet, Some(RateLimitConfig::default()));
+        assert!(WalletTrait::is_rate_limited(&wallet));
+    }
+
+    #[tokio::test]
+    async fn flushing_an_untouched_wallet_returns() {
+        let wallet = test_wallet().await;
+        WalletTrait::flush_rate_limits(&wallet).await;
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -574,6 +574,7 @@
               # Run Python tests
               python3 crates/cdk-ffi/tests/test_transactions.py
               python3 crates/cdk-ffi/tests/test_kvstore.py
+              python3 crates/cdk-ffi/tests/test_rate_limit.py
             '';
             doCheck = false;
             installPhaseCommand = "mkdir -p $out";

--- a/justfile
+++ b/justfile
@@ -994,6 +994,7 @@ ffi-test: ffi-generate-python
   echo "🧪 Running Python FFI tests..."
   python3 crates/cdk-ffi/tests/test_transactions.py
   python3 crates/cdk-ffi/tests/test_kvstore.py
+  python3 crates/cdk-ffi/tests/test_rate_limit.py
   echo "✅ Tests completed!"
 
 # Build debug version and generate Python bindings quickly (for development)


### PR DESCRIPTION


### Description

Fixes #2315

The FFI wallet could only change pacing after construction, so every wallet started on the built-in default and burst against a mint that wanted less before the host app could intervene. The shared wallet trait had no rate-limit surface at all, so a trait-only consumer could not reach it.

Rate limiting belongs in the trait next to set_metadata_cache_ttl: both are client policy rather than transport plumbing, and RateLimitConfig already lives in cdk-common beside the trait. The trait takes Option<RateLimitConfig>, where None is off.

FFI WalletConfig and the new WalletRepositoryConfig select default, disabled or custom pacing at construction. Disabled builds the limiter and leaves it off rather than dropping it, so it can be turned back on; a repository shares one limiter, so that is the only disable it could offer, and the two paths now behave alike. WalletBuilder::without_rate_limiting keeps dropping the limiter for callers who want no overhead.

is_rate_limited reports whether pacing is actually on. Without it neither a test nor a host UI could tell default from disabled, and a custom transport leaves the setters silently doing nothing.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
