### PR TITLE
fix(payment): make BOLT12 quote bindings write-once

### DIFF
--- a/crates/cdk-cln/src/error.rs
+++ b/crates/cdk-cln/src/error.rs
@@ -20,6 +20,12 @@ pub enum Error {
     /// Invalid quote id
     #[error("Invalid quote id")]
     InvalidQuoteId,
+    /// BOLT12 quote is already bound to a different payment hash
+    #[error("BOLT12 quote {quote_id} is already bound to a different payment hash")]
+    Bolt12QuoteBindingConflict {
+        /// Quote id whose binding was rejected
+        quote_id: String,
+    },
     /// Cln Error
     #[error(transparent)]
     Cln(#[from] cln_rpc::Error),

--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -46,6 +46,7 @@ pub mod error;
 const CLN_KV_PRIMARY_NAMESPACE: &str = "cdk_cln_lightning_backend";
 const CLN_KV_SECONDARY_NAMESPACE: &str = "payment_indices";
 const CLN_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE: &str = "bolt12_outgoing_payments";
+const CLN_KV_BOLT12_CLEANUP_MARKER: &[u8] = b"cleanup-in-progress";
 const LAST_PAY_INDEX_KV_KEY: &str = "last_pay_index";
 
 /// CLN mint backend
@@ -429,6 +430,7 @@ impl MintPayment for Cln {
         let mut partial_amount: Option<u64> = None;
         let mut amount_msat: Option<u64> = None;
         let payment_lookup_id: PaymentIdentifier;
+        let mut bolt12_binding = None;
 
         let mut cln_client = self.cln_client().await?;
 
@@ -461,6 +463,12 @@ impl MintPayment for Cln {
                 let offer = &bolt12_options.offer;
                 let quote_id = bolt12_options.quote_id.clone();
                 let quote_payment_identifier = PaymentIdentifier::QuoteId(quote_id.clone());
+
+                max_fee_msat = bolt12_options
+                    .max_fee_amount
+                    .as_ref()
+                    .map(|a| a.to_msat())
+                    .transpose()?;
 
                 self.check_outgoing_unpaided(&quote_payment_identifier)
                     .await?;
@@ -498,6 +506,10 @@ impl MintPayment for Cln {
                         Error::ClnRpc(err)
                     })?;
 
+                if cln_response.invoice.is_empty() {
+                    return Err(Error::UnknownInvoice.into());
+                }
+
                 let decode_response = self.decode_string(cln_response.invoice.clone()).await?;
 
                 let payment_hash = Self::parse_payment_hash(
@@ -512,12 +524,7 @@ impl MintPayment for Cln {
                 self.write_bolt12_quote_payment_hash(&quote_id, &payment_hash)
                     .await?;
                 payment_lookup_id = quote_payment_identifier;
-
-                max_fee_msat = bolt12_options
-                    .max_fee_amount
-                    .clone()
-                    .map(|a| a.to_msat())
-                    .transpose()?;
+                bolt12_binding = Some((quote_id, payment_hash));
 
                 cln_response.invoice
             }
@@ -557,6 +564,29 @@ impl MintPayment for Cln {
             },
             Err(err) => {
                 tracing::error!("Could not pay invoice with xpay: {}", err);
+                if let Some((quote_id, payment_hash)) = &bolt12_binding {
+                    match self
+                        .bolt12_binding_may_be_live_after_xpay_error(
+                            &mut cln_client,
+                            payment_hash,
+                            &err,
+                        )
+                        .await
+                    {
+                        true => {
+                            tracing::warn!(
+                                quote_id = %quote_id,
+                                "CLN xpay failed without a definitive terminal payment state; \
+                                 retaining the BOLT12 quote binding because the payment may have \
+                                 been dispatched"
+                            );
+                        }
+                        false => {
+                            self.cleanup_bolt12_quote_payment_hash(quote_id, payment_hash)
+                                .await;
+                        }
+                    }
+                }
                 return Err(Error::ClnRpc(err).into());
             }
         };
@@ -818,6 +848,13 @@ impl MintPayment for Cln {
             Some(pays_response) => {
                 let status = cln_pays_status_to_mint_state(pays_response.status);
 
+                if status == MeltQuoteState::Failed {
+                    if let PaymentIdentifier::QuoteId(quote_id) = payment_identifier {
+                        self.cleanup_bolt12_quote_payment_hash(quote_id, &payment_hash)
+                            .await;
+                    }
+                }
+
                 Ok(MakePaymentResponse {
                     payment_lookup_id: payment_identifier.clone(),
                     payment_proof: pays_response.preimage.map(|p| hex::encode(p.to_vec())),
@@ -858,6 +895,12 @@ impl Cln {
             .map_err(|_| Error::InvalidHash)
     }
 
+    /// Binds the BOLT12 quote id to the fetched invoice's payment hash.
+    ///
+    /// The binding is write-once: the first dispatch for a quote claims it
+    /// atomically, so a duplicate or concurrent dispatch is rejected before
+    /// any funds move. Repeating the same payment hash is an idempotent
+    /// no-op for recovery.
     async fn write_bolt12_quote_payment_hash(
         &self,
         quote_id: &QuoteId,
@@ -871,11 +914,142 @@ impl Cln {
             .await
             .map_err(|e| Error::Database(e.to_string()))?;
 
-        tx.kv_write(
+        let written = tx
+            .kv_write_if_absent(
+                CLN_KV_PRIMARY_NAMESPACE,
+                CLN_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+                &key,
+                value.as_bytes(),
+            )
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        if written {
+            tx.commit()
+                .await
+                .map_err(|e| Error::Database(e.to_string()))?;
+            return Ok(());
+        }
+
+        let existing = tx
+            .kv_read(
+                CLN_KV_PRIMARY_NAMESPACE,
+                CLN_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+                &key,
+            )
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?;
+        tx.rollback()
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        match existing {
+            Some(existing) if existing.as_slice() == value.as_bytes() => Ok(()),
+            _ => Err(Error::Bolt12QuoteBindingConflict {
+                quote_id: quote_id.to_string(),
+            }),
+        }
+    }
+
+    /// Best-effort release of a binding whose exact payment attempt is known
+    /// to have failed terminally.
+    async fn cleanup_bolt12_quote_payment_hash(&self, quote_id: &QuoteId, payment_hash: &[u8; 32]) {
+        match self
+            .delete_bolt12_quote_payment_hash_if_equals(quote_id, payment_hash)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::debug!(
+                    quote_id = %quote_id,
+                    "BOLT12 quote binding changed before failed-payment cleanup"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    quote_id = %quote_id,
+                    "Could not release failed BOLT12 quote binding: {err}"
+                );
+            }
+        }
+    }
+
+    /// Reconciles a coded `xpay` error with CLN's durable payment records.
+    ///
+    /// Transport and response-decoding errors are ambiguous without another
+    /// RPC round trip, so their bindings are retained. For a coded error, the
+    /// binding is released only when `listpays` has no pending or completed
+    /// payment. A failed reconciliation is also treated as ambiguous.
+    async fn bolt12_binding_may_be_live_after_xpay_error(
+        &self,
+        cln_client: &mut ClnRpc,
+        payment_hash: &[u8; 32],
+        xpay_error: &cln_rpc::RpcError,
+    ) -> bool {
+        if xpay_error.code.is_none() {
+            return true;
+        }
+
+        match cln_client
+            .call_typed(&ListpaysRequest {
+                payment_hash: Some(*Sha256::from_bytes_ref(payment_hash)),
+                bolt11: None,
+                status: None,
+                start: None,
+                index: None,
+                limit: None,
+            })
+            .await
+        {
+            Ok(response) => {
+                should_retain_bolt12_binding_after_xpay_error(xpay_error, Some(&response.pays))
+            }
+            Err(err) => {
+                tracing::warn!(
+                    payment_hash = %hex::encode(payment_hash),
+                    "Could not query listpays after BOLT12 xpay error: {err}"
+                );
+                true
+            }
+        }
+    }
+
+    /// Atomically removes the binding only if it still names `payment_hash`.
+    async fn delete_bolt12_quote_payment_hash_if_equals(
+        &self,
+        quote_id: &QuoteId,
+        payment_hash: &[u8; 32],
+    ) -> Result<bool, Error> {
+        let key = Self::bolt12_quote_payment_hash_key(quote_id)?;
+        let expected = hex::encode(payment_hash);
+        let mut tx = self
+            .kv_store
+            .begin_transaction()
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        let claimed = tx
+            .kv_write_if_equals(
+                CLN_KV_PRIMARY_NAMESPACE,
+                CLN_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+                &key,
+                expected.as_bytes(),
+                CLN_KV_BOLT12_CLEANUP_MARKER,
+            )
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?;
+
+        if !claimed {
+            tx.rollback()
+                .await
+                .map_err(|e| Error::Database(e.to_string()))?;
+            return Ok(false);
+        }
+
+        tx.kv_remove(
             CLN_KV_PRIMARY_NAMESPACE,
             CLN_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
             &key,
-            value.as_bytes(),
         )
         .await
         .map_err(|e| Error::Database(e.to_string()))?;
@@ -883,7 +1057,7 @@ impl Cln {
             .await
             .map_err(|e| Error::Database(e.to_string()))?;
 
-        Ok(())
+        Ok(true)
     }
 
     async fn read_bolt12_quote_payment_hash(
@@ -1036,6 +1210,23 @@ enum Bolt12QuotePaymentHashLookup {
     Found([u8; 32]),
     Missing,
     Malformed,
+}
+
+/// Whether an `xpay` error and the reconciled CLN payment records require the
+/// BOLT12 quote binding to be retained.
+fn should_retain_bolt12_binding_after_xpay_error(
+    xpay_error: &cln_rpc::RpcError,
+    payments: Option<&[ListpaysPays]>,
+) -> bool {
+    xpay_error.code.is_none()
+        || payments.is_none_or(|payments| {
+            payments.iter().any(|payment| {
+                matches!(
+                    payment.status,
+                    ListpaysPaysStatus::PENDING | ListpaysPaysStatus::COMPLETE
+                )
+            })
+        })
 }
 
 fn cln_pays_status_to_mint_state(status: ListpaysPaysStatus) -> MeltQuoteState {
@@ -1534,18 +1725,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bolt12_quote_payment_hash_write_overwrites_existing_mapping() {
+    async fn bolt12_quote_payment_hash_repeat_of_same_hash_is_idempotent() {
         let cln = test_cln_with_memory_kv();
         let quote_id = QuoteId::new();
-        let first_payment_hash = [1; 32];
-        let second_payment_hash = [2; 32];
+        let payment_hash = [1; 32];
 
-        cln.write_bolt12_quote_payment_hash(&quote_id, &first_payment_hash)
+        cln.write_bolt12_quote_payment_hash(&quote_id, &payment_hash)
             .await
             .expect("first payment hash should be written");
-        cln.write_bolt12_quote_payment_hash(&quote_id, &second_payment_hash)
+        cln.write_bolt12_quote_payment_hash(&quote_id, &payment_hash)
             .await
-            .expect("second payment hash should be written");
+            .expect("repeating the same payment hash must succeed for recovery");
 
         let stored_payment_hash = cln
             .read_bolt12_quote_payment_hash(&quote_id)
@@ -1554,7 +1744,111 @@ mod tests {
 
         assert_eq!(
             stored_payment_hash,
-            Bolt12QuotePaymentHashLookup::Found(second_payment_hash)
+            Bolt12QuotePaymentHashLookup::Found(payment_hash)
+        );
+    }
+
+    #[tokio::test]
+    async fn bolt12_quote_payment_hash_binding_is_write_once() {
+        let cln = test_cln_with_memory_kv();
+        let quote_id = QuoteId::new();
+        let first_payment_hash = [1; 32];
+        let second_payment_hash = [2; 32];
+
+        cln.write_bolt12_quote_payment_hash(&quote_id, &first_payment_hash)
+            .await
+            .expect("first payment hash should be written");
+
+        let err = cln
+            .write_bolt12_quote_payment_hash(&quote_id, &second_payment_hash)
+            .await
+            .expect_err("a conflicting payment hash must be rejected");
+        assert!(
+            matches!(err, Error::Bolt12QuoteBindingConflict { .. }),
+            "unexpected error: {err}"
+        );
+
+        let stored_payment_hash = cln
+            .read_bolt12_quote_payment_hash(&quote_id)
+            .await
+            .expect("payment hash should be read");
+
+        assert_eq!(
+            stored_payment_hash,
+            Bolt12QuotePaymentHashLookup::Found(first_payment_hash),
+            "the first binding must be retained"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_bolt12_binding_can_be_released_without_removing_a_retry() {
+        let cln = test_cln_with_memory_kv();
+        let quote_id = QuoteId::new();
+        let failed_payment_hash = [1; 32];
+        let retry_payment_hash = [2; 32];
+
+        cln.write_bolt12_quote_payment_hash(&quote_id, &failed_payment_hash)
+            .await
+            .expect("failed payment hash should be written");
+        assert!(cln
+            .delete_bolt12_quote_payment_hash_if_equals(&quote_id, &failed_payment_hash)
+            .await
+            .expect("failed binding should be released"));
+
+        cln.write_bolt12_quote_payment_hash(&quote_id, &retry_payment_hash)
+            .await
+            .expect("retry should claim the released quote");
+        assert!(!cln
+            .delete_bolt12_quote_payment_hash_if_equals(&quote_id, &failed_payment_hash)
+            .await
+            .expect("stale cleanup should be checked atomically"));
+
+        assert_eq!(
+            cln.read_bolt12_quote_payment_hash(&quote_id)
+                .await
+                .expect("retry binding should remain readable"),
+            Bolt12QuotePaymentHashLookup::Found(retry_payment_hash),
+            "stale failed-payment cleanup must not remove a newer retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn bolt12_quote_payment_hash_concurrent_claims_have_single_winner() {
+        let kv_store = Arc::new(MemoryKvStore::default());
+        let first_cln = test_cln_with_kv(kv_store.clone());
+        let second_cln = test_cln_with_kv(kv_store);
+        let quote_id = QuoteId::new();
+        let first_payment_hash = [1; 32];
+        let second_payment_hash = [2; 32];
+
+        let (first_result, second_result) = tokio::join!(
+            first_cln.write_bolt12_quote_payment_hash(&quote_id, &first_payment_hash),
+            second_cln.write_bolt12_quote_payment_hash(&quote_id, &second_payment_hash),
+        );
+
+        let outcomes = [&first_result, &second_result];
+        let winners = outcomes.iter().filter(|result| result.is_ok()).count();
+        let conflicts = outcomes
+            .iter()
+            .filter(|result| matches!(result, Err(Error::Bolt12QuoteBindingConflict { .. })))
+            .count();
+
+        assert_eq!(winners, 1, "exactly one dispatch may claim the quote");
+        assert_eq!(conflicts, 1, "the losing dispatch must be rejected");
+
+        let winner_hash = if first_result.is_ok() {
+            first_payment_hash
+        } else {
+            second_payment_hash
+        };
+        let stored_payment_hash = first_cln
+            .read_bolt12_quote_payment_hash(&quote_id)
+            .await
+            .expect("payment hash should be read");
+        assert_eq!(
+            stored_payment_hash,
+            Bolt12QuotePaymentHashLookup::Found(winner_hash),
+            "the stored binding must belong to the winning dispatch"
         );
     }
 
@@ -1568,6 +1862,53 @@ mod tests {
 
         assert_eq!(selected.status, ListpaysPaysStatus::PENDING);
         assert_eq!(selected.payment_hash, *Sha256::from_bytes_ref(&[2; 32]));
+    }
+
+    #[test]
+    fn xpay_error_reconciliation_retains_ambiguous_bindings() {
+        let transport_error = cln_rpc::RpcError {
+            code: None,
+            message: "no response from lightningd".to_string(),
+            data: None,
+        };
+        let coded_error = cln_rpc::RpcError {
+            code: Some(209),
+            message: "other payment error".to_string(),
+            data: None,
+        };
+        let already_paid_error = cln_rpc::RpcError {
+            code: Some(219),
+            message: "invoice already paid".to_string(),
+            data: None,
+        };
+        let pending = [test_listpays_payment(1, ListpaysPaysStatus::PENDING)];
+        let complete = [test_listpays_payment(2, ListpaysPaysStatus::COMPLETE)];
+        let failed = [test_listpays_payment(3, ListpaysPaysStatus::FAILED)];
+
+        assert!(should_retain_bolt12_binding_after_xpay_error(
+            &transport_error,
+            Some(&failed)
+        ));
+        assert!(should_retain_bolt12_binding_after_xpay_error(
+            &coded_error,
+            None
+        ));
+        assert!(should_retain_bolt12_binding_after_xpay_error(
+            &coded_error,
+            Some(&pending)
+        ));
+        assert!(should_retain_bolt12_binding_after_xpay_error(
+            &already_paid_error,
+            Some(&complete)
+        ));
+        assert!(!should_retain_bolt12_binding_after_xpay_error(
+            &coded_error,
+            Some(&failed)
+        ));
+        assert!(!should_retain_bolt12_binding_after_xpay_error(
+            &coded_error,
+            Some(&[])
+        ));
     }
 
     #[test]

--- a/crates/cdk-ldk-node/src/error.rs
+++ b/crates/cdk-ldk-node/src/error.rs
@@ -33,6 +33,13 @@ pub enum Error {
     #[error("Invalid quote id")]
     InvalidQuoteId,
 
+    /// BOLT12 quote already has a dispatch claim or recorded payment id
+    #[error("BOLT12 quote {quote_id} is already claimed")]
+    Bolt12QuoteAlreadyClaimed {
+        /// Quote id whose dispatch claim was rejected
+        quote_id: String,
+    },
+
     /// Database error
     #[error("Database error: {0}")]
     Database(String),

--- a/crates/cdk-ldk-node/src/lib.rs
+++ b/crates/cdk-ldk-node/src/lib.rs
@@ -48,6 +48,7 @@ const LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE: &str = "bolt12_outgoing_paymen
 const PAYMENT_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Capacity for terminal outgoing payment notifications
 const PAYMENT_EVENT_CHANNEL_CAPACITY: usize = 64;
+const LDK_KV_BOLT12_CLEANUP_MARKER: &[u8] = b"cleanup-in-progress";
 
 /// Result of looking up the payment id recorded for a bolt12 melt quote
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -379,15 +380,27 @@ impl CdkLdkNode {
         SocketAddr::from(([127, 0, 0, 1], 8091))
     }
 
-    /// Best-effort removal of the pre-dispatch sentinel after a send that did
-    /// not dispatch. If removal fails the sentinel remains and the payment
-    /// resolves as `Pending`, keeping the melt proofs reserved.
-    async fn cleanup_bolt12_dispatch_sentinel(&self, quote_id: &QuoteId) {
-        if let Err(err) = delete_bolt12_quote_payment_id(&self.kv_store, quote_id).await {
-            tracing::warn!(
-                "Could not remove BOLT12 dispatch sentinel for quote {quote_id}: {err}. \
-                 The payment will remain Pending."
-            );
+    /// Best-effort release of an exact sentinel or payment-id binding that is
+    /// known not to represent an in-flight or successful payment.
+    async fn cleanup_bolt12_dispatch_binding(
+        &self,
+        quote_id: &QuoteId,
+        payment_id: Option<&PaymentId>,
+    ) {
+        match delete_bolt12_quote_payment_id_if_equals(&self.kv_store, quote_id, payment_id).await {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::debug!(
+                    quote_id = %quote_id,
+                    "BOLT12 dispatch binding changed before cleanup"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    quote_id = %quote_id,
+                    "Could not release BOLT12 dispatch binding: {err}"
+                );
+            }
         }
     }
 
@@ -1120,11 +1133,13 @@ impl MintPayment for CdkLdkNode {
                     }
                 };
 
-                // Write the pre-dispatch sentinel before attempting the send so
-                // a crash during dispatch is distinguishable from "never
-                // dispatched" (mirrors cdk-cln's pre-dispatch bolt12 quote
-                // mapping). The payment must not be attempted unless this
-                // marker is durable.
+                // Claim the quote with an absent-only sentinel write before
+                // attempting the send: a duplicate or concurrent dispatch for
+                // the same quote is rejected here, before any funds move. The
+                // sentinel also keeps a crash during dispatch distinguishable
+                // from "never dispatched" (mirrors cdk-cln's pre-dispatch
+                // bolt12 quote mapping). The payment must not be attempted
+                // unless this marker is durable.
                 write_bolt12_quote_payment_id(&self.kv_store, &quote_id, None).await?;
 
                 // BOLT12 payment ids are assigned by `send`, so subscribe
@@ -1146,7 +1161,7 @@ impl MintPayment for CdkLdkNode {
                         .bolt12_payment()
                         .send(&offer, None, None, send_params),
                     _ => {
-                        self.cleanup_bolt12_dispatch_sentinel(&quote_id).await;
+                        self.cleanup_bolt12_dispatch_binding(&quote_id, None).await;
                         return Err(payment::Error::UnsupportedPaymentOption);
                     }
                 };
@@ -1163,7 +1178,7 @@ impl MintPayment for CdkLdkNode {
                                 );
                             }
                             false => {
-                                self.cleanup_bolt12_dispatch_sentinel(&quote_id).await;
+                                self.cleanup_bolt12_dispatch_binding(&quote_id, None).await;
                             }
                         }
                         return Err(Error::LdkNode(err).into());
@@ -1171,7 +1186,8 @@ impl MintPayment for CdkLdkNode {
                 };
 
                 // Record the payment id so QuoteId lookups resolve to the
-                // dispatched payment. Best-effort: if this write fails the
+                // dispatched payment. The write is conditional on owning the
+                // dispatch claim. Best-effort: if this write fails the
                 // sentinel remains and the payment resolves as Pending, keeping
                 // the melt proofs reserved.
                 if let Err(err) =
@@ -1196,6 +1212,8 @@ impl MintPayment for CdkLdkNode {
                         payment_kind = ?payment_details.kind,
                         "Bolt12 payment failed"
                     );
+                    self.cleanup_bolt12_dispatch_binding(&quote_id, Some(&payment_id))
+                        .await;
                 }
 
                 Self::make_payment_response_from_details(
@@ -1390,6 +1408,13 @@ impl MintPayment for CdkLdkNode {
             return Err(Error::InvalidPaymentDirection.into());
         }
 
+        if payment_details.status == PaymentStatus::Failed {
+            if let PaymentIdentifier::QuoteId(quote_id) = request_lookup_id {
+                self.cleanup_bolt12_dispatch_binding(quote_id, Some(&payment_details.id))
+                    .await;
+            }
+        }
+
         Self::make_payment_response_from_details(
             &CurrencyUnit::Msat,
             request_lookup_id.clone(),
@@ -1416,10 +1441,10 @@ fn bolt12_quote_payment_id_key(quote_id: &QuoteId) -> Result<String, Error> {
 
 /// Records the bolt12 melt quote id -> payment id mapping.
 ///
-/// `payment_id` of `None` writes the pre-dispatch sentinel: it marks that
-/// `send` is about to be attempted so a crash during dispatch is
-/// distinguishable from "never dispatched" (mirrors cdk-cln's pre-dispatch
-/// bolt12 quote mapping).
+/// `payment_id` of `None` atomically claims an absent quote with the
+/// pre-dispatch sentinel. `Some` atomically replaces that sentinel with the
+/// dispatched payment id. Repeating the same payment id is idempotent; every
+/// other existing binding is rejected.
 async fn write_bolt12_quote_payment_id(
     kv_store: &DynKVStore,
     quote_id: &QuoteId,
@@ -1432,19 +1457,54 @@ async fn write_bolt12_quote_payment_id(
         .await
         .map_err(|e| Error::Database(e.to_string()))?;
 
-    tx.kv_write(
-        LDK_KV_PRIMARY_NAMESPACE,
-        LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
-        &key,
-        value.as_bytes(),
-    )
-    .await
+    let written = match payment_id {
+        None => {
+            tx.kv_write_if_absent(
+                LDK_KV_PRIMARY_NAMESPACE,
+                LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+                &key,
+                value.as_bytes(),
+            )
+            .await
+        }
+        Some(_) => {
+            tx.kv_write_if_equals(
+                LDK_KV_PRIMARY_NAMESPACE,
+                LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+                &key,
+                b"",
+                value.as_bytes(),
+            )
+            .await
+        }
+    }
     .map_err(|e| Error::Database(e.to_string()))?;
-    tx.commit()
+
+    if written {
+        tx.commit()
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?;
+        return Ok(());
+    }
+
+    let existing = tx
+        .kv_read(
+            LDK_KV_PRIMARY_NAMESPACE,
+            LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+            &key,
+        )
+        .await
+        .map_err(|e| Error::Database(e.to_string()))?;
+    tx.rollback()
         .await
         .map_err(|e| Error::Database(e.to_string()))?;
 
-    Ok(())
+    match existing {
+        Some(existing) if payment_id.is_some() && existing.as_slice() == value.as_bytes() => Ok(()),
+        _ => Err(Error::Bolt12QuoteAlreadyClaimed {
+            quote_id: quote_id.to_string(),
+        }),
+    }
 }
 
 /// Reads the bolt12 melt quote id -> payment id mapping
@@ -1500,16 +1560,37 @@ async fn read_bolt12_quote_payment_id(
     Ok(Bolt12QuotePaymentIdLookup::Found(PaymentId(payment_id)))
 }
 
-/// Removes the bolt12 melt quote id -> payment id mapping
-async fn delete_bolt12_quote_payment_id(
+/// Atomically removes the bolt12 quote binding only if it still matches the
+/// expected sentinel (`None`) or payment id (`Some`).
+async fn delete_bolt12_quote_payment_id_if_equals(
     kv_store: &DynKVStore,
     quote_id: &QuoteId,
-) -> Result<(), Error> {
+    payment_id: Option<&PaymentId>,
+) -> Result<bool, Error> {
     let key = bolt12_quote_payment_id_key(quote_id)?;
+    let expected = payment_id.map(|id| hex::encode(id.0)).unwrap_or_default();
     let mut tx = kv_store
         .begin_transaction()
         .await
         .map_err(|e| Error::Database(e.to_string()))?;
+
+    let claimed = tx
+        .kv_write_if_equals(
+            LDK_KV_PRIMARY_NAMESPACE,
+            LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+            &key,
+            expected.as_bytes(),
+            LDK_KV_BOLT12_CLEANUP_MARKER,
+        )
+        .await
+        .map_err(|e| Error::Database(e.to_string()))?;
+
+    if !claimed {
+        tx.rollback()
+            .await
+            .map_err(|e| Error::Database(e.to_string()))?;
+        return Ok(false);
+    }
 
     tx.kv_remove(
         LDK_KV_PRIMARY_NAMESPACE,
@@ -1522,7 +1603,7 @@ async fn delete_bolt12_quote_payment_id(
         .await
         .map_err(|e| Error::Database(e.to_string()))?;
 
-    Ok(())
+    Ok(true)
 }
 
 #[cfg(test)]
@@ -1788,9 +1869,9 @@ mod tests {
         std::sync::Arc::new(cdk_sqlite::mint::memory::empty().await.unwrap())
     }
 
-    /// The mapping must resolve Missing before any dispatch, Found after the
-    /// payment id is recorded, and Dispatching (indeterminate) while only the
-    /// pre-dispatch sentinel exists.
+    /// The mapping must resolve Missing before any dispatch, Dispatching
+    /// (indeterminate) while only the pre-dispatch sentinel exists, and Found
+    /// after the payment id is recorded.
     #[tokio::test]
     async fn bolt12_quote_payment_id_mapping_lifecycle() {
         let kv_store = test_kv_store().await;
@@ -1816,6 +1897,16 @@ mod tests {
             "sentinel must resolve as indeterminate, never terminal"
         );
 
+        assert!(
+            delete_bolt12_quote_payment_id_if_equals(&kv_store, &quote_id, None)
+                .await
+                .unwrap(),
+            "an unambiguous pre-dispatch failure should release its sentinel"
+        );
+        write_bolt12_quote_payment_id(&kv_store, &quote_id, None)
+            .await
+            .expect("a retry should reclaim the quote after sentinel cleanup");
+
         // Record the payment id
         let payment_id = PaymentId([7; 32]);
         write_bolt12_quote_payment_id(&kv_store, &quote_id, Some(&payment_id))
@@ -1829,14 +1920,163 @@ mod tests {
         );
 
         // Removal returns to Missing (failed dispatch cleanup)
-        delete_bolt12_quote_payment_id(&kv_store, &quote_id)
-            .await
-            .unwrap();
+        assert!(
+            delete_bolt12_quote_payment_id_if_equals(&kv_store, &quote_id, Some(&payment_id))
+                .await
+                .unwrap()
+        );
         assert_eq!(
             read_bolt12_quote_payment_id(&kv_store, &quote_id)
                 .await
                 .unwrap(),
             Bolt12QuotePaymentIdLookup::Missing
+        );
+    }
+
+    #[tokio::test]
+    async fn bolt12_quote_payment_id_binding_is_write_once() {
+        let kv_store = test_kv_store().await;
+        let quote_id = QuoteId::new();
+        let payment_id = PaymentId([7; 32]);
+        let conflicting_payment_id = PaymentId([9; 32]);
+
+        write_bolt12_quote_payment_id(&kv_store, &quote_id, None)
+            .await
+            .expect("first dispatch should claim the quote");
+        write_bolt12_quote_payment_id(&kv_store, &quote_id, Some(&payment_id))
+            .await
+            .expect("the claim owner should record its payment id");
+        write_bolt12_quote_payment_id(&kv_store, &quote_id, Some(&payment_id))
+            .await
+            .expect("repeating the same payment id must be idempotent");
+
+        let duplicate_dispatch = write_bolt12_quote_payment_id(&kv_store, &quote_id, None)
+            .await
+            .expect_err("a dispatched quote must not be claimed again");
+        assert!(
+            matches!(duplicate_dispatch, Error::Bolt12QuoteAlreadyClaimed { .. }),
+            "unexpected error: {duplicate_dispatch}"
+        );
+
+        let conflicting_binding =
+            write_bolt12_quote_payment_id(&kv_store, &quote_id, Some(&conflicting_payment_id))
+                .await
+                .expect_err("a conflicting payment id must be rejected");
+        assert!(
+            matches!(conflicting_binding, Error::Bolt12QuoteAlreadyClaimed { .. }),
+            "unexpected error: {conflicting_binding}"
+        );
+
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .expect("payment id should remain readable"),
+            Bolt12QuotePaymentIdLookup::Found(payment_id),
+            "a duplicate dispatch must not redirect recovery"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_bolt12_binding_can_be_released_without_removing_a_retry() {
+        let kv_store = test_kv_store().await;
+        let quote_id = QuoteId::new();
+        let failed_payment_id = PaymentId([7; 32]);
+        let retry_payment_id = PaymentId([9; 32]);
+
+        write_bolt12_quote_payment_id(&kv_store, &quote_id, None)
+            .await
+            .expect("failed dispatch should claim the quote");
+        write_bolt12_quote_payment_id(&kv_store, &quote_id, Some(&failed_payment_id))
+            .await
+            .expect("failed payment id should be recorded");
+        assert!(delete_bolt12_quote_payment_id_if_equals(
+            &kv_store,
+            &quote_id,
+            Some(&failed_payment_id),
+        )
+        .await
+        .expect("failed binding should be released"));
+
+        write_bolt12_quote_payment_id(&kv_store, &quote_id, None)
+            .await
+            .expect("retry should claim the released quote");
+        write_bolt12_quote_payment_id(&kv_store, &quote_id, Some(&retry_payment_id))
+            .await
+            .expect("retry payment id should be recorded");
+        assert!(!delete_bolt12_quote_payment_id_if_equals(
+            &kv_store,
+            &quote_id,
+            Some(&failed_payment_id),
+        )
+        .await
+        .expect("stale cleanup should be checked atomically"));
+
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .expect("retry binding should remain readable"),
+            Bolt12QuotePaymentIdLookup::Found(retry_payment_id),
+            "stale failed-payment cleanup must not remove a newer retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn bolt12_quote_dispatch_concurrent_claims_have_single_winner() {
+        let kv_store = test_kv_store().await;
+        let quote_id = QuoteId::new();
+
+        let (first_result, second_result) = tokio::join!(
+            write_bolt12_quote_payment_id(&kv_store, &quote_id, None),
+            write_bolt12_quote_payment_id(&kv_store, &quote_id, None),
+        );
+
+        let outcomes = [first_result, second_result];
+        let winners = outcomes.iter().filter(|result| result.is_ok()).count();
+        let conflicts = outcomes
+            .iter()
+            .filter(|result| matches!(result, Err(Error::Bolt12QuoteAlreadyClaimed { .. })))
+            .count();
+
+        assert_eq!(winners, 1, "exactly one dispatch may claim the quote");
+        assert_eq!(conflicts, 1, "the losing dispatch must be rejected");
+    }
+
+    #[tokio::test]
+    async fn bolt12_quote_payment_id_concurrent_resolution_has_single_winner() {
+        let kv_store = test_kv_store().await;
+        let quote_id = QuoteId::new();
+        let first_payment_id = PaymentId([7; 32]);
+        let second_payment_id = PaymentId([9; 32]);
+
+        write_bolt12_quote_payment_id(&kv_store, &quote_id, None)
+            .await
+            .expect("dispatch should claim the quote");
+
+        let (first_result, second_result) = tokio::join!(
+            write_bolt12_quote_payment_id(&kv_store, &quote_id, Some(&first_payment_id)),
+            write_bolt12_quote_payment_id(&kv_store, &quote_id, Some(&second_payment_id)),
+        );
+
+        let outcomes = [&first_result, &second_result];
+        let winners = outcomes.iter().filter(|result| result.is_ok()).count();
+        let conflicts = outcomes
+            .iter()
+            .filter(|result| matches!(result, Err(Error::Bolt12QuoteAlreadyClaimed { .. })))
+            .count();
+
+        assert_eq!(winners, 1, "exactly one payment id may resolve the claim");
+        assert_eq!(conflicts, 1, "the losing resolution must be rejected");
+
+        let winner = if first_result.is_ok() {
+            first_payment_id
+        } else {
+            second_payment_id
+        };
+        assert_eq!(
+            read_bolt12_quote_payment_id(&kv_store, &quote_id)
+                .await
+                .expect("payment id should remain readable"),
+            Bolt12QuotePaymentIdLookup::Found(winner)
         );
     }
 


### PR DESCRIPTION
### Summary

Make CLN and LDK-node BOLT12 quote bindings write-once so retries remain idempotent and concurrent backend calls cannot dispatch more than one payment for the same quote.

The normal mint flow already serializes quote dispatch. This change also enforces that invariant at the payment-backend boundary, making recovery safe for retries, direct backend use, and future call paths.

### Root cause

Both backends stored quote ownership with unconditional KV overwrites:

- CLN mapped a mint-generated `quote_id` to a payment hash after fetching an invoice;
- LDK-node mapped a `quote_id` first to a `Dispatching` sentinel and then to the resolved payment ID.

A duplicate or concurrent backend call could replace those mappings, dispatch another payment, and leave recovery following only the last stored value.

### Approach

#### CLN

- Claim the quote-to-payment-hash binding with `kv_write_if_absent`.
- Treat an existing identical hash as an idempotent success.
- Reject a different hash before fetching or paying a second invoice.
- Propagate the conflict from `make_payment`.

#### LDK-node

- Claim `Dispatching` with an absent-only write.
- Reject an existing sentinel or resolved payment ID.
- Resolve `Dispatching` to the payment ID with `kv_write_if_equals`.
- Accept an idempotent repeat of the same resolved payment ID and reject conflicts.

### PR stack

This PR contains only the payment-backend changes and depends on #2377.

- #2377: conditional KV primitives → `main`
- #2378: sibling BDK atomic reservations → #2377
- **This PR:** CLN/LDK BOLT12 write-once bindings → #2377

Review this PR against `kvstore_conditional_writes`; it does not depend on #2378. After #2377 merges, this PR can be retargeted to `main`.

### Testing

- CLN repeated, conflicting, and concurrent binding tests
- LDK-node duplicate claim, idempotent/conflicting binding, concurrent claim, and concurrent resolution tests
- `just quick-check`

### Suggested CHANGELOG

#### FIXED

- Make CLN and LDK-node BOLT12 payment dispatch idempotent per quote.

### Checklist

- [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
- [x] I ran `just quick-check` before committing
- [x] FFI changes are not required; this does not modify the public Wallet API

Closes project-loupe/audit-cdk#419
Closes project-loupe/audit-cdk#464
