### PR TITLE
fix(wallet): reject invalid stored mint public keys

### DIFF
--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -2015,9 +2015,9 @@ fn sql_row_to_mint_info(row: Vec<Column>) -> Result<MintInfo, Error> {
 
     Ok(MintInfo {
         name: column_as_nullable_string!(&name),
-        pubkey: column_as_nullable_string!(&pubkey, |_| None, |v| {
-            cdk_common::nuts::PublicKey::from_slice(v).ok()
-        }),
+        pubkey: column_as_nullable_binary!(&pubkey)
+            .map(|bytes| cdk_common::nuts::PublicKey::from_slice(&bytes))
+            .transpose()?,
         version: column_as_nullable_string!(&version).and_then(|v| serde_json::from_str(&v).ok()),
         description: column_as_nullable_string!(description),
         description_long: column_as_nullable_string!(description_long),


### PR DESCRIPTION
Use the binary column decoder for the mint public key and propagate invalid stored key data instead of silently treating it as absent.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
