### PR TITLE
fix(cln): respect BOLT12 disable configuration

### DIFF
--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -54,6 +54,7 @@ pub struct Cln {
     rpc_socket: PathBuf,
     fee_reserve: FeeReserve,
     expose_private_channels: bool,
+    bolt12: bool,
     wait_invoice_cancel_token: CancellationToken,
     wait_invoice_is_active: Arc<AtomicBool>,
     kv_store: DynKVStore,
@@ -80,10 +81,17 @@ impl Cln {
             rpc_socket,
             fee_reserve,
             expose_private_channels,
+            bolt12: true,
             wait_invoice_cancel_token: CancellationToken::new(),
             wait_invoice_is_active: Arc::new(AtomicBool::new(false)),
             kv_store,
         })
+    }
+
+    /// Enable or disable BOLT12 support.
+    pub fn with_bolt12(mut self, bolt12: bool) -> Self {
+        self.bolt12 = bolt12;
+        self
     }
 }
 
@@ -100,7 +108,9 @@ impl MintPayment for Cln {
                 amountless: true,
                 invoice_description: true,
             }),
-            bolt12: Some(payment::Bolt12Settings { amountless: true }),
+            bolt12: self
+                .bolt12
+                .then_some(payment::Bolt12Settings { amountless: true }),
             onchain: None,
             custom: HashMap::new(),
         })
@@ -1425,6 +1435,7 @@ mod tests {
                 percent_fee_reserve: 0.0,
             },
             expose_private_channels: false,
+            bolt12: true,
             wait_invoice_cancel_token: CancellationToken::new(),
             wait_invoice_is_active: Arc::new(AtomicBool::new(false)),
             kv_store,

--- a/crates/cdk-integration-tests/src/bin/start_regtest_mints.rs
+++ b/crates/cdk-integration-tests/src/bin/start_regtest_mints.rs
@@ -125,7 +125,7 @@ async fn start_cln_mint(
 
     let cln_config = cdk_mintd::config::Cln {
         rpc_path: cln_rpc_path,
-        bolt12: false,
+        bolt12: true,
         expose_private_channels: false,
         fee_percent: 0.0,
         reserve_fee_min: 0.into(),

--- a/crates/cdk-mintd/src/env_vars/cln.rs
+++ b/crates/cdk-mintd/src/env_vars/cln.rs
@@ -50,3 +50,58 @@ impl Cln {
         self
     }
 }
+
+#[cfg(all(test, feature = "sqlite"))]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    use cdk::cdk_payment::MintPayment;
+    use cdk::nuts::CurrencyUnit;
+    use cdk_sqlite::mint::memory;
+
+    use super::*;
+    use crate::config::Settings;
+    use crate::setup::PaymentBackendSetup;
+
+    #[tokio::test]
+    async fn bolt12_false_removes_bolt12_from_cln_capabilities() {
+        let config = {
+            let _guard = crate::test_utils::env_lock();
+            let previous_bolt12 = std::env::var_os(ENV_CLN_BOLT12);
+            std::env::set_var(ENV_CLN_BOLT12, "false");
+
+            let config = Cln {
+                rpc_path: PathBuf::from("/nonexistent/lightning-rpc"),
+                ..Default::default()
+            }
+            .from_env();
+
+            match previous_bolt12 {
+                Some(value) => std::env::set_var(ENV_CLN_BOLT12, value),
+                None => std::env::remove_var(ENV_CLN_BOLT12),
+            }
+
+            config
+        };
+        assert!(!config.bolt12, "the environment override must be applied");
+
+        let kv_store = Arc::new(memory::empty().await.expect("in-memory database"));
+        let backend = config
+            .setup(
+                &Settings::default(),
+                CurrencyUnit::Sat,
+                None,
+                Path::new("."),
+                Some(kv_store),
+            )
+            .await
+            .expect("CLN setup does not connect eagerly");
+
+        let capabilities = backend.get_settings().await.expect("CLN capabilities");
+        assert!(
+            capabilities.bolt12.is_none(),
+            "CDK_MINTD_CLN_BOLT12=false must disable BOLT12 capabilities"
+        );
+    }
+}

--- a/crates/cdk-mintd/src/setup.rs
+++ b/crates/cdk-mintd/src/setup.rs
@@ -88,7 +88,8 @@ impl PaymentBackendSetup for config::Cln {
             self.expose_private_channels,
             kv_store.expect("Cln needs kv store"),
         )
-        .await?;
+        .await?
+        .with_bolt12(self.bolt12);
 
         Ok(cln)
     }

--- a/crates/cdk-payment-processor/src/bin/payment_processor.rs
+++ b/crates/cdk-payment-processor/src/bin/payment_processor.rs
@@ -113,7 +113,8 @@ async fn main() -> anyhow::Result<()> {
                     let kv_store = Arc::new(MintSqliteDatabase::new(":memory:").await?);
                     Arc::new(
                         cdk_cln::Cln::new(cln_settings.rpc_path, fee_reserve, false, kv_store)
-                            .await?,
+                            .await?
+                            .with_bolt12(cln_settings.bolt12),
                     )
                 }
                 #[cfg(feature = "fake")]


### PR DESCRIPTION
Propagate the configured BOLT12 flag into CLN backends and omit BOLT12 capabilities when disabled. Cover the mintd environment setting with a regression test.

Found by project Loupe

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
