### PR TITLE
feat(db): add transactional conditional KV writes

### DIFF
--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -1270,6 +1270,59 @@ mod tests {
             Ok(())
         }
 
+        async fn kv_write_if_absent(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            value: &[u8],
+        ) -> Result<bool, DatabaseError> {
+            let key = memory_kv_key(primary_namespace, secondary_namespace, key);
+
+            let exists = match self.writes.get(&key) {
+                Some(pending) => pending.is_some(),
+                None => {
+                    let entries = self.entries.lock().map_err(|_| memory_kv_lock_error())?;
+                    entries.contains_key(&key)
+                }
+            };
+
+            if exists {
+                return Ok(false);
+            }
+
+            self.writes.insert(key, Some(value.to_vec()));
+
+            Ok(true)
+        }
+
+        async fn kv_write_if_equals(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            expected: &[u8],
+            replacement: &[u8],
+        ) -> Result<bool, DatabaseError> {
+            let key = memory_kv_key(primary_namespace, secondary_namespace, key);
+
+            let current = match self.writes.get(&key) {
+                Some(pending) => pending.clone(),
+                None => {
+                    let entries = self.entries.lock().map_err(|_| memory_kv_lock_error())?;
+                    entries.get(&key).cloned()
+                }
+            };
+
+            match current {
+                Some(current) if current == expected => {
+                    self.writes.insert(key, Some(replacement.to_vec()));
+                    Ok(true)
+                }
+                _ => Ok(false),
+            }
+        }
+
         async fn kv_list(
             &mut self,
             primary_namespace: &str,

--- a/crates/cdk-common/src/database/kvstore.rs
+++ b/crates/cdk-common/src/database/kvstore.rs
@@ -87,6 +87,20 @@ pub trait KVStoreTransaction<Error>: DbTransactionFinalizer<Err = Error> {
         value: &[u8],
     ) -> Result<(), Error>;
 
+    /// Write value to key-value store only when the key does not exist.
+    ///
+    /// Returns `true` when the value was written and `false` when the key
+    /// already exists. Implementations must perform the check-and-insert
+    /// atomically (for example `INSERT ... ON CONFLICT DO NOTHING` with a
+    /// rows-affected check).
+    async fn kv_write_if_absent(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        value: &[u8],
+    ) -> Result<bool, Error>;
+
     /// Remove value from key-value store
     async fn kv_remove(
         &mut self,
@@ -94,6 +108,21 @@ pub trait KVStoreTransaction<Error>: DbTransactionFinalizer<Err = Error> {
         secondary_namespace: &str,
         key: &str,
     ) -> Result<(), Error>;
+
+    /// Replace a value only when it currently equals `expected`.
+    ///
+    /// Returns `true` when the value was replaced and `false` when the key
+    /// does not exist or holds a different value. Implementations must perform
+    /// the check-and-write atomically (for example
+    /// `UPDATE ... WHERE value = ?` with a rows-affected check).
+    async fn kv_write_if_equals(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        expected: &[u8],
+        replacement: &[u8],
+    ) -> Result<bool, Error>;
 
     /// List keys in a namespace
     async fn kv_list(

--- a/crates/cdk-common/src/database/mint/test/mod.rs
+++ b/crates/cdk-common/src/database/mint/test/mod.rs
@@ -184,6 +184,164 @@ where
     assert_eq!(stored, expected);
 }
 
+/// Test atomic insert-if-absent within transactions, including concurrent contenders
+pub async fn kvstore_write_if_absent<DB>(db: DB)
+where
+    DB: Database<crate::database::Error> + KVStoreDatabase<Err = crate::database::Error>,
+{
+    const PRIMARY: &str = "write_if_absent_test";
+    const SECONDARY: &str = "reservation";
+
+    // First insert wins and is committed.
+    {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        assert!(tx
+            .kv_write_if_absent(PRIMARY, SECONDARY, "key1", b"first")
+            .await
+            .unwrap());
+        tx.commit().await.unwrap();
+    }
+
+    // A conflicting insert in a later transaction loses and rolls back cleanly.
+    {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        assert!(!tx
+            .kv_write_if_absent(PRIMARY, SECONDARY, "key1", b"second")
+            .await
+            .unwrap());
+        tx.rollback().await.unwrap();
+    }
+
+    let stored = db.kv_read(PRIMARY, SECONDARY, "key1").await.unwrap();
+    assert_eq!(stored, Some(b"first".to_vec()));
+
+    // Concurrent contenders for the same key: exactly one wins, and the
+    // stored value is the winner's.
+    let left = async {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        let won = tx
+            .kv_write_if_absent(PRIMARY, SECONDARY, "race", b"left")
+            .await
+            .unwrap();
+        if won {
+            tx.commit().await.unwrap();
+        } else {
+            tx.rollback().await.unwrap();
+        }
+        won
+    };
+    let right = async {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        let won = tx
+            .kv_write_if_absent(PRIMARY, SECONDARY, "race", b"right")
+            .await
+            .unwrap();
+        if won {
+            tx.commit().await.unwrap();
+        } else {
+            tx.rollback().await.unwrap();
+        }
+        won
+    };
+
+    let (left, right) = tokio::join!(left, right);
+    assert_ne!(left, right);
+
+    let stored = db.kv_read(PRIMARY, SECONDARY, "race").await.unwrap();
+    let expected = if left {
+        b"left".as_slice()
+    } else {
+        b"right".as_slice()
+    };
+    assert_eq!(stored.as_deref(), Some(expected));
+}
+
+/// Test atomic value-matched writes within transactions, including
+/// concurrent contenders
+pub async fn kvstore_write_if_equals<DB>(db: DB)
+where
+    DB: Database<crate::database::Error> + KVStoreDatabase<Err = crate::database::Error>,
+{
+    const PRIMARY: &str = "write_if_equals_test";
+    const SECONDARY: &str = "reservation";
+
+    // Replacement only happens when the stored value matches.
+    {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        tx.kv_write(PRIMARY, SECONDARY, "key1", b"first")
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+    }
+
+    {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        assert!(!tx
+            .kv_write_if_equals(PRIMARY, SECONDARY, "key1", b"wrong", b"unexpected")
+            .await
+            .unwrap());
+        assert!(!tx
+            .kv_write_if_equals(PRIMARY, SECONDARY, "missing", b"first", b"unexpected")
+            .await
+            .unwrap());
+        tx.commit().await.unwrap();
+    }
+
+    let stored = db.kv_read(PRIMARY, SECONDARY, "key1").await.unwrap();
+    assert_eq!(stored, Some(b"first".to_vec()));
+
+    {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        assert!(tx
+            .kv_write_if_equals(PRIMARY, SECONDARY, "key1", b"first", b"second")
+            .await
+            .unwrap());
+        tx.commit().await.unwrap();
+    }
+
+    let stored = db.kv_read(PRIMARY, SECONDARY, "key1").await.unwrap();
+    assert_eq!(stored, Some(b"second".to_vec()));
+
+    // Concurrent contenders replacing the same value: exactly one wins.
+    {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        tx.kv_write(PRIMARY, SECONDARY, "race", b"value")
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+    }
+
+    let left = async {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        let written = tx
+            .kv_write_if_equals(PRIMARY, SECONDARY, "race", b"value", b"left")
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+        written
+    };
+    let right = async {
+        let mut tx = Database::begin_transaction(&db).await.unwrap();
+        let written = tx
+            .kv_write_if_equals(PRIMARY, SECONDARY, "race", b"value", b"right")
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+        written
+    };
+
+    let (left, right) = tokio::join!(left, right);
+    assert_ne!(left, right);
+
+    let stored = db.kv_read(PRIMARY, SECONDARY, "race").await.unwrap();
+    let expected = if left {
+        b"left".as_slice()
+    } else {
+        b"right".as_slice()
+    };
+    assert_eq!(stored.as_deref(), Some(expected));
+}
+
 /// Unit test that is expected to be passed for a correct database implementation
 #[macro_export]
 macro_rules! mint_db_test {
@@ -193,6 +351,8 @@ macro_rules! mint_db_test {
             add_and_find_proofs,
             add_duplicate_proofs,
             kvstore_functionality,
+            kvstore_write_if_absent,
+            kvstore_write_if_equals,
             add_mint_quote,
             add_mint_quote_only_once,
             register_payments,

--- a/crates/cdk-sql-common/src/keyvalue.rs
+++ b/crates/cdk-sql-common/src/keyvalue.rs
@@ -89,6 +89,43 @@ where
     Ok(())
 }
 
+/// Generic implementation of kv_write_if_absent for transactions
+#[cfg(feature = "mint")]
+pub(crate) async fn kv_write_if_absent_in_transaction<RM>(
+    conn: &ConnectionWithTransaction<RM::Connection, PooledResource<RM>>,
+    primary_namespace: &str,
+    secondary_namespace: &str,
+    key: &str,
+    value: &[u8],
+) -> Result<bool, Error>
+where
+    RM: DatabasePool,
+{
+    // Validate parameters according to KV store requirements
+    validate_kvstore_params(primary_namespace, secondary_namespace, Some(key))?;
+
+    let current_time = unix_time();
+
+    let affected = query(
+        r#"
+        INSERT INTO kv_store
+        (primary_namespace, secondary_namespace, key, value, created_time, updated_time)
+        VALUES (:primary_namespace, :secondary_namespace, :key, :value, :created_time, :updated_time)
+        ON CONFLICT(primary_namespace, secondary_namespace, key) DO NOTHING
+        "#,
+    )?
+    .bind("primary_namespace", primary_namespace.to_owned())
+    .bind("secondary_namespace", secondary_namespace.to_owned())
+    .bind("key", key.to_owned())
+    .bind("value", value.to_vec())
+    .bind("created_time", current_time as i64)
+    .bind("updated_time", current_time as i64)
+    .execute(conn)
+    .await?;
+
+    Ok(affected == 1)
+}
+
 /// Generic implementation of kv_remove for transactions
 #[cfg(feature = "mint")]
 pub(crate) async fn kv_remove_in_transaction<RM>(
@@ -117,6 +154,44 @@ where
     .await?;
 
     Ok(())
+}
+
+/// Generic implementation of kv_write_if_equals for transactions
+#[cfg(feature = "mint")]
+pub(crate) async fn kv_write_if_equals_in_transaction<RM>(
+    conn: &ConnectionWithTransaction<RM::Connection, PooledResource<RM>>,
+    primary_namespace: &str,
+    secondary_namespace: &str,
+    key: &str,
+    expected: &[u8],
+    replacement: &[u8],
+) -> Result<bool, Error>
+where
+    RM: DatabasePool,
+{
+    // Validate parameters according to KV store requirements
+    validate_kvstore_params(primary_namespace, secondary_namespace, Some(key))?;
+    let affected = query(
+        r#"
+        UPDATE kv_store
+        SET value = :replacement,
+            updated_time = :updated_time
+        WHERE primary_namespace = :primary_namespace
+        AND secondary_namespace = :secondary_namespace
+        AND key = :key
+        AND value = :expected
+        "#,
+    )?
+    .bind("primary_namespace", primary_namespace.to_owned())
+    .bind("secondary_namespace", secondary_namespace.to_owned())
+    .bind("key", key.to_owned())
+    .bind("expected", expected.to_vec())
+    .bind("replacement", replacement.to_vec())
+    .bind("updated_time", unix_time() as i64)
+    .execute(conn)
+    .await?;
+
+    Ok(affected == 1)
 }
 
 /// Generic implementation of kv_list for transactions

--- a/crates/cdk-sql-common/src/mint/keyvalue.rs
+++ b/crates/cdk-sql-common/src/mint/keyvalue.rs
@@ -44,6 +44,23 @@ where
         .await
     }
 
+    async fn kv_write_if_absent(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        value: &[u8],
+    ) -> Result<bool, Error> {
+        crate::keyvalue::kv_write_if_absent_in_transaction(
+            &self.inner,
+            primary_namespace,
+            secondary_namespace,
+            key,
+            value,
+        )
+        .await
+    }
+
     async fn kv_remove(
         &mut self,
         primary_namespace: &str,
@@ -55,6 +72,25 @@ where
             primary_namespace,
             secondary_namespace,
             key,
+        )
+        .await
+    }
+
+    async fn kv_write_if_equals(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        expected: &[u8],
+        replacement: &[u8],
+    ) -> Result<bool, Error> {
+        crate::keyvalue::kv_write_if_equals_in_transaction(
+            &self.inner,
+            primary_namespace,
+            secondary_namespace,
+            key,
+            expected,
+            replacement,
         )
         .await
     }


### PR DESCRIPTION
### Summary

Add transactional conditional writes to the shared key-value store interface so callers can claim or transition a key without a read-then-write race.

### Root cause

`KVStoreTransaction` only exposed unconditional `kv_write`. Callers that needed write-once ownership had to read a key and then overwrite it, allowing concurrent transactions to observe the same initial state and both proceed.

### Approach

- Add `kv_write_if_absent` for atomic first-writer-wins claims.
- Add `kv_write_if_equals` for compare-and-set transitions.
- Implement SQL claims with `INSERT ... ON CONFLICT DO NOTHING` and affected-row checks.
- Implement SQL transitions with a conditional `UPDATE` and affected-row checks.
- Extend the shared database conformance suite with success, missing-value, mismatched-value, and concurrent-writer cases.
- Update the CLN transactional test store implementation for the expanded trait.

### PR stack

This is the shared prerequisite and should merge first.

- **This PR:** conditional KV primitives → `main`
- #2378: BDK atomic quote/address reservations → this PR
- #2379: CLN/LDK BOLT12 write-once bindings → this PR

After this PR merges, #2378 and #2379 can be retargeted to `main` and merged independently.

### Testing

- `just quick-check`
- Shared conditional-write conformance tests on SQLite
- Relevant SQL, CLN, BDK, and LDK-node targets compile through the full stack

### Suggested CHANGELOG

#### ADDED

- Transactional absent-only and compare-and-set operations for `DynKVStore`.

### Checklist

- [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
- [x] I ran `just quick-check` before committing
- [x] FFI changes are not required; this does not modify the public Wallet API
