### PR TITLE
fix(cdk-bdk): reserve quote IDs and receive addresses atomically

### DIFF
--- a/crates/cdk-bdk/src/error.rs
+++ b/crates/cdk-bdk/src/error.rs
@@ -199,6 +199,13 @@ pub enum Error {
     #[error("Receive address not found: {0}")]
     ReceiveAddressNotFound(String),
 
+    /// No unreserved receive address was found within the retry limit.
+    #[error("Could not reserve a fresh receive address after {attempts} attempts")]
+    ReceiveAddressReservationExhausted {
+        /// Number of addresses derived before giving up.
+        attempts: usize,
+    },
+
     /// Database
     #[error("Database error")]
     BdkPersist,

--- a/crates/cdk-bdk/src/lib.rs
+++ b/crates/cdk-bdk/src/lib.rs
@@ -60,6 +60,8 @@ pub use crate::wallet_info::{
     WalletTransactionInput, WalletTransactionOutput,
 };
 
+const MAX_RECEIVE_ADDRESS_RESERVATION_ATTEMPTS: usize = 100;
+
 /// Wrapper struct that combines wallet and database to prevent deadlocks
 pub(crate) struct WalletWithDb {
     pub(crate) wallet: PersistedWallet<Connection>,
@@ -690,23 +692,48 @@ impl MintPayment for CdkBdk {
             _ => return Err(cdk_common::payment::Error::UnsupportedPaymentOption),
         };
 
-        let mut wallet_with_db = self.wallet_with_db.lock().await;
-        let address = wallet_with_db
-            .wallet
-            .reveal_next_address(KeychainKind::External);
-        let address_str = address.address.to_string();
-
-        wallet_with_db.persist().map_err(|err| {
-            tracing::error!("Could not persist to bdk db: {}", err);
-
-            Error::BdkPersist
-        })?;
-
         let quote_id = onchain_options.quote_id;
+        let quote_id_string = quote_id.to_string();
 
-        self.storage
-            .track_receive_address(&address_str, &quote_id.to_string())
-            .await?;
+        let mut wallet_with_db = self.wallet_with_db.lock().await;
+
+        // An address already tracked for another quote (derived by another
+        // instance sharing this seed, or by a re-initialised local wallet)
+        // must not be handed out again; advance to a fresh address.
+        let address_str = 'reserve_address: {
+            for attempt in 1..=MAX_RECEIVE_ADDRESS_RESERVATION_ATTEMPTS {
+                let address = wallet_with_db
+                    .wallet
+                    .reveal_next_address(KeychainKind::External);
+                let candidate = address.address.to_string();
+
+                wallet_with_db.persist().map_err(|err| {
+                    tracing::warn!("Could not persist to bdk db: {}", err);
+
+                    Error::BdkPersist
+                })?;
+
+                if self
+                    .storage
+                    .track_receive_address(&candidate, &quote_id_string)
+                    .await?
+                {
+                    break 'reserve_address candidate;
+                }
+
+                tracing::debug!(
+                    quote_id = %quote_id,
+                    attempt,
+                    max_attempts = MAX_RECEIVE_ADDRESS_RESERVATION_ATTEMPTS,
+                    "Receive address is already reserved for another quote"
+                );
+            }
+
+            return Err(Error::ReceiveAddressReservationExhausted {
+                attempts: MAX_RECEIVE_ADDRESS_RESERVATION_ATTEMPTS,
+            }
+            .into());
+        };
 
         Ok(CreateIncomingPaymentResponse {
             request_lookup_id: PaymentIdentifier::QuoteId(quote_id),
@@ -929,6 +956,119 @@ mod tests {
         )?;
 
         Ok((backend, tmp))
+    }
+
+    /// Build a `CdkBdk` instance with its own local wallet directory but a
+    /// shared KV store, like a second replica or a re-initialised node using
+    /// the same seed.
+    async fn build_test_instance_with_shared_kv(
+        kv: Arc<cdk_sqlite::mint::MintSqliteDatabase>,
+    ) -> (CdkBdk, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mnemonic = Mnemonic::from_str(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+        )
+        .expect("mnemonic");
+        let chain_source = ChainSource::Esplora(EsploraConfig {
+            url: "http://127.0.0.1:1".to_string(),
+            parallel_requests: 1,
+        });
+        let fee_reserve = FeeReserve {
+            min_fee_reserve: Amount::new(1, CurrencyUnit::Sat).into(),
+            percent_fee_reserve: 0.02,
+        };
+
+        let backend = CdkBdk::new(
+            mnemonic,
+            Network::Regtest,
+            chain_source,
+            tmp.path().to_string_lossy().into_owned(),
+            fee_reserve,
+            kv,
+            None,
+            1,
+            0,
+            546,
+            60,
+            Some(5),
+            None,
+        )
+        .expect("build CdkBdk test instance");
+
+        (backend, tmp)
+    }
+
+    #[tokio::test]
+    async fn instances_sharing_seed_and_kv_never_share_a_receive_address() {
+        let kv = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory kv store"),
+        );
+        let (first, _tmp_first) = build_test_instance_with_shared_kv(kv.clone()).await;
+        let (second, _tmp_second) = build_test_instance_with_shared_kv(kv).await;
+
+        let first_request = first
+            .create_incoming_payment_request(IncomingPaymentOptions::Onchain(
+                OnchainIncomingPaymentOptions {
+                    quote_id: cdk_common::QuoteId::new(),
+                },
+            ))
+            .await
+            .expect("first receive request");
+        let second_request = second
+            .create_incoming_payment_request(IncomingPaymentOptions::Onchain(
+                OnchainIncomingPaymentOptions {
+                    quote_id: cdk_common::QuoteId::new(),
+                },
+            ))
+            .await
+            .expect("second receive request");
+
+        assert_ne!(
+            first_request.request, second_request.request,
+            "each instance must hand out a distinct receive address"
+        );
+    }
+
+    #[tokio::test]
+    async fn receive_address_reservation_stops_after_attempt_limit() {
+        let kv = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory kv store"),
+        );
+        let (first, _tmp_first) = build_test_instance_with_shared_kv(kv.clone()).await;
+        let (second, _tmp_second) = build_test_instance_with_shared_kv(kv).await;
+
+        for _ in 0..MAX_RECEIVE_ADDRESS_RESERVATION_ATTEMPTS {
+            first
+                .create_incoming_payment_request(IncomingPaymentOptions::Onchain(
+                    OnchainIncomingPaymentOptions {
+                        quote_id: cdk_common::QuoteId::new(),
+                    },
+                ))
+                .await
+                .expect("reserve receive address");
+        }
+
+        let err = second
+            .create_incoming_payment_request(IncomingPaymentOptions::Onchain(
+                OnchainIncomingPaymentOptions {
+                    quote_id: cdk_common::QuoteId::new(),
+                },
+            ))
+            .await
+            .expect_err("reservation should stop after the attempt limit");
+
+        let cdk_common::payment::Error::Onchain(inner) = err else {
+            panic!("expected onchain error");
+        };
+        assert!(matches!(
+            inner.downcast_ref::<Error>(),
+            Some(Error::ReceiveAddressReservationExhausted { attempts })
+                if *attempts == MAX_RECEIVE_ADDRESS_RESERVATION_ATTEMPTS
+        ));
     }
 
     #[tokio::test]

--- a/crates/cdk-bdk/src/send/payment_intent/mod.rs
+++ b/crates/cdk-bdk/src/send/payment_intent/mod.rs
@@ -332,13 +332,287 @@ pub(crate) enum SendIntentAny {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::collections::{HashMap, HashSet};
+    use std::sync::{Arc, Mutex as StdMutex};
 
+    use async_trait::async_trait;
+    use cdk_common::database::{
+        DbTransactionFinalizer, Error as DatabaseError, KVStore, KVStoreDatabase,
+        KVStoreTransaction,
+    };
     use cdk_common::payment::{MakePaymentResponse, PaymentIdentifier};
     use cdk_common::{Amount, CurrencyUnit, MeltQuoteState};
+    use tokio::sync::Barrier;
 
     use super::*;
-    use crate::storage::BdkStorage;
+    use crate::storage::{BdkStorage, SEND_INTENT_QUOTE_ID_NAMESPACE};
+
+    type KvKey = (String, String, String);
+
+    /// KV store that lets two concurrent transactions both observe a missing
+    /// quote-id index entry before either writes. `kv_write_if_absent` is
+    /// atomic across transactions, mirroring the SQL backend.
+    #[derive(Clone)]
+    struct RacingKvStore {
+        data: Arc<StdMutex<HashMap<KvKey, Vec<u8>>>>,
+        reservations: Arc<StdMutex<HashSet<KvKey>>>,
+        index_read_barrier: Arc<Barrier>,
+    }
+
+    impl RacingKvStore {
+        fn new(parties: usize) -> Self {
+            Self {
+                data: Arc::new(StdMutex::new(HashMap::new())),
+                reservations: Arc::new(StdMutex::new(HashSet::new())),
+                index_read_barrier: Arc::new(Barrier::new(parties)),
+            }
+        }
+    }
+
+    struct RacingTransaction {
+        store: RacingKvStore,
+        writes: Vec<(KvKey, Option<Vec<u8>>)>,
+        reserved: Vec<KvKey>,
+    }
+
+    #[async_trait]
+    impl DbTransactionFinalizer for RacingTransaction {
+        type Err = DatabaseError;
+
+        async fn commit(self: Box<Self>) -> Result<(), Self::Err> {
+            let mut data = self.store.data.lock().expect("lock racing kv store");
+            for (key, value) in self.writes {
+                if let Some(value) = value {
+                    data.insert(key, value);
+                } else {
+                    data.remove(&key);
+                }
+            }
+            Ok(())
+        }
+
+        async fn rollback(self: Box<Self>) -> Result<(), Self::Err> {
+            let mut reservations = self.store.reservations.lock().expect("lock reservations");
+            for key in &self.reserved {
+                reservations.remove(key);
+            }
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl KVStoreTransaction<DatabaseError> for RacingTransaction {
+        async fn kv_read(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+        ) -> Result<Option<Vec<u8>>, DatabaseError> {
+            let map_key = (
+                primary_namespace.to_string(),
+                secondary_namespace.to_string(),
+                key.to_string(),
+            );
+            let value = self
+                .writes
+                .iter()
+                .rev()
+                .find(|(candidate, _)| candidate == &map_key)
+                .map(|(_, value)| value.clone())
+                .unwrap_or_else(|| {
+                    self.store
+                        .data
+                        .lock()
+                        .expect("lock racing kv store")
+                        .get(&map_key)
+                        .cloned()
+                });
+
+            if secondary_namespace == SEND_INTENT_QUOTE_ID_NAMESPACE {
+                self.store.index_read_barrier.wait().await;
+            }
+
+            Ok(value)
+        }
+
+        async fn kv_write(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            value: &[u8],
+        ) -> Result<(), DatabaseError> {
+            self.writes.push((
+                (
+                    primary_namespace.to_string(),
+                    secondary_namespace.to_string(),
+                    key.to_string(),
+                ),
+                Some(value.to_vec()),
+            ));
+            Ok(())
+        }
+
+        async fn kv_write_if_absent(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            value: &[u8],
+        ) -> Result<bool, DatabaseError> {
+            let map_key = (
+                primary_namespace.to_string(),
+                secondary_namespace.to_string(),
+                key.to_string(),
+            );
+
+            let exists = match self
+                .writes
+                .iter()
+                .rev()
+                .find(|(candidate, _)| candidate == &map_key)
+            {
+                Some((_, pending)) => pending.is_some(),
+                None => {
+                    let data = self.store.data.lock().expect("lock racing kv store");
+                    let reservations = self.store.reservations.lock().expect("lock reservations");
+                    data.contains_key(&map_key) || reservations.contains(&map_key)
+                }
+            };
+
+            if exists {
+                return Ok(false);
+            }
+
+            self.store
+                .reservations
+                .lock()
+                .expect("lock reservations")
+                .insert(map_key.clone());
+            self.reserved.push(map_key.clone());
+            self.writes.push((map_key, Some(value.to_vec())));
+
+            Ok(true)
+        }
+
+        async fn kv_remove(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+        ) -> Result<(), DatabaseError> {
+            self.writes.push((
+                (
+                    primary_namespace.to_string(),
+                    secondary_namespace.to_string(),
+                    key.to_string(),
+                ),
+                None,
+            ));
+            Ok(())
+        }
+
+        async fn kv_write_if_equals(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            expected: &[u8],
+            replacement: &[u8],
+        ) -> Result<bool, DatabaseError> {
+            let map_key = (
+                primary_namespace.to_string(),
+                secondary_namespace.to_string(),
+                key.to_string(),
+            );
+
+            let current = self
+                .writes
+                .iter()
+                .rev()
+                .find(|(candidate, _)| candidate == &map_key)
+                .map(|(_, value)| value.clone())
+                .unwrap_or_else(|| {
+                    self.store
+                        .data
+                        .lock()
+                        .expect("lock racing kv store")
+                        .get(&map_key)
+                        .cloned()
+                });
+
+            match current {
+                Some(current) if current == expected => {
+                    self.writes.push((map_key, Some(replacement.to_vec())));
+                    Ok(true)
+                }
+                _ => Ok(false),
+            }
+        }
+
+        async fn kv_list(
+            &mut self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+        ) -> Result<Vec<String>, DatabaseError> {
+            self.store
+                .kv_list(primary_namespace, secondary_namespace)
+                .await
+        }
+    }
+
+    #[async_trait]
+    impl KVStoreDatabase for RacingKvStore {
+        type Err = DatabaseError;
+
+        async fn kv_read(
+            &self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+        ) -> Result<Option<Vec<u8>>, Self::Err> {
+            Ok(self
+                .data
+                .lock()
+                .expect("lock racing kv store")
+                .get(&(
+                    primary_namespace.to_string(),
+                    secondary_namespace.to_string(),
+                    key.to_string(),
+                ))
+                .cloned())
+        }
+
+        async fn kv_list(
+            &self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+        ) -> Result<Vec<String>, Self::Err> {
+            Ok(self
+                .data
+                .lock()
+                .expect("lock racing kv store")
+                .keys()
+                .filter(|(primary, secondary, _)| {
+                    primary == primary_namespace && secondary == secondary_namespace
+                })
+                .map(|(_, _, key)| key.clone())
+                .collect())
+        }
+    }
+
+    #[async_trait]
+    impl KVStore for RacingKvStore {
+        async fn begin_transaction(
+            &self,
+        ) -> Result<Box<dyn KVStoreTransaction<Self::Err> + Send + Sync>, DatabaseError> {
+            Ok(Box::new(RacingTransaction {
+                store: self.clone(),
+                writes: Vec::new(),
+                reserved: Vec::new(),
+            }))
+        }
+    }
 
     /// Helper: create an in-memory KVStore-backed BdkStorage for tests
     async fn test_storage() -> BdkStorage {
@@ -346,6 +620,41 @@ mod tests {
             .await
             .expect("in-memory db");
         BdkStorage::new(Arc::new(db))
+    }
+
+    #[tokio::test]
+    async fn concurrent_duplicate_quote_creates_only_one_intent() {
+        let storage = BdkStorage::new(Arc::new(RacingKvStore::new(2)));
+        let create = || {
+            SendIntent::new(
+                &storage,
+                "quote-race".to_string(),
+                "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+                10_000,
+                500,
+                PaymentTier::Immediate,
+                PaymentMetadata::default(),
+            )
+        };
+
+        let (first, second) = tokio::join!(create(), create());
+
+        let success_count = usize::from(first.is_ok()) + usize::from(second.is_ok());
+        assert_eq!(success_count, 1, "only one intent per quote id");
+
+        let duplicate_count = [&first, &second]
+            .iter()
+            .filter(
+                |result| matches!(result, Err(Error::DuplicateQuoteId(id)) if id == "quote-race"),
+            )
+            .count();
+        assert_eq!(duplicate_count, 1, "loser must get DuplicateQuoteId");
+
+        let records = storage
+            .get_all_send_intents()
+            .await
+            .expect("list send intents");
+        assert_eq!(records.len(), 1, "only one intent record may be persisted");
     }
 
     #[tokio::test]

--- a/crates/cdk-bdk/src/storage/mod.rs
+++ b/crates/cdk-bdk/src/storage/mod.rs
@@ -1658,6 +1658,41 @@ mod tests {
         assert!(missing.is_none());
     }
 
+    #[tokio::test]
+    async fn test_track_receive_address_never_remaps_to_another_quote() {
+        let storage = test_storage().await;
+
+        let q1 = Uuid::new_v4().to_string();
+        let q2 = Uuid::new_v4().to_string();
+
+        let reserved = storage
+            .track_receive_address("bcrt1qaddr1", &q1)
+            .await
+            .expect("track addr1");
+        assert!(reserved);
+
+        // Same address, same quote: idempotent no-op.
+        let reserved = storage
+            .track_receive_address("bcrt1qaddr1", &q1)
+            .await
+            .expect("re-track addr1");
+        assert!(reserved);
+
+        // Same address, different quote: rejected, mapping unchanged.
+        let reserved = storage
+            .track_receive_address("bcrt1qaddr1", &q2)
+            .await
+            .expect("track addr1 for q2");
+        assert!(!reserved);
+
+        let fetched = storage
+            .get_quote_id_by_receive_address("bcrt1qaddr1")
+            .await
+            .expect("get by address")
+            .expect("should exist");
+        assert_eq!(fetched, q1);
+    }
+
     // ── Receive saga: intent CRUD tests ──────────────────────────────
 
     #[tokio::test]

--- a/crates/cdk-bdk/src/storage/receive.rs
+++ b/crates/cdk-bdk/src/storage/receive.rs
@@ -13,24 +13,46 @@ impl BdkStorage {
     // ── Receive address index storage ────────────────────────────────
 
     /// Track a generated receive address by quote ID.
-    pub async fn track_receive_address(&self, address: &str, quote_id: &str) -> Result<(), Error> {
+    ///
+    /// Returns `true` when the address was reserved for `quote_id` (or was
+    /// already tracked for that same quote). Returns `false` when the
+    /// address is already tracked for a different quote; the caller must
+    /// derive a fresh address and retry.
+    pub async fn track_receive_address(
+        &self,
+        address: &str,
+        quote_id: &str,
+    ) -> Result<bool, Error> {
         let mut tx = self
             .kv_store
             .begin_transaction()
             .await
             .map_err(Error::from)?;
 
-        tx.kv_write(
-            BDK_NAMESPACE,
-            RECEIVE_ADDRESS_QUOTE_ID_NAMESPACE,
-            address,
-            quote_id.as_bytes(),
-        )
-        .await
-        .map_err(Error::from)?;
+        // Reserve the address atomically: an address must never be remapped
+        // to a different quote once tracked.
+        let reserved = tx
+            .kv_write_if_absent(
+                BDK_NAMESPACE,
+                RECEIVE_ADDRESS_QUOTE_ID_NAMESPACE,
+                address,
+                quote_id.as_bytes(),
+            )
+            .await
+            .map_err(Error::from)?;
+
+        if !reserved {
+            let existing = tx
+                .kv_read(BDK_NAMESPACE, RECEIVE_ADDRESS_QUOTE_ID_NAMESPACE, address)
+                .await
+                .map_err(Error::from)?;
+            let same_quote = existing.as_deref() == Some(quote_id.as_bytes());
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(same_quote);
+        }
 
         tx.commit().await.map_err(Error::from)?;
-        Ok(())
+        Ok(true)
     }
 
     /// Get the quote ID for a tracked receive address.

--- a/crates/cdk-bdk/src/storage/send.rs
+++ b/crates/cdk-bdk/src/storage/send.rs
@@ -63,14 +63,20 @@ impl BdkStorage {
         )
         .await
         .map_err(Error::from)?;
-        tx.kv_write(
-            BDK_NAMESPACE,
-            SEND_INTENT_QUOTE_ID_NAMESPACE,
-            &intent.quote_id,
-            intent.intent_id.to_string().as_bytes(),
-        )
-        .await
-        .map_err(Error::from)?;
+        // Reserve the quote id atomically with the record write.
+        let reserved = tx
+            .kv_write_if_absent(
+                BDK_NAMESPACE,
+                SEND_INTENT_QUOTE_ID_NAMESPACE,
+                &intent.quote_id,
+                intent.intent_id.to_string().as_bytes(),
+            )
+            .await
+            .map_err(Error::from)?;
+        if !reserved {
+            tx.rollback().await.map_err(Error::from)?;
+            return Err(Error::DuplicateQuoteId(intent.quote_id.clone()));
+        }
         if let SendIntentState::AwaitingConfirmation { outpoint, .. } = &intent.state {
             tx.kv_write(
                 BDK_NAMESPACE,
@@ -148,14 +154,20 @@ impl BdkStorage {
                 state: intent.state.clone(),
             }
         } else {
-            tx.kv_write(
-                BDK_NAMESPACE,
-                SEND_INTENT_QUOTE_ID_NAMESPACE,
-                &intent.quote_id,
-                intent.intent_id.to_string().as_bytes(),
-            )
-            .await
-            .map_err(Error::from)?;
+            // Reserve the quote id atomically with the record write.
+            let reserved = tx
+                .kv_write_if_absent(
+                    BDK_NAMESPACE,
+                    SEND_INTENT_QUOTE_ID_NAMESPACE,
+                    &intent.quote_id,
+                    intent.intent_id.to_string().as_bytes(),
+                )
+                .await
+                .map_err(Error::from)?;
+            if !reserved {
+                tx.rollback().await.map_err(Error::from)?;
+                return Err(Error::DuplicateQuoteId(intent.quote_id.clone()));
+            }
             intent.clone()
         };
 


### PR DESCRIPTION
### Summary

Make the BDK payment store reserve quote IDs and receive addresses atomically, preventing concurrent callers from assigning the same identity to different payments.

### Root cause

Two BDK paths used read-then-write ownership checks:

- send-intent creation could persist more than one intent for the same quote ID when concurrent transactions both observed a missing index entry;
- receive-address tracking could overwrite an existing address-to-quote mapping, allowing another instance sharing the seed and KV store to reassign a tracked address.

### Approach

- Reserve send-intent quote IDs with `kv_write_if_absent` in the same transaction as the intent record.
- Roll back the losing transaction with `DuplicateQuoteId`.
- Preserve retry behavior for the original failed intent.
- Reserve receive-address mappings with `kv_write_if_absent`.
- Keep same-address/same-quote repeats idempotent.
- Reject conflicting mappings and advance to a fresh derivation index.

### PR stack

This PR contains only the BDK consumer changes and depends on #2377.

- #2377: conditional KV primitives → `main`
- **This PR:** BDK atomic quote/address reservations → #2377
- #2379: sibling CLN/LDK BOLT12 hardening → #2377

Review this PR against `kvstore_conditional_writes`; the #2377 changes are intentionally excluded from its diff.

### Testing

- Concurrent send-intent reservation regression test
- Receive-address reservation, idempotency, and conflict tests
- Two-instance shared-seed/shared-store receive-address regression test
- `just quick-check`

### Suggested CHANGELOG

#### FIXED

- Prevent concurrent BDK payments from sharing a quote ID or reassigning a tracked receive address.

### Checklist

- [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
- [x] I ran `just quick-check` before committing
- [x] FFI changes are not required; this does not modify the public Wallet API
