### PR TITLE
fix(mint): coordinate melt dispatch across replicas with quote advisory locks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
           useDaemon: false
         continue-on-error: true
       - name: Run clippy and Postgres tests
-        run: nix develop --fallback -i -L .#regtest --command bash -c "start-postgres && cargo clippy -p cdk-postgres -- -D warnings && cargo test -p cdk-postgres && cargo test -p cdk-integration-tests --test signatory_rotation"
+        run: nix develop --fallback -i -L .#regtest --command bash -c "start-postgres && cargo clippy -p cdk-postgres -- -D warnings && cargo test -p cdk-postgres -- --test-threads 8 && CDK_REQUIRE_POSTGRES_TESTS=1 cargo test -p cdk --lib second_replica && cargo test -p cdk-integration-tests --test signatory_rotation"
 
 # Tests for cdk-supabase that require a local Supabase stack (PostgREST + GoTrue + PostgreSQL)
   supabase-tests:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ dependencies = [
  "cdk-http-client",
  "cdk-npubcash",
  "cdk-nwc",
+ "cdk-postgres",
  "cdk-prometheus",
  "cdk-signatory",
  "cdk-sqlite",

--- a/crates/cdk-bdk/src/lib.rs
+++ b/crates/cdk-bdk/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![doc = include_str!("../README.md")]
 
-use std::fs;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -11,6 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
+use std::{fmt, fs};
 
 use async_trait::async_trait;
 use bdk_wallet::bitcoin::Network;
@@ -158,6 +158,23 @@ pub struct CdkBdk {
 }
 
 impl CdkBdk {
+    fn outgoing_payment_failure_response(
+        unit: &CurrencyUnit,
+        quote_id: &cdk_common::QuoteId,
+        reason: impl fmt::Display,
+    ) -> MakePaymentResponse {
+        tracing::warn!(
+            quote_id = %quote_id,
+            "BDK rejected onchain payment before dispatch: {reason}"
+        );
+        MakePaymentResponse {
+            payment_lookup_id: PaymentIdentifier::QuoteId(quote_id.clone()),
+            payment_proof: None,
+            status: MeltQuoteState::Failed,
+            total_spent: Amount::new(0, unit.clone()),
+        }
+    }
+
     fn ensure_supported_payment_unit(
         unit: &CurrencyUnit,
     ) -> Result<(), cdk_common::payment::Error> {
@@ -617,8 +634,6 @@ impl MintPayment for CdkBdk {
         unit: &CurrencyUnit,
         options: OutgoingPaymentOptions,
     ) -> Result<MakePaymentResponse, Self::Err> {
-        Self::ensure_supported_payment_unit(unit)?;
-
         let onchain_options = match options {
             OutgoingPaymentOptions::Onchain(o) => o,
             _ => return Err(cdk_common::payment::Error::UnsupportedPaymentOption),
@@ -628,30 +643,72 @@ impl MintPayment for CdkBdk {
         let amount = onchain_options.amount;
         let quote_id = onchain_options.quote_id;
 
-        let amount_sat = Self::payment_amount_to_sat(unit, &amount)?;
-        self.validate_send_amount(&address, amount_sat)?;
+        if let Err(err) = Self::ensure_supported_payment_unit(unit) {
+            return Ok(Self::outgoing_payment_failure_response(
+                unit, &quote_id, err,
+            ));
+        }
+
+        let amount_sat = match Self::payment_amount_to_sat(unit, &amount) {
+            Ok(amount_sat) => amount_sat,
+            Err(err) => {
+                return Ok(Self::outgoing_payment_failure_response(
+                    unit, &quote_id, err,
+                ));
+            }
+        };
+        if let Err(err) = self.validate_send_amount(&address, amount_sat) {
+            return Ok(Self::outgoing_payment_failure_response(
+                unit, &quote_id, err,
+            ));
+        }
 
         let max_fee_sat = match onchain_options.max_fee_amount {
-            Some(max_fee) => Self::fee_limit_to_sat(unit, &max_fee)?,
+            Some(max_fee) => match Self::fee_limit_to_sat(unit, &max_fee) {
+                Ok(max_fee_sat) => max_fee_sat,
+                Err(err) => {
+                    return Ok(Self::outgoing_payment_failure_response(
+                        unit, &quote_id, err,
+                    ));
+                }
+            },
             None => 1_000,
         };
         // Resolve the wallet-selected `fee_index` back to a configured tier.
         // Older callers that omit `fee_index` continue to default to
         // Immediate.
-        let tier = self
+        let tier = match self
             .batch_config
             .tier_for_fee_index(onchain_options.fee_index)
-            .map_err(Error::UnknownFeeIndex)?;
+            .map_err(Error::UnknownFeeIndex)
+        {
+            Ok(tier) => tier,
+            Err(err) => {
+                return Ok(Self::outgoing_payment_failure_response(
+                    unit, &quote_id, err,
+                ));
+            }
+        };
         let metadata = PaymentMetadata::from_optional_json(onchain_options.metadata.as_deref());
-        let fee_estimate = self
+        let fee_estimate = match self
             .estimate_onchain_fee_reserve(&address, amount_sat, tier)
-            .await?;
+            .await
+        {
+            Ok(fee_estimate) => fee_estimate,
+            Err(err) => {
+                return Ok(Self::outgoing_payment_failure_response(
+                    unit, &quote_id, err,
+                ));
+            }
+        };
         if fee_estimate.raw_fee_sat > max_fee_sat {
-            return Err(Error::EstimatedFeeTooHigh {
+            let err = Error::EstimatedFeeTooHigh {
                 estimated_fee: fee_estimate.raw_fee_sat,
                 max_fee: max_fee_sat,
-            }
-            .into());
+            };
+            return Ok(Self::outgoing_payment_failure_response(
+                unit, &quote_id, err,
+            ));
         }
 
         crate::send::payment_intent::SendIntent::new(
@@ -1828,6 +1885,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_make_payment_returns_failed_for_unknown_fee_index() {
+        let backend = build_test_instance(5).await;
+        let (quote_id, mut options) = onchain_options_for(10_000);
+        let OutgoingPaymentOptions::Onchain(onchain) = &mut options else {
+            panic!("expected onchain options");
+        };
+        onchain.fee_index = Some(99);
+
+        let response = backend
+            .make_payment(&CurrencyUnit::Sat, options)
+            .await
+            .expect("definitive pre-dispatch rejection should return a payment response");
+
+        assert_authoritative_failure_response(response, quote_id.clone(), CurrencyUnit::Sat);
+        assert!(
+            backend
+                .storage
+                .get_send_intent_by_quote_id(&quote_id.to_string())
+                .await
+                .expect("lookup send intent by quote id")
+                .is_none(),
+            "unknown fee index rejection must not leave a pending send intent behind"
+        );
+    }
+
+    #[tokio::test]
     async fn test_make_payment_omitted_fee_index_defaults_to_immediate() {
         let batch_config = BatchConfig {
             fee_options: vec![PaymentTier::Immediate, PaymentTier::Economy],
@@ -1901,7 +1984,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_make_payment_rechecks_current_fee_against_max_fee() {
+    async fn test_make_payment_returns_failed_when_current_fee_exceeds_max_fee() {
         let (backend, _tmp) = build_test_instance_with_tempdir(5).await;
         fund_backend_wallet(&backend, 100_000).await;
         let (quote_id, mut options) = onchain_options_for(10_000);
@@ -1910,18 +1993,12 @@ mod tests {
         };
         onchain.max_fee_amount = Some(Amount::new(1, CurrencyUnit::Sat));
 
-        let err = backend
+        let response = backend
             .make_payment(&CurrencyUnit::Sat, options)
             .await
-            .expect_err("payment should be rejected when current fee exceeds max");
+            .expect("definitive pre-dispatch rejection should return a payment response");
 
-        let cdk_common::payment::Error::Onchain(inner) = err else {
-            panic!("expected onchain error");
-        };
-        match inner.downcast_ref::<Error>() {
-            Some(Error::EstimatedFeeTooHigh { max_fee, .. }) => assert_eq!(*max_fee, 1),
-            other => panic!("expected EstimatedFeeTooHigh, got {other:?}"),
-        }
+        assert_authoritative_failure_response(response, quote_id.clone(), CurrencyUnit::Sat);
 
         assert!(
             backend
@@ -1992,6 +2069,20 @@ mod tests {
         }))
     }
 
+    fn assert_authoritative_failure_response(
+        response: MakePaymentResponse,
+        quote_id: QuoteId,
+        unit: CurrencyUnit,
+    ) {
+        assert_eq!(
+            response.payment_lookup_id,
+            PaymentIdentifier::QuoteId(quote_id)
+        );
+        assert_eq!(response.status, MeltQuoteState::Failed);
+        assert_eq!(response.total_spent, Amount::new(0, unit));
+        assert!(response.payment_proof.is_none());
+    }
+
     #[tokio::test]
     async fn test_get_payment_quote_converts_fee_options_to_msat() {
         let (backend, _tmp) = build_test_instance_with_tempdir(5).await;
@@ -2046,25 +2137,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_make_payment_rejects_fractional_satoshi_amount() {
+    async fn test_make_payment_returns_failed_for_fractional_satoshi_amount() {
         let backend = build_test_instance(5).await;
         let quote_id = QuoteId::UUID(Uuid::new_v4());
         let options = onchain_options_for_msat(quote_id.clone(), 10_000_001, 10_000_000);
 
-        let err = backend
+        let response = backend
             .make_payment(&CurrencyUnit::Msat, options)
             .await
-            .expect_err("fractional-satoshi payment should be rejected");
+            .expect("definitive pre-dispatch rejection should return a payment response");
 
-        let cdk_common::payment::Error::Onchain(inner) = err else {
-            panic!("expected onchain error");
-        };
-        assert!(matches!(
-            inner.downcast_ref::<Error>(),
-            Some(Error::FractionalSatoshiAmount {
-                amount_msat: 10_000_001
-            })
-        ));
+        assert_authoritative_failure_response(response, quote_id.clone(), CurrencyUnit::Msat);
         assert!(backend
             .storage
             .get_send_intent_by_quote_id(&quote_id.to_string())
@@ -2074,7 +2157,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_make_payment_rejects_mismatched_fee_unit() {
+    async fn test_make_payment_returns_failed_for_mismatched_fee_unit() {
         let backend = build_test_instance(5).await;
         let quote_id = QuoteId::UUID(Uuid::new_v4());
         let mut options = onchain_options_for_msat(quote_id.clone(), 10_000_000, 10_000_000);
@@ -2083,21 +2166,12 @@ mod tests {
         };
         onchain.max_fee_amount = Some(Amount::new(10_000, CurrencyUnit::Sat));
 
-        let err = backend
+        let response = backend
             .make_payment(&CurrencyUnit::Msat, options)
             .await
-            .expect_err("mismatched fee unit should be rejected");
+            .expect("definitive pre-dispatch rejection should return a payment response");
 
-        let cdk_common::payment::Error::Onchain(inner) = err else {
-            panic!("expected onchain error");
-        };
-        assert!(matches!(
-            inner.downcast_ref::<Error>(),
-            Some(Error::AmountUnitMismatch {
-                expected: CurrencyUnit::Msat,
-                actual: CurrencyUnit::Sat,
-            })
-        ));
+        assert_authoritative_failure_response(response, quote_id.clone(), CurrencyUnit::Msat);
         assert!(backend
             .storage
             .get_send_intent_by_quote_id(&quote_id.to_string())
@@ -2154,23 +2228,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_make_payment_rejects_dust_output_without_persisting_intent() {
+    async fn test_make_payment_returns_failed_for_dust_without_persisting_intent() {
         let backend = build_test_instance(5).await;
         let (quote_id, options) = onchain_options_for(1);
 
-        let err = backend
+        let response = backend
             .make_payment(&CurrencyUnit::Sat, options)
             .await
-            .expect_err("dust output should be rejected before enqueue");
+            .expect("definitive pre-dispatch rejection should return a payment response");
 
-        let cdk_common::payment::Error::Onchain(inner) = err else {
-            panic!("expected onchain error");
-        };
-
-        let backend_err = inner
-            .downcast_ref::<Error>()
-            .expect("expected cdk-bdk backend error");
-        assert!(matches!(backend_err, Error::DustOutput { .. }));
+        assert_authoritative_failure_response(response, quote_id.clone(), CurrencyUnit::Sat);
         assert!(
             backend
                 .storage
@@ -2209,29 +2276,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_make_payment_rejects_amount_below_minimum_send_without_persisting_intent() {
+    async fn test_make_payment_returns_failed_below_minimum_without_persisting_intent() {
         let backend = build_test_instance(5).await;
         let (quote_id, options) = onchain_options_for(545);
 
-        let err = backend
+        let response = backend
             .make_payment(&CurrencyUnit::Sat, options)
             .await
-            .expect_err("amount below configured minimum should be rejected before enqueue");
+            .expect("definitive pre-dispatch rejection should return a payment response");
 
-        let cdk_common::payment::Error::Onchain(inner) = err else {
-            panic!("expected onchain error");
-        };
-
-        let backend_err = inner
-            .downcast_ref::<Error>()
-            .expect("expected cdk-bdk backend error");
-        assert!(matches!(
-            backend_err,
-            Error::AmountBelowMinimumSend {
-                amount: 545,
-                min: 546
-            }
-        ));
+        assert_authoritative_failure_response(response, quote_id.clone(), CurrencyUnit::Sat);
         assert!(
             backend
                 .storage

--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -48,6 +48,10 @@ const CLN_KV_SECONDARY_NAMESPACE: &str = "payment_indices";
 const CLN_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE: &str = "bolt12_outgoing_payments";
 const CLN_KV_BOLT12_CLEANUP_MARKER: &[u8] = b"cleanup-in-progress";
 const LAST_PAY_INDEX_KV_KEY: &str = "last_pay_index";
+const XPAY_DESTINATION_PERMANENT_FAILURE_ERROR_CODE: i32 = 203;
+const XPAY_ROUTE_NOT_FOUND_ERROR_CODE: i32 = 205;
+const XPAY_ROUTE_TOO_EXPENSIVE_ERROR_CODE: i32 = 206;
+const XPAY_INVOICE_EXPIRED_ERROR_CODE: i32 = 207;
 
 /// CLN mint backend
 #[derive(Clone)]
@@ -563,16 +567,61 @@ impl MintPayment for Cln {
                     .convert_to(unit)?,
             },
             Err(err) => {
-                tracing::error!("Could not pay invoice with xpay: {}", err);
-                if let Some((quote_id, payment_hash)) = &bolt12_binding {
-                    match self
-                        .bolt12_binding_may_be_live_after_xpay_error(
-                            &mut cln_client,
-                            payment_hash,
-                            &err,
-                        )
-                        .await
+                tracing::warn!("xpay returned an error: {}", err);
+
+                // Reconcile BOLT12 payments by hash so a failed observation does
+                // not release the quote binding before the xpay error itself has
+                // been classified.
+                let reconciliation_payment_identifier = match &bolt12_binding {
+                    Some((_, payment_hash)) => PaymentIdentifier::Bolt12PaymentHash(*payment_hash),
+                    None => payment_lookup_id.clone(),
+                };
+
+                let (observed_state, response) = match self
+                    .check_outgoing_payment(&reconciliation_payment_identifier)
+                    .await
+                {
+                    Ok(observed_response)
+                        if matches!(
+                            observed_response.status,
+                            MeltQuoteState::Paid | MeltQuoteState::Pending
+                        ) =>
                     {
+                        (
+                            Some(observed_response.status),
+                            MakePaymentResponse {
+                                payment_lookup_id: payment_lookup_id.clone(),
+                                ..observed_response
+                            },
+                        )
+                    }
+                    Ok(observed_response) => {
+                        let observed_state = Some(observed_response.status);
+                        (
+                            observed_state,
+                            outgoing_payment_response_with_status(
+                                &payment_lookup_id,
+                                xpay_error_state(&err, observed_state),
+                            ),
+                        )
+                    }
+                    Err(status_err) => {
+                        tracing::warn!(
+                            "Could not reconcile xpay error with listpays: {}",
+                            status_err
+                        );
+                        (
+                            None,
+                            outgoing_payment_response_with_status(
+                                &payment_lookup_id,
+                                xpay_error_state(&err, None),
+                            ),
+                        )
+                    }
+                };
+
+                if let Some((quote_id, payment_hash)) = &bolt12_binding {
+                    match should_retain_bolt12_binding_after_xpay_error(&err, observed_state) {
                         true => {
                             tracing::warn!(
                                 quote_id = %quote_id,
@@ -587,7 +636,8 @@ impl MintPayment for Cln {
                         }
                     }
                 }
-                return Err(Error::ClnRpc(err).into());
+
+                response
             }
         };
 
@@ -974,46 +1024,6 @@ impl Cln {
         }
     }
 
-    /// Reconciles a coded `xpay` error with CLN's durable payment records.
-    ///
-    /// Transport and response-decoding errors are ambiguous without another
-    /// RPC round trip, so their bindings are retained. For a coded error, the
-    /// binding is released only when `listpays` has no pending or completed
-    /// payment. A failed reconciliation is also treated as ambiguous.
-    async fn bolt12_binding_may_be_live_after_xpay_error(
-        &self,
-        cln_client: &mut ClnRpc,
-        payment_hash: &[u8; 32],
-        xpay_error: &cln_rpc::RpcError,
-    ) -> bool {
-        if xpay_error.code.is_none() {
-            return true;
-        }
-
-        match cln_client
-            .call_typed(&ListpaysRequest {
-                payment_hash: Some(*Sha256::from_bytes_ref(payment_hash)),
-                bolt11: None,
-                status: None,
-                start: None,
-                index: None,
-                limit: None,
-            })
-            .await
-        {
-            Ok(response) => {
-                should_retain_bolt12_binding_after_xpay_error(xpay_error, Some(&response.pays))
-            }
-            Err(err) => {
-                tracing::warn!(
-                    payment_hash = %hex::encode(payment_hash),
-                    "Could not query listpays after BOLT12 xpay error: {err}"
-                );
-                true
-            }
-        }
-    }
-
     /// Atomically removes the binding only if it still names `payment_hash`.
     async fn delete_bolt12_quote_payment_hash_if_equals(
         &self,
@@ -1212,21 +1222,13 @@ enum Bolt12QuotePaymentHashLookup {
     Malformed,
 }
 
-/// Whether an `xpay` error and the reconciled CLN payment records require the
+/// Whether an `xpay` error and the reconciled CLN payment state require the
 /// BOLT12 quote binding to be retained.
 fn should_retain_bolt12_binding_after_xpay_error(
     xpay_error: &cln_rpc::RpcError,
-    payments: Option<&[ListpaysPays]>,
+    observed_state: Option<MeltQuoteState>,
 ) -> bool {
-    xpay_error.code.is_none()
-        || payments.is_none_or(|payments| {
-            payments.iter().any(|payment| {
-                matches!(
-                    payment.status,
-                    ListpaysPaysStatus::PENDING | ListpaysPaysStatus::COMPLETE
-                )
-            })
-        })
+    xpay_error_state(xpay_error, observed_state) != MeltQuoteState::Failed
 }
 
 fn cln_pays_status_to_mint_state(status: ListpaysPaysStatus) -> MeltQuoteState {
@@ -1315,6 +1317,35 @@ fn outgoing_payment_response_with_status(
     }
 }
 
+fn xpay_error_state(
+    error: &cln_rpc::RpcError,
+    observed_state: Option<MeltQuoteState>,
+) -> MeltQuoteState {
+    // listpays aggregates attempts by payment hash, so a negative or missing
+    // record cannot prove what happened to this specific xpay invocation. Only
+    // positive evidence (Paid/Pending) may override the RPC result. Explicit
+    // terminal xpay errors prove that this invocation cannot settle even when
+    // no send attempt was created and listpays has no row.
+    match observed_state {
+        Some(MeltQuoteState::Paid) => MeltQuoteState::Paid,
+        Some(MeltQuoteState::Pending) => MeltQuoteState::Pending,
+        _ if xpay_error_is_explicit_terminal_failure(error) => MeltQuoteState::Failed,
+        _ => MeltQuoteState::Unknown,
+    }
+}
+
+fn xpay_error_is_explicit_terminal_failure(error: &cln_rpc::RpcError) -> bool {
+    matches!(
+        error.code,
+        Some(
+            XPAY_DESTINATION_PERMANENT_FAILURE_ERROR_CODE
+                | XPAY_ROUTE_NOT_FOUND_ERROR_CODE
+                | XPAY_ROUTE_TOO_EXPENSIVE_ERROR_CODE
+                | XPAY_INVOICE_EXPIRED_ERROR_CODE
+        )
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeSet, HashMap};
@@ -1328,6 +1359,8 @@ mod tests {
     use cdk_common::payment::Bolt11OutgoingPaymentOptions;
 
     use super::*;
+
+    const XPAY_ALREADY_PAID_ERROR_CODE: i32 = 219;
 
     type MemoryKvKey = (String, String, String);
 
@@ -1346,6 +1379,14 @@ mod tests {
         DatabaseError::Database(Box::new(std::io::Error::other(
             "memory kv store lock poisoned",
         )))
+    }
+
+    fn test_rpc_error(code: Option<i32>) -> cln_rpc::RpcError {
+        cln_rpc::RpcError {
+            code,
+            message: "xpay failed".to_string(),
+            data: None,
+        }
     }
 
     fn memory_kv_key(primary_namespace: &str, secondary_namespace: &str, key: &str) -> MemoryKvKey {
@@ -1865,7 +1906,7 @@ mod tests {
     }
 
     #[test]
-    fn xpay_error_reconciliation_retains_ambiguous_bindings() {
+    fn xpay_error_classification_controls_bolt12_binding_retention() {
         let transport_error = cln_rpc::RpcError {
             code: None,
             message: "no response from lightningd".to_string(),
@@ -1881,33 +1922,43 @@ mod tests {
             message: "invoice already paid".to_string(),
             data: None,
         };
-        let pending = [test_listpays_payment(1, ListpaysPaysStatus::PENDING)];
-        let complete = [test_listpays_payment(2, ListpaysPaysStatus::COMPLETE)];
-        let failed = [test_listpays_payment(3, ListpaysPaysStatus::FAILED)];
+        let no_route_error = cln_rpc::RpcError {
+            code: Some(XPAY_ROUTE_NOT_FOUND_ERROR_CODE),
+            message: "could not find a route".to_string(),
+            data: None,
+        };
 
         assert!(should_retain_bolt12_binding_after_xpay_error(
             &transport_error,
-            Some(&failed)
+            Some(MeltQuoteState::Failed)
         ));
         assert!(should_retain_bolt12_binding_after_xpay_error(
             &coded_error,
             None
         ));
+        assert!(!should_retain_bolt12_binding_after_xpay_error(
+            &no_route_error,
+            None
+        ));
         assert!(should_retain_bolt12_binding_after_xpay_error(
             &coded_error,
-            Some(&pending)
+            Some(MeltQuoteState::Unknown)
+        ));
+        assert!(should_retain_bolt12_binding_after_xpay_error(
+            &coded_error,
+            Some(MeltQuoteState::Pending)
         ));
         assert!(should_retain_bolt12_binding_after_xpay_error(
             &already_paid_error,
-            Some(&complete)
+            Some(MeltQuoteState::Paid)
         ));
-        assert!(!should_retain_bolt12_binding_after_xpay_error(
+        assert!(should_retain_bolt12_binding_after_xpay_error(
             &coded_error,
-            Some(&failed)
+            Some(MeltQuoteState::Failed)
         ));
-        assert!(!should_retain_bolt12_binding_after_xpay_error(
+        assert!(should_retain_bolt12_binding_after_xpay_error(
             &coded_error,
-            Some(&[])
+            Some(MeltQuoteState::Unpaid)
         ));
     }
 
@@ -1936,6 +1987,82 @@ mod tests {
     #[test]
     fn cln_payment_selection_returns_none_when_missing() {
         assert!(select_cln_payment(&[]).is_none());
+    }
+
+    #[test]
+    fn xpay_explicit_terminal_errors_do_not_require_payment_record() {
+        for code in [
+            XPAY_DESTINATION_PERMANENT_FAILURE_ERROR_CODE,
+            XPAY_ROUTE_NOT_FOUND_ERROR_CODE,
+            XPAY_ROUTE_TOO_EXPENSIVE_ERROR_CODE,
+            XPAY_INVOICE_EXPIRED_ERROR_CODE,
+        ] {
+            assert_eq!(
+                xpay_error_state(&test_rpc_error(Some(code)), None),
+                MeltQuoteState::Failed
+            );
+            assert_eq!(
+                xpay_error_state(&test_rpc_error(Some(code)), Some(MeltQuoteState::Unknown)),
+                MeltQuoteState::Failed
+            );
+            assert_eq!(
+                xpay_error_state(&test_rpc_error(Some(code)), Some(MeltQuoteState::Failed)),
+                MeltQuoteState::Failed
+            );
+        }
+    }
+
+    #[test]
+    fn xpay_nonspecific_rpc_errors_ignore_negative_reconciliation() {
+        for code in [-1, 209] {
+            assert_eq!(
+                xpay_error_state(&test_rpc_error(Some(code)), None),
+                MeltQuoteState::Unknown
+            );
+            assert_eq!(
+                xpay_error_state(&test_rpc_error(Some(code)), Some(MeltQuoteState::Unknown)),
+                MeltQuoteState::Unknown
+            );
+            assert_eq!(
+                xpay_error_state(&test_rpc_error(Some(code)), Some(MeltQuoteState::Failed)),
+                MeltQuoteState::Unknown
+            );
+            assert_eq!(
+                xpay_error_state(&test_rpc_error(Some(code)), Some(MeltQuoteState::Unpaid)),
+                MeltQuoteState::Unknown
+            );
+        }
+    }
+
+    #[test]
+    fn xpay_transport_and_already_paid_errors_are_ambiguous() {
+        assert_eq!(
+            xpay_error_state(&test_rpc_error(None), None),
+            MeltQuoteState::Unknown
+        );
+        assert_eq!(
+            xpay_error_state(&test_rpc_error(Some(XPAY_ALREADY_PAID_ERROR_CODE)), None),
+            MeltQuoteState::Unknown
+        );
+        assert_eq!(
+            xpay_error_state(&test_rpc_error(None), Some(MeltQuoteState::Failed)),
+            MeltQuoteState::Unknown
+        );
+    }
+
+    #[test]
+    fn xpay_positive_reconciliation_takes_precedence() {
+        let transport_error = test_rpc_error(None);
+        let terminal_rpc_error = test_rpc_error(Some(XPAY_ROUTE_NOT_FOUND_ERROR_CODE));
+
+        assert_eq!(
+            xpay_error_state(&transport_error, Some(MeltQuoteState::Paid)),
+            MeltQuoteState::Paid
+        );
+        assert_eq!(
+            xpay_error_state(&terminal_rpc_error, Some(MeltQuoteState::Pending)),
+            MeltQuoteState::Pending
+        );
     }
 
     #[tokio::test]

--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -666,7 +666,26 @@ pub trait CompletedOperationsDatabase {
     async fn get_completed_operations(&self) -> Result<Vec<mint::Operation>, Self::Err>;
 }
 
+/// Outcome of a non-blocking quote advisory lock attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuoteLockAttempt {
+    /// This transaction holds the cross-process lock.
+    Acquired,
+    /// Another transaction holds the lock. Callers must fail closed (leave the
+    /// quote pending) and never compensate on this outcome.
+    Contended,
+    /// The backend has no cross-process lock; callers retain a process-local
+    /// guard.
+    Unsupported,
+}
+
 /// Base database writer
+///
+/// Quote advisory locks coordinate operations whose critical section extends
+/// beyond an existing row lock. Callers must acquire all quote locks before
+/// taking row locks, and implementations must acquire a batch in stable order.
+/// Locks are held until the transaction commits or rolls back.
+#[async_trait]
 pub trait Transaction<Error>:
     DbTransactionFinalizer<Err = Error>
     + QuotesTransaction<Err = Error>
@@ -676,6 +695,24 @@ pub trait Transaction<Error>:
     + SagaTransaction<Err = Error>
     + CompletedOperationsTransaction<Err = Error>
 {
+    /// Lock a set of quote identifiers for this transaction.
+    ///
+    /// Returns `true` when the backend acquired a cross-process lock. Backends
+    /// that serialize writes without a lock that can span the required critical
+    /// section return `false`, allowing callers to retain a process-local guard.
+    async fn lock_quotes(&mut self, _quote_ids: &[QuoteId]) -> Result<bool, Error> {
+        Ok(false)
+    }
+
+    /// Non-blocking variant of [`Transaction::lock_quotes`].
+    ///
+    /// Returns [`QuoteLockAttempt::Contended`] when another transaction holds
+    /// any of the locks, instead of waiting for it. Any partial acquisitions
+    /// are held until the transaction ends, so callers should roll back on
+    /// `Contended`.
+    async fn try_lock_quotes(&mut self, _quote_ids: &[QuoteId]) -> Result<QuoteLockAttempt, Error> {
+        Ok(QuoteLockAttempt::Unsupported)
+    }
 }
 
 /// Mint Database trait
@@ -690,6 +727,16 @@ pub trait Database<Error>:
 {
     /// Begins a transaction
     async fn begin_transaction(&self) -> Result<Box<dyn Transaction<Error> + Send + Sync>, Error>;
+
+    /// Begins a transaction that may remain open across payment dispatch.
+    ///
+    /// Backends may override this to isolate long-lived dispatch locks from
+    /// the connection pool used by ordinary database operations.
+    async fn begin_dispatch_transaction(
+        &self,
+    ) -> Result<Box<dyn Transaction<Error> + Send + Sync>, Error> {
+        self.begin_transaction().await
+    }
 }
 
 /// Type alias for Mint Database

--- a/crates/cdk-common/src/mint.rs
+++ b/crates/cdk-common/src/mint.rs
@@ -164,6 +164,10 @@ pub enum MeltSagaState {
     SetupComplete,
     /// Payment attempted through the configured backend (may or may not have succeeded)
     PaymentAttempted,
+    /// The backend acknowledged that the payment is pending or indeterminate.
+    /// Contradictory public `Unpaid` or `Failed` polls must not return the
+    /// reserved proofs; recovery requires a trusted failure event.
+    PaymentPending,
     /// TX1 committed (proofs Spent, quote Paid) - change signing + cleanup pending
     Finalizing,
 }
@@ -173,6 +177,7 @@ impl fmt::Display for MeltSagaState {
         match self {
             MeltSagaState::SetupComplete => write!(f, "setup_complete"),
             MeltSagaState::PaymentAttempted => write!(f, "payment_attempted"),
+            MeltSagaState::PaymentPending => write!(f, "payment_pending"),
             MeltSagaState::Finalizing => write!(f, "finalizing"),
         }
     }
@@ -185,6 +190,7 @@ impl FromStr for MeltSagaState {
         match value.as_str() {
             "setup_complete" => Ok(MeltSagaState::SetupComplete),
             "payment_attempted" => Ok(MeltSagaState::PaymentAttempted),
+            "payment_pending" => Ok(MeltSagaState::PaymentPending),
             "finalizing" => Ok(MeltSagaState::Finalizing),
             _ => Err(Error::Custom(format!("Invalid melt saga state: {}", value))),
         }
@@ -225,6 +231,7 @@ impl SagaStateEnum {
             SagaStateEnum::Melt(state) => match state {
                 MeltSagaState::SetupComplete => "setup_complete",
                 MeltSagaState::PaymentAttempted => "payment_attempted",
+                MeltSagaState::PaymentPending => "payment_pending",
                 MeltSagaState::Finalizing => "finalizing",
             },
         }

--- a/crates/cdk-common/src/payment.rs
+++ b/crates/cdk-common/src/payment.rs
@@ -574,7 +574,13 @@ pub struct MakePaymentResponse {
     pub payment_lookup_id: PaymentIdentifier,
     /// Payment proof
     pub payment_proof: Option<String>,
-    /// Status
+    /// Status.
+    ///
+    /// When this response is returned by [`MintPayment::make_payment`],
+    /// [`MeltQuoteState::Failed`] and [`MeltQuoteState::Unpaid`] are treated as
+    /// authoritative terminal outcomes. Backends must return
+    /// [`MeltQuoteState::Pending`], [`MeltQuoteState::Unknown`], or an error if
+    /// they are uncertain whether payment dispatch can still settle.
     pub status: MeltQuoteState,
     /// Total amount spent, including fees. Only authoritative when `status`
     /// is [`MeltQuoteState::Paid`]; otherwise backends return `0`.

--- a/crates/cdk-integration-tests/tests/fake_wallet.rs
+++ b/crates/cdk-integration-tests/tests/fake_wallet.rs
@@ -144,10 +144,12 @@ async fn test_fake_melt_payment_fail() {
         .len();
     assert!(pending_before_failed > 0);
 
+    // Model an authoritative backend failure response. A dispatch error remains
+    // ambiguous even if an immediate follow-up check reports Failed.
     let fake_description = FakeInvoiceDescription {
         pay_invoice_state: MeltQuoteState::Failed,
         check_payment_state: MeltQuoteState::Failed,
-        pay_err: true,
+        pay_err: false,
         check_err: false,
     };
 
@@ -159,13 +161,14 @@ async fn test_fake_melt_payment_fail() {
         .unwrap();
 
     // A confirmed failure should return an error and release its proofs.
-    let melt = async {
+    let melt = tokio::time::timeout(Duration::from_secs(15), async {
         let prepared = wallet
             .prepare_melt(&melt_quote.id, std::collections::HashMap::new())
             .await?;
         prepared.confirm().await
-    }
-    .await;
+    })
+    .await
+    .expect("authoritative failure should not remain pending");
     assert!(melt.is_err());
 
     let pending_after_failed = wallet
@@ -1849,11 +1852,13 @@ async fn test_wallet_proof_recovery_after_failed_melt() {
 
     assert_eq!(wallet.total_balance().await.unwrap(), Amount::from(100));
 
-    // Create a melt quote that will fail
+    // Model an authoritative backend failure response. An error from the
+    // dispatch call would be ambiguous even if an immediate status check
+    // reported Unpaid.
     let fake_description = FakeInvoiceDescription {
-        pay_invoice_state: MeltQuoteState::Unknown,
-        check_payment_state: MeltQuoteState::Unpaid,
-        pay_err: true,
+        pay_invoice_state: MeltQuoteState::Failed,
+        check_payment_state: MeltQuoteState::Failed,
+        pay_err: false,
         check_err: false,
     };
 
@@ -1864,13 +1869,14 @@ async fn test_wallet_proof_recovery_after_failed_melt() {
         .unwrap();
 
     // Attempt to melt - this should fail but trigger proof recovery
-    let melt_result = async {
+    let melt_result = tokio::time::timeout(Duration::from_secs(15), async {
         let prepared = wallet
             .prepare_melt(&melt_quote.id, std::collections::HashMap::new())
             .await?;
         prepared.confirm().await
-    }
-    .await;
+    })
+    .await
+    .expect("authoritative failure should not remain pending");
     assert!(melt_result.is_err(), "Melt should have failed");
 
     // Verify wallet still has balance (proofs recovered)

--- a/crates/cdk-ldk-node/src/lib.rs
+++ b/crates/cdk-ldk-node/src/lib.rs
@@ -97,6 +97,36 @@ fn bolt12_send_error_has_ambiguous_dispatch(err: &ldk_node::NodeError) -> bool {
     matches!(err, ldk_node::NodeError::PersistenceFailed)
 }
 
+/// Whether a BOLT11 send error authoritatively proves that this invocation
+/// cannot settle.
+///
+/// `PersistenceFailed` is ambiguous because `ldk-node` may return it after the
+/// channel manager accepted the payment but before the pending payment record
+/// was persisted. `DuplicatePayment` is also non-terminal for this invocation:
+/// the existing payment may already be pending or succeeded. The remaining
+/// errors listed here are returned only when dispatch was rejected.
+fn bolt11_send_error_is_explicit_terminal_failure(err: &ldk_node::NodeError) -> bool {
+    matches!(
+        err,
+        ldk_node::NodeError::NotRunning
+            | ldk_node::NodeError::InvalidAmount
+            | ldk_node::NodeError::InvalidInvoice
+            | ldk_node::NodeError::PaymentSendingFailed
+    )
+}
+
+fn outgoing_payment_failure_response(
+    unit: &CurrencyUnit,
+    payment_lookup_id: PaymentIdentifier,
+) -> MakePaymentResponse {
+    MakePaymentResponse {
+        payment_lookup_id,
+        payment_proof: None,
+        status: MeltQuoteState::Failed,
+        total_spent: Amount::new(0, unit.clone()),
+    }
+}
+
 /// CDK Lightning backend using LDK Node
 ///
 /// Provides Lightning Network functionality for CDK with support for Cashu operations.
@@ -1041,11 +1071,16 @@ impl MintPayment for CdkLdkNode {
         options: OutgoingPaymentOptions,
     ) -> Result<MakePaymentResponse, Self::Err> {
         match options {
-            cdk_common::payment::OutgoingPaymentOptions::Custom(_) => {
-                Err(cdk_common::payment::Error::UnsupportedPaymentOption)
+            cdk_common::payment::OutgoingPaymentOptions::Custom(options) => {
+                Ok(outgoing_payment_failure_response(
+                    unit,
+                    PaymentIdentifier::QuoteId(options.quote_id),
+                ))
             }
             OutgoingPaymentOptions::Bolt11(bolt11_options) => {
                 let bolt11 = bolt11_options.bolt11;
+                let payment_lookup_id =
+                    PaymentIdentifier::PaymentHash(bolt11.payment_hash().to_byte_array());
 
                 let send_params = match bolt11_options
                     .max_fee_amount
@@ -1061,7 +1096,7 @@ impl MintPayment for CdkLdkNode {
                     Ok(params) => params,
                     Err(err) => {
                         tracing::error!("Failed to convert fee amount: {}", err);
-                        return Err(payment::Error::Custom(format!("Invalid fee amount: {err}")));
+                        return Ok(outgoing_payment_failure_response(unit, payment_lookup_id));
                     }
                 };
 
@@ -1073,27 +1108,41 @@ impl MintPayment for CdkLdkNode {
                     Some(MeltOptions::Amountless { amountless }) => {
                         if let Some(invoice_amount) = bolt11.amount_milli_satoshis() {
                             if invoice_amount != u64::from(amountless.amount_msat) {
-                                return Err(payment::Error::AmountMismatch);
+                                return Ok(outgoing_payment_failure_response(
+                                    unit,
+                                    payment_lookup_id,
+                                ));
                             }
                         }
 
-                        self.inner
-                            .bolt11_payment()
-                            .send_using_amount(&bolt11, amountless.amount_msat.into(), send_params)
-                            .map_err(|err| {
-                                tracing::error!("Could not send send amountless bolt11: {}", err);
-                                Error::CouldNotSendBolt11WithoutAmount
-                            })?
+                        self.inner.bolt11_payment().send_using_amount(
+                            &bolt11,
+                            amountless.amount_msat.into(),
+                            send_params,
+                        )
                     }
-                    None => self
-                        .inner
-                        .bolt11_payment()
-                        .send(&bolt11, send_params)
-                        .map_err(|err| {
-                            tracing::error!("Could not send bolt11 {}", err);
-                            Error::CouldNotSendBolt11
-                        })?,
-                    _ => return Err(payment::Error::UnsupportedPaymentOption),
+                    None => self.inner.bolt11_payment().send(&bolt11, send_params),
+                    _ => {
+                        return Ok(outgoing_payment_failure_response(unit, payment_lookup_id));
+                    }
+                };
+
+                let payment_id = match payment_id {
+                    Ok(payment_id) => payment_id,
+                    Err(err) if bolt11_send_error_is_explicit_terminal_failure(&err) => {
+                        tracing::warn!(
+                            payment_hash = %bolt11.payment_hash(),
+                            "LDK rejected BOLT11 payment before dispatch: {err}"
+                        );
+                        return Ok(outgoing_payment_failure_response(unit, payment_lookup_id));
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            payment_hash = %bolt11.payment_hash(),
+                            "LDK BOLT11 send outcome is indeterminate: {err}"
+                        );
+                        return Err(Error::LdkNode(err).into());
+                    }
                 };
 
                 let payment_details = self
@@ -1104,11 +1153,7 @@ impl MintPayment for CdkLdkNode {
                     tracing::error!(payment_id = %payment_id, "Bolt11 payment failed");
                 }
 
-                Self::make_payment_response_from_details(
-                    unit,
-                    PaymentIdentifier::PaymentHash(bolt11.payment_hash().to_byte_array()),
-                    &payment_details,
-                )
+                Self::make_payment_response_from_details(unit, payment_lookup_id, &payment_details)
             }
             OutgoingPaymentOptions::Bolt12(bolt12_options) => {
                 let offer = bolt12_options.offer;
@@ -1129,7 +1174,10 @@ impl MintPayment for CdkLdkNode {
                     Ok(params) => params,
                     Err(err) => {
                         tracing::error!("Failed to convert fee amount: {}", err);
-                        return Err(payment::Error::Custom(format!("Invalid fee amount: {err}")));
+                        return Ok(outgoing_payment_failure_response(
+                            unit,
+                            quote_payment_identifier,
+                        ));
                     }
                 };
 
@@ -1140,7 +1188,18 @@ impl MintPayment for CdkLdkNode {
                 // from "never dispatched" (mirrors cdk-cln's pre-dispatch
                 // bolt12 quote mapping). The payment must not be attempted
                 // unless this marker is durable.
-                write_bolt12_quote_payment_id(&self.kv_store, &quote_id, None).await?;
+                if let Err(err) =
+                    write_bolt12_quote_payment_id(&self.kv_store, &quote_id, None).await
+                {
+                    tracing::error!(
+                        quote_id = %quote_id,
+                        "Could not persist BOLT12 dispatch claim before sending: {err}"
+                    );
+                    return Ok(outgoing_payment_failure_response(
+                        unit,
+                        quote_payment_identifier,
+                    ));
+                }
 
                 // BOLT12 payment ids are assigned by `send`, so subscribe
                 // first and filter the queued terminal events once it returns.
@@ -1162,7 +1221,10 @@ impl MintPayment for CdkLdkNode {
                         .send(&offer, None, None, send_params),
                     _ => {
                         self.cleanup_bolt12_dispatch_binding(&quote_id, None).await;
-                        return Err(payment::Error::UnsupportedPaymentOption);
+                        return Ok(outgoing_payment_failure_response(
+                            unit,
+                            quote_payment_identifier,
+                        ));
                     }
                 };
 
@@ -1179,6 +1241,14 @@ impl MintPayment for CdkLdkNode {
                             }
                             false => {
                                 self.cleanup_bolt12_dispatch_binding(&quote_id, None).await;
+                                tracing::warn!(
+                                    quote_id = %quote_id,
+                                    "LDK rejected BOLT12 payment before dispatch: {err}"
+                                );
+                                return Ok(outgoing_payment_failure_response(
+                                    unit,
+                                    quote_payment_identifier,
+                                ));
                             }
                         }
                         return Err(Error::LdkNode(err).into());
@@ -1222,9 +1292,10 @@ impl MintPayment for CdkLdkNode {
                     &payment_details,
                 )
             }
-            OutgoingPaymentOptions::Onchain(_) => {
-                Err(cdk_common::payment::Error::UnsupportedPaymentOption)
-            }
+            OutgoingPaymentOptions::Onchain(options) => Ok(outgoing_payment_failure_response(
+                unit,
+                PaymentIdentifier::QuoteId(options.quote_id),
+            )),
         }
     }
 
@@ -1844,6 +1915,43 @@ mod tests {
                 "{not_dispatched} must be treated as not dispatched"
             );
         }
+    }
+
+    #[test]
+    fn bolt11_send_errors_only_classify_explicit_rejections_as_terminal() {
+        for terminal_error in [
+            ldk_node::NodeError::NotRunning,
+            ldk_node::NodeError::InvalidAmount,
+            ldk_node::NodeError::InvalidInvoice,
+            ldk_node::NodeError::PaymentSendingFailed,
+        ] {
+            assert!(
+                bolt11_send_error_is_explicit_terminal_failure(&terminal_error),
+                "{terminal_error} must be treated as a definitive failure"
+            );
+        }
+
+        for ambiguous_error in [
+            ldk_node::NodeError::PersistenceFailed,
+            ldk_node::NodeError::DuplicatePayment,
+        ] {
+            assert!(
+                !bolt11_send_error_is_explicit_terminal_failure(&ambiguous_error),
+                "{ambiguous_error} must not authorize proof release"
+            );
+        }
+    }
+
+    #[test]
+    fn authoritative_outgoing_failure_response_is_terminal_and_spends_nothing() {
+        let payment_lookup_id = PaymentIdentifier::PaymentHash([42; 32]);
+        let response =
+            outgoing_payment_failure_response(&CurrencyUnit::Msat, payment_lookup_id.clone());
+
+        assert_eq!(response.payment_lookup_id, payment_lookup_id);
+        assert_eq!(response.status, MeltQuoteState::Failed);
+        assert_eq!(response.total_spent, Amount::new(0, CurrencyUnit::Msat));
+        assert!(response.payment_proof.is_none());
     }
 
     #[test]

--- a/crates/cdk-lnd/src/error.rs
+++ b/crates/cdk-lnd/src/error.rs
@@ -24,6 +24,16 @@ pub enum Error {
     /// Payment failed
     #[error("LND payment failed")]
     PaymentFailed,
+    /// Payment dispatch outcome is indeterminate
+    ///
+    /// Returned when a `send_*` call or its status stream fails at the
+    /// dispatch boundary: LND may or may not have accepted the payment. This
+    /// is deliberately distinct from [`Error::PaymentFailed`], which is only
+    /// constructed after every route retry ended in a definitive no-route
+    /// result (i.e. pre-dispatch). Backends must keep this variant out of the
+    /// terminal-failure classifier so the melt stays indeterminate.
+    #[error("LND payment dispatch outcome is indeterminate")]
+    AmbiguousDispatch,
     /// Unknown payment status
     #[error("LND unknown payment status")]
     UnknownPaymentStatus,

--- a/crates/cdk-lnd/src/lib.rs
+++ b/crates/cdk-lnd/src/lib.rs
@@ -214,6 +214,31 @@ fn msat_total_spent_for_unit(
     }
 }
 
+/// Build an authoritative terminal-failure response for a payment that was
+/// rejected before dispatch.
+///
+/// The mint treats an `Ok` response with `MeltQuoteState::Failed` as
+/// authoritative (it may compensate the melt), unlike an `Err`, whose dispatch
+/// phase is unknown and which is therefore kept indeterminate. Pre-dispatch
+/// rejections must be returned as this response so the melt can be rolled back
+/// instead of parked pending.
+///
+/// Conversely, errors that straddle the dispatch boundary — a gRPC `Status`
+/// error from `send_*` (`Error::LndError`), or a stream that drops after
+/// dispatch began (`Error::AmbiguousDispatch`) — must stay `Err` so the melt
+/// stays indeterminate. Do not convert those to this response.
+fn outgoing_payment_failure_response(
+    unit: &CurrencyUnit,
+    payment_lookup_id: PaymentIdentifier,
+) -> MakePaymentResponse {
+    MakePaymentResponse {
+        payment_lookup_id,
+        payment_proof: None,
+        status: MeltQuoteState::Failed,
+        total_spent: Amount::new(0, unit.clone()),
+    }
+}
+
 #[async_trait]
 impl MintPayment for Lnd {
     type Err = payment::Error;
@@ -448,31 +473,47 @@ impl MintPayment for Lnd {
         match options {
             OutgoingPaymentOptions::Bolt11(bolt11_options) => {
                 let bolt11 = bolt11_options.bolt11;
+                let payment_lookup_id =
+                    PaymentIdentifier::PaymentHash(*bolt11.payment_hash().as_ref());
 
-                let pay_state = self
-                    .check_outgoing_payment(&PaymentIdentifier::PaymentHash(
-                        *bolt11.payment_hash().as_ref(),
-                    ))
-                    .await?;
+                // A prior lookup is authoritative evidence, not an error:
+                // report the already-recorded outcome so the mint reconciles
+                // against durable state instead of treating the duplicate melt
+                // as an ambiguous dispatch failure.
+                let pay_state = self.check_outgoing_payment(&payment_lookup_id).await?;
 
                 match pay_state.status {
                     MeltQuoteState::Unpaid | MeltQuoteState::Unknown | MeltQuoteState::Failed => (),
                     MeltQuoteState::Paid => {
                         tracing::debug!("Melt attempted on invoice already paid");
-                        return Err(Self::Err::InvoiceAlreadyPaid);
+                        return Ok(MakePaymentResponse {
+                            payment_lookup_id: payment_lookup_id.clone(),
+                            ..pay_state
+                        });
                     }
                     MeltQuoteState::Pending => {
                         tracing::debug!("Melt attempted on invoice already pending");
-                        return Err(Self::Err::InvoicePaymentPending);
+                        return Ok(MakePaymentResponse {
+                            payment_lookup_id: payment_lookup_id.clone(),
+                            ..pay_state
+                        });
                     }
                 }
 
                 // Detect partial payments
                 match bolt11_options.melt_options {
                     Some(MeltOptions::Mpp { mpp }) => {
-                        let amount_msat: u64 = bolt11
-                            .amount_milli_satoshis()
-                            .ok_or(Error::UnknownInvoiceAmount)?;
+                        let amount_msat: u64 = match bolt11.amount_milli_satoshis() {
+                            Some(amount_msat) => amount_msat,
+                            None => {
+                                // Invoice carries no amount; a local parse
+                                // failure before any dispatch.
+                                return Ok(outgoing_payment_failure_response(
+                                    unit,
+                                    payment_lookup_id,
+                                ));
+                            }
+                        };
                         {
                             let partial_amount_msat = mpp.amount;
                             let invoice = bolt11;
@@ -511,13 +552,29 @@ impl MintPayment for Lnd {
                                     .map_err(Error::LndError)?
                                     .into_inner();
 
-                                // Get first route and update its MPP record
-                                let route =
-                                    routes_response.routes.first_mut().ok_or(Error::NoRoute)?;
+                                // Get first route and update its MPP record. An
+                                // empty route set means LND found no path; the
+                                // payment was never dispatched.
+                                let route = match routes_response.routes.first_mut() {
+                                    Some(route) => route,
+                                    None => {
+                                        return Ok(outgoing_payment_failure_response(
+                                            unit,
+                                            payment_lookup_id,
+                                        ));
+                                    }
+                                };
 
                                 // attempt it and check the result
-                                let last_hop: &mut Hop =
-                                    route.hops.last_mut().ok_or(Error::MissingLastHop)?;
+                                let last_hop: &mut Hop = match route.hops.last_mut() {
+                                    Some(last_hop) => last_hop,
+                                    None => {
+                                        return Ok(outgoing_payment_failure_response(
+                                            unit,
+                                            payment_lookup_id,
+                                        ));
+                                    }
+                                };
                                 let mpp_record = MppRecord {
                                     payment_addr: payer_addr.clone(),
                                     total_amt_msat: amount_msat as i64,
@@ -572,9 +629,10 @@ impl MintPayment for Lnd {
                             }
 
                             // "We have exhausted all tactical options" -- STEM, Upgrade (2018)
-                            // The payment was not possible within 50 retries.
+                            // Every route query ended in a no-route result, so
+                            // no payment was ever dispatched.
                             tracing::error!("Limit of retries reached, payment couldn't succeed.");
-                            Err(Error::PaymentFailed.into())
+                            Ok(outgoing_payment_failure_response(unit, payment_lookup_id))
                         }
                     }
                     _ => {
@@ -588,7 +646,13 @@ impl MintPayment for Lnd {
 
                                 if let Some(invoice_amount) = bolt11.amount_milli_satoshis() {
                                     if invoice_amount != u64::from(amount_msat) {
-                                        return Err(payment::Error::AmountMismatch);
+                                        // Invoice/request amount disagreement is
+                                        // a local validation failure, before any
+                                        // dispatch to LND.
+                                        return Ok(outgoing_payment_failure_response(
+                                            unit,
+                                            payment_lookup_id,
+                                        ));
                                     }
                                 }
 
@@ -615,14 +679,18 @@ impl MintPayment for Lnd {
                             .send_payment_v2(pay_req)
                             .await
                             .map_err(|err| {
-                                tracing::warn!("Lightning payment failed: {}", err);
-                                Error::PaymentFailed
+                                tracing::warn!("Lightning payment dispatch error: {}", err);
+                                // A gRPC error here may arrive after LND accepted
+                                // the payment; the dispatch outcome is unknown.
+                                Error::AmbiguousDispatch
                             })?
                             .into_inner();
 
                         while let Some(update) = payment_stream.message().await.map_err(|err| {
-                            tracing::warn!("Lightning payment failed: {}", err);
-                            Error::PaymentFailed
+                            tracing::warn!("Lightning payment stream error: {}", err);
+                            // The stream dropped after dispatch began; the payment
+                            // may still settle.
+                            Error::AmbiguousDispatch
                         })? {
                             let status = update.status();
 
@@ -887,5 +955,36 @@ mod tests {
             .expect("msat total should convert to sat");
 
         assert_eq!(total_spent, Amount::new(2, CurrencyUnit::Sat));
+    }
+
+    #[test]
+    fn authoritative_outgoing_failure_response_is_terminal_and_spends_nothing() {
+        let payment_lookup_id = PaymentIdentifier::PaymentHash([42; 32]);
+        let response =
+            outgoing_payment_failure_response(&CurrencyUnit::Sat, payment_lookup_id.clone());
+
+        assert_eq!(response.payment_lookup_id, payment_lookup_id);
+        assert_eq!(response.status, MeltQuoteState::Failed);
+        assert_eq!(response.total_spent, Amount::new(0, CurrencyUnit::Sat));
+        assert!(response.payment_proof.is_none());
+    }
+
+    /// The dispatch-boundary variants must remain distinct from the
+    /// pre-dispatch `PaymentFailed`, so only the former stay `Err` (ambiguous)
+    /// and the latter can be converted to an authoritative `Failed` response.
+    /// This guards against a future change re-collapsing the two.
+    #[test]
+    fn dispatch_boundary_errors_are_distinct_from_pre_dispatch_failure() {
+        // `AmbiguousDispatch` is returned by send_* / stream failures (may have
+        // been accepted by LND) and must never be treated as a terminal
+        // pre-dispatch failure. It is a separate variant from `PaymentFailed`.
+        assert_ne!(
+            Error::AmbiguousDispatch.to_string(),
+            Error::PaymentFailed.to_string()
+        );
+        assert_ne!(
+            Error::UnknownPaymentStatus.to_string(),
+            Error::PaymentFailed.to_string()
+        );
     }
 }

--- a/crates/cdk-mintd/README.md
+++ b/crates/cdk-mintd/README.md
@@ -566,6 +566,10 @@ cdk-mint-cli get-info --addr https://127.0.0.1:8086 --tls-dir /path/to/tls
 - `CDK_MINTD_DATABASE_URL`: PostgreSQL connection string
 - `CDK_MINTD_POSTGRES_URL`: Canonical PostgreSQL connection variable.
 
+SQLite is intended for a single `cdk-mintd` process. WAL mode allows readers
+to continue during writes, but it does not coordinate payment dispatch across
+processes. Use PostgreSQL when multiple mint replicas share a database.
+
 Other environment variables are read only when explicitly named by an
 `env:VARIABLE` secret reference in the persisted document. They do not act as
 automatic operational overrides. The legacy `--config` and `--seed-file` flags

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -85,6 +85,7 @@ tti = 60
 
 [database]
 # Database engine (sqlite/postgres) defaults to sqlite
+# SQLite supports one mint process. Use PostgreSQL for multiple replicas.
 engine = "sqlite"
 
 # PostgreSQL configuration (when engine = "postgres")
@@ -95,7 +96,11 @@ engine = "sqlite"
 url = "env:CDK_MINTD_POSTGRES_URL"
 # TLS mode: "disable", "prefer", "require" (optional, defaults to "disable")
 tls_mode = "disable"
-# Maximum number of connections in the pool (optional, defaults to 20)
+# Maximum total number of connections (optional, defaults to 20).
+# PostgreSQL reserves part of this budget for long-lived payment-dispatch locks
+# so quote checks and recovery retain database capacity. At least 2 is
+# recommended; with 1, dispatch and ordinary work share the pool and may block
+# each other.
 max_connections = 20
 # Connection timeout in seconds (optional, defaults to 10)
 connection_timeout_seconds = 10

--- a/crates/cdk-postgres/src/lib.rs
+++ b/crates/cdk-postgres/src/lib.rs
@@ -406,7 +406,7 @@ pub async fn new_wallet_pg_database(conn_str: &str) -> Result<WalletPgDatabase, 
 
 #[cfg(test)]
 mod test {
-    use cdk_common::{mint_db_test, wallet_db_test};
+    use cdk_common::{mint_db_test, wallet_db_test, QuoteId};
 
     use super::*;
 
@@ -426,6 +426,150 @@ mod test {
     }
 
     mint_db_test!(provide_mint_db);
+
+    #[tokio::test]
+    async fn mint_pool_accepts_single_connection_configuration() {
+        use cdk_common::database::MintDatabase;
+
+        let test_id = format!("test_single_connection_pool_{}", uuid::Uuid::new_v4());
+        let db_url = std::env::var("CDK_MINTD_DATABASE_URL")
+            .or_else(|_| std::env::var("PG_DB_URL"))
+            .unwrap_or(
+                "host=localhost user=cdk_user password=cdk_password dbname=cdk_mint port=5432"
+                    .to_owned(),
+            );
+        let config = PgConfig::new(
+            &format!("{db_url} schema={test_id}"),
+            None,
+            Some(1),
+            Some(10),
+        );
+
+        let db = MintPgDatabase::new(config)
+            .await
+            .expect("single-connection mint pool should remain supported");
+        let dispatch = MintDatabase::begin_dispatch_transaction(&db)
+            .await
+            .expect("dispatch transaction");
+        dispatch.rollback().await.expect("dispatch rollback");
+        let regular = MintDatabase::begin_transaction(&db)
+            .await
+            .expect("regular transaction");
+        regular.rollback().await.expect("regular rollback");
+    }
+
+    #[tokio::test]
+    async fn try_quote_lock_reports_contended_without_waiting() {
+        use std::sync::Arc;
+
+        use cdk_common::database::mint::QuoteLockAttempt;
+        use cdk_common::database::MintDatabase;
+
+        let test_id = format!("test_try_quote_lock_{}", uuid::Uuid::new_v4());
+        let db = Arc::new(provide_mint_db(test_id).await);
+        let quote_id = QuoteId::new();
+
+        let mut holder = MintDatabase::begin_transaction(&*db).await.expect("tx");
+        assert!(holder
+            .lock_quotes(std::slice::from_ref(&quote_id))
+            .await
+            .expect("lock"));
+
+        let mut waiter = MintDatabase::begin_transaction(&*db).await.expect("tx");
+        assert_eq!(
+            waiter
+                .try_lock_quotes(std::slice::from_ref(&quote_id))
+                .await
+                .expect("try lock"),
+            QuoteLockAttempt::Contended
+        );
+        waiter.rollback().await.expect("rollback");
+
+        holder.commit().await.expect("commit");
+
+        let mut free = MintDatabase::begin_transaction(&*db).await.expect("tx");
+        assert_eq!(
+            free.try_lock_quotes(std::slice::from_ref(&quote_id))
+                .await
+                .expect("try lock"),
+            QuoteLockAttempt::Acquired
+        );
+        free.rollback().await.expect("rollback");
+    }
+
+    #[tokio::test]
+    async fn dispatch_transaction_preserves_regular_pool_capacity() {
+        use std::time::Duration;
+
+        use cdk_common::database::MintDatabase;
+
+        let test_id = format!("test_dispatch_pool_{}", uuid::Uuid::new_v4());
+        let db_url = std::env::var("CDK_MINTD_DATABASE_URL")
+            .or_else(|_| std::env::var("PG_DB_URL"))
+            .unwrap_or(
+                "host=localhost user=cdk_user password=cdk_password dbname=cdk_mint port=5432"
+                    .to_owned(),
+            );
+        let config = PgConfig::new(
+            &format!("{db_url} schema={test_id}"),
+            None,
+            Some(2),
+            Some(10),
+        );
+        let db = MintPgDatabase::new(config).await.expect("database");
+
+        let dispatch = MintDatabase::begin_dispatch_transaction(&db)
+            .await
+            .expect("dispatch transaction");
+        let regular =
+            tokio::time::timeout(Duration::from_secs(5), MintDatabase::begin_transaction(&db))
+                .await
+                .expect("regular pool capacity must remain available")
+                .expect("regular transaction");
+
+        regular.rollback().await.expect("regular rollback");
+        dispatch.rollback().await.expect("dispatch rollback");
+    }
+
+    #[tokio::test]
+    async fn quote_lock_batch_excludes_concurrent_transaction() {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use cdk_common::database::MintDatabase;
+
+        let test_id = format!("test_quote_lock_batch_{}", uuid::Uuid::new_v4());
+        let db = Arc::new(provide_mint_db(test_id).await);
+        let first = QuoteId::new();
+        let second = QuoteId::new();
+
+        let mut holder = MintDatabase::begin_transaction(&*db).await.expect("tx");
+        holder
+            .lock_quotes(&[first.clone(), second.clone()])
+            .await
+            .expect("lock");
+
+        let waiter = tokio::spawn({
+            let db = db.clone();
+            async move {
+                let mut tx = MintDatabase::begin_transaction(&*db).await.expect("tx");
+                tx.lock_quotes(&[second, first]).await.expect("lock");
+                tx.commit().await.expect("commit");
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            !waiter.is_finished(),
+            "reversed quote batch did not wait for the holder"
+        );
+
+        holder.commit().await.expect("commit");
+        tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("reversed quote batch remained blocked")
+            .expect("waiter task");
+    }
 
     #[tokio::test]
     async fn kvstore_compare_and_swap() {

--- a/crates/cdk-prometheus/src/metrics.rs
+++ b/crates/cdk-prometheus/src/metrics.rs
@@ -381,6 +381,16 @@ impl CdkMetrics {
         self.db_connections_active.set(count);
     }
 
+    /// Increment the number of active database connections.
+    pub fn increment_db_connections_active(&self) {
+        self.db_connections_active.inc();
+    }
+
+    /// Decrement the number of active database connections.
+    pub fn decrement_db_connections_active(&self) {
+        self.db_connections_active.dec();
+    }
+
     // Error metrics methods
     /// Record an error
     pub fn record_error(&self) {

--- a/crates/cdk-sql-common/src/mint/mod.rs
+++ b/crates/cdk-sql-common/src/mint/mod.rs
@@ -13,10 +13,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use cdk_common::database::{self, DbTransactionFinalizer, Error, MintDatabase};
+use cdk_common::QuoteId;
 
 use crate::common::migrate;
 use crate::database::{ConnectionWithTransaction, DatabaseExecutor};
-use crate::pool::{DatabasePool, Pool, PooledResource};
+use crate::pool::{DatabaseConfig, DatabasePool, Pool, PooledResource};
+use crate::stmt::query;
 
 mod auth;
 mod completed_operations;
@@ -44,6 +46,7 @@ where
     RM: DatabasePool + 'static,
 {
     pub(crate) pool: Arc<Pool<RM>>,
+    dispatch_pool: Option<Arc<Pool<RM>>>,
 }
 
 /// SQL Transaction Writer
@@ -55,6 +58,17 @@ where
     pub(crate) inner: ConnectionWithTransaction<RM::Connection, PooledResource<RM>>,
 }
 
+/// Sorted, deduplicated advisory lock keys for a batch of quotes.
+fn quote_lock_keys(quote_ids: &[QuoteId]) -> Vec<String> {
+    let mut keys = quote_ids
+        .iter()
+        .map(|quote_id| format!("cdk:quote:{quote_id}"))
+        .collect::<Vec<_>>();
+    keys.sort();
+    keys.dedup();
+    keys
+}
+
 impl<RM> SQLMintDatabase<RM>
 where
     RM: DatabasePool + 'static,
@@ -64,11 +78,42 @@ where
     where
         X: Into<RM::Config>,
     {
-        let pool = Pool::new(db.into());
+        let config = db.into();
+        let configured_max_size = config.max_size();
+        let (pool, dispatch_pool) =
+            if RM::Connection::name() == "postgres" && configured_max_size >= 2 {
+                // Keep long-lived payment dispatches from consuming the pool used
+                // for quote checks, payment events, and recovery. Both pools share
+                // the configured connection budget.
+                let dispatch_pool_size = (configured_max_size / 4).clamp(1, 8);
+                let regular_pool_size = configured_max_size - dispatch_pool_size;
+                (
+                    Pool::new_with_max_size(config.clone(), regular_pool_size),
+                    Some(Pool::new_with_max_size(config, dispatch_pool_size)),
+                )
+            } else {
+                (Pool::new(config), None)
+            };
 
         Self::migrate(pool.get().await.map_err(|e| Error::Database(Box::new(e)))?).await?;
 
-        Ok(Self { pool })
+        Ok(Self {
+            pool,
+            dispatch_pool,
+        })
+    }
+
+    async fn begin_transaction_from_pool(
+        pool: &Arc<Pool<RM>>,
+    ) -> Result<Box<dyn database::MintTransaction<Error> + Send + Sync>, Error> {
+        let tx = SQLTransaction {
+            inner: ConnectionWithTransaction::new(
+                pool.get().await.map_err(|e| Error::Database(Box::new(e)))?,
+            )
+            .await?,
+        };
+
+        Ok(Box::new(tx))
     }
 
     /// Migrate
@@ -80,8 +125,79 @@ where
     }
 }
 
+impl<RM> SQLTransaction<RM>
+where
+    RM: DatabasePool + 'static,
+{
+    /// Take quote advisory locks in one statement and stable key order.
+    async fn take_quote_locks(&mut self, quote_ids: &[QuoteId]) -> Result<bool, Error> {
+        if quote_ids.is_empty() || RM::Connection::name() != "postgres" {
+            return Ok(false);
+        }
+
+        query(
+            r#"
+            SELECT pg_advisory_xact_lock(hashtextextended(key, 0))
+            FROM (
+                SELECT key FROM unnest(ARRAY[:keys]::TEXT[]) AS t(key) ORDER BY key
+            ) sorted
+            "#,
+        )?
+        .bind_vec("keys", quote_lock_keys(quote_ids))?
+        .execute(&self.inner)
+        .await?;
+
+        Ok(true)
+    }
+
+    /// Attempt quote advisory locks without waiting, in stable key order.
+    async fn try_take_quote_locks(
+        &mut self,
+        quote_ids: &[QuoteId],
+    ) -> Result<database::mint::QuoteLockAttempt, Error> {
+        if quote_ids.is_empty() || RM::Connection::name() != "postgres" {
+            return Ok(database::mint::QuoteLockAttempt::Unsupported);
+        }
+
+        // Rows that fail to lock are returned; rows that succeed are locked
+        // until the transaction ends. The caller rolls back on `Contended`,
+        // releasing any partial acquisitions.
+        let missed = query(
+            r#"
+            SELECT key FROM (
+                SELECT key FROM unnest(ARRAY[:keys]::TEXT[]) AS t(key) ORDER BY key
+            ) sorted
+            WHERE NOT pg_try_advisory_xact_lock(hashtextextended(key, 0))
+            "#,
+        )?
+        .bind_vec("keys", quote_lock_keys(quote_ids))?
+        .fetch_all(&self.inner)
+        .await?;
+
+        Ok(if missed.is_empty() {
+            database::mint::QuoteLockAttempt::Acquired
+        } else {
+            database::mint::QuoteLockAttempt::Contended
+        })
+    }
+}
+
 #[async_trait]
-impl<RM> database::MintTransaction<Error> for SQLTransaction<RM> where RM: DatabasePool + 'static {}
+impl<RM> database::MintTransaction<Error> for SQLTransaction<RM>
+where
+    RM: DatabasePool + 'static,
+{
+    async fn lock_quotes(&mut self, quote_ids: &[QuoteId]) -> Result<bool, Error> {
+        self.take_quote_locks(quote_ids).await
+    }
+
+    async fn try_lock_quotes(
+        &mut self,
+        quote_ids: &[QuoteId],
+    ) -> Result<database::mint::QuoteLockAttempt, Error> {
+        self.try_take_quote_locks(quote_ids).await
+    }
+}
 
 #[async_trait]
 impl<RM> DbTransactionFinalizer for SQLTransaction<RM>
@@ -126,17 +242,14 @@ where
     async fn begin_transaction(
         &self,
     ) -> Result<Box<dyn database::MintTransaction<Error> + Send + Sync>, Error> {
-        let tx = SQLTransaction {
-            inner: ConnectionWithTransaction::new(
-                self.pool
-                    .get()
-                    .await
-                    .map_err(|e| Error::Database(Box::new(e)))?,
-            )
-            .await?,
-        };
+        Self::begin_transaction_from_pool(&self.pool).await
+    }
 
-        Ok(Box::new(tx))
+    async fn begin_dispatch_transaction(
+        &self,
+    ) -> Result<Box<dyn database::MintTransaction<Error> + Send + Sync>, Error> {
+        let pool = self.dispatch_pool.as_ref().unwrap_or(&self.pool);
+        Self::begin_transaction_from_pool(pool).await
     }
 }
 
@@ -440,5 +553,20 @@ mod tests {
             gauge_value("cdk_mint_in_flight_requests", &in_flight_labels),
             in_flight_before
         );
+    }
+}
+
+#[cfg(test)]
+mod quote_lock_tests {
+    use super::*;
+
+    #[test]
+    fn quote_lock_keys_are_sorted_and_deduplicated() {
+        let first = QuoteId::BASE64("YQ==".to_owned());
+        let second = QuoteId::BASE64("Yg==".to_owned());
+        let mut expected = vec![format!("cdk:quote:{first}"), format!("cdk:quote:{second}")];
+        expected.sort();
+
+        assert_eq!(quote_lock_keys(&[second.clone(), first, second]), expected);
     }
 }

--- a/crates/cdk-sql-common/src/pool.rs
+++ b/crates/cdk-sql-common/src/pool.rs
@@ -125,12 +125,7 @@ where
 
             #[cfg(feature = "prometheus")]
             {
-                let in_use = self
-                    .pool
-                    .max_size
-                    .saturating_sub(self.pool.semaphore.available_permits())
-                    .saturating_sub(1);
-                METRICS.set_db_connections_active(in_use as i64);
+                METRICS.decrement_db_connections_active();
 
                 let duration = self.start_time.elapsed().as_secs_f64();
 
@@ -170,6 +165,15 @@ where
     /// Creates a new pool
     pub fn new(config: RM::Config) -> Arc<Self> {
         let max_size = config.max_size();
+        Self::new_with_max_size(config, max_size)
+    }
+
+    /// Creates a pool with an explicit size instead of the configuration's
+    /// default.
+    ///
+    /// This is used when one configured connection budget is partitioned into
+    /// separate pools for short database work and long-lived operations.
+    pub(crate) fn new_with_max_size(config: RM::Config, max_size: usize) -> Arc<Self> {
         Arc::new(Self {
             default_timeout: config.default_timeout(),
             max_size,
@@ -214,15 +218,19 @@ where
         };
 
         #[cfg(feature = "prometheus")]
-        {
-            let in_use = self.max_size - self.semaphore.available_permits();
-            METRICS.set_db_connections_active(in_use as i64);
-        }
+        METRICS.increment_db_connections_active();
 
         // Briefly lock the idle queue to try to pop a non-stale connection.
         // This mutex is held for nanoseconds (just a Vec::pop).
         {
-            let mut resources = self.queue.lock().map_err(|_| Error::Poison)?;
+            let mut resources = match self.queue.lock() {
+                Ok(resources) => resources,
+                Err(_) => {
+                    #[cfg(feature = "prometheus")]
+                    METRICS.decrement_db_connections_active();
+                    return Err(Error::Poison);
+                }
+            };
             while let Some((stale, resource)) = resources.pop() {
                 if !stale.load(Ordering::SeqCst) {
                     return Ok(PooledResource {
@@ -250,13 +258,7 @@ where
             }),
             Err(e) => {
                 #[cfg(feature = "prometheus")]
-                {
-                    let in_use = self
-                        .max_size
-                        .saturating_sub(self.semaphore.available_permits())
-                        .saturating_sub(1);
-                    METRICS.set_db_connections_active(in_use as i64);
-                }
+                METRICS.decrement_db_connections_active();
 
                 // Permit is dropped here, releasing the slot back to the semaphore.
                 Err(e)
@@ -466,5 +468,22 @@ mod tests {
         assert!(matches!(result, Err(Error::Resource(_))));
         assert_eq!(db_connections_active(), 0.0);
         assert_eq!(pool.semaphore.available_permits(), pool.max_size);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn active_connections_gauge_aggregates_multiple_pools() {
+        let _lock = crate::metrics_test_lock::lock().await;
+        METRICS.set_db_connections_active(0);
+
+        let regular_pool = Pool::<TestPool>::new(test_config(1, false));
+        let dispatch_pool = Pool::<TestPool>::new(test_config(1, false));
+        let regular = regular_pool.get().await.expect("regular resource");
+        let dispatch = dispatch_pool.get().await.expect("dispatch resource");
+
+        assert_eq!(db_connections_active(), 2.0);
+
+        drop(regular);
+        drop(dispatch);
+        assert_eq!(db_connections_active(), 0.0);
     }
 }

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -180,6 +180,7 @@ required-features = ["wallet"]
 [dev-dependencies]
 rand.workspace = true
 cdk-sqlite.workspace = true
+cdk-postgres.workspace = true
 cdk-fake-wallet.workspace = true
 bip39.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/cdk/src/mint/melt/melt_saga/mod.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/mod.rs
@@ -1,7 +1,8 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
 
-use cdk_common::database::DynMintDatabase;
+use cdk_common::database::mint::Acquired;
+use cdk_common::database::{DynMintDatabase, DynMintTransaction};
 use cdk_common::mint::{MeltFinalizationData, MeltSagaState, Operation, Saga, SagaStateEnum};
 use cdk_common::nut00::KnownMethod;
 use cdk_common::nuts::MeltQuoteState;
@@ -444,12 +445,14 @@ impl MeltSaga<SetupComplete> {
     /// # What This Does
     ///
     /// Within a single database transaction:
-    /// 1. Checks if payment request matches a mint quote on this mint
-    /// 2. If not a match or different unit: returns (self, RequiresExternalPayment)
-    /// 3. If match found: validates quote state and amount
-    /// 4. Increments the mint quote's paid amount
-    /// 5. Publishes mint quote payment notification
-    /// 6. Returns (self, Internal{amount})
+    /// 1. Locks the melt quote row and verifies it is still `Pending`
+    /// 2. Checks if payment request matches a mint quote on this mint
+    /// 3. If not a match or different unit: returns (self, RequiresExternalPayment)
+    /// 4. If match found: validates quote state and amount
+    /// 5. Increments the mint quote's paid amount
+    /// 6. Marks the melt quote `Paid` in the same transaction
+    /// 7. Publishes mint quote payment notification
+    /// 8. Returns (self, Internal{amount})
     ///
     /// # Compensation
     ///
@@ -467,6 +470,8 @@ impl MeltSaga<SetupComplete> {
     ///
     /// - `RequestAlreadyPaid`: Mint quote already settled
     /// - `InsufficientFunds`: Not enough input proofs for mint quote amount
+    /// - `UnpaidQuote`: Melt quote is no longer pending (rolled back or already settled)
+    /// - `UnknownQuote`: Melt quote not found
     /// - `Internal`: Database error during settlement
     #[instrument(skip_all)]
     pub async fn attempt_internal_settlement(
@@ -474,6 +479,31 @@ impl MeltSaga<SetupComplete> {
         melt_request: &MeltRequest<QuoteId>,
     ) -> Result<(Self, SettlementDecision), Error> {
         let mut tx = self.db.begin_transaction().await?;
+
+        // Coordinate the internal-settlement commit with cross-replica status
+        // reconciliation for this melt quote.
+        tx.lock_quotes(std::slice::from_ref(&self.state_data.quote.id))
+            .await?;
+
+        // Re-read the melt quote state under a row lock in this transaction.
+        let mut melt_quote = match tx.get_melt_quote(&self.state_data.quote.id).await? {
+            Some(quote) if quote.state == MeltQuoteState::Pending => quote,
+            Some(quote) => {
+                tracing::warn!(
+                    "Melt quote {} is {}, not Pending; aborting internal settlement",
+                    quote.id,
+                    quote.state
+                );
+                tx.rollback().await?;
+                self.compensate_all().await?;
+                return Err(Error::UnpaidQuote);
+            }
+            None => {
+                tx.rollback().await?;
+                self.compensate_all().await?;
+                return Err(Error::UnknownQuote);
+            }
+        };
 
         let mut mint_quote = match tx
             .get_mint_quote_by_request(&self.state_data.quote.request.to_string())
@@ -546,6 +576,23 @@ impl MeltSaga<SetupComplete> {
 
         mint_quote.add_payment(amount.clone(), self.state_data.quote.id.to_string(), None)?;
         tx.update_mint_quote(&mut mint_quote).await?;
+
+        // Mark the melt quote Paid in the same transaction as the mint quote
+        // credit.
+        tx.update_melt_quote_state(&mut melt_quote, MeltQuoteState::Paid, None)
+            .await?;
+
+        // Internally-settled melts never reach a payment backend, so persist
+        // the synthetic lookup id the settlement response will use.
+        if melt_quote.request_lookup_id.is_none() {
+            tx.update_melt_quote_request_lookup_id(
+                &mut melt_quote,
+                &cdk_common::payment::PaymentIdentifier::CustomId(
+                    self.state_data.quote.id.to_string(),
+                ),
+            )
+            .await?;
+        }
 
         tx.commit().await?;
         self.pubsub
@@ -624,8 +671,6 @@ impl MeltSaga<SetupComplete> {
                     }
                     MeltQuoteState::Unknown => {
                         tracing::warn!("Payment for quote {} unknown.", self.state_data.quote.id);
-                        self.persist_pending_payment_lookup_id(&response.payment_lookup_id)
-                            .await;
                         return Ok(PaymentOutcome::Pending {
                             #[cfg(feature = "prometheus")]
                             metrics: self.metrics,
@@ -636,8 +681,6 @@ impl MeltSaga<SetupComplete> {
                             "Payment pending, proofs remain pending for quote: {}",
                             self.state_data.quote.id
                         );
-                        self.persist_pending_payment_lookup_id(&response.payment_lookup_id)
-                            .await;
                         return Ok(PaymentOutcome::Pending {
                             #[cfg(feature = "prometheus")]
                             metrics: self.metrics,
@@ -704,8 +747,9 @@ impl MeltSaga<SetupComplete> {
                 Error::UnsupportedUnit
             })?;
 
-        // Update saga state to PaymentAttempted BEFORE making payment
-        // This ensures crash recovery knows payment may have been attempted
+        // Commit the write-ahead marker before acquiring the dispatch lock. If
+        // reconciliation wins the small intervening race, the dispatcher
+        // re-reads the saga under the lock and aborts before calling the backend.
         {
             let mut tx = self.db.begin_transaction().await?;
             let mut saga = tx
@@ -720,8 +764,97 @@ impl MeltSaga<SetupComplete> {
             tx.commit().await?;
         }
 
-        self.execute_payment_and_verify(Arc::clone(payment_backend))
-            .await
+        // PostgreSQL returns the transaction that owns the quote advisory lock.
+        // Use that same connection for protected state changes so concurrent
+        // melts cannot exhaust the pool by each holding one connection while
+        // waiting for a second.
+        let dispatch_lock =
+            shared::acquire_melt_dispatch_lock(&self.db, &self.state_data.quote.id).await?;
+
+        match dispatch_lock {
+            Some(mut tx) => {
+                let Some(mut saga) = tx.get_saga_for_update(&self.operation_id).await? else {
+                    tx.rollback().await?;
+                    return Err(Error::UnknownPaymentState);
+                };
+                if !matches!(
+                    saga.state,
+                    SagaStateEnum::Melt(MeltSagaState::PaymentAttempted)
+                ) {
+                    tx.rollback().await?;
+                    return Err(Error::UnknownPaymentState);
+                }
+
+                let response = match self
+                    .execute_payment_and_verify(Arc::clone(payment_backend))
+                    .await
+                {
+                    Ok(response) => response,
+                    Err(err) => {
+                        tx.rollback().await?;
+                        return Err(err);
+                    }
+                };
+
+                match response.status {
+                    MeltQuoteState::Paid => {
+                        if let Err(err) =
+                            shared::persist_melt_finalization_handoff(&mut tx, &mut saga, &response)
+                                .await
+                        {
+                            tx.rollback().await?;
+                            return Err(err);
+                        }
+                        tx.commit().await?;
+                    }
+                    MeltQuoteState::Pending | MeltQuoteState::Unknown => {
+                        if let Err(err) = self
+                            .persist_pending_payment_in_transaction(
+                                &mut tx,
+                                &mut saga,
+                                &response.payment_lookup_id,
+                            )
+                            .await
+                        {
+                            tx.rollback().await?;
+                            return Err(err);
+                        }
+                        tx.commit().await?;
+                    }
+                    MeltQuoteState::Unpaid | MeltQuoteState::Failed => {
+                        // Compensate while this transaction still owns the
+                        // cross-process dispatch lock. Releasing it first would
+                        // let another replica persist PaymentPending before the
+                        // stale failure removes the reserved proofs.
+                        shared::rollback_failed_melt_with_dispatch_lock(
+                            tx,
+                            &self.pubsub,
+                            &self.state_data.quote.id,
+                            &self.operation_id,
+                        )
+                        .await?;
+                    }
+                }
+
+                Ok(response)
+            }
+            None => {
+                let response = self
+                    .execute_payment_and_verify(Arc::clone(payment_backend))
+                    .await?;
+                match response.status {
+                    MeltQuoteState::Paid => {
+                        self.persist_paid_payment(&response).await?;
+                    }
+                    MeltQuoteState::Pending | MeltQuoteState::Unknown => {
+                        self.persist_pending_payment(&response.payment_lookup_id)
+                            .await?;
+                    }
+                    MeltQuoteState::Unpaid | MeltQuoteState::Failed => {}
+                }
+                Ok(response)
+            }
+        }
     }
 
     async fn execute_payment_and_verify(
@@ -772,19 +905,22 @@ impl MeltSaga<SetupComplete> {
             return Ok(check_response);
         }
 
-        // If we knew it was Pending, but now it's Unknown, stick with Pending to avoid
-        // accidental refund of an in-flight payment.
-        if pay.status == MeltQuoteState::Pending && check_response.status == MeltQuoteState::Unknown
-        {
+        // Pending and Unknown are monotonic for an immediate verification. A
+        // contradictory Unpaid/Failed/Unknown read may come from a lagging
+        // backend replica; refunding here would return proofs while the payment
+        // can still settle.
+        if matches!(
+            pay.status,
+            MeltQuoteState::Pending | MeltQuoteState::Unknown
+        ) {
             tracing::warn!(
-                "Payment was initially Pending but verification returned Unknown. Keeping as Pending for safety."
+                "Payment was initially {} but verification returned {}. Keeping the initial status for safety.",
+                pay.status,
+                check_response.status
             );
             return Ok(pay);
         }
 
-        // Unknown is indeterminate, not a confirmed failure: keep it as-is so
-        // make_payment parks the melt as pending instead of compensating a
-        // payment that may still settle.
         Ok(check_response)
     }
 
@@ -819,7 +955,7 @@ impl MeltSaga<SetupComplete> {
                 Error::Internal
             })?;
 
-        let check_response = self.check_payment_state(payment_backend, lookup_id).await?;
+        let mut check_response = self.check_payment_state(payment_backend, lookup_id).await?;
 
         tracing::info!(
             "Initial payment attempt for {} errored. Follow up check status: {}",
@@ -827,14 +963,28 @@ impl MeltSaga<SetupComplete> {
             check_response.status
         );
 
-        // Unknown is indeterminate, not a confirmed failure: keep it as-is so
-        // make_payment parks the melt as pending instead of compensating a
-        // payment that may still settle.
+        // make_payment returned no authoritative terminal result. A positive
+        // Paid check can safely finalize and Pending remains pending, but a
+        // Failed or Unpaid follow-up may be a stale backend read after an
+        // ambiguous dispatch error. Keep every non-positive terminal read
+        // indeterminate so the melt cannot compensate while payment may settle.
+        if matches!(
+            check_response.status,
+            MeltQuoteState::Unpaid | MeltQuoteState::Failed
+        ) {
+            tracing::warn!(
+                "Payment attempt for {} errored and follow up check returned {}. Keeping payment status Unknown for safety.",
+                self.state_data.quote.id,
+                check_response.status
+            );
+            check_response.status = MeltQuoteState::Unknown;
+        }
+
         Ok(check_response)
     }
 
-    /// Persists the backend's payment lookup id on the quote before the saga
-    /// parks the payment as pending.
+    /// Persists the backend's payment lookup id and the durable pending marker
+    /// before releasing the cross-replica dispatch lock.
     ///
     /// For bolt12 melts the quote is created with `request_lookup_id: None`
     /// (no invoice exists until `make_payment`), so the id returned by the
@@ -844,52 +994,84 @@ impl MeltSaga<SetupComplete> {
     /// a payment that settles after the in-process recheck can never be
     /// resolved, and startup recovery would treat the quote as never sent and
     /// compensate while the payment may still settle.
-    ///
-    /// Best-effort: a database failure here is logged loudly but does not
-    /// change the outcome — the payment is still pending and the in-process
-    /// state is no worse than before.
-    async fn persist_pending_payment_lookup_id(
+    async fn persist_pending_payment(
         &self,
         payment_lookup_id: &cdk_common::payment::PaymentIdentifier,
-    ) {
+    ) -> Result<(), Error> {
         let quote_id = &self.state_data.quote.id;
 
-        if self.state_data.quote.request_lookup_id.as_ref() == Some(payment_lookup_id) {
-            return;
-        }
+        let mut tx = self.db.begin_transaction().await?;
+        let mut quote = tx
+            .get_melt_quote(quote_id)
+            .await?
+            .ok_or(Error::UnknownQuote)?;
 
-        let result: Result<(), Error> = async {
-            let mut tx = self.db.begin_transaction().await?;
-            let mut quote = tx
-                .get_melt_quote(quote_id)
-                .await?
-                .ok_or(Error::UnknownQuote)?;
-
-            if quote.request_lookup_id.as_ref() != Some(payment_lookup_id) {
-                tracing::info!(
-                    "Updating payment lookup id for pending melt quote {} from {:?} to {}",
-                    quote_id,
-                    quote.request_lookup_id,
-                    payment_lookup_id
-                );
-                tx.update_melt_quote_request_lookup_id(&mut quote, payment_lookup_id)
-                    .await?;
-            }
-
-            tx.commit().await?;
-            Ok(())
-        }
-        .await;
-
-        if let Err(err) = result {
-            tracing::error!(
-                "Failed to persist payment lookup id {} for pending melt quote {}: {}. \
-                 Recovery will derive the backend identifier from the quote if needed.",
-                payment_lookup_id,
+        if quote.request_lookup_id.as_ref() != Some(payment_lookup_id) {
+            tracing::info!(
+                "Updating payment lookup id for pending melt quote {} from {:?} to {}",
                 quote_id,
-                err
+                quote.request_lookup_id,
+                payment_lookup_id
             );
+            tx.update_melt_quote_request_lookup_id(&mut quote, payment_lookup_id)
+                .await?;
         }
+
+        let mut saga = tx
+            .get_saga_for_update(&self.operation_id)
+            .await?
+            .ok_or(Error::Internal)?;
+        tx.update_acquired_saga(
+            &mut saga,
+            SagaStateEnum::Melt(MeltSagaState::PaymentPending),
+        )
+        .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Persists a confirmed payment before releasing the process-local quote
+    /// guard used by backends without cross-process advisory locks.
+    async fn persist_paid_payment(
+        &self,
+        payment_response: &MakePaymentResponse,
+    ) -> Result<(), Error> {
+        let mut tx = self.db.begin_transaction().await?;
+        let Some(mut saga) = tx.get_saga_for_update(&self.operation_id).await? else {
+            tx.rollback().await?;
+            return Err(Error::UnknownPaymentState);
+        };
+
+        if let Err(err) =
+            shared::persist_melt_finalization_handoff(&mut tx, &mut saga, payment_response).await
+        {
+            tx.rollback().await?;
+            return Err(err);
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn persist_pending_payment_in_transaction(
+        &self,
+        tx: &mut DynMintTransaction,
+        saga: &mut Acquired<Saga>,
+        payment_lookup_id: &cdk_common::payment::PaymentIdentifier,
+    ) -> Result<(), Error> {
+        let quote_id = &self.state_data.quote.id;
+        let mut quote = tx
+            .get_melt_quote(quote_id)
+            .await?
+            .ok_or(Error::UnknownQuote)?;
+
+        if quote.request_lookup_id.as_ref() != Some(payment_lookup_id) {
+            tx.update_melt_quote_request_lookup_id(&mut quote, payment_lookup_id)
+                .await?;
+        }
+        tx.update_acquired_saga(saga, SagaStateEnum::Melt(MeltSagaState::PaymentPending))
+            .await?;
+        Ok(())
     }
 
     /// Helper to check payment state with the payment backend
@@ -947,7 +1129,7 @@ impl MeltSaga<PaymentConfirmed> {
     /// the user while the mint has already paid the invoice, causing fund loss.
     ///
     /// Instead, the error is returned and the saga remains in the database with
-    /// `PaymentAttempted` state. On startup, the recovery process will:
+    /// `Finalizing` state. On startup, the recovery process will:
     /// 1. Find the incomplete saga
     /// 2. Check the payment backend (which will confirm payment as Paid)
     /// 3. Retry finalization

--- a/crates/cdk/src/mint/melt/melt_saga/mod.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/mod.rs
@@ -773,14 +773,23 @@ impl MeltSaga<SetupComplete> {
 
         match dispatch_lock {
             Some(mut tx) => {
-                let Some(mut saga) = tx.get_saga_for_update(&self.operation_id).await? else {
+                // Read through the regular pool: the transaction-level saga
+                // getter locks the row on SQL backends, which would prevent a
+                // trusted Paid event from preempting this in-flight dispatch.
+                let Some(saga) = self
+                    .db
+                    .get_melt_saga_by_quote_id(&self.state_data.quote.id)
+                    .await?
+                else {
                     tx.rollback().await?;
                     return Err(Error::UnknownPaymentState);
                 };
-                if !matches!(
-                    saga.state,
-                    SagaStateEnum::Melt(MeltSagaState::PaymentAttempted)
-                ) {
+                if saga.operation_id != self.operation_id
+                    || !matches!(
+                        saga.state,
+                        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted)
+                    )
+                {
                     tx.rollback().await?;
                     return Err(Error::UnknownPaymentState);
                 }
@@ -795,6 +804,24 @@ impl MeltSaga<SetupComplete> {
                         return Err(err);
                     }
                 };
+
+                // Do not hold the saga row lock across the external payment
+                // call. A trusted Paid event must be able to persist the
+                // finalization handoff while dispatch is in flight. Re-locking
+                // and re-reading here makes that handoff authoritative: if the
+                // event advanced or completed the saga, this stale dispatcher
+                // must not compensate based on its own terminal response.
+                let Some(mut saga) = tx.get_saga_for_update(&self.operation_id).await? else {
+                    tx.rollback().await?;
+                    return Err(Error::UnknownPaymentState);
+                };
+                if !matches!(
+                    saga.state,
+                    SagaStateEnum::Melt(MeltSagaState::PaymentAttempted)
+                ) {
+                    tx.rollback().await?;
+                    return Err(Error::UnknownPaymentState);
+                }
 
                 match response.status {
                     MeltQuoteState::Paid => {
@@ -917,6 +944,21 @@ impl MeltSaga<SetupComplete> {
                 "Payment was initially {} but verification returned {}. Keeping the initial status for safety.",
                 pay.status,
                 check_response.status
+            );
+            return Ok(pay);
+        }
+
+        // An Ok response with a terminal negative status is the backend's
+        // authoritative outcome, unlike an Err whose dispatch phase is
+        // unknown. A positive or in-flight follow-up overrides it, but a
+        // missing/Unknown observation does not erase that terminal result.
+        if matches!(pay.status, MeltQuoteState::Unpaid | MeltQuoteState::Failed)
+            && check_response.status == MeltQuoteState::Unknown
+        {
+            tracing::warn!(
+                "Payment backend returned authoritative {} for quote {}, but verification returned Unknown. Keeping the terminal response.",
+                pay.status,
+                self.state_data.quote.id
             );
             return Ok(pay);
         }

--- a/crates/cdk/src/mint/melt/melt_saga/tests.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/tests.rs
@@ -2034,6 +2034,78 @@ async fn test_payment_error_with_pending_check_does_not_compensate() {
     assert_eq!(stored_quote.state, MeltQuoteState::Pending);
 }
 
+async fn assert_payment_error_with_terminal_follow_up_does_not_compensate(
+    follow_up_state: MeltQuoteState,
+) {
+    assert!(matches!(
+        follow_up_state,
+        MeltQuoteState::Failed | MeltQuoteState::Unpaid
+    ));
+
+    let mint = create_test_mint().await.unwrap();
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+    let quote = create_test_melt_quote_with_description(
+        &mint,
+        Amount::from(9_000),
+        FakeInvoiceDescription {
+            pay_invoice_state: MeltQuoteState::Unknown,
+            check_payment_state: follow_up_state,
+            pay_err: true,
+            check_err: false,
+        },
+    )
+    .await;
+    let melt_request = create_test_melt_request(&proofs, &quote);
+    let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+    let saga = MeltSaga::new(
+        std::sync::Arc::new(mint.clone()),
+        mint.localstore(),
+        mint.pubsub_manager(),
+    );
+    let setup_saga = saga
+        .setup_melt(
+            &melt_request,
+            verification,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+        )
+        .await
+        .unwrap();
+    let operation_id = setup_saga.operation_id;
+    let (payment_saga, decision) = setup_saga
+        .attempt_internal_settlement(&melt_request)
+        .await
+        .unwrap();
+
+    let outcome = payment_saga.make_payment(decision).await.unwrap();
+
+    assert!(matches!(outcome, PaymentOutcome::Pending { .. }));
+    assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+    let pending_saga = assert_saga_exists(&mint, &operation_id).await;
+    assert_eq!(
+        pending_saga.state,
+        SagaStateEnum::Melt(MeltSagaState::PaymentPending),
+        "an untrusted terminal follow-up must leave the payment recoverable"
+    );
+    let stored_quote = mint
+        .localstore
+        .get_melt_quote(&quote.id)
+        .await
+        .unwrap()
+        .expect("quote should remain persisted");
+    assert_eq!(stored_quote.state, MeltQuoteState::Pending);
+}
+
+#[tokio::test]
+async fn test_payment_error_with_failed_check_does_not_compensate() {
+    assert_payment_error_with_terminal_follow_up_does_not_compensate(MeltQuoteState::Failed).await;
+}
+
+#[tokio::test]
+async fn test_payment_error_with_unpaid_check_does_not_compensate() {
+    assert_payment_error_with_terminal_follow_up_does_not_compensate(MeltQuoteState::Unpaid).await;
+}
+
 /// An Unknown dispatch result cannot be overridden by an immediate stale
 /// Unpaid read: the payment may still settle after the proofs are returned.
 #[tokio::test]

--- a/crates/cdk/src/mint/melt/melt_saga/tests.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/tests.rs
@@ -434,6 +434,18 @@ async fn test_saga_deletion_on_success() {
         panic!("Expected Confirmed outcome");
     };
 
+    // A paid backend result must be durably handed off before make_payment
+    // returns and releases the cross-replica dispatch lock.
+    let finalizing_saga = assert_saga_exists(&mint, &operation_id).await;
+    assert_eq!(
+        finalizing_saga.state,
+        SagaStateEnum::Melt(MeltSagaState::Finalizing)
+    );
+    assert!(
+        finalizing_saga.finalization_data.is_some(),
+        "paid dispatch must persist the data needed for recovery"
+    );
+
     // Finalize
     let _response = confirmed_saga.finalize().await.unwrap();
 
@@ -1191,6 +1203,219 @@ async fn test_crash_recovery_internal_settlement() {
 }
 
 // ============================================================================
+// Internal Settlement Tests
+// ============================================================================
+
+/// Helper: create a mint quote on the test mint and a melt quote paying its
+/// invoice (i.e. an internally-settled melt), then run setup_melt.
+///
+/// Returns (mint_quote_id, melt_quote, melt_request, setup saga, input_ys).
+async fn setup_internal_melt(
+    mint: &crate::mint::Mint,
+) -> (
+    cdk_common::QuoteId,
+    MeltQuote,
+    MeltRequest<cdk_common::QuoteId>,
+    MeltSaga<crate::mint::melt::melt_saga::state::SetupComplete>,
+    Vec<cdk_common::PublicKey>,
+) {
+    let proofs = mint_test_proofs(mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+
+    let mint_quote_response: cdk_common::MintQuoteBolt11Response<_> = mint
+        .get_mint_quote(
+            MintQuoteBolt11Request {
+                amount: Amount::from(4_000),
+                unit: CurrencyUnit::Sat,
+                description: None,
+                pubkey: None,
+            }
+            .into(),
+        )
+        .await
+        .unwrap()
+        .into();
+    let mint_quote_id = cdk_common::QuoteId::from_str(&mint_quote_response.quote).unwrap();
+    let mint_quote = mint
+        .localstore
+        .get_mint_quote(&mint_quote_id)
+        .await
+        .unwrap()
+        .expect("Mint quote should exist");
+
+    let melt_quote_request = MeltQuoteRequest::Bolt11(MeltQuoteBolt11Request {
+        request: mint_quote.request.to_string().parse().unwrap(),
+        unit: CurrencyUnit::Sat,
+        options: None,
+    });
+    let melt_quote_response = mint.get_melt_quote(melt_quote_request).await.unwrap();
+    let melt_quote = mint
+        .localstore
+        .get_melt_quote(melt_quote_response.quote().expect("single-quote method"))
+        .await
+        .unwrap()
+        .expect("Melt quote should exist");
+
+    let melt_request = create_test_melt_request(&proofs, &melt_quote);
+    let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+    let saga = MeltSaga::new(
+        std::sync::Arc::new(mint.clone()),
+        mint.localstore(),
+        mint.pubsub_manager(),
+    );
+    let setup_saga = saga
+        .setup_melt(
+            &melt_request,
+            verification,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+        )
+        .await
+        .expect("Setup should succeed");
+
+    (
+        mint_quote_id,
+        melt_quote,
+        melt_request,
+        setup_saga,
+        input_ys,
+    )
+}
+
+/// Test: internal settlement aborts when the melt quote is no longer pending,
+/// and the mint quote is not credited.
+#[tokio::test]
+async fn test_internal_settlement_aborts_after_rollback() {
+    let mint = create_test_mint().await.unwrap();
+    let (mint_quote_id, melt_quote, melt_request, setup_saga, input_ys) =
+        setup_internal_melt(&mint).await;
+    let operation_id = setup_saga.operation_id;
+
+    // Roll the melt back (proofs released, quote reset to Unpaid, saga deleted)
+    let blinded_secrets = mint
+        .localstore
+        .get_blinded_secrets_by_operation_id(&operation_id)
+        .await
+        .unwrap();
+    rollback_melt_quote(
+        &mint.localstore(),
+        &mint.pubsub_manager(),
+        &melt_quote.id,
+        &input_ys,
+        &blinded_secrets,
+        &operation_id,
+    )
+    .await
+    .unwrap();
+
+    // Settlement of the no-longer-pending melt must fail...
+    let result = setup_saga.attempt_internal_settlement(&melt_request).await;
+    assert!(
+        result.is_err(),
+        "internal settlement must abort when the melt quote is not pending"
+    );
+
+    // ...and the mint quote must NOT have been credited
+    let mint_quote_after = mint
+        .localstore
+        .get_mint_quote(&mint_quote_id)
+        .await
+        .unwrap()
+        .expect("Mint quote should exist");
+    assert_eq!(
+        mint_quote_after.state(),
+        MintQuoteState::Unpaid,
+        "mint quote must remain unpaid when settlement aborts"
+    );
+    assert_eq!(
+        mint_quote_after.amount_paid(),
+        Amount::ZERO.with_unit(CurrencyUnit::Sat)
+    );
+
+    // Melt quote remains Unpaid, saga gone
+    let melt_quote_after = mint
+        .localstore
+        .get_melt_quote(&melt_quote.id)
+        .await
+        .unwrap()
+        .expect("Melt quote should exist");
+    assert_eq!(melt_quote_after.state, MeltQuoteState::Unpaid);
+    assert_saga_not_exists(&mint, &operation_id).await;
+}
+
+/// Test: rollback of an internally settled (Paid) melt quote is refused, and
+/// the in-band finalize still completes normally and spends the proofs.
+#[tokio::test]
+async fn test_rollback_refused_after_internal_settlement() {
+    let mint = create_test_mint().await.unwrap();
+    let (_mint_quote_id, melt_quote, melt_request, setup_saga, input_ys) =
+        setup_internal_melt(&mint).await;
+    let operation_id = setup_saga.operation_id;
+
+    let (payment_saga, decision) = setup_saga
+        .attempt_internal_settlement(&melt_request)
+        .await
+        .expect("internal settlement should succeed");
+    assert!(matches!(
+        decision,
+        crate::mint::melt::melt_saga::state::SettlementDecision::Internal { .. }
+    ));
+
+    // The melt quote is Paid together with the mint quote credit
+    let settled_quote = mint
+        .localstore
+        .get_melt_quote(&melt_quote.id)
+        .await
+        .unwrap()
+        .expect("Melt quote should exist");
+    assert_eq!(settled_quote.state, MeltQuoteState::Paid);
+
+    // Rollback of a Paid quote must be refused and must not release proofs
+    let blinded_secrets = mint
+        .localstore
+        .get_blinded_secrets_by_operation_id(&operation_id)
+        .await
+        .unwrap();
+    let result = rollback_melt_quote(
+        &mint.localstore(),
+        &mint.pubsub_manager(),
+        &melt_quote.id,
+        &input_ys,
+        &blinded_secrets,
+        &operation_id,
+    )
+    .await;
+    assert!(
+        matches!(result, Err(crate::Error::PaidQuote)),
+        "rollback of a settled (Paid) melt quote must be refused"
+    );
+    assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+
+    // Finalize completes through the already-Paid path and spends the proofs
+    let PaymentOutcome::Confirmed(confirmed_saga) = payment_saga
+        .make_payment(decision)
+        .await
+        .expect("payment should succeed")
+    else {
+        panic!("Expected Confirmed outcome");
+    };
+    confirmed_saga
+        .finalize()
+        .await
+        .expect("finalize should succeed");
+
+    assert_proofs_state(&mint, &input_ys, Some(State::Spent)).await;
+    assert_saga_not_exists(&mint, &operation_id).await;
+
+    let final_quote = mint
+        .localstore
+        .get_melt_quote(&melt_quote.id)
+        .await
+        .unwrap()
+        .expect("Melt quote should exist");
+    assert_eq!(final_quote.state, MeltQuoteState::Paid);
+}
+
+// ============================================================================
 // Startup Integration Tests
 // ============================================================================
 
@@ -1789,7 +2014,7 @@ async fn test_payment_error_with_pending_check_does_not_compensate() {
     let pending_saga = assert_saga_exists(&mint, &operation_id).await;
     assert_eq!(
         pending_saga.state,
-        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted),
+        SagaStateEnum::Melt(MeltSagaState::PaymentPending),
         "a pending backend response should remain recoverable"
     );
     assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
@@ -1800,6 +2025,63 @@ async fn test_payment_error_with_pending_check_does_not_compensate() {
 
     assert_saga_exists(&mint, &operation_id).await;
     assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+    let stored_quote = mint
+        .localstore
+        .get_melt_quote(&quote.id)
+        .await
+        .unwrap()
+        .expect("quote should remain persisted");
+    assert_eq!(stored_quote.state, MeltQuoteState::Pending);
+}
+
+/// An Unknown dispatch result cannot be overridden by an immediate stale
+/// Unpaid read: the payment may still settle after the proofs are returned.
+#[tokio::test]
+async fn test_unknown_dispatch_with_unpaid_check_does_not_compensate() {
+    let mint = create_test_mint().await.unwrap();
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+    let quote = create_test_melt_quote_with_description(
+        &mint,
+        Amount::from(9_000),
+        FakeInvoiceDescription {
+            pay_invoice_state: MeltQuoteState::Unknown,
+            check_payment_state: MeltQuoteState::Unpaid,
+            pay_err: false,
+            check_err: false,
+        },
+    )
+    .await;
+    let melt_request = create_test_melt_request(&proofs, &quote);
+    let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+    let saga = MeltSaga::new(
+        std::sync::Arc::new(mint.clone()),
+        mint.localstore(),
+        mint.pubsub_manager(),
+    );
+    let setup_saga = saga
+        .setup_melt(
+            &melt_request,
+            verification,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+        )
+        .await
+        .unwrap();
+    let operation_id = setup_saga.operation_id;
+    let (payment_saga, decision) = setup_saga
+        .attempt_internal_settlement(&melt_request)
+        .await
+        .unwrap();
+
+    let outcome = payment_saga.make_payment(decision).await.unwrap();
+
+    assert!(matches!(outcome, PaymentOutcome::Pending { .. }));
+    assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+    let pending_saga = assert_saga_exists(&mint, &operation_id).await;
+    assert_eq!(
+        pending_saga.state,
+        SagaStateEnum::Melt(MeltSagaState::PaymentPending)
+    );
     let stored_quote = mint
         .localstore
         .get_melt_quote(&quote.id)
@@ -3089,7 +3371,7 @@ async fn test_unknown_follow_up_after_payment_error_keeps_proofs_pending() {
     let pending_saga = assert_saga_exists(&mint, &operation_id).await;
     assert_eq!(
         pending_saga.state,
-        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted),
+        SagaStateEnum::Melt(MeltSagaState::PaymentPending),
         "a backend Unknown response must leave dispatch marked ambiguous"
     );
 
@@ -3631,14 +3913,14 @@ async fn test_saga_drop_after_payment() {
         panic!("Expected Confirmed outcome");
     };
 
-    // STEP 3: Verify saga state is now PaymentAttempted (not SetupComplete)
+    // STEP 3: Verify the paid result is durably handed off for finalization
     let saga_in_db = assert_saga_exists(&mint, &operation_id).await;
     match &saga_in_db.state {
         cdk_common::mint::SagaStateEnum::Melt(state) => {
             assert_eq!(
                 *state,
-                MeltSagaState::PaymentAttempted,
-                "Saga state should be PaymentAttempted after make_payment"
+                MeltSagaState::Finalizing,
+                "Saga state should be Finalizing after a confirmed payment"
             );
         }
         _ => panic!("Expected Melt saga state"),
@@ -3676,13 +3958,13 @@ async fn test_saga_drop_after_payment() {
     // SUCCESS: Drop after payment correctly finalizes (doesn't compensate)!
 }
 
-/// Test: PaymentAttempted state triggers payment backend check during recovery
+/// Test: Finalizing state resumes a paid melt during recovery
 ///
-/// This test verifies that when recovery finds a saga in PaymentAttempted state,
-/// it checks the payment backend to determine whether to finalize or compensate,
-/// rather than blindly compensating like SetupComplete state.
+/// This test verifies that a confirmed payment is persisted as `Finalizing`, so
+/// recovery can complete it from the durable payment result without risking
+/// compensation.
 #[tokio::test]
-async fn test_payment_attempted_state_triggers_backend_check() {
+async fn test_finalizing_state_resumes_paid_melt() {
     // STEP 1: Setup test environment
     let mint = create_test_mint().await.unwrap();
     let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
@@ -3731,14 +4013,14 @@ async fn test_payment_attempted_state_triggers_backend_check() {
         panic!("Expected Confirmed outcome");
     };
 
-    // STEP 3: Verify state transitioned to PaymentAttempted
+    // STEP 3: Verify state transitioned to Finalizing
     let saga_after_payment = assert_saga_exists(&mint, &operation_id).await;
     match &saga_after_payment.state {
         cdk_common::mint::SagaStateEnum::Melt(state) => {
             assert_eq!(
                 *state,
-                MeltSagaState::PaymentAttempted,
-                "State should be PaymentAttempted after make_payment"
+                MeltSagaState::Finalizing,
+                "State should be Finalizing after make_payment"
             );
         }
         _ => panic!("Expected Melt saga state"),
@@ -3747,7 +4029,7 @@ async fn test_payment_attempted_state_triggers_backend_check() {
     // STEP 4: Drop saga (simulate crash after payment but before finalize)
     drop(confirmed_saga);
 
-    // STEP 5: Run recovery - should check payment backend and finalize
+    // STEP 5: Run recovery from the durable finalization handoff
     mint.recover_from_incomplete_melt_sagas()
         .await
         .expect("Recovery should succeed");
@@ -3771,7 +4053,7 @@ async fn test_payment_attempted_state_triggers_backend_check() {
         "Quote should be Paid - payment backend check should have triggered finalization"
     );
 
-    // SUCCESS: PaymentAttempted state correctly triggers payment backend check and finalizes!
+    // SUCCESS: Finalizing state resumes and completes the paid melt!
 }
 
 /// Test: SetupComplete state compensates without payment backend check

--- a/crates/cdk/src/mint/melt/shared.rs
+++ b/crates/cdk/src/mint/melt/shared.rs
@@ -8,7 +8,7 @@
 
 use cdk_common::amount::MSAT_IN_SAT;
 use cdk_common::database::mint::Acquired;
-use cdk_common::database::{self, DynMintDatabase};
+use cdk_common::database::{self, DynMintDatabase, DynMintTransaction};
 use cdk_common::mint::{self as mint_types};
 use cdk_common::nuts::{BlindSignature, BlindedMessage, MeltQuoteState, Proofs, State};
 use cdk_common::{Amount, CurrencyUnit, Error, PublicKey, QuoteId};
@@ -19,6 +19,76 @@ use cdk_signatory::signatory::SignatoryKeySet;
 use crate::mint::subscription::PubSubManager;
 use crate::mint::MeltQuote;
 use crate::Mint;
+
+/// Acquire the cross-process lock for a melt quote when the database supports
+/// it. PostgreSQL keeps the returned transaction open to hold its advisory
+/// lock; embedded backends return `None` and continue to use the mint's
+/// process-local quote guard.
+pub(crate) async fn acquire_melt_dispatch_lock(
+    db: &DynMintDatabase,
+    quote_id: &QuoteId,
+) -> Result<Option<DynMintTransaction>, Error> {
+    let mut tx = db.begin_dispatch_transaction().await?;
+    match tx.lock_quotes(std::slice::from_ref(quote_id)).await {
+        Ok(true) => Ok(Some(tx)),
+        Ok(false) => {
+            tx.rollback().await?;
+            Ok(None)
+        }
+        Err(err) => {
+            tx.rollback().await?;
+            Err(err.into())
+        }
+    }
+}
+
+/// Outcome of a non-blocking melt-dispatch lock attempt.
+pub(crate) enum DispatchLockAttempt {
+    /// This transaction holds the cross-process quote lock.
+    Acquired(DynMintTransaction),
+    /// A live dispatch or reconciliation holds the quote lock. The caller must
+    /// fail closed: reload the quote, leave it pending, and never compensate.
+    Contended,
+    /// The backend has no cross-process lock; use the process-local guard.
+    Unsupported,
+}
+
+impl std::fmt::Debug for DispatchLockAttempt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Acquired(_) => f.write_str("DispatchLockAttempt::Acquired(..)"),
+            Self::Contended => f.write_str("DispatchLockAttempt::Contended"),
+            Self::Unsupported => f.write_str("DispatchLockAttempt::Unsupported"),
+        }
+    }
+}
+
+/// Non-blocking variant of [`acquire_melt_dispatch_lock`] for reconciliation
+/// paths. A contended lock proves a live dispatch owns the quote, so callers
+/// reload state and leave it pending instead of waiting on the advisory lock.
+/// The dispatch pool is used because an acquired transaction may remain open
+/// across payment-backend network I/O during reconciliation.
+pub(crate) async fn try_acquire_melt_dispatch_lock(
+    db: &DynMintDatabase,
+    quote_id: &QuoteId,
+) -> Result<DispatchLockAttempt, Error> {
+    let mut tx = db.begin_dispatch_transaction().await?;
+    match tx.try_lock_quotes(std::slice::from_ref(quote_id)).await {
+        Ok(database::mint::QuoteLockAttempt::Acquired) => Ok(DispatchLockAttempt::Acquired(tx)),
+        Ok(database::mint::QuoteLockAttempt::Contended) => {
+            tx.rollback().await?;
+            Ok(DispatchLockAttempt::Contended)
+        }
+        Ok(database::mint::QuoteLockAttempt::Unsupported) => {
+            tx.rollback().await?;
+            Ok(DispatchLockAttempt::Unsupported)
+        }
+        Err(err) => {
+            tx.rollback().await?;
+            Err(err.into())
+        }
+    }
+}
 
 /// Retrieves fee and amount configuration for the keyset matching the change outputs.
 ///
@@ -90,6 +160,33 @@ pub(crate) fn total_spent_for_quote_unit(
     }
 }
 
+/// Persist a paid payment result before releasing a quote dispatch lock.
+///
+/// The caller must commit this update using the transaction that owns the
+/// cross-process quote lock. This closes the handoff between observing a paid
+/// backend result and later finalization: once the lock is released, recovery
+/// will see `Finalizing` and must never compensate the melt.
+pub(crate) async fn persist_melt_finalization_handoff(
+    tx: &mut DynMintTransaction,
+    saga: &mut Acquired<mint_types::Saga>,
+    payment_response: &cdk_common::payment::MakePaymentResponse,
+) -> Result<(), Error> {
+    let finalization_data = mint_types::MeltFinalizationData {
+        total_spent: payment_response.total_spent.clone(),
+        payment_lookup_id: payment_response.payment_lookup_id.clone(),
+        payment_proof: payment_response.payment_proof.clone(),
+    };
+
+    tx.update_acquired_saga_with_finalization_data(
+        saga,
+        mint_types::SagaStateEnum::Melt(mint_types::MeltSagaState::Finalizing),
+        Some(&finalization_data),
+    )
+    .await?;
+
+    Ok(())
+}
+
 /// Rolls back a melt quote by removing all setup artifacts and resetting state.
 ///
 /// This function is used by both:
@@ -135,6 +232,119 @@ pub async fn rollback_melt_quote(
         return Ok(());
     }
 
+    let mut tx = db.begin_transaction().await?;
+    tx.lock_quotes(std::slice::from_ref(quote_id)).await?;
+    rollback_melt_quote_inner(
+        tx,
+        pubsub,
+        quote_id,
+        input_ys,
+        blinded_secrets,
+        operation_id,
+        None,
+    )
+    .await
+}
+
+/// Roll back while the caller holds this quote's dispatch advisory lock.
+pub(crate) async fn rollback_melt_quote_with_dispatch_lock(
+    tx: DynMintTransaction,
+    pubsub: &PubSubManager,
+    quote_id: &QuoteId,
+    input_ys: &[PublicKey],
+    blinded_secrets: &[PublicKey],
+    operation_id: &uuid::Uuid,
+) -> Result<(), Error> {
+    rollback_melt_quote_inner(
+        tx,
+        pubsub,
+        quote_id,
+        input_ys,
+        blinded_secrets,
+        operation_id,
+        None,
+    )
+    .await
+}
+
+/// Roll back a terminally failed dispatch before releasing its quote lock.
+///
+/// The transaction owns the cross-process dispatch lock. Loading the rollback
+/// metadata and removing the saga in that same transaction prevents another
+/// replica from advancing the saga to `PaymentPending` between the terminal
+/// backend result and compensation.
+pub(crate) async fn rollback_failed_melt_with_dispatch_lock(
+    mut tx: DynMintTransaction,
+    pubsub: &PubSubManager,
+    quote_id: &QuoteId,
+    operation_id: &uuid::Uuid,
+) -> Result<(), Error> {
+    let input_ys = tx.get_proof_ys_by_operation_id(operation_id).await?;
+    let blinded_secrets = tx
+        .get_melt_request_and_blinded_messages(quote_id)
+        .await?
+        .map(|request| {
+            request
+                .change_outputs
+                .into_iter()
+                .map(|output| output.blinded_secret)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    rollback_melt_quote_inner(
+        tx,
+        pubsub,
+        quote_id,
+        &input_ys,
+        &blinded_secrets,
+        operation_id,
+        None,
+    )
+    .await
+}
+
+/// Roll back setup only if the saga still proves payment was never attempted.
+pub(crate) async fn rollback_setup_melt_quote(
+    db: &DynMintDatabase,
+    pubsub: &PubSubManager,
+    quote_id: &QuoteId,
+    input_ys: &[PublicKey],
+    blinded_secrets: &[PublicKey],
+    operation_id: &uuid::Uuid,
+) -> Result<(), Error> {
+    if input_ys.is_empty() && blinded_secrets.is_empty() {
+        return Ok(());
+    }
+
+    let mut tx = db.begin_transaction().await?;
+    tx.lock_quotes(std::slice::from_ref(quote_id)).await?;
+    rollback_melt_quote_inner(
+        tx,
+        pubsub,
+        quote_id,
+        input_ys,
+        blinded_secrets,
+        operation_id,
+        Some(mint_types::MeltSagaState::SetupComplete),
+    )
+    .await
+}
+
+async fn rollback_melt_quote_inner(
+    mut tx: DynMintTransaction,
+    pubsub: &PubSubManager,
+    quote_id: &QuoteId,
+    input_ys: &[PublicKey],
+    blinded_secrets: &[PublicKey],
+    operation_id: &uuid::Uuid,
+    required_saga_state: Option<mint_types::MeltSagaState>,
+) -> Result<(), Error> {
+    if input_ys.is_empty() && blinded_secrets.is_empty() {
+        tx.rollback().await?;
+        return Ok(());
+    }
+
     tracing::info!(
         "Rolling back melt quote {} ({} proofs, {} blinded messages, saga {})",
         quote_id,
@@ -142,8 +352,6 @@ pub async fn rollback_melt_quote(
         blinded_secrets.len(),
         operation_id
     );
-
-    let mut tx = db.begin_transaction().await?;
 
     // Acquire quote locks before touching the saga, melt-request,
     // blinded-signature, or proof rows. Finalization uses the same order.
@@ -164,6 +372,19 @@ pub async fn rollback_melt_quote(
             return Ok(());
         }
         Some(saga) => {
+            if let Some(required_state) = required_saga_state {
+                if saga.state != mint_types::SagaStateEnum::Melt(required_state.clone()) {
+                    tracing::info!(
+                        "Refusing setup rollback for melt quote {} because saga {} advanced to {}",
+                        quote_id,
+                        operation_id,
+                        saga.state.state()
+                    );
+                    tx.rollback().await?;
+                    return Err(Error::UnknownPaymentState);
+                }
+            }
+
             if matches!(
                 &saga.state,
                 mint_types::SagaStateEnum::Melt(mint_types::MeltSagaState::Finalizing)
@@ -793,12 +1014,15 @@ pub async fn finalize_melt_quote(
     let should_record_payment_metrics = locked_quote.state != MeltQuoteState::Paid;
 
     // Check if TX1 already completed (e.g., crash between TX1 commit and TX2 commit).
-    // If the quote is already Paid, proofs are already Spent — calling finalize_melt_core
-    // would fail on the Paid→Paid and Spent→Spent state transitions. Skip directly to
-    // change signing and cleanup so the user receives their change.
+    // If the quote is already Paid, calling finalize_melt_core would fail on the
+    // Paid→Paid state transition. Skip directly to change signing and cleanup so
+    // the user receives their change.
     //
-    // We still need the proofs for fee calculation (operation recording), so fetch them
-    // from the DB even in the already-Paid case.
+    // The proofs may still be Pending here; spend any that are still Pending,
+    // otherwise this is a no-op.
+    //
+    // We still need the proofs for fee calculation (operation recording), so fetch
+    // them from the DB even in the already-Paid case.
     let (proofs, quote) = if locked_quote.state == MeltQuoteState::Paid {
         let locked_quote = locked_quote.inner();
 
@@ -811,8 +1035,23 @@ pub async fn finalize_melt_quote(
             "Melt quote {} already Paid, skipping to change/cleanup",
             quote.id
         );
-        let proofs = tx.get_proofs(&input_ys).await?.to_vec();
+        let mut proofs_with_state = tx.get_proofs(&input_ys).await?;
+        let spend_pending = proofs_with_state.state == State::Pending;
+        if spend_pending {
+            if let Err(err) =
+                Mint::update_proofs_state(&mut tx, &mut proofs_with_state, State::Spent).await
+            {
+                tx.rollback().await?;
+                return Err(err);
+            }
+        }
+        let proofs = proofs_with_state.to_vec();
         tx.commit().await?;
+        if spend_pending {
+            for pk in input_ys.iter() {
+                pubsub.proof_state((*pk, State::Spent));
+            }
+        }
         (proofs, locked_quote)
     } else {
         let (proofs, quote) = finalize_melt_core(
@@ -946,4 +1185,61 @@ pub async fn finalize_melt_quote(
     }
 
     Ok(change_sigs)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use cdk_common::database::DynMintDatabase;
+    use cdk_common::QuoteId;
+
+    use super::{try_acquire_melt_dispatch_lock, DispatchLockAttempt};
+
+    #[tokio::test]
+    async fn reconciliation_lock_preserves_regular_postgres_pool_capacity() {
+        let postgres_required = std::env::var_os("CDK_REQUIRE_POSTGRES_TESTS").is_some();
+        let db_url =
+            match std::env::var("CDK_MINTD_DATABASE_URL").or_else(|_| std::env::var("PG_DB_URL")) {
+                Ok(db_url) => db_url,
+                Err(err) if postgres_required => {
+                    panic!("PostgreSQL reconciliation-lock test requires a database URL: {err}")
+                }
+                Err(_) => return,
+            };
+        let schema = format!("test_reconciliation_pool_{}", uuid::Uuid::new_v4());
+        let config = cdk_postgres::PgConfig::new(
+            &format!("{db_url} schema={schema}"),
+            None,
+            Some(2),
+            Some(10),
+        );
+        let db = match cdk_postgres::MintPgDatabase::new(config).await {
+            Ok(db) => db,
+            Err(err) if postgres_required => {
+                panic!("Could not create required PostgreSQL reconciliation-lock database: {err}")
+            }
+            Err(err) => {
+                tracing::warn!("Skipping PostgreSQL reconciliation-lock test: {}", err);
+                return;
+            }
+        };
+        let db: DynMintDatabase = Arc::new(db);
+
+        let dispatch = match try_acquire_melt_dispatch_lock(&db, &QuoteId::new())
+            .await
+            .expect("reconciliation lock")
+        {
+            DispatchLockAttempt::Acquired(tx) => tx,
+            attempt => panic!("PostgreSQL must acquire the reconciliation lock: {attempt:?}"),
+        };
+        let regular = tokio::time::timeout(Duration::from_secs(1), db.begin_transaction())
+            .await
+            .expect("reconciliation lock must preserve regular pool capacity")
+            .expect("regular transaction");
+
+        regular.rollback().await.expect("regular rollback");
+        dispatch.rollback().await.expect("dispatch rollback");
+    }
 }

--- a/crates/cdk/src/mint/melt/tests/pending_async_melt_tests.rs
+++ b/crates/cdk/src/mint/melt/tests/pending_async_melt_tests.rs
@@ -33,6 +33,7 @@ struct NoEventPendingBackend {
     dispatch_status: MeltQuoteState,
     final_status: Option<MeltQuoteState>,
     strip_quote_lookup_id: bool,
+    amount_mismatch_dispatch_error: bool,
     dispatch_gate: Option<Arc<DispatchGate>>,
 }
 
@@ -74,6 +75,7 @@ impl NoEventPendingBackend {
             dispatch_status: MeltQuoteState::Pending,
             final_status,
             strip_quote_lookup_id: false,
+            amount_mismatch_dispatch_error: false,
             dispatch_gate: None,
         }
     }
@@ -92,6 +94,11 @@ impl NoEventPendingBackend {
 
     fn with_dispatch_status(mut self, dispatch_status: MeltQuoteState) -> Self {
         self.dispatch_status = dispatch_status;
+        self
+    }
+
+    fn with_amount_mismatch_dispatch_error(mut self) -> Self {
+        self.amount_mismatch_dispatch_error = true;
         self
     }
 }
@@ -134,6 +141,10 @@ impl MintPayment for NoEventPendingBackend {
                 .store(true, Ordering::SeqCst);
             dispatch_gate.make_payment_started.notify_one();
             dispatch_gate.allow_dispatch.notified().await;
+        }
+
+        if self.amount_mismatch_dispatch_error {
+            return Err(payment::Error::AmountMismatch);
         }
 
         let mut response = self.inner.make_payment(unit, options).await?;
@@ -619,6 +630,123 @@ async fn second_replica_cannot_advance_saga_before_terminal_failure_rollback() {
 }
 
 #[tokio::test]
+async fn second_replica_paid_event_preempts_terminal_failure_rollback() {
+    let dispatch_gate = Arc::new(DispatchGate::default());
+    let backend = Arc::new(
+        NoEventPendingBackend::new(1, Some(MeltQuoteState::Failed))
+            .with_dispatch_status(MeltQuoteState::Failed)
+            .with_dispatch_gate(dispatch_gate.clone()),
+    );
+    let Some(mint) = create_postgres_pending_test_mint(backend).await else {
+        return;
+    };
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+    let quote = create_test_melt_quote(&mint, Amount::from(9_000)).await;
+    let melt_request = create_test_melt_request(&proofs, &quote);
+    let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+    let saga = crate::mint::melt::melt_saga::MeltSaga::new(
+        Arc::new(mint.clone()),
+        mint.localstore(),
+        mint.pubsub_manager(),
+    );
+    let setup = saga
+        .setup_melt(
+            &melt_request,
+            verification,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+        )
+        .await
+        .unwrap();
+    let (setup, decision) = setup
+        .attempt_internal_settlement(&melt_request)
+        .await
+        .unwrap();
+
+    let payment = tokio::spawn(async move { setup.make_payment(decision).await });
+    dispatch_gate.wait_for_make_payment().await;
+
+    // Model an independent replica receiving a trusted positive event while
+    // the dispatching replica is still waiting for its backend response.
+    let mut event_mint = mint.clone();
+    event_mint.melt_quote_locks = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let event_mint = Arc::new(event_mint);
+    let payment_response = MakePaymentResponse {
+        payment_lookup_id: quote
+            .request_lookup_id
+            .clone()
+            .expect("bolt11 quote should have a payment lookup id"),
+        payment_proof: Some("trusted_event_preimage".to_string()),
+        status: MeltQuoteState::Paid,
+        total_spent: quote.amount(),
+    };
+    tokio::time::timeout(
+        POSTGRES_NONBLOCKING_TIMEOUT,
+        Mint::handle_successful_melt_payment_event(
+            &event_mint,
+            &event_mint.localstore(),
+            &event_mint.pubsub_manager(),
+            &quote.id,
+            payment_response,
+        ),
+    )
+    .await
+    .expect("trusted paid event must not wait for the live dispatch call")
+    .expect("trusted paid event should finalize the melt");
+
+    assert_eq!(
+        mint.localstore()
+            .get_melt_quote(&quote.id)
+            .await
+            .unwrap()
+            .expect("quote exists")
+            .state,
+        MeltQuoteState::Paid
+    );
+    let states = mint
+        .localstore()
+        .get_proofs_states(&input_ys)
+        .await
+        .unwrap();
+    assert!(
+        states
+            .iter()
+            .all(|state| *state == Some(cdk_common::State::Spent)),
+        "trusted paid event must spend the reserved proofs"
+    );
+
+    // The stale terminal failure arrives after the paid handoff. It must see
+    // that the saga was advanced/completed and decline to compensate.
+    dispatch_gate.release_dispatch();
+    let payment_result = payment.await.unwrap();
+    assert!(matches!(payment_result, Err(Error::UnknownPaymentState)));
+    assert_eq!(
+        mint.localstore()
+            .get_melt_quote(&quote.id)
+            .await
+            .unwrap()
+            .expect("quote exists")
+            .state,
+        MeltQuoteState::Paid
+    );
+    let states = mint
+        .localstore()
+        .get_proofs_states(&input_ys)
+        .await
+        .unwrap();
+    assert!(states
+        .iter()
+        .all(|state| *state == Some(cdk_common::State::Spent)));
+    assert!(mint
+        .localstore()
+        .get_melt_saga_by_quote_id(&quote.id)
+        .await
+        .unwrap()
+        .is_none());
+    mint.stop().await.expect("mint should stop cleanly");
+}
+
+#[tokio::test]
 async fn second_replica_recovery_keeps_live_dispatch_pending() {
     let dispatch_gate = Arc::new(DispatchGate::default());
     let backend = Arc::new(
@@ -786,6 +914,107 @@ async fn pending_melt_ignores_failed_status_check_without_notification() {
         saga.state,
         cdk_common::mint::SagaStateEnum::Melt(cdk_common::mint::MeltSagaState::PaymentPending)
     );
+}
+
+#[tokio::test]
+async fn payment_error_that_looks_local_still_stays_pending() {
+    let backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync> = Arc::new(
+        NoEventPendingBackend::new(usize::MAX, None).with_amount_mismatch_dispatch_error(),
+    );
+    let mint = create_pending_test_mint(backend).await.unwrap();
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+    let quote = create_test_melt_quote(&mint, Amount::from(9_000)).await;
+    let melt_request = create_test_melt_request(&proofs, &quote);
+
+    // Even an error that resembles local validation can be returned after a
+    // backend crossed its dispatch boundary. A subsequent Unpaid read does
+    // not prove that no payment is in flight.
+    let pending = mint.melt(&melt_request).await.unwrap();
+    assert_eq!(pending.pending_response().state(), MeltQuoteState::Pending);
+    let pending_saga = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let saga = mint
+                .localstore()
+                .get_melt_saga_by_quote_id(&quote.id)
+                .await
+                .unwrap()
+                .expect("ambiguous payment should remain recoverable");
+            if saga.state
+                == cdk_common::mint::SagaStateEnum::Melt(
+                    cdk_common::mint::MeltSagaState::PaymentPending,
+                )
+            {
+                break saga;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("ambiguous payment should reach its durable pending handoff");
+    drop(pending);
+
+    assert_eq!(
+        mint.localstore()
+            .get_melt_quote(&quote.id)
+            .await
+            .unwrap()
+            .expect("quote exists")
+            .state,
+        MeltQuoteState::Pending
+    );
+    let states = mint
+        .localstore()
+        .get_proofs_states(&input_ys)
+        .await
+        .unwrap();
+    assert!(states
+        .iter()
+        .all(|state| *state == Some(cdk_common::State::Pending)));
+    assert_eq!(
+        pending_saga.state,
+        cdk_common::mint::SagaStateEnum::Melt(cdk_common::mint::MeltSagaState::PaymentPending)
+    );
+}
+
+#[tokio::test]
+async fn authoritative_failed_response_survives_unknown_recheck() {
+    let backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync> = Arc::new(
+        NoEventPendingBackend::new(1, Some(MeltQuoteState::Unknown))
+            .with_dispatch_status(MeltQuoteState::Failed),
+    );
+    let mint = create_pending_test_mint(backend).await.unwrap();
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+    let quote = create_test_melt_quote(&mint, Amount::from(9_000)).await;
+    let melt_request = create_test_melt_request(&proofs, &quote);
+
+    let pending = mint.melt(&melt_request).await.unwrap();
+    let err = pending
+        .await
+        .expect_err("authoritative failed response should compensate the melt");
+    assert!(matches!(err, Error::PaymentFailed));
+    assert_eq!(
+        mint.localstore()
+            .get_melt_quote(&quote.id)
+            .await
+            .unwrap()
+            .expect("quote exists")
+            .state,
+        MeltQuoteState::Unpaid
+    );
+    let states = mint
+        .localstore()
+        .get_proofs_states(&input_ys)
+        .await
+        .unwrap();
+    assert!(states.iter().all(Option::is_none));
+    assert!(mint
+        .localstore()
+        .get_melt_saga_by_quote_id(&quote.id)
+        .await
+        .unwrap()
+        .is_none());
 }
 
 #[tokio::test]

--- a/crates/cdk/src/mint/melt/tests/pending_async_melt_tests.rs
+++ b/crates/cdk/src/mint/melt/tests/pending_async_melt_tests.rs
@@ -23,10 +23,14 @@ use crate::test_helpers::mint::mint_test_proofs;
 use crate::types::{FeeReserve, QuoteTTL};
 use crate::Error;
 
+const POSTGRES_NONBLOCKING_TIMEOUT: Duration = Duration::from_secs(5);
+const POSTGRES_COMPLETION_TIMEOUT: Duration = Duration::from_secs(30);
+
 struct NoEventPendingBackend {
     inner: FakeWallet,
     status_checks: AtomicUsize,
     settle_after_checks: usize,
+    dispatch_status: MeltQuoteState,
     final_status: Option<MeltQuoteState>,
     strip_quote_lookup_id: bool,
     dispatch_gate: Option<Arc<DispatchGate>>,
@@ -36,6 +40,7 @@ struct NoEventPendingBackend {
 struct DispatchGate {
     make_payment_started: Notify,
     allow_dispatch: Notify,
+    make_payment_entered: AtomicBool,
     dispatched: AtomicBool,
 }
 
@@ -66,6 +71,7 @@ impl NoEventPendingBackend {
             ),
             status_checks: AtomicUsize::new(0),
             settle_after_checks,
+            dispatch_status: MeltQuoteState::Pending,
             final_status,
             strip_quote_lookup_id: false,
             dispatch_gate: None,
@@ -81,6 +87,11 @@ impl NoEventPendingBackend {
 
     fn with_dispatch_gate(mut self, dispatch_gate: Arc<DispatchGate>) -> Self {
         self.dispatch_gate = Some(dispatch_gate);
+        self
+    }
+
+    fn with_dispatch_status(mut self, dispatch_status: MeltQuoteState) -> Self {
+        self.dispatch_status = dispatch_status;
         self
     }
 }
@@ -118,6 +129,9 @@ impl MintPayment for NoEventPendingBackend {
         options: OutgoingPaymentOptions,
     ) -> Result<MakePaymentResponse, Self::Err> {
         if let Some(dispatch_gate) = &self.dispatch_gate {
+            dispatch_gate
+                .make_payment_entered
+                .store(true, Ordering::SeqCst);
             dispatch_gate.make_payment_started.notify_one();
             dispatch_gate.allow_dispatch.notified().await;
         }
@@ -126,8 +140,11 @@ impl MintPayment for NoEventPendingBackend {
         if let Some(dispatch_gate) = &self.dispatch_gate {
             dispatch_gate.dispatched.store(true, Ordering::SeqCst);
         }
-        response.status = MeltQuoteState::Pending;
-        response.payment_proof = None;
+        response.status = self.dispatch_status;
+        if self.dispatch_status != MeltQuoteState::Paid {
+            response.payment_proof = None;
+            response.total_spent = Amount::new(0, CurrencyUnit::Sat);
+        }
         Ok(response)
     }
 
@@ -201,6 +218,57 @@ async fn create_pending_test_mint(
     backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync>,
 ) -> Result<Mint, Error> {
     let db = Arc::new(cdk_sqlite::mint::memory::empty().await?);
+    build_pending_test_mint(db, backend).await
+}
+
+async fn create_postgres_pending_test_mint(
+    backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync>,
+) -> Option<Mint> {
+    let postgres_required = std::env::var_os("CDK_REQUIRE_POSTGRES_TESTS").is_some();
+    let db_url =
+        match std::env::var("CDK_MINTD_DATABASE_URL").or_else(|_| std::env::var("PG_DB_URL")) {
+            Ok(db_url) => db_url,
+            Err(err) if postgres_required => {
+                panic!("PostgreSQL melt-dispatch tests require a database URL: {err}")
+            }
+            Err(_) => return None,
+        };
+    let schema = format!("test_melt_dispatch_{}", uuid::Uuid::new_v4());
+    let db_config = format!("{db_url} schema={schema}");
+    let db = match cdk_postgres::MintPgDatabase::new(db_config.as_str()).await {
+        Ok(db) => db,
+        Err(err) if postgres_required => {
+            panic!("Could not create required PostgreSQL melt-dispatch database: {err}")
+        }
+        Err(err) => {
+            tracing::warn!("Skipping PostgreSQL melt-dispatch test: {}", err);
+            return None;
+        }
+    };
+
+    match build_pending_test_mint(Arc::new(db), backend).await {
+        Ok(mint) => Some(mint),
+        Err(err) if postgres_required => {
+            panic!("Could not build required PostgreSQL melt-dispatch mint: {err}")
+        }
+        Err(err) => {
+            tracing::warn!("Skipping PostgreSQL melt-dispatch test: {}", err);
+            None
+        }
+    }
+}
+
+async fn build_pending_test_mint<DB>(
+    db: Arc<DB>,
+    backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync>,
+) -> Result<Mint, Error>
+where
+    DB: cdk_common::database::MintDatabase<cdk_common::database::Error>
+        + cdk_common::database::MintKeysDatabase<Err = cdk_common::database::Error>
+        + Send
+        + Sync
+        + 'static,
+{
     let mut mint_builder = MintBuilder::new(db.clone());
 
     mint_builder
@@ -265,14 +333,23 @@ fn create_test_melt_request(
     cdk_common::nuts::MeltRequest::new(quote.id.clone(), proofs.clone(), None)
 }
 
+async fn finish_pending_melt_task(pending: crate::mint::melt::PendingMelt) {
+    match pending.await {
+        Ok(_) | Err(Error::PendingMeltTimeout { .. }) => {}
+        Err(err) => panic!("pending melt task failed unexpectedly: {err}"),
+    }
+}
+
 #[tokio::test]
-async fn quote_check_waits_for_live_dispatch_before_trusting_unpaid() {
+async fn second_replica_quote_check_keeps_live_dispatch_pending() {
     let dispatch_gate = Arc::new(DispatchGate::default());
     let backend = Arc::new(
         NoEventPendingBackend::new(2, Some(MeltQuoteState::Paid))
             .with_dispatch_gate(dispatch_gate.clone()),
     );
-    let mint = create_pending_test_mint(backend.clone()).await.unwrap();
+    let Some(mint) = create_postgres_pending_test_mint(backend.clone()).await else {
+        return;
+    };
     let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
     let quote = create_test_melt_quote(&mint, Amount::from(9_000)).await;
     let melt_request = create_test_melt_request(&proofs, &quote);
@@ -280,24 +357,365 @@ async fn quote_check_waits_for_live_dispatch_before_trusting_unpaid() {
     let pending = mint.melt(&melt_request).await.unwrap();
     dispatch_gate.wait_for_make_payment().await;
 
-    let check_mint = mint.clone();
+    // Model a second mint process: it shares the database and backend, but not
+    // the first process's in-memory quote lock table.
+    let mut check_mint = mint.clone();
+    check_mint.melt_quote_locks = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
     let check_quote_id = quote.id.clone();
-    let mut check = tokio::spawn(async move { check_mint.check_melt_quote(&check_quote_id).await });
+    let check = tokio::spawn(async move { check_mint.check_melt_quote(&check_quote_id).await });
+    let checked = tokio::time::timeout(POSTGRES_NONBLOCKING_TIMEOUT, check)
+        .await
+        .expect("contended quote check must not wait for dispatch")
+        .unwrap()
+        .unwrap();
+    assert_eq!(checked.state(), MeltQuoteState::Pending);
 
-    assert!(
-        tokio::time::timeout(Duration::from_millis(50), &mut check)
-            .await
-            .is_err(),
-        "quote check must wait while make_payment can still dispatch"
-    );
+    let input_ys = proofs.ys().unwrap();
+    let proof_states = mint
+        .localstore()
+        .get_proofs_states(&input_ys)
+        .await
+        .unwrap();
+    assert!(proof_states
+        .iter()
+        .all(|state| *state == Some(cdk_common::State::Pending)));
 
     dispatch_gate.release_dispatch();
 
-    let response = pending.await.unwrap();
-    assert_eq!(response.state(), MeltQuoteState::Paid);
+    tokio::time::timeout(POSTGRES_COMPLETION_TIMEOUT, async {
+        while !dispatch_gate.dispatched.load(Ordering::SeqCst) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("payment dispatch should complete");
 
-    let checked = check.await.unwrap().unwrap();
+    // The public status check is throttled per quote, so poll past the
+    // throttle window until the settled state is visible.
+    let checked = tokio::time::timeout(POSTGRES_COMPLETION_TIMEOUT, async {
+        loop {
+            let checked = mint.check_melt_quote(&quote.id).await.unwrap();
+            if checked.state() == MeltQuoteState::Paid {
+                break checked;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    })
+    .await
+    .expect("quote should reach Paid");
     assert_eq!(checked.state(), MeltQuoteState::Paid);
+    finish_pending_melt_task(pending).await;
+    mint.stop().await.expect("mint should stop cleanly");
+}
+
+#[tokio::test]
+async fn second_replica_reconciliation_keeps_payment_marker_pending() {
+    let dispatch_gate = Arc::new(DispatchGate::default());
+    let backend = Arc::new(
+        NoEventPendingBackend::new(1, Some(MeltQuoteState::Paid))
+            .with_dispatch_gate(dispatch_gate.clone()),
+    );
+    let Some(mint) = create_postgres_pending_test_mint(backend).await else {
+        return;
+    };
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let quote = create_test_melt_quote(&mint, Amount::from(9_000)).await;
+    let melt_request = create_test_melt_request(&proofs, &quote);
+    let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+    let saga = crate::mint::melt::melt_saga::MeltSaga::new(
+        Arc::new(mint.clone()),
+        mint.localstore(),
+        mint.pubsub_manager(),
+    );
+    let setup = saga
+        .setup_melt(
+            &melt_request,
+            verification,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+        )
+        .await
+        .unwrap();
+    let (setup, decision) = setup
+        .attempt_internal_settlement(&melt_request)
+        .await
+        .unwrap();
+
+    // Model the write-ahead marker committed immediately before dispatch. A
+    // replica that reconciles this ambiguous state must fail closed and leave
+    // the dispatcher able to continue under the shared advisory lock.
+    let operation_id = mint
+        .localstore()
+        .get_melt_saga_by_quote_id(&quote.id)
+        .await
+        .unwrap()
+        .expect("melt saga")
+        .operation_id;
+    let mut marker_tx = mint.localstore().begin_transaction().await.unwrap();
+    let mut saga = marker_tx
+        .get_saga_for_update(&operation_id)
+        .await
+        .unwrap()
+        .expect("melt saga");
+    marker_tx
+        .update_acquired_saga(
+            &mut saga,
+            cdk_common::mint::SagaStateEnum::Melt(
+                cdk_common::mint::MeltSagaState::PaymentAttempted,
+            ),
+        )
+        .await
+        .unwrap();
+    marker_tx.commit().await.unwrap();
+
+    let mut check_mint = mint.clone();
+    check_mint.melt_quote_locks = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let check_quote_id = quote.id.clone();
+    let checked = check_mint.check_melt_quote(&check_quote_id).await.unwrap();
+    assert_eq!(checked.state(), MeltQuoteState::Pending);
+
+    let dispatch = tokio::spawn(async move { setup.make_payment(decision).await });
+    dispatch_gate.wait_for_make_payment().await;
+    assert!(
+        dispatch_gate.make_payment_entered.load(Ordering::SeqCst),
+        "dispatcher should retain ownership of the ambiguous payment attempt"
+    );
+    dispatch_gate.release_dispatch();
+
+    let outcome = tokio::time::timeout(Duration::from_secs(5), dispatch)
+        .await
+        .expect("payment dispatch should complete")
+        .expect("payment task should not panic")
+        .expect("payment dispatch should succeed");
+    assert!(matches!(
+        outcome,
+        crate::mint::melt::melt_saga::PaymentOutcome::Confirmed(_)
+    ));
+    mint.stop().await.expect("mint should stop cleanly");
+}
+
+#[tokio::test]
+async fn second_replica_cannot_advance_saga_before_terminal_failure_rollback() {
+    let dispatch_gate = Arc::new(DispatchGate::default());
+    let backend = Arc::new(
+        NoEventPendingBackend::new(1, Some(MeltQuoteState::Failed))
+            .with_dispatch_status(MeltQuoteState::Failed)
+            .with_dispatch_gate(dispatch_gate.clone()),
+    );
+    let Some(mint) = create_postgres_pending_test_mint(backend).await else {
+        return;
+    };
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+    let quote = create_test_melt_quote(&mint, Amount::from(9_000)).await;
+    let melt_request = create_test_melt_request(&proofs, &quote);
+    let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+    let saga = crate::mint::melt::melt_saga::MeltSaga::new(
+        Arc::new(mint.clone()),
+        mint.localstore(),
+        mint.pubsub_manager(),
+    );
+    let setup = saga
+        .setup_melt(
+            &melt_request,
+            verification,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+        )
+        .await
+        .unwrap();
+    let operation_id = mint
+        .localstore()
+        .get_melt_saga_by_quote_id(&quote.id)
+        .await
+        .unwrap()
+        .expect("melt saga")
+        .operation_id;
+    let (setup, decision) = setup
+        .attempt_internal_settlement(&melt_request)
+        .await
+        .unwrap();
+
+    let payment = tokio::spawn(async move { setup.make_payment(decision).await });
+    dispatch_gate.wait_for_make_payment().await;
+
+    // Queue a second replica behind the live dispatch lock. Before this fix it
+    // could acquire the lock after the terminal backend response but before
+    // compensation, advance the saga to PaymentPending, and then have that
+    // durable state removed by the stale compensation.
+    let observer_started = Arc::new(Notify::new());
+    let observer = tokio::spawn({
+        let db = mint.localstore();
+        let quote_id = quote.id.clone();
+        let observer_started = observer_started.clone();
+        async move {
+            let mut tx = db
+                .begin_dispatch_transaction()
+                .await
+                .expect("observer transaction");
+            observer_started.notify_one();
+            assert!(tx
+                .lock_quotes(std::slice::from_ref(&quote_id))
+                .await
+                .expect("observer quote lock"));
+
+            match tx
+                .get_saga_for_update(&operation_id)
+                .await
+                .expect("observer saga read")
+            {
+                Some(mut saga) => {
+                    tx.update_acquired_saga(
+                        &mut saga,
+                        cdk_common::mint::SagaStateEnum::Melt(
+                            cdk_common::mint::MeltSagaState::PaymentPending,
+                        ),
+                    )
+                    .await
+                    .expect("observer pending handoff");
+                    tx.commit().await.expect("observer commit");
+                    true
+                }
+                None => {
+                    tx.rollback().await.expect("observer rollback");
+                    false
+                }
+            }
+        }
+    });
+    observer_started.notified().await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    dispatch_gate.release_dispatch();
+
+    let observer_saw_saga = observer.await.unwrap();
+    let payment_result = payment.await.unwrap();
+    assert!(matches!(payment_result, Err(Error::PaymentFailed)));
+    assert!(
+        !observer_saw_saga,
+        "terminal failure must remove the saga before releasing the dispatch lock"
+    );
+
+    let states = mint
+        .localstore()
+        .get_proofs_states(&input_ys)
+        .await
+        .unwrap();
+    assert!(states.iter().all(Option::is_none));
+    assert!(mint
+        .localstore()
+        .get_melt_saga_by_quote_id(&quote.id)
+        .await
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        mint.localstore()
+            .get_melt_quote(&quote.id)
+            .await
+            .unwrap()
+            .expect("quote exists")
+            .state,
+        MeltQuoteState::Unpaid
+    );
+    mint.stop().await.expect("mint should stop cleanly");
+}
+
+#[tokio::test]
+async fn second_replica_recovery_keeps_live_dispatch_pending() {
+    let dispatch_gate = Arc::new(DispatchGate::default());
+    let backend = Arc::new(
+        NoEventPendingBackend::new(2, Some(MeltQuoteState::Paid))
+            .with_dispatch_gate(dispatch_gate.clone()),
+    );
+    let Some(mint) = create_postgres_pending_test_mint(backend).await else {
+        return;
+    };
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+    let quote = create_test_melt_quote(&mint, Amount::from(9_000)).await;
+    let melt_request = create_test_melt_request(&proofs, &quote);
+
+    let pending = mint.melt(&melt_request).await.unwrap();
+    dispatch_gate.wait_for_make_payment().await;
+
+    let mut recovery_mint = mint.clone();
+    recovery_mint.melt_quote_locks = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let recovery =
+        tokio::spawn(async move { recovery_mint.recover_from_incomplete_melt_sagas().await });
+    tokio::time::timeout(POSTGRES_NONBLOCKING_TIMEOUT, recovery)
+        .await
+        .expect("contended recovery must not wait for dispatch")
+        .unwrap()
+        .unwrap();
+
+    let proof_states = mint
+        .localstore()
+        .get_proofs_states(&input_ys)
+        .await
+        .unwrap();
+    assert!(proof_states
+        .iter()
+        .all(|state| *state == Some(cdk_common::State::Pending)));
+    assert!(mint
+        .localstore()
+        .get_melt_saga_by_quote_id(&quote.id)
+        .await
+        .unwrap()
+        .is_some());
+
+    dispatch_gate.release_dispatch();
+    tokio::time::timeout(POSTGRES_COMPLETION_TIMEOUT, async {
+        while !dispatch_gate.dispatched.load(Ordering::SeqCst) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("payment dispatch should complete");
+    let checked = mint.check_melt_quote(&quote.id).await.unwrap();
+    assert_eq!(checked.state(), MeltQuoteState::Paid);
+    finish_pending_melt_task(pending).await;
+    mint.stop().await.expect("mint should stop cleanly");
+}
+
+#[tokio::test]
+async fn pending_dispatch_is_sticky_across_stale_unpaid_verification() {
+    let backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync> =
+        Arc::new(NoEventPendingBackend::new(1, Some(MeltQuoteState::Unpaid)));
+    let mint = create_pending_test_mint(backend).await.unwrap();
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+    let quote = create_test_melt_quote(&mint, Amount::from(9_000)).await;
+    let melt_request = create_test_melt_request(&proofs, &quote);
+
+    let pending = mint.melt(&melt_request).await.unwrap();
+    assert!(matches!(
+        pending.await,
+        Err(Error::PendingMeltTimeout { .. })
+    ));
+
+    let stored_quote = mint
+        .localstore()
+        .get_melt_quote(&quote.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored_quote.state, MeltQuoteState::Pending);
+    let proof_states = mint
+        .localstore()
+        .get_proofs_states(&input_ys)
+        .await
+        .unwrap();
+    assert!(proof_states
+        .iter()
+        .all(|state| *state == Some(cdk_common::State::Pending)));
+    let saga = mint
+        .localstore()
+        .get_melt_saga_by_quote_id(&quote.id)
+        .await
+        .unwrap()
+        .expect("pending saga should remain");
+    assert_eq!(
+        saga.state,
+        cdk_common::mint::SagaStateEnum::Melt(cdk_common::mint::MeltSagaState::PaymentPending)
+    );
 }
 
 #[tokio::test]
@@ -327,7 +745,7 @@ async fn pending_melt_completes_via_explicit_status_check_without_notification()
 }
 
 #[tokio::test]
-async fn pending_melt_rolls_back_via_explicit_status_check_without_notification() {
+async fn pending_melt_ignores_failed_status_check_without_notification() {
     let backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync> =
         Arc::new(NoEventPendingBackend::new(2, Some(MeltQuoteState::Failed)));
     let mint = create_pending_test_mint(backend).await.unwrap();
@@ -338,11 +756,8 @@ async fn pending_melt_rolls_back_via_explicit_status_check_without_notification(
 
     let pending = mint.melt(&melt_request).await.unwrap();
     let checked = mint.check_melt_quote(&quote.id).await.unwrap();
-    assert_eq!(checked.state(), MeltQuoteState::Unpaid);
-
-    let response = pending.await.unwrap();
-
-    assert_eq!(response.state(), MeltQuoteState::Unpaid);
+    assert_eq!(checked.state(), MeltQuoteState::Pending);
+    drop(pending);
 
     let stored_quote = mint
         .localstore()
@@ -350,14 +765,27 @@ async fn pending_melt_rolls_back_via_explicit_status_check_without_notification(
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(stored_quote.state, MeltQuoteState::Unpaid);
+    assert_eq!(stored_quote.state, MeltQuoteState::Pending);
 
     let proof_states = mint
         .localstore()
         .get_proofs_states(&input_ys)
         .await
         .unwrap();
-    assert!(proof_states.iter().all(|state| state.is_none()));
+    assert!(proof_states
+        .iter()
+        .all(|state| *state == Some(cdk_common::State::Pending)));
+
+    let saga = mint
+        .localstore()
+        .get_melt_saga_by_quote_id(&quote.id)
+        .await
+        .unwrap()
+        .expect("ambiguous dispatch saga should remain");
+    assert_eq!(
+        saga.state,
+        cdk_common::mint::SagaStateEnum::Melt(cdk_common::mint::MeltSagaState::PaymentPending)
+    );
 }
 
 #[tokio::test]
@@ -645,10 +1073,11 @@ async fn internal_settlement_without_lookup_id_finalizes_on_demand() {
     );
 }
 
-/// Startup recovery derives a stable backend identifier when an older quote
-/// has no persisted lookup id and compensates a definitively unpaid attempt.
+/// After a crashed dispatcher releases its advisory lock, startup recovery must
+/// keep the write-ahead attempt pending because it cannot prove whether the
+/// backend call happened before the crash.
 #[tokio::test]
-async fn payment_attempted_without_lookup_id_recovers_unpaid_at_startup() {
+async fn payment_attempt_without_lookup_id_stays_pending_at_startup() {
     let backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync> = Arc::new(
         NoEventPendingBackend::new(1, Some(MeltQuoteState::Unpaid)).with_stripped_quote_lookup_id(),
     );
@@ -688,8 +1117,8 @@ async fn payment_attempted_without_lookup_id_recovers_unpaid_at_startup() {
         .expect("saga should exist")
         .operation_id;
 
-    // Simulate a crash after the write-ahead PaymentAttempted marker but
-    // before make_payment runs or a lookup id is persisted.
+    // Simulate a crash after the write-ahead PaymentAttempted marker. The
+    // durable state cannot prove whether make_payment ran before the crash.
     {
         let mut tx = mint.localstore().begin_transaction().await.unwrap();
         let mut saga = tx
@@ -718,30 +1147,36 @@ async fn payment_attempted_without_lookup_id_recovers_unpaid_at_startup() {
         .iter()
         .all(|s| *s == Some(cdk_common::State::Pending)));
 
-    // Simulate the crash: run startup recovery.
+    // The crashed process no longer holds the advisory lock.
     mint.recover_from_incomplete_melt_sagas()
         .await
         .expect("recovery should succeed");
 
-    // The backend was checked with the identifier derived from the quote and
-    // definitively reported Unpaid, so recovery returns the reserved proofs.
+    // A public backend poll cannot resolve the ambiguous dispatch, even after
+    // the crashed process releases its advisory lock.
     let states = mint
         .localstore()
         .get_proofs_states(&input_ys)
         .await
         .unwrap();
-    assert!(states.iter().all(Option::is_none));
+    assert!(states
+        .iter()
+        .all(|state| *state == Some(cdk_common::State::Pending)));
     let stored_quote = mint
         .localstore()
         .get_melt_quote(&quote.id)
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(stored_quote.state, MeltQuoteState::Unpaid);
-    assert!(mint
+    assert_eq!(stored_quote.state, MeltQuoteState::Pending);
+    let saga = mint
         .localstore()
         .get_melt_saga_by_quote_id(&quote.id)
         .await
         .unwrap()
-        .is_none());
+        .expect("ambiguous dispatch saga should remain");
+    assert_eq!(
+        saga.state,
+        cdk_common::mint::SagaStateEnum::Melt(cdk_common::mint::MeltSagaState::PaymentAttempted)
+    );
 }

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1114,7 +1114,7 @@ impl Mint {
 
         let payment_response = mint.check_melt_payment_status(&quote).await?;
 
-        saga_recovery::process_melt_saga_outcome(
+        saga_recovery::process_melt_saga_failure_event(
             &saga,
             &mut quote,
             &payment_response,

--- a/crates/cdk/src/mint/saga_recovery.rs
+++ b/crates/cdk/src/mint/saga_recovery.rs
@@ -86,9 +86,10 @@ async fn process_melt_saga_outcome_inner(
     match payment_response.status {
         MeltQuoteState::Paid => {
             // Persist the paid handoff before releasing an acquired dispatch
-            // lock. When contended, the live owner holds the saga row through
-            // dispatch, so finalization serializes on that row after its own
-            // pending or paid handoff commits.
+            // lock. When contended, finalization proceeds by locking the saga
+            // row: a live dispatcher deliberately does not hold that row across
+            // the external call and must re-read it before compensating. This
+            // lets a trusted positive event durably preempt a stale failure.
             match super::melt::shared::try_acquire_melt_dispatch_lock(db, &quote.id).await? {
                 super::melt::shared::DispatchLockAttempt::Acquired(mut tx) => {
                     match tx.get_saga_for_update(&saga.operation_id).await? {
@@ -113,7 +114,7 @@ async fn process_melt_saga_outcome_inner(
                 }
                 super::melt::shared::DispatchLockAttempt::Contended => {
                     tracing::info!(
-                        "Melt quote {} dispatch lock is contended; finalizing paid outcome after the live owner releases it (saga {})",
+                        "Melt quote {} dispatch lock is contended; using the trusted paid outcome to preempt any later dispatch rollback (saga {})",
                         quote.id,
                         saga.operation_id
                     );
@@ -154,7 +155,10 @@ async fn persist_pending_after_dispatch(
 ) -> Result<(), Error> {
     match super::melt::shared::try_acquire_melt_dispatch_lock(db, &quote.id).await? {
         super::melt::shared::DispatchLockAttempt::Acquired(mut tx) => {
-            let Some(saga) = tx.get_saga(&stale_saga.operation_id).await? else {
+            // Lock the saga row: this transaction goes on to persist the
+            // pending marker, so the existence read and the write must observe
+            // the same row (every other mutation path uses `get_saga_for_update`).
+            let Some(saga) = tx.get_saga_for_update(&stale_saga.operation_id).await? else {
                 tx.rollback().await?;
                 *quote = db
                     .get_melt_quote(&quote.id)

--- a/crates/cdk/src/mint/saga_recovery.rs
+++ b/crates/cdk/src/mint/saga_recovery.rs
@@ -21,14 +21,18 @@ use crate::Error;
 /// is the single finalization path — it handles operation recording, saga deletion, and all
 /// cleanup atomically.
 ///
-/// For the `Unpaid`/`Failed` case, compensation is only allowed after three fresh checks:
+/// For the `Unpaid`/`Failed` case, compensation is only allowed after these
+/// cross-replica checks:
 /// 1. the melt did not settle internally (a credited mint quote can never be
 ///    compensated — that would return the payer's proofs while the recipient
 ///    keeps the credit),
-/// 2. a fresh backend status check confirms the payment did not succeed (the
+/// 2. the quote-scoped advisory lock proves no replica is still dispatching,
+/// 3. a fresh backend status check confirms the payment did not succeed (the
 ///    caller's observation may be stale),
-/// 3. the saga still owns the quote and has not advanced to `Finalizing`
-///    (enforced inside [`super::melt::shared::rollback_melt_quote`]).
+/// 4. a payment with an ambiguous dispatch state is only compensated after a
+///    trusted failure event (public `Unpaid` and `Failed` polls remain
+///    fail-closed), and
+/// 5. the saga has not advanced to `Finalizing`.
 ///
 /// Any check that cannot be answered fails closed: the quote is left pending
 /// rather than compensated.
@@ -52,149 +56,77 @@ pub(crate) async fn process_melt_saga_outcome(
     pubsub: &PubSubManager,
     mint: &Mint,
 ) -> Result<(), Error> {
+    process_melt_saga_outcome_inner(saga, quote, payment_response, db, pubsub, mint, false).await
+}
+
+/// Process a failure delivered by the trusted payment-backend event stream.
+/// Unlike public polling, a definitive failure event may resolve a previously
+/// acknowledged pending payment after a fresh terminal backend check.
+pub(crate) async fn process_melt_saga_failure_event(
+    saga: &Saga,
+    quote: &mut MeltQuote,
+    payment_response: &MakePaymentResponse,
+    db: &cdk_common::database::DynMintDatabase,
+    pubsub: &PubSubManager,
+    mint: &Mint,
+) -> Result<(), Error> {
+    process_melt_saga_outcome_inner(saga, quote, payment_response, db, pubsub, mint, true).await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn process_melt_saga_outcome_inner(
+    saga: &Saga,
+    quote: &mut MeltQuote,
+    payment_response: &MakePaymentResponse,
+    db: &cdk_common::database::DynMintDatabase,
+    pubsub: &PubSubManager,
+    mint: &Mint,
+    definitive_failure_event: bool,
+) -> Result<(), Error> {
     match payment_response.status {
         MeltQuoteState::Paid => {
+            // Persist the paid handoff before releasing an acquired dispatch
+            // lock. When contended, the live owner holds the saga row through
+            // dispatch, so finalization serializes on that row after its own
+            // pending or paid handoff commits.
+            match super::melt::shared::try_acquire_melt_dispatch_lock(db, &quote.id).await? {
+                super::melt::shared::DispatchLockAttempt::Acquired(mut tx) => {
+                    match tx.get_saga_for_update(&saga.operation_id).await? {
+                        Some(mut current_saga) => {
+                            if let Err(err) =
+                                super::melt::shared::persist_melt_finalization_handoff(
+                                    &mut tx,
+                                    &mut current_saga,
+                                    payment_response,
+                                )
+                                .await
+                            {
+                                tx.rollback().await?;
+                                return Err(err);
+                            }
+                            tx.commit().await?;
+                        }
+                        None => {
+                            tx.rollback().await?;
+                        }
+                    }
+                }
+                super::melt::shared::DispatchLockAttempt::Contended => {
+                    tracing::info!(
+                        "Melt quote {} dispatch lock is contended; finalizing paid outcome after the live owner releases it (saga {})",
+                        quote.id,
+                        saga.operation_id
+                    );
+                }
+                super::melt::shared::DispatchLockAttempt::Unsupported => {}
+            }
             finalize_paid_melt_outcome(saga, quote, payment_response, db, pubsub, mint).await
         }
         MeltQuoteState::Unpaid | MeltQuoteState::Failed => {
-            // Internal settlement guard: if this melt already credited a local
-            // mint quote, the recipient was paid and the payer's proofs must be
-            // consumed. The backend never saw this payment, so any non-paid
-            // status it reports is meaningless — finalize instead of compensating.
-            match mint.internal_melt_settlement_response(quote, saga).await {
-                Ok(Some(internal_response)) => {
-                    tracing::info!(
-                        "Melt quote {} was settled internally; finalizing instead of compensating (saga {})",
-                        quote.id,
-                        saga.operation_id
-                    );
-                    return finalize_paid_melt_outcome(
-                        saga,
-                        quote,
-                        &internal_response,
-                        db,
-                        pubsub,
-                        mint,
-                    )
-                    .await;
-                }
-                Ok(None) => {}
-                Err(err) => {
-                    // Fail closed: if internal settlement cannot be determined,
-                    // never compensate.
-                    tracing::error!(
-                        "Could not determine internal settlement state for melt quote {} (saga {}): {}. Leaving pending.",
-                        quote.id,
-                        saga.operation_id,
-                        err
-                    );
-                    return Ok(());
-                }
-            }
-
-            // Fresh backend re-check: the caller's payment observation may be
-            // stale (loaded before a concurrent paid handoff). Only a fresh
-            // terminal failure may trigger compensation.
-            let fresh_response = match mint.check_melt_payment_status(quote).await {
-                Ok(response) => response,
-                Err(err) => {
-                    // Fail closed when the backend cannot provide a verifiable
-                    // status: the payment may have been sent.
-                    tracing::error!(
-                        "Cannot verify payment status for melt quote {} (saga {}): {}. Leaving pending.",
-                        quote.id,
-                        saga.operation_id,
-                        err
-                    );
-                    return Ok(());
-                }
-            };
-
-            match fresh_response.status {
-                MeltQuoteState::Paid => {
-                    tracing::info!(
-                        "Stale failure for melt quote {} superseded by fresh Paid status; finalizing (saga {})",
-                        quote.id,
-                        saga.operation_id
-                    );
-                    return finalize_paid_melt_outcome(
-                        saga,
-                        quote,
-                        &fresh_response,
-                        db,
-                        pubsub,
-                        mint,
-                    )
-                    .await;
-                }
-                MeltQuoteState::Pending => {
-                    persist_payment_lookup_id(quote, &fresh_response, db).await?;
-                    tracing::info!(
-                        "Fresh payment status for melt quote {} is Pending; leaving saga {} pending",
-                        quote.id,
-                        saga.operation_id
-                    );
-                    return Ok(());
-                }
-                MeltQuoteState::Unknown => {
-                    tracing::info!(
-                        "Fresh payment status for melt quote {} is {}; leaving pending (saga {})",
-                        quote.id,
-                        fresh_response.status,
-                        saga.operation_id
-                    );
-                    return Ok(());
-                }
-                MeltQuoteState::Unpaid | MeltQuoteState::Failed => {}
-            }
-
-            tracing::info!(
-                "Compensating failed melt quote {} (saga {})",
-                quote.id,
-                saga.operation_id
-            );
-            let input_ys = db.get_proof_ys_by_operation_id(&saga.operation_id).await?;
-            let blinded_secrets = db
-                .get_blinded_secrets_by_operation_id(&saga.operation_id)
-                .await?;
-            match super::melt::shared::rollback_melt_quote(
-                db,
-                pubsub,
-                &quote.id,
-                &input_ys,
-                &blinded_secrets,
-                &saga.operation_id,
-            )
-            .await
-            {
-                Ok(()) => {
-                    // `Ok(())` also covers a stale no-op when a concurrent
-                    // finalizer already deleted the saga. Reload instead of
-                    // overwriting that finalizer's persisted `Paid` state
-                    // with `Unpaid` in this caller's stale in-memory copy.
-                    *quote = db
-                        .get_melt_quote(&quote.id)
-                        .await?
-                        .ok_or(Error::UnknownQuote)?;
-                }
-                Err(Error::UnknownPaymentState) => {
-                    // The rollback was refused because the saga advanced to
-                    // Finalizing (or the quote reached an unexpected state)
-                    // concurrently. The finalizer owns terminality now; leave
-                    // the quote pending rather than fighting it.
-                    tracing::info!(
-                        "Rollback refused for melt quote {}; finalization in progress, leaving pending (saga {})",
-                        quote.id,
-                        saga.operation_id
-                    );
-                }
-                Err(err) => return Err(err),
-            }
-
-            Ok(())
+            reconcile_terminal_melt(saga, quote, db, pubsub, mint, definitive_failure_event).await
         }
         MeltQuoteState::Pending => {
-            persist_payment_lookup_id(quote, payment_response, db).await?;
+            persist_pending_after_dispatch(saga, quote, payment_response, db).await?;
             tracing::debug!(
                 "Melt quote {} (saga {}) payment remains Pending",
                 quote.id,
@@ -214,18 +146,398 @@ pub(crate) async fn process_melt_saga_outcome(
     }
 }
 
-/// Persists a backend-provided lookup id so later checks can recover a pending
-/// payment even when no identifier was available at quote creation.
-async fn persist_payment_lookup_id(
+async fn persist_pending_after_dispatch(
+    stale_saga: &Saga,
     quote: &mut MeltQuote,
     payment_response: &MakePaymentResponse,
     db: &cdk_common::database::DynMintDatabase,
 ) -> Result<(), Error> {
-    if quote.request_lookup_id.as_ref() == Some(&payment_response.payment_lookup_id) {
+    match super::melt::shared::try_acquire_melt_dispatch_lock(db, &quote.id).await? {
+        super::melt::shared::DispatchLockAttempt::Acquired(mut tx) => {
+            let Some(saga) = tx.get_saga(&stale_saga.operation_id).await? else {
+                tx.rollback().await?;
+                *quote = db
+                    .get_melt_quote(&quote.id)
+                    .await?
+                    .ok_or(Error::UnknownQuote)?;
+                return Ok(());
+            };
+            *quote = tx
+                .get_melt_quote(&quote.id)
+                .await?
+                .ok_or(Error::UnknownQuote)?
+                .inner();
+            if quote.state == MeltQuoteState::Pending {
+                persist_payment_lookup_id_in_transaction(&mut tx, &saga, quote, payment_response)
+                    .await?;
+                tx.commit().await?;
+            } else {
+                tx.rollback().await?;
+            }
+            Ok(())
+        }
+        super::melt::shared::DispatchLockAttempt::Contended => {
+            // A live dispatch holds the lock and persists its own pending
+            // marker; leave the quote pending.
+            *quote = db
+                .get_melt_quote(&quote.id)
+                .await?
+                .ok_or(Error::UnknownQuote)?;
+            Ok(())
+        }
+        super::melt::shared::DispatchLockAttempt::Unsupported => {
+            persist_payment_lookup_id(stale_saga, quote, payment_response, db).await
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn reconcile_terminal_melt(
+    saga: &Saga,
+    quote: &mut MeltQuote,
+    db: &cdk_common::database::DynMintDatabase,
+    pubsub: &PubSubManager,
+    mint: &Mint,
+    definitive_failure_event: bool,
+) -> Result<(), Error> {
+    let result = match super::melt::shared::try_acquire_melt_dispatch_lock(db, &quote.id).await? {
+        super::melt::shared::DispatchLockAttempt::Acquired(tx) => {
+            reconcile_terminal_melt_with_dispatch_lock(
+                tx,
+                saga,
+                quote,
+                db,
+                pubsub,
+                mint,
+                definitive_failure_event,
+            )
+            .await
+        }
+        super::melt::shared::DispatchLockAttempt::Contended => {
+            // A live dispatch or reconciliation owns the quote; fail closed and
+            // leave it pending rather than wait on a connection held across
+            // network I/O.
+            tracing::info!(
+                "Melt quote {} dispatch lock is contended; leaving pending (saga {})",
+                quote.id,
+                saga.operation_id
+            );
+            *quote = db
+                .get_melt_quote(&quote.id)
+                .await?
+                .ok_or(Error::UnknownQuote)?;
+            Ok(None)
+        }
+        super::melt::shared::DispatchLockAttempt::Unsupported => {
+            reconcile_terminal_melt_without_advisory_lock(
+                saga,
+                quote,
+                db,
+                pubsub,
+                mint,
+                definitive_failure_event,
+            )
+            .await
+        }
+    };
+
+    match result? {
+        Some((saga, payment_response)) => {
+            finalize_paid_melt_outcome(&saga, quote, &payment_response, db, pubsub, mint).await
+        }
+        None => Ok(()),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn reconcile_terminal_melt_with_dispatch_lock(
+    mut tx: cdk_common::database::DynMintTransaction,
+    stale_saga: &Saga,
+    quote: &mut MeltQuote,
+    db: &cdk_common::database::DynMintDatabase,
+    pubsub: &PubSubManager,
+    mint: &Mint,
+    definitive_failure_event: bool,
+) -> Result<Option<(Saga, MakePaymentResponse)>, Error> {
+    let Some(mut saga) = tx.get_saga_for_update(&stale_saga.operation_id).await? else {
+        tx.rollback().await?;
+        *quote = db
+            .get_melt_quote(&quote.id)
+            .await?
+            .ok_or(Error::UnknownQuote)?;
+        return Ok(None);
+    };
+    *quote = tx
+        .get_melt_quote(&quote.id)
+        .await?
+        .ok_or(Error::UnknownQuote)?
+        .inner();
+
+    let internal_response = match Mint::internal_melt_settlement_response_tx(&mut tx, quote).await {
+        Ok(internal_response) => internal_response,
+        Err(err) => {
+            tracing::error!(
+                "Could not determine internal settlement state for melt quote {} (saga {}): {}. Leaving pending.",
+                quote.id,
+                saga.operation_id,
+                err
+            );
+            tx.rollback().await?;
+            return Ok(None);
+        }
+    };
+    if let Some(internal_response) = internal_response {
+        let saga = saga.inner();
+        tx.rollback().await?;
+        return Ok(Some((saga, internal_response)));
+    }
+
+    let fresh_response = match mint.check_melt_payment_status(quote).await {
+        Ok(response) => response,
+        Err(err) => {
+            tracing::error!(
+                "Cannot verify payment status for melt quote {} (saga {}): {}. Leaving pending.",
+                quote.id,
+                saga.operation_id,
+                err
+            );
+            tx.rollback().await?;
+            return Ok(None);
+        }
+    };
+
+    match fresh_response.status {
+        MeltQuoteState::Paid => {
+            if let Err(err) = super::melt::shared::persist_melt_finalization_handoff(
+                &mut tx,
+                &mut saga,
+                &fresh_response,
+            )
+            .await
+            {
+                tx.rollback().await?;
+                return Err(err);
+            }
+            let saga = saga.inner();
+            tx.commit().await?;
+            return Ok(Some((saga, fresh_response)));
+        }
+        MeltQuoteState::Pending => {
+            persist_payment_lookup_id_in_transaction(&mut tx, &saga, quote, &fresh_response)
+                .await?;
+            tx.commit().await?;
+            return Ok(None);
+        }
+        MeltQuoteState::Unknown => {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+        MeltQuoteState::Unpaid | MeltQuoteState::Failed => {}
+    }
+
+    if matches!(
+        &saga.state,
+        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted | MeltSagaState::PaymentPending)
+    ) && !definitive_failure_event
+    {
+        tracing::warn!(
+            "Ignoring contradictory {} status for melt quote {} because saga {} has an ambiguous dispatch state",
+            fresh_response.status,
+            quote.id,
+            saga.operation_id
+        );
+        tx.rollback().await?;
+        return Ok(None);
+    }
+
+    let input_ys = tx.get_proof_ys_by_operation_id(&saga.operation_id).await?;
+    let blinded_secrets = tx
+        .get_melt_request_and_blinded_messages(&quote.id)
+        .await?
+        .map(|request| {
+            request
+                .change_outputs
+                .into_iter()
+                .map(|output| output.blinded_secret)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    match super::melt::shared::rollback_melt_quote_with_dispatch_lock(
+        tx,
+        pubsub,
+        &quote.id,
+        &input_ys,
+        &blinded_secrets,
+        &saga.operation_id,
+    )
+    .await
+    {
+        Ok(()) => {
+            *quote = db
+                .get_melt_quote(&quote.id)
+                .await?
+                .ok_or(Error::UnknownQuote)?;
+        }
+        Err(Error::UnknownPaymentState) => {}
+        Err(err) => return Err(err),
+    }
+    Ok(None)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn reconcile_terminal_melt_without_advisory_lock(
+    stale_saga: &Saga,
+    quote: &mut MeltQuote,
+    db: &cdk_common::database::DynMintDatabase,
+    pubsub: &PubSubManager,
+    mint: &Mint,
+    definitive_failure_event: bool,
+) -> Result<Option<(Saga, MakePaymentResponse)>, Error> {
+    let current_saga = db.get_melt_saga_by_quote_id(&quote.id).await?;
+    let Some(saga) = current_saga else {
+        *quote = db
+            .get_melt_quote(&quote.id)
+            .await?
+            .ok_or(Error::UnknownQuote)?;
+        if quote.state != MeltQuoteState::Paid {
+            tracing::warn!(
+                "Melt saga {} disappeared while quote {} is {}; leaving it unchanged",
+                stale_saga.operation_id,
+                quote.id,
+                quote.state
+            );
+        }
+        return Ok(None);
+    };
+
+    *quote = db
+        .get_melt_quote(&quote.id)
+        .await?
+        .ok_or(Error::UnknownQuote)?;
+
+    match mint.internal_melt_settlement_response(quote).await {
+        Ok(Some(internal_response)) => {
+            return Ok(Some((saga, internal_response)));
+        }
+        Ok(None) => {}
+        Err(err) => {
+            tracing::error!(
+                "Could not determine internal settlement state for melt quote {} (saga {}): {}. Leaving pending.",
+                quote.id,
+                saga.operation_id,
+                err
+            );
+            return Ok(None);
+        }
+    }
+
+    let fresh_response = match mint.check_melt_payment_status(quote).await {
+        Ok(response) => response,
+        Err(err) => {
+            tracing::error!(
+                "Cannot verify payment status for melt quote {} (saga {}): {}. Leaving pending.",
+                quote.id,
+                saga.operation_id,
+                err
+            );
+            return Ok(None);
+        }
+    };
+
+    match fresh_response.status {
+        MeltQuoteState::Paid => return Ok(Some((saga, fresh_response))),
+        MeltQuoteState::Pending => {
+            persist_payment_lookup_id(&saga, quote, &fresh_response, db).await?;
+            return Ok(None);
+        }
+        MeltQuoteState::Unknown => return Ok(None),
+        MeltQuoteState::Unpaid | MeltQuoteState::Failed => {}
+    }
+
+    if matches!(
+        &saga.state,
+        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted | MeltSagaState::PaymentPending)
+    ) && !definitive_failure_event
+    {
+        tracing::warn!(
+            "Ignoring contradictory {} status for melt quote {} because saga {} has an ambiguous dispatch state",
+            fresh_response.status,
+            quote.id,
+            saga.operation_id
+        );
+        return Ok(None);
+    }
+
+    let input_ys = db.get_proof_ys_by_operation_id(&saga.operation_id).await?;
+    let blinded_secrets = db
+        .get_blinded_secrets_by_operation_id(&saga.operation_id)
+        .await?;
+    let rollback = super::melt::shared::rollback_melt_quote(
+        db,
+        pubsub,
+        &quote.id,
+        &input_ys,
+        &blinded_secrets,
+        &saga.operation_id,
+    )
+    .await;
+
+    match rollback {
+        Ok(()) => {
+            *quote = db
+                .get_melt_quote(&quote.id)
+                .await?
+                .ok_or(Error::UnknownQuote)?;
+        }
+        Err(Error::UnknownPaymentState) => {
+            tracing::info!(
+                "Rollback refused for melt quote {}; finalization owns terminality (saga {})",
+                quote.id,
+                saga.operation_id
+            );
+        }
+        Err(err) => return Err(err),
+    }
+
+    Ok(None)
+}
+
+/// Persists a backend-provided lookup id so later checks can recover a pending
+/// payment even when no identifier was available at quote creation.
+async fn persist_payment_lookup_id(
+    saga: &Saga,
+    quote: &mut MeltQuote,
+    payment_response: &MakePaymentResponse,
+    db: &cdk_common::database::DynMintDatabase,
+) -> Result<(), Error> {
+    let mut tx = db.begin_transaction().await?;
+    persist_payment_lookup_id_in_transaction(&mut tx, saga, quote, payment_response).await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+async fn persist_payment_lookup_id_in_transaction(
+    tx: &mut cdk_common::database::DynMintTransaction,
+    saga: &Saga,
+    quote: &mut MeltQuote,
+    payment_response: &MakePaymentResponse,
+) -> Result<(), Error> {
+    let mut current_saga = tx
+        .get_saga_for_update(&saga.operation_id)
+        .await?
+        .ok_or(Error::Internal)?;
+    if matches!(
+        &current_saga.state,
+        SagaStateEnum::Melt(MeltSagaState::Finalizing)
+    ) {
+        tracing::info!(
+            "Ignoring pending payment result for melt quote {} because saga {} is already finalizing",
+            quote.id,
+            saga.operation_id
+        );
         return Ok(());
     }
 
-    let mut tx = db.begin_transaction().await?;
     let mut current_quote = tx
         .get_melt_quote(&quote.id)
         .await?
@@ -237,7 +549,12 @@ async fn persist_payment_lookup_id(
         )
         .await?;
     }
-    tx.commit().await?;
+
+    tx.update_acquired_saga(
+        &mut current_saga,
+        SagaStateEnum::Melt(MeltSagaState::PaymentPending),
+    )
+    .await?;
 
     quote.request_lookup_id = Some(payment_response.payment_lookup_id.clone());
     Ok(())
@@ -527,105 +844,130 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unpaid_compensates_payment_attempted_saga() {
-        let fake_description = FakeInvoiceDescription {
-            pay_invoice_state: MeltQuoteState::Unpaid,
-            check_payment_state: MeltQuoteState::Unpaid,
-            pay_err: false,
-            check_err: false,
-        };
-        let amount_msats: u64 = Amount::from(9_000).into();
-        let invoice = create_fake_invoice(
-            amount_msats,
-            serde_json::to_string(&fake_description).unwrap(),
-        );
-        let payment_states = std::collections::HashMap::from([(
-            invoice.payment_hash().to_string(),
-            (
-                MeltQuoteState::Unpaid,
-                Amount::from(9_000).with_unit(CurrencyUnit::Sat),
-            ),
-        )]);
-        let mint = create_test_mint_with_payment_states(payment_states)
-            .await
-            .unwrap();
-        let request = cdk_common::melt::MeltQuoteRequest::Bolt11(MeltQuoteBolt11Request {
-            request: invoice,
-            unit: CurrencyUnit::Sat,
-            options: None,
-        });
-        let quote_response = mint.get_melt_quote(request).await.unwrap();
-        let quote = mint
-            .localstore
-            .get_melt_quote(quote_response.quote().unwrap())
-            .await
-            .unwrap()
-            .expect("quote should exist");
-        let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
-        let input_ys = proofs.ys().unwrap();
-        let melt_request = create_test_melt_request(&proofs, &quote);
-        let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
-        let saga = MeltSaga::new(
-            std::sync::Arc::new(mint.clone()),
-            mint.localstore(),
-            mint.pubsub_manager(),
-        );
-        let setup_saga = saga
-            .setup_melt(
-                &melt_request,
-                verification,
-                PaymentMethod::Known(KnownMethod::Bolt11),
-            )
-            .await
-            .unwrap();
-        let operation_id = assert_single_melt_saga_operation_id(&mint).await;
-        drop(setup_saga);
+    async fn test_ambiguous_dispatch_recovers_only_from_definitive_failure() {
+        for saga_state in [
+            MeltSagaState::PaymentAttempted,
+            MeltSagaState::PaymentPending,
+        ] {
+            for fresh_status in [MeltQuoteState::Unpaid, MeltQuoteState::Failed] {
+                let fake_description = FakeInvoiceDescription {
+                    pay_invoice_state: fresh_status,
+                    check_payment_state: fresh_status,
+                    pay_err: false,
+                    check_err: false,
+                };
+                let amount_msats: u64 = Amount::from(9_000).into();
+                let invoice = create_fake_invoice(
+                    amount_msats,
+                    serde_json::to_string(&fake_description).unwrap(),
+                );
+                let payment_states = std::collections::HashMap::from([(
+                    invoice.payment_hash().to_string(),
+                    (
+                        fresh_status,
+                        Amount::from(9_000).with_unit(CurrencyUnit::Sat),
+                    ),
+                )]);
+                let mint = create_test_mint_with_payment_states(payment_states)
+                    .await
+                    .unwrap();
+                let request = cdk_common::melt::MeltQuoteRequest::Bolt11(MeltQuoteBolt11Request {
+                    request: invoice,
+                    unit: CurrencyUnit::Sat,
+                    options: None,
+                });
+                let quote_response = mint.get_melt_quote(request).await.unwrap();
+                let quote = mint
+                    .localstore
+                    .get_melt_quote(quote_response.quote().unwrap())
+                    .await
+                    .unwrap()
+                    .expect("quote should exist");
+                let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+                let input_ys = proofs.ys().unwrap();
+                let melt_request = create_test_melt_request(&proofs, &quote);
+                let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+                let saga = MeltSaga::new(
+                    std::sync::Arc::new(mint.clone()),
+                    mint.localstore(),
+                    mint.pubsub_manager(),
+                );
+                let setup_saga = saga
+                    .setup_melt(
+                        &melt_request,
+                        verification,
+                        PaymentMethod::Known(KnownMethod::Bolt11),
+                    )
+                    .await
+                    .unwrap();
+                let operation_id = assert_single_melt_saga_operation_id(&mint).await;
+                drop(setup_saga);
 
-        let mut tx = mint.localstore.begin_transaction().await.unwrap();
-        let mut acquired_saga = tx
-            .get_saga_for_update(&operation_id)
-            .await
-            .unwrap()
-            .expect("saga should exist");
-        tx.update_acquired_saga(
-            &mut acquired_saga,
-            SagaStateEnum::Melt(MeltSagaState::PaymentAttempted),
-        )
-        .await
-        .unwrap();
-        tx.commit().await.unwrap();
+                let mut tx = mint.localstore.begin_transaction().await.unwrap();
+                let mut acquired_saga = tx
+                    .get_saga_for_update(&operation_id)
+                    .await
+                    .unwrap()
+                    .expect("saga should exist");
+                tx.update_acquired_saga(
+                    &mut acquired_saga,
+                    SagaStateEnum::Melt(saga_state.clone()),
+                )
+                .await
+                .unwrap();
+                tx.commit().await.unwrap();
 
-        let saga = assert_saga_exists(&mint, &operation_id).await;
-        let mut quote = mint
-            .localstore
-            .get_melt_quote(&quote.id)
-            .await
-            .unwrap()
-            .expect("quote should exist");
-        let payment_response = MakePaymentResponse {
-            payment_lookup_id: quote
-                .request_lookup_id
-                .clone()
-                .expect("bolt11 quote should have a lookup id"),
-            payment_proof: None,
-            status: MeltQuoteState::Unpaid,
-            total_spent: quote.amount(),
-        };
+                let saga = assert_saga_exists(&mint, &operation_id).await;
+                let mut quote = mint
+                    .localstore
+                    .get_melt_quote(&quote.id)
+                    .await
+                    .unwrap()
+                    .expect("quote should exist");
+                let payment_response = MakePaymentResponse {
+                    payment_lookup_id: quote
+                        .request_lookup_id
+                        .clone()
+                        .expect("bolt11 quote should have a lookup id"),
+                    payment_proof: None,
+                    status: fresh_status,
+                    total_spent: quote.amount(),
+                };
 
-        process_melt_saga_outcome(
-            &saga,
-            &mut quote,
-            &payment_response,
-            &mint.localstore,
-            &mint.pubsub_manager,
-            &mint,
-        )
-        .await
-        .unwrap();
+                process_melt_saga_outcome(
+                    &saga,
+                    &mut quote,
+                    &payment_response,
+                    &mint.localstore,
+                    &mint.pubsub_manager,
+                    &mint,
+                )
+                .await
+                .unwrap();
 
-        assert_saga_not_exists(&mint, &operation_id).await;
-        assert_proofs_state(&mint, &input_ys, None).await;
-        assert_eq!(quote.state, MeltQuoteState::Unpaid);
+                let _ = assert_saga_exists(&mint, &operation_id).await;
+                assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+                assert_eq!(quote.state, MeltQuoteState::Pending);
+
+                let stored_saga = assert_saga_exists(&mint, &operation_id).await;
+                assert_eq!(stored_saga.state, SagaStateEnum::Melt(saga_state.clone()));
+
+                process_melt_saga_failure_event(
+                    &stored_saga,
+                    &mut quote,
+                    &payment_response,
+                    &mint.localstore,
+                    &mint.pubsub_manager,
+                    &mint,
+                )
+                .await
+                .unwrap();
+
+                assert_saga_not_exists(&mint, &operation_id).await;
+                assert_proofs_state(&mint, &input_ys, None).await;
+                assert_eq!(quote.state, MeltQuoteState::Unpaid);
+            }
+        }
     }
 
     #[tokio::test]
@@ -1120,7 +1462,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_pending_outcome_leaves_state_unchanged() {
+    async fn test_stale_pending_outcome_does_not_regress_finalizing_saga() {
         let mint = create_test_mint().await.unwrap();
         let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
         let input_ys = proofs.ys().unwrap();
@@ -1149,7 +1491,27 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        let saga = assert_saga_exists(&mint, &operation_id).await;
+        let stale_saga = assert_saga_exists(&mint, &operation_id).await;
+        let finalization_data = MeltFinalizationData {
+            total_spent: Amount::from(9_250).with_unit(CurrencyUnit::Sat),
+            payment_lookup_id: PaymentIdentifier::CustomId("paid_lookup".to_string()),
+            payment_proof: Some("paid_preimage".to_string()),
+        };
+        let mut tx = mint.localstore.begin_transaction().await.unwrap();
+        let mut saga = tx
+            .get_saga_for_update(&operation_id)
+            .await
+            .unwrap()
+            .expect("saga should exist");
+        tx.update_acquired_saga_with_finalization_data(
+            &mut saga,
+            SagaStateEnum::Melt(MeltSagaState::Finalizing),
+            Some(&finalization_data),
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+
         let payment_response = MakePaymentResponse {
             payment_lookup_id: PaymentIdentifier::CustomId("pending_outcome_lookup".to_string()),
             payment_proof: None,
@@ -1158,7 +1520,7 @@ mod tests {
         };
 
         process_melt_saga_outcome(
-            &saga,
+            &stale_saga,
             &mut quote,
             &payment_response,
             &mint.localstore,
@@ -1168,7 +1530,12 @@ mod tests {
         .await
         .unwrap();
 
-        assert_saga_exists(&mint, &operation_id).await;
+        let persisted_saga = assert_saga_exists(&mint, &operation_id).await;
+        assert_eq!(
+            persisted_saga.state,
+            SagaStateEnum::Melt(MeltSagaState::Finalizing)
+        );
+        assert_eq!(persisted_saga.finalization_data, Some(finalization_data));
         assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
 
         let pending_quote = mint

--- a/crates/cdk/src/mint/saga_recovery.rs
+++ b/crates/cdk/src/mint/saga_recovery.rs
@@ -12,6 +12,49 @@ use crate::mint::subscription::PubSubManager;
 use crate::mint::Mint;
 use crate::Error;
 
+/// Maximum time to wait for a payment-backend status check during melt
+/// reconciliation.
+///
+/// Reconciliation holds the quote advisory lock and the saga row lock while it
+/// re-checks the backend, so an unbounded call would let a slow or unreachable
+/// Lightning node hold those locks (and the dispatch-pool connection) for as
+/// long as it takes to answer. Bounding the call caps that window; on timeout
+/// the reconciler fails closed and leaves the melt pending for a later pass.
+#[cfg(not(test))]
+const MELT_PAYMENT_STATUS_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+/// Shorter timeout in tests so the fail-closed path is exercised without
+/// slowing the suite.
+#[cfg(test)]
+const MELT_PAYMENT_STATUS_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Check the payment status with the backend, bounding the call so the locks
+/// held by the caller cannot be pinned by an unresponsive backend.
+///
+/// Returns `Ok(None)` on timeout (treated as indeterminate, fail closed);
+/// backend errors propagate so the caller can apply its own handling.
+async fn check_melt_payment_status_bounded(
+    mint: &Mint,
+    quote: &MeltQuote,
+) -> Result<Option<MakePaymentResponse>, Error> {
+    match tokio::time::timeout(
+        MELT_PAYMENT_STATUS_CHECK_TIMEOUT,
+        mint.check_melt_payment_status(quote),
+    )
+    .await
+    {
+        Ok(Ok(response)) => Ok(Some(response)),
+        Ok(Err(err)) => Err(err),
+        Err(_elapsed) => {
+            tracing::warn!(
+                "Payment status check for melt quote {} timed out after {:?}. Leaving pending.",
+                quote.id,
+                MELT_PAYMENT_STATUS_CHECK_TIMEOUT
+            );
+            Ok(None)
+        }
+    }
+}
+
 /// Process the outcome of a melt saga based on payment status.
 ///
 /// This function handles the shared logic for deciding whether to finalize, compensate, or skip
@@ -296,8 +339,13 @@ async fn reconcile_terminal_melt_with_dispatch_lock(
         return Ok(Some((saga, internal_response)));
     }
 
-    let fresh_response = match mint.check_melt_payment_status(quote).await {
-        Ok(response) => response,
+    let fresh_response = match check_melt_payment_status_bounded(mint, quote).await {
+        Ok(Some(response)) => response,
+        Ok(None) => {
+            // Timed out: fail closed, release the locks, leave pending.
+            tx.rollback().await?;
+            return Ok(None);
+        }
         Err(err) => {
             tracing::error!(
                 "Cannot verify payment status for melt quote {} (saga {}): {}. Leaving pending.",
@@ -435,8 +483,12 @@ async fn reconcile_terminal_melt_without_advisory_lock(
         }
     }
 
-    let fresh_response = match mint.check_melt_payment_status(quote).await {
-        Ok(response) => response,
+    let fresh_response = match check_melt_payment_status_bounded(mint, quote).await {
+        Ok(Some(response)) => response,
+        Ok(None) => {
+            // Timed out: fail closed, leave pending.
+            return Ok(None);
+        }
         Err(err) => {
             tracing::error!(
                 "Cannot verify payment status for melt quote {} (saga {}): {}. Leaving pending.",
@@ -670,6 +722,197 @@ mod tests {
     use super::*;
     use crate::mint::melt::melt_saga::MeltSaga;
     use crate::test_helpers::mint::{create_test_mint, mint_test_proofs};
+
+    /// A slow backend must not pin the reconciliation locks for the full
+    /// duration of its response: the bounded status check times out and the
+    /// reconciler fails closed, leaving the melt pending.
+    #[tokio::test]
+    async fn slow_backend_status_check_fails_closed_without_holding_locks() {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use cdk_common::payment::{self, MintPayment};
+
+        use crate::mint::{MintBuilder, MintMeltLimits};
+        use crate::types::{FeeReserve, QuoteTTL};
+
+        // Backend whose status check never answers within the bounded window.
+        struct HangingStatusBackend {
+            inner: cdk_fake_wallet::FakeWallet,
+        }
+
+        #[async_trait::async_trait]
+        impl MintPayment for HangingStatusBackend {
+            type Err = payment::Error;
+
+            async fn get_settings(&self) -> Result<payment::SettingsResponse, Self::Err> {
+                self.inner.get_settings().await
+            }
+            async fn create_incoming_payment_request(
+                &self,
+                options: payment::IncomingPaymentOptions,
+            ) -> Result<payment::CreateIncomingPaymentResponse, Self::Err> {
+                self.inner.create_incoming_payment_request(options).await
+            }
+            async fn get_payment_quote(
+                &self,
+                unit: &CurrencyUnit,
+                options: payment::OutgoingPaymentOptions,
+            ) -> Result<payment::PaymentQuoteResponse, Self::Err> {
+                self.inner.get_payment_quote(unit, options).await
+            }
+            async fn make_payment(
+                &self,
+                unit: &CurrencyUnit,
+                options: payment::OutgoingPaymentOptions,
+            ) -> Result<MakePaymentResponse, Self::Err> {
+                self.inner.make_payment(unit, options).await
+            }
+            async fn check_incoming_payment_status(
+                &self,
+                payment_identifier: &PaymentIdentifier,
+            ) -> Result<Vec<payment::WaitPaymentResponse>, Self::Err> {
+                self.inner
+                    .check_incoming_payment_status(payment_identifier)
+                    .await
+            }
+            async fn check_outgoing_payment(
+                &self,
+                _payment_identifier: &PaymentIdentifier,
+            ) -> Result<MakePaymentResponse, Self::Err> {
+                // Longer than MELT_PAYMENT_STATUS_CHECK_TIMEOUT.
+                std::future::pending::<()>().await;
+                unreachable!("pending never resolves")
+            }
+            async fn wait_payment_event(
+                &self,
+            ) -> Result<
+                std::pin::Pin<Box<dyn futures::Stream<Item = payment::Event> + Send>>,
+                Self::Err,
+            > {
+                Ok(Box::pin(futures::stream::pending()))
+            }
+            fn is_payment_event_stream_active(&self) -> bool {
+                false
+            }
+            fn cancel_payment_event_stream(&self) {}
+        }
+
+        let db = Arc::new(cdk_sqlite::mint::memory::empty().await.unwrap());
+        let mut mint_builder = MintBuilder::new(db.clone());
+        let backend = HangingStatusBackend {
+            inner: cdk_fake_wallet::FakeWallet::new(
+                FeeReserve {
+                    min_fee_reserve: 1.into(),
+                    percent_fee_reserve: 1.0,
+                },
+                std::collections::HashMap::default(),
+                std::collections::HashSet::default(),
+                2,
+                CurrencyUnit::Sat,
+            ),
+        };
+        mint_builder
+            .add_payment_processor(
+                CurrencyUnit::Sat,
+                PaymentMethod::Known(KnownMethod::Bolt11),
+                MintMeltLimits::new(1, 10_000),
+                Arc::new(backend),
+            )
+            .await
+            .unwrap();
+        let mnemonic = bip39::Mnemonic::generate(12).unwrap();
+        let mint = mint_builder
+            .with_name("test mint".to_string())
+            .with_description("test mint".to_string())
+            .with_urls(vec!["https://test-mint".to_string()])
+            .build_with_seed(db.clone(), &mnemonic.to_seed_normalized(""))
+            .await
+            .unwrap();
+        mint.set_quote_ttl(QuoteTTL::new(10000, 10000))
+            .await
+            .unwrap();
+        mint.start().await.unwrap();
+
+        let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+        let input_ys = proofs.ys().unwrap();
+        let quote = create_test_melt_quote(&mint, Amount::from(9_000)).await;
+        let melt_request = create_test_melt_request(&proofs, &quote);
+        let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+        let saga = MeltSaga::new(
+            Arc::new(mint.clone()),
+            mint.localstore(),
+            mint.pubsub_manager(),
+        );
+        let setup_saga = saga
+            .setup_melt(
+                &melt_request,
+                verification,
+                PaymentMethod::Known(KnownMethod::Bolt11),
+            )
+            .await
+            .unwrap();
+        let operation_id = assert_single_melt_saga_operation_id(&mint).await;
+        drop(setup_saga);
+
+        // Park the saga as an ambiguous dispatch so reconciliation takes the
+        // status-check path.
+        let mut tx = mint.localstore.begin_transaction().await.unwrap();
+        let mut acquired = tx
+            .get_saga_for_update(&operation_id)
+            .await
+            .unwrap()
+            .expect("saga should exist");
+        tx.update_acquired_saga(
+            &mut acquired,
+            SagaStateEnum::Melt(MeltSagaState::PaymentPending),
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+
+        let saga = assert_saga_exists(&mint, &operation_id).await;
+        let mut quote = mint
+            .localstore
+            .get_melt_quote(&quote.id)
+            .await
+            .unwrap()
+            .expect("quote should exist");
+        let payment_response = MakePaymentResponse {
+            payment_lookup_id: quote
+                .request_lookup_id
+                .clone()
+                .expect("bolt11 quote should have a lookup id"),
+            payment_proof: None,
+            status: MeltQuoteState::Failed,
+            total_spent: quote.amount(),
+        };
+
+        // The reconciler would normally block for the full backend response;
+        // the bounded check must return within the timeout instead.
+        let started = std::time::Instant::now();
+        process_melt_saga_outcome(
+            &saga,
+            &mut quote,
+            &payment_response,
+            &mint.localstore,
+            &mint.pubsub_manager,
+            &mint,
+        )
+        .await
+        .unwrap();
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(60),
+            "reconciliation returned after the bounded status check, not the hanging backend (elapsed {:?})",
+            elapsed
+        );
+        // Failed-closed: the melt stays pending and the saga survives.
+        assert_eq!(quote.state, MeltQuoteState::Pending);
+        assert_saga_exists(&mint, &operation_id).await;
+        assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+    }
 
     #[tokio::test]
     async fn test_paid_outcome_finalizes_and_records_completed_operation() {

--- a/crates/cdk/src/mint/start_up_check.rs
+++ b/crates/cdk/src/mint/start_up_check.rs
@@ -5,6 +5,7 @@
 
 use std::str::FromStr;
 
+use cdk_common::database::DynMintTransaction;
 use cdk_common::mint::{MeltPaymentRequest, OperationKind, Saga};
 use cdk_common::payment::PaymentIdentifier;
 use cdk_common::{PublicKey, QuoteId, State};
@@ -149,39 +150,6 @@ impl Mint {
         Ok(())
     }
 
-    /// Checks whether this melt quote already settled a mint quote on this same
-    /// mint (internal settlement).
-    ///
-    /// Returns `Ok(true)` only when the mint quote's recorded payments include
-    /// this melt quote id, i.e. the recipient was actually credited by this
-    /// melt. Errors must be treated fail-closed by callers: when internal
-    /// settlement cannot be determined, compensation must not proceed.
-    async fn is_internal_melt_settlement(
-        &self,
-        quote: &MeltQuote,
-        saga: &Saga,
-    ) -> Result<bool, Error> {
-        match self
-            .localstore
-            .get_mint_quote_by_request(&quote.request.to_string())
-            .await
-        {
-            Ok(Some(mint_quote)) => {
-                let melt_quote_id_str = quote.id.to_string();
-                Ok(mint_quote.payment_ids().contains(&&melt_quote_id_str))
-            }
-            Ok(None) => Ok(false),
-            Err(e) => {
-                tracing::warn!(
-                    "Error checking for internal settlement for saga {}: {}",
-                    saga.operation_id,
-                    e
-                );
-                Err(e.into())
-            }
-        }
-    }
-
     /// Returns the synthetic paid response for a melt settled on this mint.
     ///
     /// Internal settlements do not reach a payment backend, so recovery must
@@ -191,9 +159,28 @@ impl Mint {
     pub(crate) async fn internal_melt_settlement_response(
         &self,
         quote: &MeltQuote,
-        saga: &Saga,
     ) -> Result<Option<crate::cdk_payment::MakePaymentResponse>, Error> {
-        if !self.is_internal_melt_settlement(quote, saga).await? {
+        let mut tx = self.localstore.begin_transaction().await?;
+        let response = Self::internal_melt_settlement_response_tx(&mut tx, quote).await;
+        tx.rollback().await?;
+        response
+    }
+
+    /// Transaction-scoped internal-settlement check used by reconciliation
+    /// paths that already hold the quote dispatch lock.
+    pub(crate) async fn internal_melt_settlement_response_tx(
+        tx: &mut DynMintTransaction,
+        quote: &MeltQuote,
+    ) -> Result<Option<crate::cdk_payment::MakePaymentResponse>, Error> {
+        let Some(mint_quote) = tx
+            .get_mint_quote_by_request(&quote.request.to_string())
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let melt_quote_id = quote.id.to_string();
+        if !mint_quote.payment_ids().contains(&&melt_quote_id) {
             return Ok(None);
         }
 
@@ -214,7 +201,7 @@ impl Mint {
         saga: &Saga,
         quote: &MeltQuote,
     ) -> Result<Option<crate::cdk_payment::MakePaymentResponse>, Error> {
-        if let Some(payment_response) = self.internal_melt_settlement_response(quote, saga).await? {
+        if let Some(payment_response) = self.internal_melt_settlement_response(quote).await? {
             tracing::info!(
                 "Legacy Finalizing saga {} identified as internal settlement",
                 saga.operation_id
@@ -533,12 +520,13 @@ impl Mint {
             // quote check, then refresh the saga state acquired before waiting.
             let quote_lock = self.melt_quote_lock(&quote_id_parsed).await;
             let _quote_guard = quote_lock.lock_owned().await;
-            let mut saga_tx = self.localstore.begin_transaction().await?;
-            let Some(saga) = saga_tx.get_saga(&saga.operation_id).await? else {
-                saga_tx.rollback().await?;
+            let Some(saga) = self
+                .localstore
+                .get_melt_saga_by_quote_id(&quote_id_parsed)
+                .await?
+            else {
                 continue;
             };
-            saga_tx.rollback().await?;
 
             let input_ys = self
                 .localstore
@@ -663,7 +651,8 @@ impl Mint {
                             );
                             continue;
                         }
-                        cdk_common::mint::MeltSagaState::PaymentAttempted => {
+                        cdk_common::mint::MeltSagaState::PaymentAttempted
+                        | cdk_common::mint::MeltSagaState::PaymentPending => {
                             // Payment was attempted - check for internal settlement first, then the payment backend
                             tracing::info!(
                                 "Saga {} in {} state - checking for internal or external payment",
@@ -674,7 +663,7 @@ impl Mint {
                             // Check if this was an internal settlement by looking for a mint quote
                             // that was paid by this melt quote
                             let internal_payment_response = match self
-                                .internal_melt_settlement_response(&quote, &saga)
+                                .internal_melt_settlement_response(&quote)
                                 .await
                             {
                                 Ok(payment_response) => payment_response,
@@ -822,7 +811,7 @@ impl Mint {
                     blinded_secrets.len()
                 );
 
-                if let Err(err) = super::melt::shared::rollback_melt_quote(
+                if let Err(err) = super::melt::shared::rollback_setup_melt_quote(
                     &self.localstore,
                     &self.pubsub_manager,
                     &quote_id_parsed,
@@ -866,26 +855,28 @@ impl Mint {
             .await?
             .ok_or(Error::UnknownQuote)?;
 
-        if quote.state != MeltQuoteState::Pending {
-            return Ok(());
-        }
-
         let saga = match self
             .get_melt_saga_by_quote_id(&quote.id.to_string())
             .await?
         {
             Some(saga) => saga,
             None => {
-                tracing::warn!(
-                    "No saga found for pending melt quote {}, cannot resume",
-                    quote.id
-                );
+                if quote.state == MeltQuoteState::Pending {
+                    tracing::warn!(
+                        "No saga found for pending melt quote {}, cannot resume",
+                        quote.id
+                    );
+                }
                 return Ok(());
             }
         };
 
-        if let Some(payment_response) = self.internal_melt_settlement_response(quote, &saga).await?
-        {
+        // An internal settlement commits the mint-quote credit and marks this
+        // quote Paid in one transaction, so the quote may be Paid here while
+        // finalization (spending proofs, change, saga cleanup) is still
+        // outstanding. Resume it on demand rather than waiting for startup
+        // recovery.
+        if let Some(payment_response) = self.internal_melt_settlement_response(quote).await? {
             return super::saga_recovery::process_melt_saga_outcome(
                 &saga,
                 quote,
@@ -895,6 +886,10 @@ impl Mint {
                 self,
             )
             .await;
+        }
+
+        if quote.state != MeltQuoteState::Pending {
+            return Ok(());
         }
 
         let payment_response = self.check_melt_payment_status(quote).await?;


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

Builds on the advisory-lock approach from #2333 (credit @crodas), scoped to melt quotes, and adds the saga coordination needed to run multiple mint replicas safely against one Postgres database.

Fixes three cross-replica races:

1. **Duplicate dispatch** — two replicas could pay the same melt quote concurrently. The dispatcher now takes a quote advisory lock, re-reads the saga under it, and aborts unless it is still `PaymentAttempted`.
2. **Refund while in flight** — a status check, failure event, or startup recovery could compensate (return proofs) while a payment was still settling. Reconciliation now happens under the same advisory lock with a fresh backend re-check, and a durable `PaymentPending` saga marker blocks compensation unless a definitive failure event arrives from the backend.
3. **Startup rollback racing live dispatch** — setup rollback is refused unless the saga is still `SetupComplete`.

Reconciliation paths use a non-blocking `pg_try_advisory_xact_lock`: a contended lock proves a live dispatch owns the quote, so reconcilers fail closed (leave pending) instead of pinning a pool connection across the holder's network I/O. Only dispatchers ever wait, at most one per quote.

All outcomes fail closed: worst case is a quote stuck `Pending` until a later poll/event/startup recovery resolves it — never a double payment or a double refund.

SQLite is a no-op for the advisory lock (single-process deployments are already serialized by the process-local quote guard), and behavior there is unchanged. **Multi-replica deployments require Postgres.**

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
