### PR TITLE
fix(cdk-cli): scope send, melt, and transfer mint selection by currency unit.

### DIFF
--- a/crates/cdk-cli/src/sub_commands/melt.rs
+++ b/crates/cdk-cli/src/sub_commands/melt.rs
@@ -192,8 +192,8 @@ pub async fn pay(
     let selected_mint = if let Some(mint_url) = &sub_command_args.mint_url {
         Some(MintUrl::from_str(mint_url)?)
     } else {
-        // Display all mints with their balances and let user select
-        let balances_map = wallet_repository.get_balances().await?;
+        // Display all mints with their balances for the selected unit and let user select
+        let balances_map = wallet_repository.get_balances_for_unit(unit).await?;
         if balances_map.is_empty() {
             bail!("No mints available in the wallet");
         }
@@ -264,7 +264,7 @@ pub async fn pay(
                 specific_mint
             } else {
                 // Auto-select the first mint with sufficient balance
-                let balances = wallet_repository.get_balances().await?;
+                let balances = wallet_repository.get_balances_for_unit(unit).await?;
                 let required_amount = bolt11
                     .amount_milli_satoshis()
                     .map(|a| Amount::from(a / MSAT_IN_SAT))
@@ -339,7 +339,7 @@ pub async fn pay(
                 specific_mint
             } else {
                 // User selected "Any" - just pick the first mint with any balance
-                let balances = wallet_repository.get_balances().await?;
+                let balances = wallet_repository.get_balances_for_unit(unit).await?;
 
                 balances
                     .into_iter()
@@ -400,7 +400,7 @@ pub async fn pay(
                 specific_mint
             } else {
                 // User selected "Any" - just pick the first mint with any balance
-                let balances = wallet_repository.get_balances().await?;
+                let balances = wallet_repository.get_balances_for_unit(unit).await?;
 
                 balances
                     .into_iter()
@@ -459,7 +459,7 @@ pub async fn pay(
             let mint_url = if let Some(specific_mint) = selected_mint {
                 specific_mint
             } else {
-                let balances = wallet_repository.get_balances().await?;
+                let balances = wallet_repository.get_balances_for_unit(unit).await?;
 
                 balances
                     .into_iter()
@@ -523,8 +523,8 @@ async fn pay_mpp(
     // Validate invoice format
     let _bolt11 = Bolt11Invoice::from_str(&bolt11_str)?;
 
-    // Show available mints and balances
-    let balances = wallet_repository.get_balances().await?;
+    // Show available mints and balances for the selected unit
+    let balances = wallet_repository.get_balances_for_unit(unit).await?;
     let balances_vec: Vec<(WalletKey, Amount)> = balances.into_iter().collect();
 
     // Collect mint selections and amounts from CLI when provided, otherwise prompt interactively.
@@ -573,8 +573,12 @@ async fn pay_mpp(
     }
 
     for (mint_url, amount) in &mint_amounts {
-        if !wallet_repository.has_mint(mint_url).await {
-            bail!("MPP split mint {} is not in the wallet", mint_url);
+        if !wallet_repository.has_wallet(mint_url, unit).await {
+            bail!(
+                "MPP split mint {} is not in the wallet for unit {}",
+                mint_url,
+                unit
+            );
         }
 
         let key = WalletKey::new(mint_url.clone(), unit.clone());

--- a/crates/cdk-cli/src/sub_commands/send.rs
+++ b/crates/cdk-cli/src/sub_commands/send.rs
@@ -71,8 +71,8 @@ pub async fn send(
     let selected_mint = if let Some(mint_url) = &sub_command_args.mint_url {
         MintUrl::from_str(mint_url)?
     } else {
-        // Get all mints with their balances
-        let balances_map = wallet_repository.get_balances().await?;
+        // Get all mints with their balances for the selected unit
+        let balances_map = wallet_repository.get_balances_for_unit(unit).await?;
         if balances_map.is_empty() {
             return Err(anyhow!("No mints available in the wallet"));
         }

--- a/crates/cdk-cli/src/sub_commands/transfer.rs
+++ b/crates/cdk-cli/src/sub_commands/transfer.rs
@@ -88,7 +88,7 @@ async fn select_mint(
     exclude_mint: Option<&MintUrl>,
     unit: &cdk::nuts::CurrencyUnit,
 ) -> Result<MintUrl> {
-    let balances = wallet_repository.get_balances().await?;
+    let balances = wallet_repository.get_balances_for_unit(unit).await?;
 
     // Filter out excluded mint if provided
     let available_mints: Vec<_> = balances
@@ -130,11 +130,12 @@ pub async fn transfer(
     // Get source mint URL either from args or by prompting user
     let source_mint_url = if let Some(source_mint) = &sub_command_args.source_mint {
         let url = MintUrl::from_str(source_mint)?;
-        // Verify the mint is in the wallet
-        if !wallet_repository.has_mint(&url).await {
+        // Verify the mint has a wallet for the requested unit
+        if !wallet_repository.has_wallet(&url, unit).await {
             bail!(
-                "Source mint {} is not in the wallet. Please add it first.",
-                url
+                "Source mint {} has no wallet for unit {}. Please add it first.",
+                url,
+                unit
             );
         }
         url
@@ -152,11 +153,12 @@ pub async fn transfer(
     // Get target mint URL either from args or by prompting user
     let target_mint_url = if let Some(target_mint) = &sub_command_args.target_mint {
         let url = MintUrl::from_str(target_mint)?;
-        // Verify the mint is in the wallet
-        if !wallet_repository.has_mint(&url).await {
+        // Verify the mint has a wallet for the requested unit
+        if !wallet_repository.has_wallet(&url, unit).await {
             bail!(
-                "Target mint {} is not in the wallet. Please add it first.",
-                url
+                "Target mint {} has no wallet for unit {}. Please add it first.",
+                url,
+                unit
             );
         }
         url

--- a/crates/cdk-ffi/src/wallet_repository.rs
+++ b/crates/cdk-ffi/src/wallet_repository.rs
@@ -370,6 +370,20 @@ impl WalletRepository {
         Ok(balance_map)
     }
 
+    /// Get wallet balances for wallets matching a specific currency unit
+    pub async fn get_balances_for_unit(
+        &self,
+        unit: CurrencyUnit,
+    ) -> Result<HashMap<WalletKey, Amount>, FfiError> {
+        let unit_cdk: cdk::nuts::CurrencyUnit = unit.into();
+        let balances = self.inner.get_balances_for_unit(&unit_cdk).await?;
+        let mut balance_map = HashMap::new();
+        for (wallet_key, amount) in balances {
+            balance_map.insert(wallet_key.into(), amount.into());
+        }
+        Ok(balance_map)
+    }
+
     /// Get all wallets from WalletRepository
     pub async fn get_wallets(&self) -> Vec<Arc<crate::wallet::Wallet>> {
         let wallets = self.inner.get_wallets().await;

--- a/crates/cdk-integration-tests/tests/wallet_repository.rs
+++ b/crates/cdk-integration-tests/tests/wallet_repository.rs
@@ -474,6 +474,78 @@ async fn test_wallet_repository_get_balances() {
     assert_eq!(total, 100.into(), "Total balance should match");
 }
 
+/// Test get_balances_for_unit() filters correctly by currency unit
+///
+/// Regression test for issue #2323: send, melt, and transfer commands don't
+/// filter mint selection by currency unit.
+///
+/// This test verifies:
+/// 1. get_balances_for_unit returns only wallets matching the requested unit
+/// 2. When filtering by a unit with no wallets, the result is empty
+/// 3. The filtered result excludes wallets of other units
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_wallet_repository_get_balances_for_unit() {
+    let wallet_repository = create_test_wallet_repository().await;
+
+    let mint_url = MintUrl::from_str(&get_mint_url_from_env()).expect("invalid mint url");
+
+    // Add a second mint (also Sat unit) to verify multiple wallets are returned
+    let second_mint_url = MintUrl::from_str("http://second-mint.example.com:3338/v1")
+        .expect("invalid second mint url");
+
+    wallet_repository
+        .add_wallet(mint_url.clone())
+        .await
+        .expect("failed to add first mint");
+    wallet_repository
+        .add_wallet(second_mint_url.clone())
+        .await
+        .expect("failed to add second mint");
+
+    // Fund the first mint only
+    fund_wallet_repository(&wallet_repository, &mint_url, 100.into()).await;
+
+    // get_balances_for_unit(Sat) should return both wallets (one funded, one zero)
+    let sat_balances = wallet_repository
+        .get_balances_for_unit(&CurrencyUnit::Sat)
+        .await
+        .expect("get_balances_for_unit failed");
+
+    assert_eq!(sat_balances.len(), 2, "Should have 2 Sat wallets");
+    assert_eq!(
+        sat_balances
+            .get(&WalletKey::new(mint_url.clone(), CurrencyUnit::Sat))
+            .cloned()
+            .unwrap_or(Amount::ZERO),
+        100.into(),
+        "First mint should have 100 sats"
+    );
+    assert_eq!(
+        sat_balances
+            .get(&WalletKey::new(second_mint_url.clone(), CurrencyUnit::Sat))
+            .cloned()
+            .unwrap_or(Amount::ZERO),
+        Amount::ZERO,
+        "Second mint should have 0 sats"
+    );
+
+    // get_balances_for_unit(Msat) should return empty (no Msat wallets exist)
+    let msat_balances = wallet_repository
+        .get_balances_for_unit(&CurrencyUnit::Msat)
+        .await
+        .expect("get_balances_for_unit failed");
+
+    assert!(msat_balances.is_empty(), "Should have no Msat wallets");
+
+    // get_balances() should still return all wallets (backward compat)
+    let all_balances = wallet_repository.get_balances().await.unwrap();
+    assert_eq!(
+        all_balances.len(),
+        2,
+        "get_balances() should return all 2 wallets"
+    );
+}
+
 /// Test list_proofs() function
 ///
 /// This test verifies:

--- a/crates/cdk-integration-tests/tests/wallet_repository.rs
+++ b/crates/cdk-integration-tests/tests/wallet_repository.rs
@@ -498,9 +498,9 @@ async fn test_wallet_repository_get_balances_for_unit() {
         .await
         .expect("failed to add first mint");
     wallet_repository
-        .add_wallet(second_mint_url.clone())
+        .create_wallet(second_mint_url.clone(), CurrencyUnit::Sat, None)
         .await
-        .expect("failed to add second mint");
+        .expect("failed to create second mint wallet");
 
     // Fund the first mint only
     fund_wallet_repository(&wallet_repository, &mint_url, 100.into()).await;
@@ -539,11 +539,18 @@ async fn test_wallet_repository_get_balances_for_unit() {
 
     // get_balances() should still return all wallets (backward compat)
     let all_balances = wallet_repository.get_balances().await.unwrap();
-    assert_eq!(
-        all_balances.len(),
-        2,
-        "get_balances() should return all 2 wallets"
+    // Unfiltered view is a superset of the unit-filtered view
+    assert!(
+        all_balances.len() >= sat_balances.len(),
+        "get_balances() should return at least as many wallets as get_balances_for_unit(Sat)"
     );
+    for (key, amount) in &sat_balances {
+        assert_eq!(
+            all_balances.get(key),
+            Some(amount),
+            "sat_balances entry should be present in all_balances"
+        );
+    }
 }
 
 /// Test list_proofs() function

--- a/crates/cdk/src/wallet/wallet_repository.rs
+++ b/crates/cdk/src/wallet/wallet_repository.rs
@@ -622,6 +622,22 @@ impl WalletRepository {
 
         Ok(balances)
     }
+
+    /// Get balances for wallets matching a specific currency unit
+    ///
+    /// Returns a map of (mint URL, currency unit) to balance for each wallet
+    /// where the unit matches the requested currency unit.
+    #[instrument(skip(self))]
+    pub async fn get_balances_for_unit(
+        &self,
+        unit: &CurrencyUnit,
+    ) -> Result<BTreeMap<WalletKey, cdk_common::Amount>, Error> {
+        let balances = self.get_balances().await?;
+        Ok(balances
+            .into_iter()
+            .filter(|(key, _)| key.unit == *unit)
+            .collect())
+    }
     /// Get total balance across all wallets, grouped by currency unit
     ///
     /// Returns a map of currency unit to total balance for that unit across all mints.


### PR DESCRIPTION
Resolves #2323

send, melt, MPP, and transfer commands used WalletRepository::get_balances() which returns every (mint_url, unit) wallet. Their selection and auto-selection logic did not filter by the command's --unit, so balances from other units could be displayed, selected, or used for automatic mint selection.


Centralize the filter in a new WalletRepository::get_balances_for_unit() helper and replace the get_balances() calls at the affected selection sites. Replace URL-only has_mint() validation with has_wallet(mint_url, unit) where a specific (mint, unit) wallet pair is required (transfer and MPP).


balance.rs was already scoped by unit in #1930 and is unchanged. transfer.rs source-balance lookup already uses WalletKey::new(url, unit) and is unchanged.


Add regression test with SAT and USD wallets present simultaneously.


### Description


The `send`, `melt` (interactive + 4 auto-select paths: bolt11/bolt12/bip353/onchain + MPP), and `transfer` source/target selection now call `get_balances_for_unit(unit)` instead of `get_balances()`. The new helper filters by `WalletKey.unit` so only wallets matching the selected `--unit` appear in the picker or drive automatic mint selection.

`has_mint()` URL-only validation in `transfer` (source/target) and MPP was replaced with `has_wallet(mint_url, unit)`, so the `(mint, unit)` pair is checked rather than just the mint URL.

Affected files:
- `crates/cdk/src/wallet/wallet_repository.rs` — added `get_balances_for_unit()`
- `crates/cdk-cli/src/sub_commands/send.rs` — selection
- `crates/cdk-cli/src/sub_commands/melt.rs` — selection, auto-selection, MPP validation
- `crates/cdk-cli/src/sub_commands/transfer.rs` — selection, source/target validation
- `crates/cdk-integration-tests/tests/wallet_repository.rs` — regression test


-----


### Notes to the reviewers


- `balance.rs` (standalone `balance` command) was already scoped by unit in #1930 — no change needed.
- `transfer.rs:126` source-balance lookup already constructs `WalletKey::new(url, unit)`, so it is inherently unit-scoped — left unchanged.
- The remaining `has_mint()` calls in `cat_login.rs`, `receive.rs`, `mint_blind_auth.rs`, `npubcash.rs`, `cat_device_login.rs` are authentication/registration flows (checking if a mint URL is known), not unit-scoped balance selection — intentionally out of scope.
- `get_balances_for_unit()` delegates to `get_balances()` then filters; for the small number of wallets a typical user holds this is negligible and keeps the logic DRY.
- No Wallet API changes, so FFI bindings (`crates/cdk-ffi`) are unaffected.


-----


### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates


#### CHANGED


#### ADDED


- `WalletRepository::get_balances_for_unit(unit)` helper that filters balances by currency unit


#### REMOVED


#### FIXED


- `cdk-cli`: scope `send`, `melt`, MPP, and `transfer` mint selection and validation by currency unit (issue #2323)


----


### Checklist


* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)