### PR TITLE
fix(ci): generate Kotlin bindings before stripping native library

### DIFF
--- a/.github/workflows/kotlin-publish.yml
+++ b/.github/workflows/kotlin-publish.yml
@@ -277,25 +277,11 @@ jobs:
           nix develop --fallback -L ../../cdk#kotlin-build --command \
             cargo build --release --target ${{ matrix.target }}
 
-      - name: Strip debug symbols
-        working-directory: cdk-kotlin/rust
-        shell: bash
-        run: |
-          FILE="target/${{ matrix.target }}/release/${{ matrix.artifact }}"
-          nix develop --fallback -L ../../cdk#kotlin-build --command \
-            bash -c '"$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip" --strip-all '"$FILE"
-
-      - name: Verify Android ELF 16 KB alignment
-        working-directory: cdk-kotlin/rust
-        shell: bash
-        run: |
-          FILE="target/${{ matrix.target }}/release/${{ matrix.artifact }}"
-          nix develop --fallback -L ../../cdk#kotlin-build --command \
-            ../../cdk/.github/scripts/check-android-elf-alignment.sh "$FILE"
-
       # uniffi 0.30 reads the component interface statically from the library
       # (it does not load it), so the arm64 Android .so works as the source on
-      # this x86_64 host.
+      # this x86_64 host. This must run before the strip step: llvm-strip
+      # --strip-all removes the ELF symbol table that uniffi extracts the
+      # metadata from, which would silently produce empty bindings.
       - name: Generate Kotlin bindings
         if: matrix.target == 'aarch64-linux-android'
         working-directory: cdk-kotlin/rust
@@ -315,6 +301,23 @@ jobs:
         with:
           name: kotlin-bindings-generated
           path: cdk-kotlin/generated-bindings/
+          if-no-files-found: error
+
+      - name: Strip debug symbols
+        working-directory: cdk-kotlin/rust
+        shell: bash
+        run: |
+          FILE="target/${{ matrix.target }}/release/${{ matrix.artifact }}"
+          nix develop --fallback -L ../../cdk#kotlin-build --command \
+            bash -c '"$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip" --strip-all '"$FILE"
+
+      - name: Verify Android ELF 16 KB alignment
+        working-directory: cdk-kotlin/rust
+        shell: bash
+        run: |
+          FILE="target/${{ matrix.target }}/release/${{ matrix.artifact }}"
+          nix develop --fallback -L ../../cdk#kotlin-build --command \
+            ../../cdk/.github/scripts/check-android-elf-alignment.sh "$FILE"
 
       - name: Prepare artifact
         shell: bash


### PR DESCRIPTION
The Kotlin nightly publish has failed since 4cbd88e moved binding generation onto the aarch64-linux-android build, whose .so is stripped with llvm-strip --strip-all before generation. uniffi 0.30 extracts the component interface from ELF symbols, so the stripped library yields zero bindings with exit code 0, upload-artifact only warns, and the publish job then fails on download with 'Artifact not found for name: kotlin-bindings-generated'.

Reorder the steps so bindings are generated from the unstripped library, and set if-no-files-found: error on the upload so a regression fails the build job that caused it instead of surfacing downstream.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
