### PR TITLE
fix(cdk-bdk): reserve send intent quote ids atomically

### DIFF
--- a/crates/cdk-bdk/src/lib.rs
+++ b/crates/cdk-bdk/src/lib.rs
@@ -688,23 +688,34 @@ impl MintPayment for CdkBdk {
             _ => return Err(cdk_common::payment::Error::UnsupportedPaymentOption),
         };
 
-        let mut wallet_with_db = self.wallet_with_db.lock().await;
-        let address = wallet_with_db
-            .wallet
-            .reveal_next_address(KeychainKind::External);
-        let address_str = address.address.to_string();
-
-        wallet_with_db.persist().map_err(|err| {
-            tracing::error!("Could not persist to bdk db: {}", err);
-
-            Error::BdkPersist
-        })?;
-
         let quote_id = onchain_options.quote_id;
+        let quote_id_string = quote_id.to_string();
 
-        self.storage
-            .track_receive_address(&address_str, &quote_id.to_string())
-            .await?;
+        let mut wallet_with_db = self.wallet_with_db.lock().await;
+
+        // An address already tracked for another quote (derived by another
+        // instance sharing this seed, or by a re-initialised local wallet)
+        // must not be handed out again; advance to a fresh address.
+        let address_str = loop {
+            let address = wallet_with_db
+                .wallet
+                .reveal_next_address(KeychainKind::External);
+            let candidate = address.address.to_string();
+
+            wallet_with_db.persist().map_err(|err| {
+                tracing::warn!("Could not persist to bdk db: {}", err);
+
+                Error::BdkPersist
+            })?;
+
+            if self
+                .storage
+                .track_receive_address(&candidate, &quote_id_string)
+                .await?
+            {
+                break candidate;
+            }
+        };
 
         Ok(CreateIncomingPaymentResponse {
             request_lookup_id: PaymentIdentifier::QuoteId(quote_id),
@@ -927,6 +938,79 @@ mod tests {
         )?;
 
         Ok((backend, tmp))
+    }
+
+    /// Build a `CdkBdk` instance with its own local wallet directory but a
+    /// shared KV store, like a second replica or a re-initialised node using
+    /// the same seed.
+    async fn build_test_instance_with_shared_kv(
+        kv: Arc<cdk_sqlite::mint::MintSqliteDatabase>,
+    ) -> (CdkBdk, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mnemonic = Mnemonic::from_str(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+        )
+        .expect("mnemonic");
+        let chain_source = ChainSource::Esplora(EsploraConfig {
+            url: "http://127.0.0.1:1".to_string(),
+            parallel_requests: 1,
+        });
+        let fee_reserve = FeeReserve {
+            min_fee_reserve: Amount::new(1, CurrencyUnit::Sat).into(),
+            percent_fee_reserve: 0.02,
+        };
+
+        let backend = CdkBdk::new(
+            mnemonic,
+            Network::Regtest,
+            chain_source,
+            tmp.path().to_string_lossy().into_owned(),
+            fee_reserve,
+            kv,
+            None,
+            1,
+            0,
+            546,
+            60,
+            Some(5),
+            None,
+        )
+        .expect("build CdkBdk test instance");
+
+        (backend, tmp)
+    }
+
+    #[tokio::test]
+    async fn instances_sharing_seed_and_kv_never_share_a_receive_address() {
+        let kv = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory kv store"),
+        );
+        let (first, _tmp_first) = build_test_instance_with_shared_kv(kv.clone()).await;
+        let (second, _tmp_second) = build_test_instance_with_shared_kv(kv).await;
+
+        let first_request = first
+            .create_incoming_payment_request(IncomingPaymentOptions::Onchain(
+                OnchainIncomingPaymentOptions {
+                    quote_id: cdk_common::QuoteId::new(),
+                },
+            ))
+            .await
+            .expect("first receive request");
+        let second_request = second
+            .create_incoming_payment_request(IncomingPaymentOptions::Onchain(
+                OnchainIncomingPaymentOptions {
+                    quote_id: cdk_common::QuoteId::new(),
+                },
+            ))
+            .await
+            .expect("second receive request");
+
+        assert_ne!(
+            first_request.request, second_request.request,
+            "each instance must hand out a distinct receive address"
+        );
     }
 
     #[tokio::test]

--- a/crates/cdk-bdk/src/send/payment_intent/mod.rs
+++ b/crates/cdk-bdk/src/send/payment_intent/mod.rs
@@ -512,6 +512,43 @@ mod tests {
             Ok(())
         }
 
+        async fn kv_remove_if_equals(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            expected: &[u8],
+        ) -> Result<bool, DatabaseError> {
+            let map_key = (
+                primary_namespace.to_string(),
+                secondary_namespace.to_string(),
+                key.to_string(),
+            );
+
+            let current = self
+                .writes
+                .iter()
+                .rev()
+                .find(|(candidate, _)| candidate == &map_key)
+                .map(|(_, value)| value.clone())
+                .unwrap_or_else(|| {
+                    self.store
+                        .data
+                        .lock()
+                        .expect("lock racing kv store")
+                        .get(&map_key)
+                        .cloned()
+                });
+
+            match current {
+                Some(current) if current == expected => {
+                    self.writes.push((map_key, None));
+                    Ok(true)
+                }
+                _ => Ok(false),
+            }
+        }
+
         async fn kv_list(
             &mut self,
             primary_namespace: &str,

--- a/crates/cdk-bdk/src/send/payment_intent/mod.rs
+++ b/crates/cdk-bdk/src/send/payment_intent/mod.rs
@@ -332,13 +332,249 @@ pub(crate) enum SendIntentAny {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::collections::{HashMap, HashSet};
+    use std::sync::{Arc, Mutex as StdMutex};
 
+    use async_trait::async_trait;
+    use cdk_common::database::{
+        DbTransactionFinalizer, Error as DatabaseError, KVStore, KVStoreDatabase,
+        KVStoreTransaction,
+    };
     use cdk_common::payment::{MakePaymentResponse, PaymentIdentifier};
     use cdk_common::{Amount, CurrencyUnit, MeltQuoteState};
+    use tokio::sync::Barrier;
 
     use super::*;
-    use crate::storage::BdkStorage;
+    use crate::storage::{BdkStorage, SEND_INTENT_QUOTE_ID_NAMESPACE};
+
+    type KvKey = (String, String, String);
+
+    /// KV store that lets two concurrent transactions both observe a missing
+    /// quote-id index entry before either writes. `kv_write_if_absent` is
+    /// atomic across transactions, mirroring the SQL backend.
+    #[derive(Clone)]
+    struct RacingKvStore {
+        data: Arc<StdMutex<HashMap<KvKey, Vec<u8>>>>,
+        reservations: Arc<StdMutex<HashSet<KvKey>>>,
+        index_read_barrier: Arc<Barrier>,
+    }
+
+    impl RacingKvStore {
+        fn new(parties: usize) -> Self {
+            Self {
+                data: Arc::new(StdMutex::new(HashMap::new())),
+                reservations: Arc::new(StdMutex::new(HashSet::new())),
+                index_read_barrier: Arc::new(Barrier::new(parties)),
+            }
+        }
+    }
+
+    struct RacingTransaction {
+        store: RacingKvStore,
+        writes: Vec<(KvKey, Option<Vec<u8>>)>,
+        reserved: Vec<KvKey>,
+    }
+
+    #[async_trait]
+    impl DbTransactionFinalizer for RacingTransaction {
+        type Err = DatabaseError;
+
+        async fn commit(self: Box<Self>) -> Result<(), Self::Err> {
+            let mut data = self.store.data.lock().expect("lock racing kv store");
+            for (key, value) in self.writes {
+                if let Some(value) = value {
+                    data.insert(key, value);
+                } else {
+                    data.remove(&key);
+                }
+            }
+            Ok(())
+        }
+
+        async fn rollback(self: Box<Self>) -> Result<(), Self::Err> {
+            let mut reservations = self.store.reservations.lock().expect("lock reservations");
+            for key in &self.reserved {
+                reservations.remove(key);
+            }
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl KVStoreTransaction<DatabaseError> for RacingTransaction {
+        async fn kv_read(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+        ) -> Result<Option<Vec<u8>>, DatabaseError> {
+            let map_key = (
+                primary_namespace.to_string(),
+                secondary_namespace.to_string(),
+                key.to_string(),
+            );
+            let value = self
+                .writes
+                .iter()
+                .rev()
+                .find(|(candidate, _)| candidate == &map_key)
+                .map(|(_, value)| value.clone())
+                .unwrap_or_else(|| {
+                    self.store
+                        .data
+                        .lock()
+                        .expect("lock racing kv store")
+                        .get(&map_key)
+                        .cloned()
+                });
+
+            if secondary_namespace == SEND_INTENT_QUOTE_ID_NAMESPACE {
+                self.store.index_read_barrier.wait().await;
+            }
+
+            Ok(value)
+        }
+
+        async fn kv_write(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            value: &[u8],
+        ) -> Result<(), DatabaseError> {
+            self.writes.push((
+                (
+                    primary_namespace.to_string(),
+                    secondary_namespace.to_string(),
+                    key.to_string(),
+                ),
+                Some(value.to_vec()),
+            ));
+            Ok(())
+        }
+
+        async fn kv_write_if_absent(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            value: &[u8],
+        ) -> Result<bool, DatabaseError> {
+            let map_key = (
+                primary_namespace.to_string(),
+                secondary_namespace.to_string(),
+                key.to_string(),
+            );
+
+            let exists = match self
+                .writes
+                .iter()
+                .rev()
+                .find(|(candidate, _)| candidate == &map_key)
+            {
+                Some((_, pending)) => pending.is_some(),
+                None => {
+                    let data = self.store.data.lock().expect("lock racing kv store");
+                    let reservations = self.store.reservations.lock().expect("lock reservations");
+                    data.contains_key(&map_key) || reservations.contains(&map_key)
+                }
+            };
+
+            if exists {
+                return Ok(false);
+            }
+
+            self.store
+                .reservations
+                .lock()
+                .expect("lock reservations")
+                .insert(map_key.clone());
+            self.reserved.push(map_key.clone());
+            self.writes.push((map_key, Some(value.to_vec())));
+
+            Ok(true)
+        }
+
+        async fn kv_remove(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+        ) -> Result<(), DatabaseError> {
+            self.writes.push((
+                (
+                    primary_namespace.to_string(),
+                    secondary_namespace.to_string(),
+                    key.to_string(),
+                ),
+                None,
+            ));
+            Ok(())
+        }
+
+        async fn kv_list(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+        ) -> Result<Vec<String>, DatabaseError> {
+            self.store
+                .kv_list(primary_namespace, secondary_namespace)
+                .await
+        }
+    }
+
+    #[async_trait]
+    impl KVStoreDatabase for RacingKvStore {
+        type Err = DatabaseError;
+
+        async fn kv_read(
+            &self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+        ) -> Result<Option<Vec<u8>>, Self::Err> {
+            Ok(self
+                .data
+                .lock()
+                .expect("lock racing kv store")
+                .get(&(
+                    primary_namespace.to_string(),
+                    secondary_namespace.to_string(),
+                    key.to_string(),
+                ))
+                .cloned())
+        }
+
+        async fn kv_list(
+            &self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+        ) -> Result<Vec<String>, Self::Err> {
+            Ok(self
+                .data
+                .lock()
+                .expect("lock racing kv store")
+                .keys()
+                .filter(|(primary, secondary, _)| {
+                    primary == primary_namespace && secondary == secondary_namespace
+                })
+                .map(|(_, _, key)| key.clone())
+                .collect())
+        }
+    }
+
+    #[async_trait]
+    impl KVStore for RacingKvStore {
+        async fn begin_transaction(
+            &self,
+        ) -> Result<Box<dyn KVStoreTransaction<Self::Err> + Send + Sync>, DatabaseError> {
+            Ok(Box::new(RacingTransaction {
+                store: self.clone(),
+                writes: Vec::new(),
+                reserved: Vec::new(),
+            }))
+        }
+    }
 
     /// Helper: create an in-memory KVStore-backed BdkStorage for tests
     async fn test_storage() -> BdkStorage {
@@ -346,6 +582,41 @@ mod tests {
             .await
             .expect("in-memory db");
         BdkStorage::new(Arc::new(db))
+    }
+
+    #[tokio::test]
+    async fn concurrent_duplicate_quote_creates_only_one_intent() {
+        let storage = BdkStorage::new(Arc::new(RacingKvStore::new(2)));
+        let create = || {
+            SendIntent::new(
+                &storage,
+                "quote-race".to_string(),
+                "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+                10_000,
+                500,
+                PaymentTier::Immediate,
+                PaymentMetadata::default(),
+            )
+        };
+
+        let (first, second) = tokio::join!(create(), create());
+
+        let success_count = usize::from(first.is_ok()) + usize::from(second.is_ok());
+        assert_eq!(success_count, 1, "only one intent per quote id");
+
+        let duplicate_count = [&first, &second]
+            .iter()
+            .filter(
+                |result| matches!(result, Err(Error::DuplicateQuoteId(id)) if id == "quote-race"),
+            )
+            .count();
+        assert_eq!(duplicate_count, 1, "loser must get DuplicateQuoteId");
+
+        let records = storage
+            .get_all_send_intents()
+            .await
+            .expect("list send intents");
+        assert_eq!(records.len(), 1, "only one intent record may be persisted");
     }
 
     #[tokio::test]

--- a/crates/cdk-bdk/src/storage/mod.rs
+++ b/crates/cdk-bdk/src/storage/mod.rs
@@ -1524,6 +1524,41 @@ mod tests {
         assert!(missing.is_none());
     }
 
+    #[tokio::test]
+    async fn test_track_receive_address_never_remaps_to_another_quote() {
+        let storage = test_storage().await;
+
+        let q1 = Uuid::new_v4().to_string();
+        let q2 = Uuid::new_v4().to_string();
+
+        let reserved = storage
+            .track_receive_address("bcrt1qaddr1", &q1)
+            .await
+            .expect("track addr1");
+        assert!(reserved);
+
+        // Same address, same quote: idempotent no-op.
+        let reserved = storage
+            .track_receive_address("bcrt1qaddr1", &q1)
+            .await
+            .expect("re-track addr1");
+        assert!(reserved);
+
+        // Same address, different quote: rejected, mapping unchanged.
+        let reserved = storage
+            .track_receive_address("bcrt1qaddr1", &q2)
+            .await
+            .expect("track addr1 for q2");
+        assert!(!reserved);
+
+        let fetched = storage
+            .get_quote_id_by_receive_address("bcrt1qaddr1")
+            .await
+            .expect("get by address")
+            .expect("should exist");
+        assert_eq!(fetched, q1);
+    }
+
     // ── Receive saga: intent CRUD tests ──────────────────────────────
 
     #[tokio::test]

--- a/crates/cdk-bdk/src/storage/receive.rs
+++ b/crates/cdk-bdk/src/storage/receive.rs
@@ -13,24 +13,46 @@ impl BdkStorage {
     // ── Receive address index storage ────────────────────────────────
 
     /// Track a generated receive address by quote ID.
-    pub async fn track_receive_address(&self, address: &str, quote_id: &str) -> Result<(), Error> {
+    ///
+    /// Returns `true` when the address was reserved for `quote_id` (or was
+    /// already tracked for that same quote). Returns `false` when the
+    /// address is already tracked for a different quote; the caller must
+    /// derive a fresh address and retry.
+    pub async fn track_receive_address(
+        &self,
+        address: &str,
+        quote_id: &str,
+    ) -> Result<bool, Error> {
         let mut tx = self
             .kv_store
             .begin_transaction()
             .await
             .map_err(Error::from)?;
 
-        tx.kv_write(
-            BDK_NAMESPACE,
-            RECEIVE_ADDRESS_QUOTE_ID_NAMESPACE,
-            address,
-            quote_id.as_bytes(),
-        )
-        .await
-        .map_err(Error::from)?;
+        // Reserve the address atomically: an address must never be remapped
+        // to a different quote once tracked.
+        let reserved = tx
+            .kv_write_if_absent(
+                BDK_NAMESPACE,
+                RECEIVE_ADDRESS_QUOTE_ID_NAMESPACE,
+                address,
+                quote_id.as_bytes(),
+            )
+            .await
+            .map_err(Error::from)?;
+
+        if !reserved {
+            let existing = tx
+                .kv_read(BDK_NAMESPACE, RECEIVE_ADDRESS_QUOTE_ID_NAMESPACE, address)
+                .await
+                .map_err(Error::from)?;
+            let same_quote = existing.as_deref() == Some(quote_id.as_bytes());
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(same_quote);
+        }
 
         tx.commit().await.map_err(Error::from)?;
-        Ok(())
+        Ok(true)
     }
 
     /// Get the quote ID for a tracked receive address.

--- a/crates/cdk-bdk/src/storage/send.rs
+++ b/crates/cdk-bdk/src/storage/send.rs
@@ -62,14 +62,20 @@ impl BdkStorage {
         )
         .await
         .map_err(Error::from)?;
-        tx.kv_write(
-            BDK_NAMESPACE,
-            SEND_INTENT_QUOTE_ID_NAMESPACE,
-            &intent.quote_id,
-            intent.intent_id.to_string().as_bytes(),
-        )
-        .await
-        .map_err(Error::from)?;
+        // Reserve the quote id atomically with the record write.
+        let reserved = tx
+            .kv_write_if_absent(
+                BDK_NAMESPACE,
+                SEND_INTENT_QUOTE_ID_NAMESPACE,
+                &intent.quote_id,
+                intent.intent_id.to_string().as_bytes(),
+            )
+            .await
+            .map_err(Error::from)?;
+        if !reserved {
+            tx.rollback().await.map_err(Error::from)?;
+            return Err(Error::DuplicateQuoteId(intent.quote_id.clone()));
+        }
         tx.commit().await.map_err(Error::from)?;
         Ok(())
     }
@@ -137,14 +143,20 @@ impl BdkStorage {
                 state: intent.state.clone(),
             }
         } else {
-            tx.kv_write(
-                BDK_NAMESPACE,
-                SEND_INTENT_QUOTE_ID_NAMESPACE,
-                &intent.quote_id,
-                intent.intent_id.to_string().as_bytes(),
-            )
-            .await
-            .map_err(Error::from)?;
+            // Reserve the quote id atomically with the record write.
+            let reserved = tx
+                .kv_write_if_absent(
+                    BDK_NAMESPACE,
+                    SEND_INTENT_QUOTE_ID_NAMESPACE,
+                    &intent.quote_id,
+                    intent.intent_id.to_string().as_bytes(),
+                )
+                .await
+                .map_err(Error::from)?;
+            if !reserved {
+                tx.rollback().await.map_err(Error::from)?;
+                return Err(Error::DuplicateQuoteId(intent.quote_id.clone()));
+            }
             intent.clone()
         };
 

--- a/crates/cdk-cln/src/error.rs
+++ b/crates/cdk-cln/src/error.rs
@@ -20,6 +20,12 @@ pub enum Error {
     /// Invalid quote id
     #[error("Invalid quote id")]
     InvalidQuoteId,
+    /// BOLT12 quote is already bound to a different payment hash
+    #[error("BOLT12 quote {quote_id} is already bound to a different payment hash")]
+    Bolt12QuoteBindingConflict {
+        /// Quote id whose binding was rejected
+        quote_id: String,
+    },
     /// Cln Error
     #[error(transparent)]
     Cln(#[from] cln_rpc::Error),

--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -1256,6 +1256,32 @@ mod tests {
             Ok(())
         }
 
+        async fn kv_write_if_absent(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            value: &[u8],
+        ) -> Result<bool, DatabaseError> {
+            let key = memory_kv_key(primary_namespace, secondary_namespace, key);
+
+            let exists = match self.writes.get(&key) {
+                Some(pending) => pending.is_some(),
+                None => {
+                    let entries = self.entries.lock().map_err(|_| memory_kv_lock_error())?;
+                    entries.contains_key(&key)
+                }
+            };
+
+            if exists {
+                return Ok(false);
+            }
+
+            self.writes.insert(key, Some(value.to_vec()));
+
+            Ok(true)
+        }
+
         async fn kv_remove(
             &mut self,
             primary_namespace: &str,

--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -419,6 +419,7 @@ impl MintPayment for Cln {
         let mut partial_amount: Option<u64> = None;
         let mut amount_msat: Option<u64> = None;
         let payment_lookup_id: PaymentIdentifier;
+        let mut bolt12_claim: Option<(QuoteId, [u8; 32])> = None;
 
         let mut cln_client = self.cln_client().await?;
 
@@ -501,6 +502,7 @@ impl MintPayment for Cln {
                 self.check_outgoing_unpaided(&payment_identifier).await?;
                 self.write_bolt12_quote_payment_hash(&quote_id, &payment_hash)
                     .await?;
+                bolt12_claim = Some((quote_id, payment_hash));
                 payment_lookup_id = quote_payment_identifier;
 
                 max_fee_msat = bolt12_options
@@ -547,6 +549,13 @@ impl MintPayment for Cln {
             },
             Err(err) => {
                 tracing::error!("Could not pay invoice with xpay: {}", err);
+                // Release a claimed BOLT12 quote binding when the payment is
+                // terminally failed so a retry can claim the quote again.
+                // Ambiguous payment states keep the binding.
+                if let Some((quote_id, payment_hash)) = bolt12_claim {
+                    self.release_failed_bolt12_claim(&quote_id, &payment_hash)
+                        .await;
+                }
                 return Err(Error::ClnRpc(err).into());
             }
         };
@@ -759,6 +768,7 @@ impl MintPayment for Cln {
         &self,
         payment_identifier: &PaymentIdentifier,
     ) -> Result<MakePaymentResponse, Self::Err> {
+        let mut bolt12_binding: Option<(QuoteId, [u8; 32])> = None;
         let (payment_hash, missing_payment_state) = match payment_identifier {
             PaymentIdentifier::PaymentHash(hash) | PaymentIdentifier::Bolt12PaymentHash(hash) => {
                 (*hash, MeltQuoteState::Unknown)
@@ -769,6 +779,7 @@ impl MintPayment for Cln {
                 .map_err(payment::Error::from)?
             {
                 Bolt12QuotePaymentHashLookup::Found(payment_hash) => {
+                    bolt12_binding = Some((quote_id.clone(), payment_hash));
                     (payment_hash, MeltQuoteState::Unpaid)
                 }
                 Bolt12QuotePaymentHashLookup::Missing => {
@@ -807,6 +818,23 @@ impl MintPayment for Cln {
         match select_cln_payment(&listpays_response.pays) {
             Some(pays_response) => {
                 let status = cln_pays_status_to_mint_state(pays_response.status);
+
+                // A terminally failed payment can never complete: release the
+                // quote binding so a retry can claim the quote again. The
+                // removal is value-matched, so a stale check cannot erase a
+                // newer binding.
+                if status == MeltQuoteState::Failed {
+                    if let Some((quote_id, payment_hash)) = bolt12_binding {
+                        if let Err(err) = self
+                            .release_bolt12_quote_payment_hash(&quote_id, &payment_hash)
+                            .await
+                        {
+                            tracing::warn!(
+                                "CLN: could not release failed BOLT12 binding for quote {quote_id}: {err}"
+                            );
+                        }
+                    }
+                }
 
                 Ok(MakePaymentResponse {
                     payment_lookup_id: payment_identifier.clone(),
@@ -848,6 +876,12 @@ impl Cln {
             .map_err(|_| Error::InvalidHash)
     }
 
+    /// Binds the BOLT12 quote id to the fetched invoice's payment hash.
+    ///
+    /// The binding is write-once: the first dispatch for a quote claims it
+    /// atomically, so a duplicate or concurrent dispatch is rejected before
+    /// any funds move. Repeating the same payment hash is an idempotent
+    /// no-op for recovery.
     async fn write_bolt12_quote_payment_hash(
         &self,
         quote_id: &QuoteId,
@@ -861,7 +895,63 @@ impl Cln {
             .await
             .map_err(|e| Error::Database(e.to_string()))?;
 
-        tx.kv_write(
+        let written = tx
+            .kv_write_if_absent(
+                CLN_KV_PRIMARY_NAMESPACE,
+                CLN_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+                &key,
+                value.as_bytes(),
+            )
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        if written {
+            tx.commit()
+                .await
+                .map_err(|e| Error::Database(e.to_string()))?;
+            return Ok(());
+        }
+
+        let existing = tx
+            .kv_read(
+                CLN_KV_PRIMARY_NAMESPACE,
+                CLN_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+                &key,
+            )
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?;
+        tx.rollback()
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        match existing {
+            Some(existing) if existing.as_slice() == value.as_bytes() => Ok(()),
+            _ => Err(Error::Bolt12QuoteBindingConflict {
+                quote_id: quote_id.to_string(),
+            }),
+        }
+    }
+
+    /// Releases the BOLT12 quote binding when it still holds `payment_hash`.
+    ///
+    /// Called when the bound payment is terminally failed so a retry can claim
+    /// the quote again. The removal is value-matched: a binding that has been
+    /// replaced since the caller read it is never deleted, so a stale releaser
+    /// cannot erase an in-flight dispatch.
+    async fn release_bolt12_quote_payment_hash(
+        &self,
+        quote_id: &QuoteId,
+        payment_hash: &[u8; 32],
+    ) -> Result<(), Error> {
+        let key = Self::bolt12_quote_payment_hash_key(quote_id)?;
+        let value = hex::encode(payment_hash);
+        let mut tx = self
+            .kv_store
+            .begin_transaction()
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        tx.kv_remove_if_equals(
             CLN_KV_PRIMARY_NAMESPACE,
             CLN_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
             &key,
@@ -874,6 +964,37 @@ impl Cln {
             .map_err(|e| Error::Database(e.to_string()))?;
 
         Ok(())
+    }
+
+    /// Releases a claimed BOLT12 quote binding when the bound payment is
+    /// terminally failed, so a retry can claim the quote again. Best-effort:
+    /// ambiguous payment states and check failures keep the binding.
+    async fn release_failed_bolt12_claim(&self, quote_id: &QuoteId, payment_hash: &[u8; 32]) {
+        match self
+            .check_outgoing_payment(&PaymentIdentifier::Bolt12PaymentHash(*payment_hash))
+            .await
+        {
+            Ok(response) if response.status == MeltQuoteState::Failed => {
+                if let Err(err) = self
+                    .release_bolt12_quote_payment_hash(quote_id, payment_hash)
+                    .await
+                {
+                    tracing::warn!(
+                        "CLN: could not release failed BOLT12 binding for quote {quote_id}: {err}"
+                    );
+                }
+            }
+            Ok(_) => {
+                tracing::warn!(
+                    "CLN: keeping BOLT12 binding for quote {quote_id}: payment state is not terminally failed"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "CLN: could not check state of failed BOLT12 payment for quote {quote_id}: {err}"
+                );
+            }
+        }
     }
 
     async fn read_bolt12_quote_payment_hash(
@@ -1296,6 +1417,32 @@ mod tests {
             Ok(())
         }
 
+        async fn kv_remove_if_equals(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            expected: &[u8],
+        ) -> Result<bool, DatabaseError> {
+            let key = memory_kv_key(primary_namespace, secondary_namespace, key);
+
+            let current = match self.writes.get(&key) {
+                Some(pending) => pending.clone(),
+                None => {
+                    let entries = self.entries.lock().map_err(|_| memory_kv_lock_error())?;
+                    entries.get(&key).cloned()
+                }
+            };
+
+            match current {
+                Some(current) if current == expected => {
+                    self.writes.insert(key, None);
+                    Ok(true)
+                }
+                _ => Ok(false),
+            }
+        }
+
         async fn kv_list(
             &mut self,
             primary_namespace: &str,
@@ -1496,18 +1643,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bolt12_quote_payment_hash_write_overwrites_existing_mapping() {
+    async fn bolt12_quote_payment_hash_repeat_of_same_hash_is_idempotent() {
         let cln = test_cln_with_memory_kv();
         let quote_id = QuoteId::new();
-        let first_payment_hash = [1; 32];
-        let second_payment_hash = [2; 32];
+        let payment_hash = [1; 32];
 
-        cln.write_bolt12_quote_payment_hash(&quote_id, &first_payment_hash)
+        cln.write_bolt12_quote_payment_hash(&quote_id, &payment_hash)
             .await
             .expect("first payment hash should be written");
-        cln.write_bolt12_quote_payment_hash(&quote_id, &second_payment_hash)
+        cln.write_bolt12_quote_payment_hash(&quote_id, &payment_hash)
             .await
-            .expect("second payment hash should be written");
+            .expect("repeating the same payment hash must succeed for recovery");
 
         let stored_payment_hash = cln
             .read_bolt12_quote_payment_hash(&quote_id)
@@ -1516,6 +1662,123 @@ mod tests {
 
         assert_eq!(
             stored_payment_hash,
+            Bolt12QuotePaymentHashLookup::Found(payment_hash)
+        );
+    }
+
+    #[tokio::test]
+    async fn bolt12_quote_payment_hash_binding_is_write_once() {
+        let cln = test_cln_with_memory_kv();
+        let quote_id = QuoteId::new();
+        let first_payment_hash = [1; 32];
+        let second_payment_hash = [2; 32];
+
+        cln.write_bolt12_quote_payment_hash(&quote_id, &first_payment_hash)
+            .await
+            .expect("first payment hash should be written");
+
+        let err = cln
+            .write_bolt12_quote_payment_hash(&quote_id, &second_payment_hash)
+            .await
+            .expect_err("a conflicting payment hash must be rejected");
+        assert!(
+            matches!(err, Error::Bolt12QuoteBindingConflict { .. }),
+            "unexpected error: {err}"
+        );
+
+        let stored_payment_hash = cln
+            .read_bolt12_quote_payment_hash(&quote_id)
+            .await
+            .expect("payment hash should be read");
+
+        assert_eq!(
+            stored_payment_hash,
+            Bolt12QuotePaymentHashLookup::Found(first_payment_hash),
+            "the first binding must be retained"
+        );
+    }
+
+    #[tokio::test]
+    async fn bolt12_quote_payment_hash_concurrent_claims_have_single_winner() {
+        let kv_store = Arc::new(MemoryKvStore::default());
+        let first_cln = test_cln_with_kv(kv_store.clone());
+        let second_cln = test_cln_with_kv(kv_store);
+        let quote_id = QuoteId::new();
+        let first_payment_hash = [1; 32];
+        let second_payment_hash = [2; 32];
+
+        let (first_result, second_result) = tokio::join!(
+            first_cln.write_bolt12_quote_payment_hash(&quote_id, &first_payment_hash),
+            second_cln.write_bolt12_quote_payment_hash(&quote_id, &second_payment_hash),
+        );
+
+        let outcomes = [&first_result, &second_result];
+        let winners = outcomes.iter().filter(|result| result.is_ok()).count();
+        let conflicts = outcomes
+            .iter()
+            .filter(|result| matches!(result, Err(Error::Bolt12QuoteBindingConflict { .. })))
+            .count();
+
+        assert_eq!(winners, 1, "exactly one dispatch may claim the quote");
+        assert_eq!(conflicts, 1, "the losing dispatch must be rejected");
+
+        let winner_hash = if first_result.is_ok() {
+            first_payment_hash
+        } else {
+            second_payment_hash
+        };
+        let stored_payment_hash = first_cln
+            .read_bolt12_quote_payment_hash(&quote_id)
+            .await
+            .expect("payment hash should be read");
+        assert_eq!(
+            stored_payment_hash,
+            Bolt12QuotePaymentHashLookup::Found(winner_hash),
+            "the stored binding must belong to the winning dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn bolt12_quote_payment_hash_release_removes_only_matching_binding() {
+        let cln = test_cln_with_memory_kv();
+        let quote_id = QuoteId::new();
+        let first_payment_hash = [1; 32];
+        let second_payment_hash = [2; 32];
+
+        cln.write_bolt12_quote_payment_hash(&quote_id, &first_payment_hash)
+            .await
+            .expect("first payment hash should be written");
+
+        // A stale value must not remove the binding
+        cln.release_bolt12_quote_payment_hash(&quote_id, &second_payment_hash)
+            .await
+            .expect("release with a stale value should succeed as a no-op");
+        assert_eq!(
+            cln.read_bolt12_quote_payment_hash(&quote_id)
+                .await
+                .expect("payment hash should be read"),
+            Bolt12QuotePaymentHashLookup::Found(first_payment_hash),
+            "a mismatched release must not remove the binding"
+        );
+
+        // Releasing the bound hash frees the quote for a retry
+        cln.release_bolt12_quote_payment_hash(&quote_id, &first_payment_hash)
+            .await
+            .expect("release should succeed");
+        assert_eq!(
+            cln.read_bolt12_quote_payment_hash(&quote_id)
+                .await
+                .expect("payment hash should be read"),
+            Bolt12QuotePaymentHashLookup::Missing
+        );
+
+        cln.write_bolt12_quote_payment_hash(&quote_id, &second_payment_hash)
+            .await
+            .expect("quote must be claimable again after a release");
+        assert_eq!(
+            cln.read_bolt12_quote_payment_hash(&quote_id)
+                .await
+                .expect("payment hash should be read"),
             Bolt12QuotePaymentHashLookup::Found(second_payment_hash)
         );
     }

--- a/crates/cdk-common/src/database/kvstore.rs
+++ b/crates/cdk-common/src/database/kvstore.rs
@@ -87,6 +87,20 @@ pub trait KVStoreTransaction<Error>: DbTransactionFinalizer<Err = Error> {
         value: &[u8],
     ) -> Result<(), Error>;
 
+    /// Write value to key-value store only when the key does not exist.
+    ///
+    /// Returns `true` when the value was written and `false` when the key
+    /// already exists. Implementations must perform the check-and-insert
+    /// atomically (for example `INSERT ... ON CONFLICT DO NOTHING` with a
+    /// rows-affected check).
+    async fn kv_write_if_absent(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        value: &[u8],
+    ) -> Result<bool, Error>;
+
     /// Remove value from key-value store
     async fn kv_remove(
         &mut self,

--- a/crates/cdk-common/src/database/kvstore.rs
+++ b/crates/cdk-common/src/database/kvstore.rs
@@ -109,6 +109,21 @@ pub trait KVStoreTransaction<Error>: DbTransactionFinalizer<Err = Error> {
         key: &str,
     ) -> Result<(), Error>;
 
+    /// Remove value from key-value store only when it currently equals
+    /// `expected`.
+    ///
+    /// Returns `true` when the value was removed and `false` when the key
+    /// does not exist or holds a different value. Implementations must
+    /// perform the check-and-remove atomically (for example
+    /// `DELETE ... WHERE value = ?` with a rows-affected check).
+    async fn kv_remove_if_equals(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        expected: &[u8],
+    ) -> Result<bool, Error>;
+
     /// List keys in a namespace
     async fn kv_list(
         &mut self,

--- a/crates/cdk-common/src/database/mint/test/mod.rs
+++ b/crates/cdk-common/src/database/mint/test/mod.rs
@@ -184,6 +184,78 @@ where
     assert_eq!(stored, expected);
 }
 
+/// Test atomic insert-if-absent within transactions, including concurrent contenders
+pub async fn kvstore_write_if_absent<DB>(db: DB)
+where
+    DB: Database<crate::database::Error> + KVStoreDatabase<Err = crate::database::Error>,
+{
+    const PRIMARY: &str = "write_if_absent_test";
+    const SECONDARY: &str = "reservation";
+
+    // First insert wins and is committed.
+    {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        assert!(tx
+            .kv_write_if_absent(PRIMARY, SECONDARY, "key1", b"first")
+            .await
+            .unwrap());
+        tx.commit().await.unwrap();
+    }
+
+    // A conflicting insert in a later transaction loses and rolls back cleanly.
+    {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        assert!(!tx
+            .kv_write_if_absent(PRIMARY, SECONDARY, "key1", b"second")
+            .await
+            .unwrap());
+        tx.rollback().await.unwrap();
+    }
+
+    let stored = db.kv_read(PRIMARY, SECONDARY, "key1").await.unwrap();
+    assert_eq!(stored, Some(b"first".to_vec()));
+
+    // Concurrent contenders for the same key: exactly one wins, and the
+    // stored value is the winner's.
+    let left = async {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        let won = tx
+            .kv_write_if_absent(PRIMARY, SECONDARY, "race", b"left")
+            .await
+            .unwrap();
+        if won {
+            tx.commit().await.unwrap();
+        } else {
+            tx.rollback().await.unwrap();
+        }
+        won
+    };
+    let right = async {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        let won = tx
+            .kv_write_if_absent(PRIMARY, SECONDARY, "race", b"right")
+            .await
+            .unwrap();
+        if won {
+            tx.commit().await.unwrap();
+        } else {
+            tx.rollback().await.unwrap();
+        }
+        won
+    };
+
+    let (left, right) = tokio::join!(left, right);
+    assert_ne!(left, right);
+
+    let stored = db.kv_read(PRIMARY, SECONDARY, "race").await.unwrap();
+    let expected = if left {
+        b"left".as_slice()
+    } else {
+        b"right".as_slice()
+    };
+    assert_eq!(stored.as_deref(), Some(expected));
+}
+
 /// Unit test that is expected to be passed for a correct database implementation
 #[macro_export]
 macro_rules! mint_db_test {
@@ -193,6 +265,7 @@ macro_rules! mint_db_test {
             add_and_find_proofs,
             add_duplicate_proofs,
             kvstore_functionality,
+            kvstore_write_if_absent,
             add_mint_quote,
             add_mint_quote_only_once,
             register_payments,

--- a/crates/cdk-common/src/database/mint/test/mod.rs
+++ b/crates/cdk-common/src/database/mint/test/mod.rs
@@ -256,6 +256,87 @@ where
     assert_eq!(stored.as_deref(), Some(expected));
 }
 
+/// Test atomic value-matched removal within transactions, including
+/// concurrent contenders
+pub async fn kvstore_remove_if_equals<DB>(db: DB)
+where
+    DB: Database<crate::database::Error> + KVStoreDatabase<Err = crate::database::Error>,
+{
+    const PRIMARY: &str = "remove_if_equals_test";
+    const SECONDARY: &str = "reservation";
+
+    // Removal only happens when the stored value matches.
+    {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        tx.kv_write(PRIMARY, SECONDARY, "key1", b"first")
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+    }
+
+    {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        assert!(!tx
+            .kv_remove_if_equals(PRIMARY, SECONDARY, "key1", b"wrong")
+            .await
+            .unwrap());
+        assert!(!tx
+            .kv_remove_if_equals(PRIMARY, SECONDARY, "missing", b"first")
+            .await
+            .unwrap());
+        tx.commit().await.unwrap();
+    }
+
+    let stored = db.kv_read(PRIMARY, SECONDARY, "key1").await.unwrap();
+    assert_eq!(stored, Some(b"first".to_vec()));
+
+    {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        assert!(tx
+            .kv_remove_if_equals(PRIMARY, SECONDARY, "key1", b"first")
+            .await
+            .unwrap());
+        tx.commit().await.unwrap();
+    }
+
+    let stored = db.kv_read(PRIMARY, SECONDARY, "key1").await.unwrap();
+    assert_eq!(stored, None);
+
+    // Concurrent contenders removing the same value: exactly one wins.
+    {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        tx.kv_write(PRIMARY, SECONDARY, "race", b"value")
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+    }
+
+    let left = async {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        let removed = tx
+            .kv_remove_if_equals(PRIMARY, SECONDARY, "race", b"value")
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+        removed
+    };
+    let right = async {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        let removed = tx
+            .kv_remove_if_equals(PRIMARY, SECONDARY, "race", b"value")
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+        removed
+    };
+
+    let (left, right) = tokio::join!(left, right);
+    assert_ne!(left, right);
+
+    let stored = db.kv_read(PRIMARY, SECONDARY, "race").await.unwrap();
+    assert_eq!(stored, None);
+}
+
 /// Unit test that is expected to be passed for a correct database implementation
 #[macro_export]
 macro_rules! mint_db_test {
@@ -266,6 +347,7 @@ macro_rules! mint_db_test {
             add_duplicate_proofs,
             kvstore_functionality,
             kvstore_write_if_absent,
+            kvstore_remove_if_equals,
             add_mint_quote,
             add_mint_quote_only_once,
             register_payments,

--- a/crates/cdk-ldk-node/src/error.rs
+++ b/crates/cdk-ldk-node/src/error.rs
@@ -33,6 +33,13 @@ pub enum Error {
     #[error("Invalid quote id")]
     InvalidQuoteId,
 
+    /// BOLT12 quote already has a dispatch claim or recorded payment id
+    #[error("BOLT12 quote {quote_id} is already claimed")]
+    Bolt12QuoteAlreadyClaimed {
+        /// Quote id whose dispatch claim was rejected
+        quote_id: String,
+    },
+
     /// Database error
     #[error("Database error: {0}")]
     Database(String),

--- a/crates/cdk-ldk-node/src/lib.rs
+++ b/crates/cdk-ldk-node/src/lib.rs
@@ -371,14 +371,25 @@ impl CdkLdkNode {
     }
 
     /// Best-effort removal of the pre-dispatch sentinel after a send that did
-    /// not dispatch. If removal fails the sentinel remains and the payment
-    /// resolves as `Pending`, keeping the melt proofs reserved.
+    /// not dispatch. The removal is value-matched: a recorded payment id is
+    /// never deleted, so recovery keeps resolving the quote to its payment.
+    /// If removal fails the sentinel remains and the payment resolves as
+    /// `Pending`, keeping the melt proofs reserved.
     async fn cleanup_bolt12_dispatch_sentinel(&self, quote_id: &QuoteId) {
-        if let Err(err) = delete_bolt12_quote_payment_id(&self.kv_store, quote_id).await {
-            tracing::warn!(
-                "Could not remove BOLT12 dispatch sentinel for quote {quote_id}: {err}. \
-                 The payment will remain Pending."
-            );
+        match delete_bolt12_quote_payment_id_if_matches(&self.kv_store, quote_id, b"").await {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::debug!(
+                    "BOLT12 dispatch sentinel for quote {quote_id} was not removed: \
+                     the binding no longer holds the sentinel"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "Could not remove BOLT12 dispatch sentinel for quote {quote_id}: {err}. \
+                     The payment will remain Pending."
+                );
+            }
         }
     }
 
@@ -1038,12 +1049,14 @@ impl MintPayment for CdkLdkNode {
                     }
                 };
 
-                // Write the pre-dispatch sentinel before attempting the send so
-                // a crash during dispatch is distinguishable from "never
-                // dispatched" (mirrors cdk-cln's pre-dispatch bolt12 quote
-                // mapping). The payment must not be attempted unless this
-                // marker is durable.
-                write_bolt12_quote_payment_id(&self.kv_store, &quote_id, None).await?;
+                // Claim the quote with an absent-only sentinel write before
+                // attempting the send: a duplicate or concurrent dispatch for
+                // the same quote is rejected here, before any funds move. The
+                // sentinel also keeps a crash during dispatch distinguishable
+                // from "never dispatched" (mirrors cdk-cln's pre-dispatch
+                // bolt12 quote mapping). The payment must not be attempted
+                // unless this marker is durable.
+                claim_bolt12_quote_dispatch(&self.kv_store, &quote_id).await?;
 
                 let payment_id = match bolt12_options.melt_options {
                     Some(MeltOptions::Amountless { amountless }) => {
@@ -1085,12 +1098,12 @@ impl MintPayment for CdkLdkNode {
                 };
 
                 // Record the payment id so QuoteId lookups resolve to the
-                // dispatched payment. Best-effort: if this write fails the
+                // dispatched payment. The write is conditional on owning the
+                // dispatch claim. Best-effort: if this write fails the
                 // sentinel remains and the payment resolves as Pending, keeping
                 // the melt proofs reserved.
                 if let Err(err) =
-                    write_bolt12_quote_payment_id(&self.kv_store, &quote_id, Some(&payment_id))
-                        .await
+                    record_bolt12_quote_payment_id(&self.kv_store, &quote_id, &payment_id).await
                 {
                     tracing::error!(
                         "Could not record BOLT12 payment id for quote {quote_id}: {err}. \
@@ -1118,6 +1131,10 @@ impl MintPayment for CdkLdkNode {
                                 payment_kind = ?details.kind,
                                 "Bolt12 payment failed"
                             );
+                            // The payment is terminally failed: release the
+                            // claim so a retry can dispatch the quote again.
+                            release_bolt12_failed_dispatch(&self.kv_store, &quote_id, &payment_id)
+                                .await;
                             break details;
                         }
                         PaymentStatus::Pending => {
@@ -1298,7 +1315,22 @@ impl MintPayment for CdkLdkNode {
                     .resolve()
                 {
                     Bolt12QuotePaymentIdResolution::PaymentId(payment_id) => {
-                        self.inner.payment(&payment_id)
+                        let payment_details = self.inner.payment(&payment_id);
+                        // A terminally failed payment can never move again:
+                        // release the claim so a retry can dispatch the quote
+                        // again. The removal is value-matched, so a stale
+                        // check cannot erase a newer binding.
+                        if let Some(details) = &payment_details {
+                            if details.status == PaymentStatus::Failed {
+                                release_bolt12_failed_dispatch(
+                                    &self.kv_store,
+                                    quote_id,
+                                    &payment_id,
+                                )
+                                .await;
+                            }
+                        }
+                        payment_details
                     }
                     Bolt12QuotePaymentIdResolution::Status(status) => {
                         return Ok(MakePaymentResponse {
@@ -1349,23 +1381,97 @@ fn bolt12_quote_payment_id_key(quote_id: &QuoteId) -> Result<String, Error> {
     }
 }
 
-/// Records the bolt12 melt quote id -> payment id mapping.
+/// Claims the bolt12 melt quote id for dispatch by writing the pre-dispatch
+/// sentinel.
 ///
-/// `payment_id` of `None` writes the pre-dispatch sentinel: it marks that
+/// The claim is an atomic absent-only insert: the first dispatch attempt for
+/// a quote owns it, and a duplicate or concurrent `make_payment` is rejected
+/// before any funds move — whether the existing record is another in-flight
+/// sentinel or an already recorded payment id. The sentinel also marks that
 /// `send` is about to be attempted so a crash during dispatch is
 /// distinguishable from "never dispatched" (mirrors cdk-cln's pre-dispatch
 /// bolt12 quote mapping).
-async fn write_bolt12_quote_payment_id(
+async fn claim_bolt12_quote_dispatch(
     kv_store: &DynKVStore,
     quote_id: &QuoteId,
-    payment_id: Option<&PaymentId>,
 ) -> Result<(), Error> {
     let key = bolt12_quote_payment_id_key(quote_id)?;
-    let value = payment_id.map(|id| hex::encode(id.0)).unwrap_or_default();
     let mut tx = kv_store
         .begin_transaction()
         .await
         .map_err(|e| Error::Database(e.to_string()))?;
+
+    let claimed = tx
+        .kv_write_if_absent(
+            LDK_KV_PRIMARY_NAMESPACE,
+            LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+            &key,
+            b"",
+        )
+        .await
+        .map_err(|e| Error::Database(e.to_string()))?;
+
+    if claimed {
+        tx.commit()
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?;
+        return Ok(());
+    }
+
+    tx.rollback()
+        .await
+        .map_err(|e| Error::Database(e.to_string()))?;
+    Err(Error::Bolt12QuoteAlreadyClaimed {
+        quote_id: quote_id.to_string(),
+    })
+}
+
+/// Records the bolt12 melt quote id -> payment id mapping after dispatch.
+///
+/// The write is conditional on owning the dispatch claim: the current record
+/// must be the empty sentinel written by [`claim_bolt12_quote_dispatch`].
+/// Re-recording the same payment id is an idempotent no-op for recovery; any
+/// other state is rejected.
+async fn record_bolt12_quote_payment_id(
+    kv_store: &DynKVStore,
+    quote_id: &QuoteId,
+    payment_id: &PaymentId,
+) -> Result<(), Error> {
+    let key = bolt12_quote_payment_id_key(quote_id)?;
+    let value = hex::encode(payment_id.0);
+    let mut tx = kv_store
+        .begin_transaction()
+        .await
+        .map_err(|e| Error::Database(e.to_string()))?;
+
+    let existing = tx
+        .kv_read(
+            LDK_KV_PRIMARY_NAMESPACE,
+            LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+            &key,
+        )
+        .await
+        .map_err(|e| Error::Database(e.to_string()))?;
+
+    match existing {
+        // Owned pre-dispatch sentinel: replace it with the payment id below.
+        Some(existing) if existing.is_empty() => {}
+        // Recovery repeat of an already recorded binding.
+        Some(existing) if existing.as_slice() == value.as_bytes() => {
+            tx.rollback()
+                .await
+                .map_err(|e| Error::Database(e.to_string()))?;
+            return Ok(());
+        }
+        _ => {
+            tx.rollback()
+                .await
+                .map_err(|e| Error::Database(e.to_string()))?;
+            return Err(Error::Bolt12QuoteAlreadyClaimed {
+                quote_id: quote_id.to_string(),
+            });
+        }
+    }
 
     tx.kv_write(
         LDK_KV_PRIMARY_NAMESPACE,
@@ -1435,29 +1541,64 @@ async fn read_bolt12_quote_payment_id(
     Ok(Bolt12QuotePaymentIdLookup::Found(PaymentId(payment_id)))
 }
 
-/// Removes the bolt12 melt quote id -> payment id mapping
-async fn delete_bolt12_quote_payment_id(
+/// Removes the bolt12 melt quote id mapping only when it still holds
+/// `expected`.
+///
+/// The removal is value-matched: a binding that has been replaced since the
+/// caller read it is never deleted, so a stale releaser cannot erase an
+/// in-flight dispatch or a newly recorded payment id. Returns `true` when
+/// the binding was removed.
+async fn delete_bolt12_quote_payment_id_if_matches(
     kv_store: &DynKVStore,
     quote_id: &QuoteId,
-) -> Result<(), Error> {
+    expected: &[u8],
+) -> Result<bool, Error> {
     let key = bolt12_quote_payment_id_key(quote_id)?;
     let mut tx = kv_store
         .begin_transaction()
         .await
         .map_err(|e| Error::Database(e.to_string()))?;
 
-    tx.kv_remove(
-        LDK_KV_PRIMARY_NAMESPACE,
-        LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
-        &key,
-    )
-    .await
-    .map_err(|e| Error::Database(e.to_string()))?;
+    let removed = tx
+        .kv_remove_if_equals(
+            LDK_KV_PRIMARY_NAMESPACE,
+            LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+            &key,
+            expected,
+        )
+        .await
+        .map_err(|e| Error::Database(e.to_string()))?;
     tx.commit()
         .await
         .map_err(|e| Error::Database(e.to_string()))?;
 
-    Ok(())
+    Ok(removed)
+}
+
+/// Releases the dispatch claim for a terminally failed payment so the quote
+/// can be claimed again by a retry. Best-effort: if the release fails the
+/// binding remains and the quote stays claimed.
+async fn release_bolt12_failed_dispatch(
+    kv_store: &DynKVStore,
+    quote_id: &QuoteId,
+    payment_id: &PaymentId,
+) {
+    // The binding holds the recorded payment id, or still the dispatch
+    // sentinel when the record write failed.
+    let recorded = hex::encode(payment_id.0);
+    for expected in [recorded.as_bytes(), b"".as_slice()] {
+        match delete_bolt12_quote_payment_id_if_matches(kv_store, quote_id, expected).await {
+            Ok(true) => return,
+            Ok(false) => continue,
+            Err(err) => {
+                tracing::warn!(
+                    "Could not release failed BOLT12 dispatch for quote {quote_id}: {err}. \
+                     The quote will remain claimed."
+                );
+                return;
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1666,9 +1807,10 @@ mod tests {
         std::sync::Arc::new(cdk_sqlite::mint::memory::empty().await.unwrap())
     }
 
-    /// The mapping must resolve Missing before any dispatch, Found after the
-    /// payment id is recorded, and Dispatching (indeterminate) while only the
-    /// pre-dispatch sentinel exists.
+    /// The mapping must resolve Missing before any dispatch, Dispatching
+    /// (indeterminate) while only the pre-dispatch sentinel exists, and Found
+    /// after the payment id is recorded. Sentinel cleanup returns to Missing;
+    /// a recorded payment id is never deleted.
     #[tokio::test]
     async fn bolt12_quote_payment_id_mapping_lifecycle() {
         let kv_store = test_kv_store().await;
@@ -1683,7 +1825,7 @@ mod tests {
         );
 
         // Pre-dispatch sentinel
-        write_bolt12_quote_payment_id(&kv_store, &quote_id, None)
+        claim_bolt12_quote_dispatch(&kv_store, &quote_id)
             .await
             .unwrap();
         assert_eq!(
@@ -1696,7 +1838,7 @@ mod tests {
 
         // Record the payment id
         let payment_id = PaymentId([7; 32]);
-        write_bolt12_quote_payment_id(&kv_store, &quote_id, Some(&payment_id))
+        record_bolt12_quote_payment_id(&kv_store, &quote_id, &payment_id)
             .await
             .unwrap();
         assert_eq!(
@@ -1706,15 +1848,228 @@ mod tests {
             Bolt12QuotePaymentIdLookup::Found(payment_id)
         );
 
-        // Removal returns to Missing (failed dispatch cleanup)
-        delete_bolt12_quote_payment_id(&kv_store, &quote_id)
+        // Sentinel cleanup never removes a recorded payment id
+        let removed = delete_bolt12_quote_payment_id_if_matches(&kv_store, &quote_id, b"")
             .await
             .unwrap();
+        assert!(!removed, "sentinel removal must not match a payment id");
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .unwrap(),
+            Bolt12QuotePaymentIdLookup::Found(payment_id),
+            "a recorded payment id must survive sentinel cleanup"
+        );
+
+        // A stale value does not remove the binding either
+        let other_payment_id = PaymentId([9; 32]);
+        let other = hex::encode(other_payment_id.0);
+        let removed =
+            delete_bolt12_quote_payment_id_if_matches(&kv_store, &quote_id, other.as_bytes())
+                .await
+                .unwrap();
+        assert!(!removed, "a mismatched value must not remove the binding");
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .unwrap(),
+            Bolt12QuotePaymentIdLookup::Found(payment_id)
+        );
+
+        // Removing the recorded payment id releases the quote
+        let recorded = hex::encode(payment_id.0);
+        let removed =
+            delete_bolt12_quote_payment_id_if_matches(&kv_store, &quote_id, recorded.as_bytes())
+                .await
+                .unwrap();
+        assert!(removed);
         assert_eq!(
             read_bolt12_quote_payment_id(&kv_store, &quote_id)
                 .await
                 .unwrap(),
             Bolt12QuotePaymentIdLookup::Missing
+        );
+    }
+
+    /// Failed-dispatch cleanup removes the sentinel so the quote can be
+    /// claimed again.
+    #[tokio::test]
+    async fn bolt12_quote_dispatch_cleanup_releases_claim() {
+        let kv_store = test_kv_store().await;
+        let quote_id = QuoteId::new();
+
+        claim_bolt12_quote_dispatch(&kv_store, &quote_id)
+            .await
+            .unwrap();
+        let removed = delete_bolt12_quote_payment_id_if_matches(&kv_store, &quote_id, b"")
+            .await
+            .unwrap();
+        assert!(removed);
+
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .unwrap(),
+            Bolt12QuotePaymentIdLookup::Missing
+        );
+
+        claim_bolt12_quote_dispatch(&kv_store, &quote_id)
+            .await
+            .expect("quote must be claimable again after sentinel cleanup");
+    }
+
+    /// A terminally failed dispatch releases the claim whether the binding
+    /// holds the recorded payment id or still the sentinel, so a retry can
+    /// dispatch the quote again.
+    #[tokio::test]
+    async fn bolt12_quote_failed_dispatch_release_allows_retry() {
+        let kv_store = test_kv_store().await;
+
+        // Binding holds the recorded payment id
+        let quote_id = QuoteId::new();
+        let payment_id = PaymentId([7; 32]);
+        claim_bolt12_quote_dispatch(&kv_store, &quote_id)
+            .await
+            .unwrap();
+        record_bolt12_quote_payment_id(&kv_store, &quote_id, &payment_id)
+            .await
+            .unwrap();
+
+        release_bolt12_failed_dispatch(&kv_store, &quote_id, &payment_id).await;
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .unwrap(),
+            Bolt12QuotePaymentIdLookup::Missing
+        );
+        claim_bolt12_quote_dispatch(&kv_store, &quote_id)
+            .await
+            .expect("quote must be claimable again after a failed dispatch");
+
+        // Binding still holds the sentinel (record write failed)
+        let quote_id = QuoteId::new();
+        claim_bolt12_quote_dispatch(&kv_store, &quote_id)
+            .await
+            .unwrap();
+
+        release_bolt12_failed_dispatch(&kv_store, &quote_id, &payment_id).await;
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .unwrap(),
+            Bolt12QuotePaymentIdLookup::Missing
+        );
+    }
+
+    /// A dispatch claim is write-once: a second claim is rejected while the
+    /// sentinel exists and after the payment id is recorded.
+    #[tokio::test]
+    async fn bolt12_quote_dispatch_claim_is_write_once() {
+        let kv_store = test_kv_store().await;
+        let quote_id = QuoteId::new();
+
+        claim_bolt12_quote_dispatch(&kv_store, &quote_id)
+            .await
+            .unwrap();
+
+        let err = claim_bolt12_quote_dispatch(&kv_store, &quote_id)
+            .await
+            .expect_err("a duplicate dispatch must not claim the quote");
+        assert!(
+            matches!(err, Error::Bolt12QuoteAlreadyClaimed { .. }),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .unwrap(),
+            Bolt12QuotePaymentIdLookup::Dispatching,
+            "the original sentinel must be retained"
+        );
+
+        let payment_id = PaymentId([7; 32]);
+        record_bolt12_quote_payment_id(&kv_store, &quote_id, &payment_id)
+            .await
+            .unwrap();
+
+        let err = claim_bolt12_quote_dispatch(&kv_store, &quote_id)
+            .await
+            .expect_err("a repeat dispatch after recording must be rejected");
+        assert!(
+            matches!(err, Error::Bolt12QuoteAlreadyClaimed { .. }),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .unwrap(),
+            Bolt12QuotePaymentIdLookup::Found(payment_id),
+            "the recorded payment id must be retained"
+        );
+    }
+
+    /// Concurrent dispatch claims for one quote have exactly one winner.
+    #[tokio::test]
+    async fn bolt12_quote_dispatch_concurrent_claims_have_single_winner() {
+        let kv_store = test_kv_store().await;
+        let quote_id = QuoteId::new();
+
+        let (first_result, second_result) = tokio::join!(
+            claim_bolt12_quote_dispatch(&kv_store, &quote_id),
+            claim_bolt12_quote_dispatch(&kv_store, &quote_id),
+        );
+
+        let outcomes = [first_result, second_result];
+        let winners = outcomes.iter().filter(|result| result.is_ok()).count();
+        let conflicts = outcomes
+            .iter()
+            .filter(|result| matches!(result, Err(Error::Bolt12QuoteAlreadyClaimed { .. })))
+            .count();
+
+        assert_eq!(winners, 1, "exactly one dispatch may claim the quote");
+        assert_eq!(conflicts, 1, "the losing dispatch must be rejected");
+    }
+
+    /// Recording a payment id requires owning the dispatch claim; repeating
+    /// the same payment id is idempotent and a conflicting one is rejected.
+    #[tokio::test]
+    async fn bolt12_quote_payment_id_recording_requires_claim() {
+        let kv_store = test_kv_store().await;
+        let quote_id = QuoteId::new();
+        let payment_id = PaymentId([7; 32]);
+        let other_payment_id = PaymentId([9; 32]);
+
+        let err = record_bolt12_quote_payment_id(&kv_store, &quote_id, &payment_id)
+            .await
+            .expect_err("recording without a dispatch claim must be rejected");
+        assert!(
+            matches!(err, Error::Bolt12QuoteAlreadyClaimed { .. }),
+            "unexpected error: {err}"
+        );
+
+        claim_bolt12_quote_dispatch(&kv_store, &quote_id)
+            .await
+            .unwrap();
+        record_bolt12_quote_payment_id(&kv_store, &quote_id, &payment_id)
+            .await
+            .unwrap();
+        record_bolt12_quote_payment_id(&kv_store, &quote_id, &payment_id)
+            .await
+            .expect("re-recording the same payment id must succeed for recovery");
+
+        let err = record_bolt12_quote_payment_id(&kv_store, &quote_id, &other_payment_id)
+            .await
+            .expect_err("a conflicting payment id must be rejected");
+        assert!(
+            matches!(err, Error::Bolt12QuoteAlreadyClaimed { .. }),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .unwrap(),
+            Bolt12QuotePaymentIdLookup::Found(payment_id),
+            "the first payment id must be retained"
         );
     }
 

--- a/crates/cdk-sql-common/src/keyvalue.rs
+++ b/crates/cdk-sql-common/src/keyvalue.rs
@@ -89,6 +89,43 @@ where
     Ok(())
 }
 
+/// Generic implementation of kv_write_if_absent for transactions
+#[cfg(feature = "mint")]
+pub(crate) async fn kv_write_if_absent_in_transaction<RM>(
+    conn: &ConnectionWithTransaction<RM::Connection, PooledResource<RM>>,
+    primary_namespace: &str,
+    secondary_namespace: &str,
+    key: &str,
+    value: &[u8],
+) -> Result<bool, Error>
+where
+    RM: DatabasePool,
+{
+    // Validate parameters according to KV store requirements
+    validate_kvstore_params(primary_namespace, secondary_namespace, Some(key))?;
+
+    let current_time = unix_time();
+
+    let affected = query(
+        r#"
+        INSERT INTO kv_store
+        (primary_namespace, secondary_namespace, key, value, created_time, updated_time)
+        VALUES (:primary_namespace, :secondary_namespace, :key, :value, :created_time, :updated_time)
+        ON CONFLICT(primary_namespace, secondary_namespace, key) DO NOTHING
+        "#,
+    )?
+    .bind("primary_namespace", primary_namespace.to_owned())
+    .bind("secondary_namespace", secondary_namespace.to_owned())
+    .bind("key", key.to_owned())
+    .bind("value", value.to_vec())
+    .bind("created_time", current_time as i64)
+    .bind("updated_time", current_time as i64)
+    .execute(conn)
+    .await?;
+
+    Ok(affected == 1)
+}
+
 /// Generic implementation of kv_remove for transactions
 #[cfg(feature = "mint")]
 pub(crate) async fn kv_remove_in_transaction<RM>(

--- a/crates/cdk-sql-common/src/keyvalue.rs
+++ b/crates/cdk-sql-common/src/keyvalue.rs
@@ -156,6 +156,39 @@ where
     Ok(())
 }
 
+/// Generic implementation of kv_remove_if_equals for transactions
+#[cfg(feature = "mint")]
+pub(crate) async fn kv_remove_if_equals_in_transaction<RM>(
+    conn: &ConnectionWithTransaction<RM::Connection, PooledResource<RM>>,
+    primary_namespace: &str,
+    secondary_namespace: &str,
+    key: &str,
+    expected: &[u8],
+) -> Result<bool, Error>
+where
+    RM: DatabasePool,
+{
+    // Validate parameters according to KV store requirements
+    validate_kvstore_params(primary_namespace, secondary_namespace, Some(key))?;
+    let affected = query(
+        r#"
+        DELETE FROM kv_store
+        WHERE primary_namespace = :primary_namespace
+        AND secondary_namespace = :secondary_namespace
+        AND key = :key
+        AND value = :expected
+        "#,
+    )?
+    .bind("primary_namespace", primary_namespace.to_owned())
+    .bind("secondary_namespace", secondary_namespace.to_owned())
+    .bind("key", key.to_owned())
+    .bind("expected", expected.to_vec())
+    .execute(conn)
+    .await?;
+
+    Ok(affected == 1)
+}
+
 /// Generic implementation of kv_list for transactions
 #[cfg(feature = "mint")]
 pub(crate) async fn kv_list_in_transaction<RM>(

--- a/crates/cdk-sql-common/src/mint/keyvalue.rs
+++ b/crates/cdk-sql-common/src/mint/keyvalue.rs
@@ -44,6 +44,23 @@ where
         .await
     }
 
+    async fn kv_write_if_absent(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        value: &[u8],
+    ) -> Result<bool, Error> {
+        crate::keyvalue::kv_write_if_absent_in_transaction(
+            &self.inner,
+            primary_namespace,
+            secondary_namespace,
+            key,
+            value,
+        )
+        .await
+    }
+
     async fn kv_remove(
         &mut self,
         primary_namespace: &str,

--- a/crates/cdk-sql-common/src/mint/keyvalue.rs
+++ b/crates/cdk-sql-common/src/mint/keyvalue.rs
@@ -76,6 +76,23 @@ where
         .await
     }
 
+    async fn kv_remove_if_equals(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        expected: &[u8],
+    ) -> Result<bool, Error> {
+        crate::keyvalue::kv_remove_if_equals_in_transaction(
+            &self.inner,
+            primary_namespace,
+            secondary_namespace,
+            key,
+            expected,
+        )
+        .await
+    }
+
     async fn kv_list(
         &mut self,
         primary_namespace: &str,


### PR DESCRIPTION
create_or_retry_failed_send_intent checked the quote-id index with a read-then-write inside one transaction. On backends that do not serialize concurrent transactions, two callers could both observe a missing index entry and each persist an intent for the same quote id.

Add KVStoreTransaction::kv_write_if_absent, an insert-if-absent primitive implemented for the SQL backend as INSERT ... ON CONFLICT DO NOTHING with a rows-affected check, and use it to reserve the quote id in the same transaction as the intent record. The losing transaction now rolls back with DuplicateQuoteId. The retry-failed path is unchanged: an existing index entry still requeues the failed intent under its original id.

Cover the primitive with a concurrent-contender conformance test in the shared mint database test suite and a racing-store regression test in cdk-bdk.

Found by project Loupe

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
