### PR TITLE
Sign arbitrary payloads with the identity key

### DIFF
--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -476,6 +476,9 @@ pub enum Error {
     /// Subscription error
     #[error("Subscription error: {0}")]
     SubscriptionError(String),
+    /// Mint identity key derivation exhausted its counter
+    #[error("Mint identity key derivation failed")]
+    IdentityKeyDerivation,
     /// Custom Error
     #[error("`{0}`")]
     Custom(String),

--- a/crates/cdk-mintd/src/config_service.rs
+++ b/crates/cdk-mintd/src/config_service.rs
@@ -302,27 +302,37 @@ impl ConfigurationService {
 pub(crate) fn discover_signing_identity(
     settings: &Settings,
 ) -> Result<SigningIdentity, ConfigurationServiceError> {
-    let pubkey = if settings.enabled_signatory().is_some() {
+    if settings.enabled_signatory().is_some() {
         return Err(ConfigurationServiceError::SigningIdentity(
             "remote signatory identity requires asynchronous validation".to_owned(),
         ));
-    } else if let Some(seed) = settings
+    }
+    let seed = local_seed(settings)?.ok_or_else(|| {
+        ConfigurationServiceError::SigningIdentity(
+            "no local signing source is configured".to_owned(),
+        )
+    })?;
+    Ok(signing_identity_from_pubkey(root_pubkey(&seed)?))
+}
+
+/// Seed bytes the local signatory would be built from, if one is configured.
+fn local_seed(settings: &Settings) -> Result<Option<Vec<u8>>, ConfigurationServiceError> {
+    if let Some(seed) = settings
         .info
         .seed
         .as_deref()
         .filter(|seed| !seed.is_empty())
     {
-        root_pubkey(seed.as_bytes())?
-    } else if let Some(mnemonic) = settings.info.mnemonic.as_deref() {
-        let mnemonic = Mnemonic::from_str(mnemonic)
-            .map_err(|error| ConfigurationServiceError::SigningIdentity(error.to_string()))?;
-        root_pubkey(&mnemonic.to_seed_normalized(""))?
-    } else {
-        return Err(ConfigurationServiceError::SigningIdentity(
-            "no local signing source is configured".to_owned(),
-        ));
-    };
-    Ok(signing_identity_from_pubkey(pubkey))
+        return Ok(Some(seed.as_bytes().to_vec()));
+    }
+    match settings.info.mnemonic.as_deref() {
+        Some(mnemonic) => {
+            let mnemonic = Mnemonic::from_str(mnemonic)
+                .map_err(|error| ConfigurationServiceError::SigningIdentity(error.to_string()))?;
+            Ok(Some(mnemonic.to_seed_normalized("").to_vec()))
+        }
+        None => Ok(None),
+    }
 }
 
 /// Resolves the signer, including a configured remote signatory.
@@ -363,6 +373,15 @@ async fn resolve_signing_identity_async(
 }
 
 fn root_pubkey(seed: &[u8]) -> Result<cdk::nuts::PublicKey, ConfigurationServiceError> {
+    Ok(cdk_signatory::identity::derive_identity_key(seed)
+        .map_err(|error| ConfigurationServiceError::SigningIdentity(error.to_string()))?
+        .public_key())
+}
+
+/// Identity key mintd published before it derived one per NUT-06: the BIP-32
+/// master pubkey. Recognized only so an upgrade whose config still pins it can
+/// start.
+fn legacy_root_pubkey(seed: &[u8]) -> Result<cdk::nuts::PublicKey, ConfigurationServiceError> {
     let secp = Secp256k1::new();
     let xpriv = Xpriv::new_master(Network::Bitcoin, seed)
         .map_err(|error| ConfigurationServiceError::SigningIdentity(error.to_string()))?;
@@ -382,14 +401,35 @@ fn validate_authored_mint_pubkey(
     settings: &Settings,
     signing_identity: &SigningIdentity,
 ) -> Result<(), ConfigurationServiceError> {
-    if settings
-        .mint_info
-        .pubkey
-        .is_some_and(|pubkey| pubkey != signing_identity.pubkey)
-    {
-        return Err(ConfigurationServiceError::SigningIdentityChange);
+    let Some(authored) = settings.mint_info.pubkey else {
+        return Ok(());
+    };
+    if authored == signing_identity.pubkey {
+        return Ok(());
     }
-    Ok(())
+    if is_legacy_identity(settings, &authored)? {
+        tracing::warn!(
+            legacy = %authored,
+            current = %signing_identity.pubkey,
+            "mint_info.pubkey pins the pre-NUT-06 identity key; starting with the derived one. \
+             Update the configuration to the current key."
+        );
+        return Ok(());
+    }
+    Err(ConfigurationServiceError::SigningIdentityChange)
+}
+
+/// Whether `pubkey` is what this seed produced under the pre-NUT-06 derivation.
+/// A remote signatory leaves mintd without a seed, so there is nothing to
+/// compare against and the answer is no.
+fn is_legacy_identity(
+    settings: &Settings,
+    pubkey: &cdk::nuts::PublicKey,
+) -> Result<bool, ConfigurationServiceError> {
+    match local_seed(settings)? {
+        Some(seed) => Ok(legacy_root_pubkey(&seed)? == *pubkey),
+        None => Ok(false),
+    }
 }
 
 fn same_primary_database(configured: &Database, bootstrap: &Database) -> bool {
@@ -1385,6 +1425,48 @@ engine = "sqlite"
             .expect("matching pubkey");
         let _ = std::fs::remove_file(secret_one);
         let _ = std::fs::remove_file(secret_two);
+    }
+
+    #[cfg(feature = "fakewallet")]
+    #[tokio::test]
+    async fn authored_mint_pubkey_may_still_pin_the_pre_nut06_identity() {
+        let secret = crate::test_utils::unique_temp_path("legacy_pubkey_config_secret");
+        std::fs::write(&secret, TEST_MNEMONIC_ONE).expect("write signing secret");
+
+        let mnemonic = Mnemonic::from_str(TEST_MNEMONIC_ONE).expect("parse mnemonic");
+        let seed = mnemonic.to_seed_normalized("");
+        let legacy = legacy_root_pubkey(&seed).expect("legacy pubkey");
+        assert_ne!(
+            legacy,
+            root_pubkey(&seed).expect("current pubkey"),
+            "the two derivations must differ or this test proves nothing"
+        );
+
+        let pinned = format!(
+            r#"
+[info]
+mnemonic = "file:{}"
+
+[mint_info]
+name = "legacy"
+pubkey = "{}"
+
+[payment_backend]
+backend = "fakewallet"
+
+[fake_wallet]
+
+[database]
+engine = "sqlite"
+"#,
+            secret.display(),
+            legacy
+        );
+        ConfigurationService::validate_import(&pinned)
+            .await
+            .expect("a config pinning the legacy identity must still start");
+
+        let _ = std::fs::remove_file(secret);
     }
 
     #[test]

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -15,18 +15,20 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use arc_swap::ArcSwap;
 use bitcoin::bip32::{DerivationPath, Xpriv};
+use bitcoin::secp256k1::schnorr::Signature;
 use bitcoin::secp256k1::{self, Secp256k1};
 use cdk_common::database::MintKeyDatabaseTransaction;
 use cdk_common::dhke::{sign_message, verify_message};
 use cdk_common::mint::MintKeySetInfo;
 use cdk_common::nuts::{BlindSignature, BlindedMessage, CurrencyUnit, Id, MintKeySet, Proof};
-use cdk_common::{database, Error, PublicKey};
+use cdk_common::{database, Error, PublicKey, SecretKey};
 use tokio::sync::{watch, Mutex};
 use tracing::instrument;
 
 use crate::common::{
     check_unit_string_collision, create_new_keyset, derivation_path_from_unit, init_keysets,
 };
+use crate::identity;
 use crate::signatory::{RotateKeyArguments, Signatory, SignatoryKeySet, SignatoryKeysets};
 
 /// Immutable in-memory view of the keysets, swapped atomically on every change.
@@ -72,6 +74,9 @@ pub struct DbSignatory {
     supported_units: HashMap<CurrencyUnit, (u64, Vec<u64>)>,
     xpriv: Xpriv,
     xpub: PublicKey,
+    /// Private half of `xpub`, kept as the identity key that signs arbitrary
+    /// payloads. No keyset derives from it directly.
+    identity_key: SecretKey,
     /// Latest keyset snapshot, published on every reload (initial load and each
     /// rotation).
     keyset_updates: watch::Sender<SignatoryKeysets>,
@@ -97,6 +102,7 @@ impl DbSignatory {
         let xpriv = Xpriv::new_master(bitcoin::Network::Bitcoin, seed).expect("RNG busted");
 
         let xpub: PublicKey = xpriv.to_keypair(&secp_ctx).public_key().into();
+        let identity_key: SecretKey = xpriv.private_key.into();
         let (keyset_updates, _) = watch::channel(SignatoryKeysets {
             pubkey: xpub,
             keysets: vec![],
@@ -109,6 +115,7 @@ impl DbSignatory {
             custom_paths,
             supported_units,
             xpub,
+            identity_key,
             secp_ctx,
             xpriv,
             keyset_updates,
@@ -396,6 +403,11 @@ impl Signatory for DbSignatory {
             verify_message(&key_pair.secret_key, proof.c, proof.secret.as_bytes())?;
             Ok(())
         })
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn sign(&self, payload: Vec<u8>) -> Result<Signature, Error> {
+        identity::sign(&self.identity_key, &payload)
     }
 
     #[tracing::instrument(skip_all)]
@@ -726,6 +738,60 @@ mod test {
             "expected ExpiredKeyset error, got: {:?}",
             result
         );
+    }
+
+    #[tokio::test]
+    async fn sign_verifies_against_published_pubkey() {
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let signatory = DbSignatory::new(
+            store,
+            b"test-seed-for-identity-signing",
+            Default::default(),
+            Default::default(),
+        )
+        .await
+        .expect("DbSignatory::new");
+
+        let payload = b"an arbitrary stream of bytes".to_vec();
+        let signature = signatory.sign(payload.clone()).await.expect("sign");
+
+        let keysets = signatory.keysets().await.expect("keysets");
+        identity::verify(&keysets.pubkey, &payload, &signature)
+            .expect("signature must verify against the published pubkey");
+
+        assert!(
+            identity::verify(&keysets.pubkey, b"tampered", &signature).is_err(),
+            "a tampered payload must not verify"
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_key_is_stable_across_instances_with_the_same_seed() {
+        let seed = b"test-seed-for-stable-identity";
+        let make = || async {
+            let store = Arc::new(
+                cdk_sqlite::mint::memory::empty()
+                    .await
+                    .expect("in-memory db"),
+            );
+            DbSignatory::new(store, seed, Default::default(), Default::default())
+                .await
+                .expect("DbSignatory::new")
+        };
+
+        let first = make().await;
+        let second = make().await;
+
+        let payload = b"payload".to_vec();
+        let signature = first.sign(payload.clone()).await.expect("sign");
+        let peer_pubkey = second.keysets().await.expect("keysets").pubkey;
+
+        identity::verify(&peer_pubkey, &payload, &signature)
+            .expect("a peer with the same seed must hold the same identity key");
     }
 
     #[tokio::test]

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -73,10 +73,11 @@ pub struct DbSignatory {
     /// Units to initialize on boot, as `init_keysets` expects them.
     supported_units: HashMap<CurrencyUnit, (u64, Vec<u64>)>,
     xpriv: Xpriv,
-    xpub: PublicKey,
-    /// Private half of `xpub`, kept as the identity key that signs arbitrary
-    /// payloads. No keyset derives from it directly.
+    /// NUT-06 mint identity key, derived from the seed outside the BIP-32 tree
+    /// so no keyset descends from it. Its public half is published as
+    /// `SignatoryKeysets::pubkey`.
     identity_key: SecretKey,
+    identity_pubkey: PublicKey,
     /// Latest keyset snapshot, published on every reload (initial load and each
     /// rotation).
     keyset_updates: watch::Sender<SignatoryKeysets>,
@@ -88,10 +89,6 @@ impl DbSignatory {
     /// The load is attempted once and any error is bubbled up: a failed load
     /// fails construction rather than returning a signatory without keys. On
     /// success the returned signatory is loaded and serving.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the seed produces an invalid master key (should never happen with valid entropy).
     pub async fn new(
         localstore: Arc<dyn database::MintKeysDatabase<Err = database::Error> + Send + Sync>,
         seed: &[u8],
@@ -99,12 +96,12 @@ impl DbSignatory {
         custom_paths: HashMap<CurrencyUnit, DerivationPath>,
     ) -> Result<Self, Error> {
         let secp_ctx = Secp256k1::new();
-        let xpriv = Xpriv::new_master(bitcoin::Network::Bitcoin, seed).expect("RNG busted");
+        let xpriv = Xpriv::new_master(bitcoin::Network::Bitcoin, seed)?;
 
-        let xpub: PublicKey = xpriv.to_keypair(&secp_ctx).public_key().into();
-        let identity_key: SecretKey = xpriv.private_key.into();
+        let identity_key = identity::derive_identity_key(seed)?;
+        let identity_pubkey = identity_key.public_key();
         let (keyset_updates, _) = watch::channel(SignatoryKeysets {
-            pubkey: xpub,
+            pubkey: identity_pubkey,
             keysets: vec![],
         });
 
@@ -114,7 +111,7 @@ impl DbSignatory {
             localstore,
             custom_paths,
             supported_units,
-            xpub,
+            identity_pubkey,
             identity_key,
             secp_ctx,
             xpriv,
@@ -310,7 +307,7 @@ impl DbSignatory {
     fn publish_latest(&self) {
         self.keyset_updates.send_modify(|out| {
             let latest = self.keysets.load();
-            out.pubkey = self.xpub;
+            out.pubkey = self.identity_pubkey;
             out.keysets = latest.by_id.values().map(|k| k.into()).collect();
         });
     }
@@ -331,7 +328,7 @@ impl DbSignatory {
     /// Snapshot the current keysets from memory (lock-free).
     fn keysets_snapshot(&self) -> SignatoryKeysets {
         SignatoryKeysets {
-            pubkey: self.xpub,
+            pubkey: self.identity_pubkey,
             keysets: self
                 .keysets
                 .load()
@@ -766,6 +763,31 @@ mod test {
         assert!(
             identity::verify(&keysets.pubkey, b"tampered", &signature).is_err(),
             "a tampered payload must not verify"
+        );
+    }
+
+    #[tokio::test]
+    async fn published_pubkey_is_not_the_bip32_master() {
+        let seed = b"test-seed-for-identity-signing";
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let signatory = DbSignatory::new(store, seed, Default::default(), Default::default())
+            .await
+            .expect("DbSignatory::new");
+
+        let master: PublicKey = Xpriv::new_master(bitcoin::Network::Bitcoin, seed)
+            .expect("master key")
+            .to_keypair(&Secp256k1::new())
+            .public_key()
+            .into();
+
+        assert_ne!(
+            signatory.keysets().await.expect("keysets").pubkey,
+            master,
+            "the identity key must be derived per NUT-06, not taken from the BIP-32 root"
         );
     }
 

--- a/crates/cdk-signatory/src/embedded.rs
+++ b/crates/cdk-signatory/src/embedded.rs
@@ -2,6 +2,7 @@
 //! run the Signatory in another thread, isolated form the main CDK, communicating through messages
 use std::sync::Arc;
 
+use bitcoin::secp256k1::schnorr::Signature;
 use cdk_common::{BlindSignature, BlindedMessage, Error, Proof};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
@@ -16,6 +17,7 @@ enum Request {
         ),
     ),
     VerifyProof((Vec<Proof>, oneshot::Sender<Result<(), Error>>)),
+    Sign((Vec<u8>, oneshot::Sender<Result<Signature, Error>>)),
     Keysets(oneshot::Sender<Result<SignatoryKeysets, Error>>),
     SubscribeKeysets(oneshot::Sender<Result<watch::Receiver<SignatoryKeysets>, Error>>),
     RotateKeyset(
@@ -79,6 +81,12 @@ impl Service {
                         );
                     }
                 }
+                Request::Sign((payload, response)) => {
+                    let output = handler.sign(payload).await;
+                    if response.send(output).is_err() {
+                        tracing::error!("Error sending sign response: receiver dropped");
+                    }
+                }
                 Request::Keysets(response) => {
                     let output = handler.keysets().await;
                     if response.send(output).is_err() {
@@ -134,6 +142,17 @@ impl Signatory for Service {
     }
 
     #[tracing::instrument(skip_all)]
+    async fn sign(&self, payload: Vec<u8>) -> Result<Signature, Error> {
+        let (tx, rx) = oneshot::channel();
+        self.pipeline
+            .send(Request::Sign((payload, tx)))
+            .await
+            .map_err(|e| Error::SendError(e.to_string()))?;
+
+        rx.await.map_err(|e| Error::RecvError(e.to_string()))?
+    }
+
+    #[tracing::instrument(skip_all)]
     async fn keysets(&self) -> Result<SignatoryKeysets, Error> {
         let (tx, rx) = oneshot::channel();
         self.pipeline
@@ -164,5 +183,38 @@ impl Signatory for Service {
             .map_err(|e| Error::SendError(e.to_string()))?;
 
         rx.await.map_err(|e| Error::RecvError(e.to_string()))?
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::db_signatory::DbSignatory;
+    use crate::identity;
+
+    #[tokio::test]
+    async fn sign_round_trips_through_the_actor() {
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let inner = DbSignatory::new(
+            store,
+            b"test-seed-for-embedded-signing",
+            Default::default(),
+            Default::default(),
+        )
+        .await
+        .expect("DbSignatory::new");
+
+        let service = Service::new(Arc::new(inner));
+
+        let payload = b"an arbitrary stream of bytes".to_vec();
+        let signature = service.sign(payload.clone()).await.expect("sign");
+
+        let pubkey = service.keysets().await.expect("keysets").pubkey;
+        identity::verify(&pubkey, &payload, &signature)
+            .expect("signature must verify against the published pubkey");
     }
 }

--- a/crates/cdk-signatory/src/identity.rs
+++ b/crates/cdk-signatory/src/identity.rs
@@ -1,0 +1,78 @@
+//! Identity signing
+//!
+//! The signatory signs arbitrary payloads with the key whose public half it
+//! already publishes as `SignatoryKeysets::pubkey`. The payload is not signed
+//! bare: it goes through the HMAC-SHA256 construction below first, so a
+//! signature produced here cannot be replayed as a NUT-11 or NUT-20 signature
+//! over the same bytes, nor those as one of these.
+use bitcoin::secp256k1::hashes::{hmac, sha256, Hash, HashEngine, HmacEngine};
+use bitcoin::secp256k1::schnorr::Signature;
+use cdk_common::{Error, PublicKey, SecretKey};
+
+/// Domain separation tag. It is the HMAC key rather than a message prefix so
+/// any verifier can recompute the digest without holding a secret.
+const SIGN_DOMAIN: &[u8] = b"Cashu_Signatory_Sign_v1";
+
+/// Digest that is actually signed, HMAC-SHA256 over the payload keyed by the
+/// domain tag.
+fn signing_digest(payload: &[u8]) -> [u8; 32] {
+    let mut engine = HmacEngine::<sha256::Hash>::new(SIGN_DOMAIN);
+    engine.input(payload);
+    hmac::Hmac::<sha256::Hash>::from_engine(engine).to_byte_array()
+}
+
+/// Sign an arbitrary payload with the signatory's identity key.
+pub fn sign(secret_key: &SecretKey, payload: &[u8]) -> Result<Signature, Error> {
+    Ok(secret_key.sign(&signing_digest(payload))?)
+}
+
+/// Verify a signature produced by [`sign`] against the mint's published pubkey.
+pub fn verify(pubkey: &PublicKey, payload: &[u8], signature: &Signature) -> Result<(), Error> {
+    Ok(pubkey.verify(&signing_digest(payload), signature)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key() -> SecretKey {
+        SecretKey::from_hex("0000000000000000000000000000000000000000000000000000000000000001")
+            .expect("valid secret key")
+    }
+
+    #[test]
+    fn digest_is_stable() {
+        assert_eq!(
+            cdk_common::util::hex::encode(signing_digest(b"an arbitrary stream of bytes")),
+            "a169782208c52b367550e7e123cc908508c82040c999c82a8920dfa64b666fd5"
+        );
+    }
+
+    #[test]
+    fn signature_round_trips() {
+        let key = key();
+        let payload = b"an arbitrary stream of bytes";
+        let signature = sign(&key, payload).expect("sign");
+
+        verify(&key.public_key(), payload, &signature).expect("signature should verify");
+    }
+
+    #[test]
+    fn tampered_payload_does_not_verify() {
+        let key = key();
+        let signature = sign(&key, b"an arbitrary stream of bytes").expect("sign");
+
+        assert!(verify(&key.public_key(), b"tampered", &signature).is_err());
+    }
+
+    #[test]
+    fn domain_separation_rejects_a_bare_signature_over_the_same_bytes() {
+        // A NUT-11 style signature over the raw payload must not pass as an
+        // identity signature over the same bytes.
+        let key = key();
+        let payload = b"an arbitrary stream of bytes";
+        let bare = key.sign(payload).expect("sign");
+
+        assert!(verify(&key.public_key(), payload, &bare).is_err());
+    }
+}

--- a/crates/cdk-signatory/src/identity.rs
+++ b/crates/cdk-signatory/src/identity.rs
@@ -1,78 +1,108 @@
-//! Identity signing
+//! Mint identity key
 //!
-//! The signatory signs arbitrary payloads with the key whose public half it
-//! already publishes as `SignatoryKeysets::pubkey`. The payload is not signed
-//! bare: it goes through the HMAC-SHA256 construction below first, so a
-//! signature produced here cannot be replayed as a NUT-11 or NUT-20 signature
-//! over the same bytes, nor those as one of these.
+//! Derivation and signing for the mint's identity key, the key published as
+//! `SignatoryKeysets::pubkey` and, downstream, as `MintInfo.pubkey`. Both
+//! follow NUT-06 so any wallet holding the published pubkey can verify without
+//! a signatory round trip.
 use bitcoin::secp256k1::hashes::{hmac, sha256, Hash, HashEngine, HmacEngine};
 use bitcoin::secp256k1::schnorr::Signature;
-use cdk_common::{Error, PublicKey, SecretKey};
+use bitcoin::secp256k1::{Keypair, Message};
+use cdk_common::{Error, PublicKey, SecretKey, SECP256K1};
 
-/// Domain separation tag. It is the HMAC key rather than a message prefix so
-/// any verifier can recompute the digest without holding a secret.
-const SIGN_DOMAIN: &[u8] = b"Cashu_Signatory_Sign_v1";
+/// NUT-06 domain separator for the identity key derivation.
+const MINT_IDENTITY_DOMAIN_SEPARATOR: &[u8] = b"Cashu_Mint_Identity_v1";
 
-/// Digest that is actually signed, HMAC-SHA256 over the payload keyed by the
-/// domain tag.
-fn signing_digest(payload: &[u8]) -> [u8; 32] {
-    let mut engine = HmacEngine::<sha256::Hash>::new(SIGN_DOMAIN);
-    engine.input(payload);
-    hmac::Hmac::<sha256::Hash>::from_engine(engine).to_byte_array()
+/// Derive the mint identity key from the mint seed, per NUT-06.
+///
+/// `HMAC-SHA256(key = seed, msg = domain_separator || ctr)`, with `ctr`
+/// incrementing while the result falls outside `1..n-1`.
+pub fn derive_identity_key(seed: &[u8]) -> Result<SecretKey, Error> {
+    for ctr in 0..=u8::MAX {
+        let mut engine = HmacEngine::<sha256::Hash>::new(seed);
+        engine.input(MINT_IDENTITY_DOMAIN_SEPARATOR);
+        engine.input(&[ctr]);
+        let candidate = hmac::Hmac::<sha256::Hash>::from_engine(engine).to_byte_array();
+
+        match SecretKey::from_slice(&candidate) {
+            Ok(secret_key) => return Ok(secret_key),
+            Err(error) => {
+                tracing::debug!(%error, ctr, "identity key candidate out of range, retrying")
+            }
+        }
+    }
+
+    Err(Error::IdentityKeyDerivation)
 }
 
-/// Sign an arbitrary payload with the signatory's identity key.
+/// Sign a payload with the mint identity key, per NUT-06.
+///
+/// BIP-340 over `SHA256(payload)`. The auxiliary randomness is zeroed so the
+/// signature over a given payload is stable across calls and reproduces the
+/// NUT-06 example vector.
 pub fn sign(secret_key: &SecretKey, payload: &[u8]) -> Result<Signature, Error> {
-    Ok(secret_key.sign(&signing_digest(payload))?)
+    let digest = sha256::Hash::hash(payload);
+    let message = Message::from_digest(digest.to_byte_array());
+    let keypair = Keypair::from_secret_key(&SECP256K1, secret_key);
+
+    Ok(SECP256K1.sign_schnorr_no_aux_rand(&message, &keypair))
 }
 
 /// Verify a signature produced by [`sign`] against the mint's published pubkey.
 pub fn verify(pubkey: &PublicKey, payload: &[u8], signature: &Signature) -> Result<(), Error> {
-    Ok(pubkey.verify(&signing_digest(payload), signature)?)
+    Ok(pubkey.verify(payload, signature)?)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn key() -> SecretKey {
-        SecretKey::from_hex("0000000000000000000000000000000000000000000000000000000000000001")
-            .expect("valid secret key")
-    }
-
     #[test]
-    fn digest_is_stable() {
+    fn derivation_matches_the_nut06_vector() {
+        let secret_key = derive_identity_key(b"NUT-06 example mint seed").expect("derive");
+
         assert_eq!(
-            cdk_common::util::hex::encode(signing_digest(b"an arbitrary stream of bytes")),
-            "a169782208c52b367550e7e123cc908508c82040c999c82a8920dfa64b666fd5"
+            secret_key.public_key().to_hex(),
+            "0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da"
         );
     }
 
     #[test]
-    fn signature_round_trips() {
-        let key = key();
-        let payload = b"an arbitrary stream of bytes";
-        let signature = sign(&key, payload).expect("sign");
+    fn derivation_is_deterministic() {
+        let first = derive_identity_key(b"seed").expect("derive");
+        let second = derive_identity_key(b"seed").expect("derive");
 
-        verify(&key.public_key(), payload, &signature).expect("signature should verify");
+        assert_eq!(first.public_key(), second.public_key());
+    }
+
+    #[test]
+    fn signature_is_stable_across_calls() {
+        let secret_key = derive_identity_key(b"seed").expect("derive");
+        let payload = b"an arbitrary stream of bytes";
+
+        assert_eq!(
+            sign(&secret_key, payload).expect("sign").serialize(),
+            sign(&secret_key, payload).expect("sign").serialize()
+        );
+    }
+
+    #[test]
+    fn signature_verifies_with_the_plain_public_key_api() {
+        let secret_key = derive_identity_key(b"seed").expect("derive");
+        let payload = b"an arbitrary stream of bytes";
+        let signature = sign(&secret_key, payload).expect("sign");
+
+        secret_key
+            .public_key()
+            .verify(payload, &signature)
+            .expect("a verifier needs nothing from this crate");
+        verify(&secret_key.public_key(), payload, &signature).expect("verify");
     }
 
     #[test]
     fn tampered_payload_does_not_verify() {
-        let key = key();
-        let signature = sign(&key, b"an arbitrary stream of bytes").expect("sign");
+        let secret_key = derive_identity_key(b"seed").expect("derive");
+        let signature = sign(&secret_key, b"an arbitrary stream of bytes").expect("sign");
 
-        assert!(verify(&key.public_key(), b"tampered", &signature).is_err());
-    }
-
-    #[test]
-    fn domain_separation_rejects_a_bare_signature_over_the_same_bytes() {
-        // A NUT-11 style signature over the raw payload must not pass as an
-        // identity signature over the same bytes.
-        let key = key();
-        let payload = b"an arbitrary stream of bytes";
-        let bare = key.sign(payload).expect("sign");
-
-        assert!(verify(&key.public_key(), payload, &bare).is_err());
+        assert!(verify(&secret_key.public_key(), b"tampered", &signature).is_err());
     }
 }

--- a/crates/cdk-signatory/src/lib.rs
+++ b/crates/cdk-signatory/src/lib.rs
@@ -19,4 +19,5 @@ mod common;
 
 pub mod db_signatory;
 pub mod embedded;
+pub mod identity;
 pub mod signatory;

--- a/crates/cdk-signatory/src/proto/client.rs
+++ b/crates/cdk-signatory/src/proto/client.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use bitcoin::secp256k1::schnorr::Signature;
 use cdk_common::error::Error;
 use cdk_common::grpc::{VersionInterceptor, VERSION_SIGNATORY_HEADER};
 use cdk_common::stream::{BackoffPolicy, SupervisedStream};
@@ -258,6 +259,20 @@ impl Signatory for SignatoryRpcClient {
                 } else {
                     Err(Error::SignatureMissingOrInvalid)
                 }
+            })
+            .map_err(|e| Error::Custom(e.to_string()))?
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn sign(&self, payload: Vec<u8>) -> Result<Signature, Error> {
+        let req = super::SignRequest { payload };
+        self.client
+            .clone()
+            .sign(tonic::Request::new(req))
+            .await
+            .map(|response| {
+                let signature = handle_error!(response, signature, scalar);
+                Signature::from_slice(&signature).map_err(|e| Error::Custom(e.to_string()))
             })
             .map_err(|e| Error::Custom(e.to_string()))?
     }

--- a/crates/cdk-signatory/src/proto/server.rs
+++ b/crates/cdk-signatory/src/proto/server.rs
@@ -119,6 +119,28 @@ where
         Ok(Response::new(result))
     }
 
+    #[tracing::instrument(skip_all)]
+    async fn sign(
+        &self,
+        request: Request<proto::SignRequest>,
+    ) -> Result<Response<proto::SignResponse>, Status> {
+        let metadata = request.metadata();
+        let signatory = self.load_signatory(metadata).await?;
+
+        let result = match signatory.sign(request.into_inner().payload).await {
+            Ok(signature) => proto::SignResponse {
+                signature: signature.serialize().to_vec(),
+                ..Default::default()
+            },
+            Err(err) => proto::SignResponse {
+                error: Some(err.into()),
+                ..Default::default()
+            },
+        };
+
+        Ok(Response::new(result))
+    }
+
     async fn keysets(
         &self,
         request: Request<proto::EmptyRequest>,

--- a/crates/cdk-signatory/src/proto/signatory.proto
+++ b/crates/cdk-signatory/src/proto/signatory.proto
@@ -5,6 +5,8 @@ package signatory;
 service Signatory {
   rpc BlindSign(BlindedMessages) returns (BlindSignResponse);
   rpc VerifyProofs(Proofs) returns (BooleanResponse);
+  // signs an arbitrary payload with the signatory identity key
+  rpc Sign(SignRequest) returns (SignResponse);
   // returns all the keysets for the mint
   rpc Keysets(EmptyRequest) returns (KeysResponse);
   // streams the keysets: the current set is sent on subscribe and again on
@@ -17,7 +19,7 @@ service Signatory {
 enum Constants {
   CONSTANTS_UNSPECIFIED = 0;
   // this constant should be sent on the header of the grpc code for verification
-  CONSTANTS_SCHEMA_VERSION = 2;
+  CONSTANTS_SCHEMA_VERSION = 3;
 }
 
 message BlindSignResponse {
@@ -54,6 +56,16 @@ message KeysResponse {
 message SignatoryKeysets {
   bytes pubkey = 1;
   repeated KeySet keysets = 2;
+}
+
+message SignRequest {
+  bytes payload = 1;
+}
+
+message SignResponse {
+  Error error = 1;
+  // 64-byte BIP340 Schnorr signature
+  bytes signature = 2;
 }
 
 message KeySet {

--- a/crates/cdk-signatory/src/signatory.rs
+++ b/crates/cdk-signatory/src/signatory.rs
@@ -6,6 +6,7 @@
 //! There is an in memory implementation, when the keys are stored in memory, in the same process,
 //! but it is isolated from the rest of the application, and they communicate through a channel with
 //! the defined API.
+use bitcoin::secp256k1::schnorr::Signature;
 use cdk_common::common::IssuerVersion;
 use cdk_common::error::Error;
 use cdk_common::mint::MintKeySetInfo;
@@ -34,7 +35,7 @@ pub struct RotateKeyArguments {
 #[derive(Debug, Clone)]
 /// Signatory keysets
 pub struct SignatoryKeysets {
-    /// The public key
+    /// The public key. Also the key [`Signatory::sign`] signs with.
     pub pubkey: PublicKey,
     /// The list of keysets
     pub keysets: Vec<SignatoryKeySet>,
@@ -149,6 +150,13 @@ pub trait Signatory {
 
     /// Verify [`Proof`] meets conditions and is signed by the mint (ignores P2PK/HTLC signatures"
     async fn verify_proofs(&self, proofs: Vec<Proof>) -> Result<(), Error>;
+
+    /// Sign an arbitrary payload with the signatory's identity key.
+    ///
+    /// Verifies against `SignatoryKeysets::pubkey` through
+    /// [`crate::identity::verify`], which applies the same domain-separated
+    /// digest [`crate::identity::sign`] used. No keyset key is involved.
+    async fn sign(&self, payload: Vec<u8>) -> Result<Signature, Error>;
 
     /// Retrieve the list of all mint keysets
     async fn keysets(&self) -> Result<SignatoryKeysets, Error>;

--- a/crates/cdk-signatory/tests/grpc_sign.rs
+++ b/crates/cdk-signatory/tests/grpc_sign.rs
@@ -1,0 +1,64 @@
+//! gRPC round trip for the identity signing key.
+//!
+//! Exercises both sides of the `Sign` RPC, which also covers the schema-version
+//! handshake between client and server.
+#![cfg(all(feature = "grpc", feature = "sqlite", not(target_arch = "wasm32")))]
+
+use std::sync::Arc;
+
+use cdk_signatory::db_signatory::DbSignatory;
+use cdk_signatory::identity;
+use cdk_signatory::signatory::Signatory;
+use cdk_signatory::{start_grpc_server_with_incoming, SignatoryRpcClient};
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+
+#[tokio::test]
+async fn sign_round_trips_over_grpc() {
+    let store = Arc::new(
+        cdk_sqlite::mint::memory::empty()
+            .await
+            .expect("in-memory db"),
+    );
+    let signatory = Arc::new(
+        DbSignatory::new(
+            store,
+            b"test-seed-for-grpc-signing",
+            Default::default(),
+            Default::default(),
+        )
+        .await
+        .expect("DbSignatory::new"),
+    );
+    let expected = signatory.keysets().await.expect("keysets");
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        if let Err(err) =
+            start_grpc_server_with_incoming(signatory, TcpListenerStream::new(listener)).await
+        {
+            tracing::error!("signatory server stopped: {err}");
+        }
+    });
+
+    let client = SignatoryRpcClient::new("127.0.0.1", addr.port(), None)
+        .await
+        .expect("connect to signatory");
+
+    let payload = b"an arbitrary stream of bytes".to_vec();
+    let signature = client.sign(payload.clone()).await.expect("sign over grpc");
+
+    let keysets = client.keysets().await.expect("keysets over grpc");
+    assert_eq!(
+        keysets.pubkey, expected.pubkey,
+        "the identity pubkey must survive the proto round trip"
+    );
+
+    identity::verify(&keysets.pubkey, &payload, &signature)
+        .expect("signature from the remote signatory must verify");
+    assert!(
+        identity::verify(&keysets.pubkey, b"tampered", &signature).is_err(),
+        "a tampered payload must not verify"
+    );
+}

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -322,9 +322,16 @@ impl Mint {
             );
         }
 
-        // Persist missing pubkey early to avoid losing it on next boot and ensure stable identity across restarts
+        // Persist the pubkey early to avoid losing it on next boot and ensure stable identity across restarts
         let mut computed_info = mint_info;
-        if computed_info.pubkey.is_none() {
+        if computed_info.pubkey != Some(keysets.pubkey) {
+            if let Some(stale) = computed_info.pubkey {
+                tracing::warn!(
+                    %stale,
+                    current = %keysets.pubkey,
+                    "advertised pubkey does not match the signatory identity key, replacing it"
+                );
+            }
             computed_info.pubkey = Some(keysets.pubkey);
         }
 
@@ -339,7 +346,7 @@ impl Mint {
             Some(bytes) => {
                 let mut stored: MintInfo = serde_json::from_slice(&bytes)?;
                 let mut mutated = false;
-                if stored.pubkey.is_none() && computed_info.pubkey.is_some() {
+                if stored.pubkey != computed_info.pubkey {
                     stored.pubkey = computed_info.pubkey;
                     mutated = true;
                 }
@@ -1657,6 +1664,69 @@ mod tests {
         )
         .await
         .unwrap()
+    }
+
+    /// A mint upgraded across the NUT-06 identity change finds a persisted
+    /// `MintInfo.pubkey` that no longer matches what the signatory signs with.
+    /// It must advertise the signatory's key, not the stored one.
+    #[tokio::test]
+    async fn stored_pubkey_is_replaced_when_the_signatory_identity_changes() {
+        let localstore = Arc::new(
+            new_with_state(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                MintInfo::default(),
+            )
+            .await
+            .expect("in-memory db"),
+        );
+
+        let boot = |seed: &'static [u8]| {
+            let localstore = localstore.clone();
+            async move {
+                let keystore = Arc::new(
+                    cdk_sqlite::mint::memory::empty()
+                        .await
+                        .expect("in-memory keystore"),
+                );
+                let signatory = Arc::new(
+                    DbSignatory::new(keystore, seed, Default::default(), Default::default())
+                        .await
+                        .expect("DbSignatory::new"),
+                );
+                let pubkey = signatory.keysets().await.expect("keysets").pubkey;
+                let mint = Mint::new(
+                    MintInfo::default(),
+                    signatory,
+                    localstore,
+                    HashMap::new(),
+                    1000,
+                    1000,
+                )
+                .await
+                .expect("Mint::new");
+                (mint, pubkey)
+            }
+        };
+
+        let (first, first_pubkey) = boot(b"identity-seed-before-upgrade").await;
+        assert_eq!(
+            first.mint_info().await.expect("mint info").pubkey,
+            Some(first_pubkey)
+        );
+        drop(first);
+
+        let (second, second_pubkey) = boot(b"identity-seed-after-upgrade").await;
+        assert_ne!(first_pubkey, second_pubkey);
+        assert_eq!(
+            second.mint_info().await.expect("mint info").pubkey,
+            Some(second_pubkey),
+            "the persisted pubkey must follow the signatory, not outlive it"
+        );
     }
 
     #[tokio::test]

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1501,6 +1501,7 @@ mod tests {
     use std::str::FromStr;
     use std::sync::Arc;
 
+    use bitcoin::secp256k1::schnorr::Signature;
     use cdk_common::melt::MeltQuoteRequest;
     use cdk_common::mint::{OperationKind, SagaStateEnum};
     use cdk_common::nut00::KnownMethod;
@@ -1564,6 +1565,10 @@ mod tests {
         }
 
         async fn verify_proofs(&self, _proofs: Vec<cdk_common::Proof>) -> Result<(), Error> {
+            Err(Error::Custom("unsupported in mock".to_string()))
+        }
+
+        async fn sign(&self, _payload: Vec<u8>) -> Result<Signature, Error> {
             Err(Error::Custom("unsupported in mock".to_string()))
         }
 
@@ -1972,6 +1977,10 @@ mod tests {
 
         async fn verify_proofs(&self, proofs: Vec<cdk_common::Proof>) -> Result<(), Error> {
             self.inner.verify_proofs(proofs).await
+        }
+
+        async fn sign(&self, payload: Vec<u8>) -> Result<Signature, Error> {
+            self.inner.sign(payload).await
         }
 
         async fn keysets(&self) -> Result<SignatoryKeysets, Error> {

--- a/docs/adr/0005-signatory-identity-signing-key.md
+++ b/docs/adr/0005-signatory-identity-signing-key.md
@@ -1,0 +1,141 @@
+# Signatory signing of arbitrary payloads
+
+* Status: accepted
+* Authors: Cesar Rodas
+* Date: 2026-08-17
+* Targeted modules: cdk-signatory
+* Associated tickets/PRs: n/a
+
+## Context and Problem Statement
+
+The `Signatory` trait is the only seam through which the mint reaches
+private-key material (ADR-0001), and every method on it is keyset-shaped:
+`blind_sign`, `verify_proofs`, `keysets`, `subscribe_keysets`,
+`rotate_keyset`. A mint that needs to attest to something that is not ecash,
+for example a statement about itself or a payload another party must attribute
+to this mint, has no way to ask for it. Producing such a signature outside the
+signatory would put a private key back inside the mint process, which is
+exactly what ADR-0001 removed.
+
+The signatory already holds a non-keyset key: the master key from
+`Xpriv::new_master(seed)`, whose public half it publishes as
+`SignatoryKeysets::pubkey` and the mint persists into `MintInfo.pubkey`. Its
+private half signs nothing today. How does the signatory sign arbitrary bytes
+with it without that signature colliding with the Cashu protocol signatures the
+same curve and hash already carry?
+
+## Decision Drivers
+
+* The signing key must stay inside the signatory, like every other key.
+* The signature must be verifiable by anyone holding the mint's published
+  pubkey, with no signatory round trip.
+* A signature over arbitrary bytes must not be reusable as a Cashu protocol
+  signature, and vice versa.
+* Existing deployments advertise a `MintInfo.pubkey`; whatever signs should be
+  the key they already advertise, not a second one.
+
+## Considered Options
+
+#### Sign the payload directly
+
+Call `SecretKey::sign(payload)`, which SHA-256s the input and Schnorr-signs the
+digest, the same path NUT-11 and NUT-20 use.
+
+**Pros:**
+
+* Good, because it is one line and reuses an existing helper.
+
+**Cons:**
+
+* Bad, because it is the identical construction NUT-11 and NUT-20 use. Anything
+  that can steer the payload can obtain a signature that is also valid as one
+  of those, and the mint is a signing oracle for arbitrary bytes. There is
+  nothing in the signed material naming what it is for.
+
+#### Derive a separate key for arbitrary payloads
+
+Derive a dedicated signing key from the seed and publish its pubkey next to the
+existing one, so the master key never signs attacker-chosen bytes.
+
+**Pros:**
+
+* Good, because a leak of the signing key reveals nothing about the master key.
+
+**Cons:**
+
+* Bad, because it adds a second public key to the signatory boundary, the proto
+  message, and everything downstream that has to discover which key to verify
+  against.
+* Bad, because `MintInfo.pubkey` already exists as the mint's identity and
+  nothing verifies against it yet; introducing a rival key before the first one
+  has a consumer splits the identity for no gain today.
+
+#### Sign a domain-separated HMAC-SHA256 digest with the published key
+
+Sign with the key behind `SignatoryKeysets::pubkey`, but over
+`HMAC_SHA256(key = domain_tag, msg = payload)` rather than over the payload
+itself, following the HMAC-SHA256 construction NUT-12 and NUT-13 already use in
+this codebase.
+
+**Pros:**
+
+* Good, because the domain tag is the HMAC key and is a public constant, so any
+  verifier recomputes the digest with no secret.
+* Good, because the digest differs from `SHA256(payload)`, so a signature here
+  is not valid as a NUT-11 or NUT-20 signature over the same bytes, and one of
+  those is not valid here.
+* Good, because it keeps one identity key: the pubkey the mint already
+  advertises is the one that verifies.
+
+**Cons:**
+
+* Bad, because the master key now signs caller-supplied material. Callers must
+  still treat `sign` as privileged.
+
+## Decision Outcome
+
+Chosen option: "Sign a domain-separated HMAC-SHA256 digest with the published
+key", because it is the only option that both keeps the mint's single
+advertised identity and stops the signature from being interchangeable with a
+Cashu protocol signature.
+
+The construction lives in `crates/cdk-signatory/src/identity.rs`:
+
+```
+digest = HMAC_SHA256(key = b"Cashu_Signatory_Sign_v1", msg = payload)
+sig    = schnorr_sign(identity_key, digest)
+```
+
+`identity::sign` and `identity::verify` are the pair; both are public so a
+verifier applies the same digest rather than reimplementing it. The identity
+key is `xpriv.private_key`, the private half of the already-published
+`SignatoryKeysets::pubkey`.
+
+The trait gains `sign(payload) -> Signature`. On the wire this is a new `Sign`
+RPC; `CONSTANTS_SCHEMA_VERSION` moves from 2 to 3 and the version interceptor
+rejects a mismatch, so a mint and a signatory across the bump refuse to
+connect.
+
+### Positive Consequences
+
+* The mint can obtain a signature over arbitrary bytes without ever holding a
+  private key.
+* Verification uses the pubkey the mint already advertises, so nothing new has
+  to be discovered or persisted.
+* Domain separation is enforced in one place that both signer and verifier go
+  through.
+
+### Negative Consequences
+
+* A mint and a signatory must be upgraded together: the schema version bump
+  makes a mixed pair refuse to connect.
+* The key at the root of the keyset derivation tree now signs caller-supplied
+  material. The domain separation keeps those signatures out of the Cashu
+  protocol, but `sign` is still a privileged operation and should not be
+  exposed to untrusted callers.
+* Nothing consumes `sign` yet. There is no `Mint::sign` pass-through; the first
+  caller adds it.
+
+## Links
+
+* Refines [ADR-0001](0001-signatory-mint-key-segregation.md)

--- a/docs/adr/0005-signatory-identity-signing-key.md
+++ b/docs/adr/0005-signatory-identity-signing-key.md
@@ -1,140 +1,156 @@
-# Signatory signing of arbitrary payloads
+# Signatory signing with the NUT-06 mint identity key
 
 * Status: accepted
 * Authors: Cesar Rodas
-* Date: 2026-08-17
-* Targeted modules: cdk-signatory
-* Associated tickets/PRs: n/a
+* Date: 2026-08-22
+* Targeted modules: cdk-signatory, cdk-mintd, cdk
+* Associated tickets/PRs: https://github.com/cashubtc/nuts/pull/416
 
 ## Context and Problem Statement
 
 The `Signatory` trait is the only seam through which the mint reaches
 private-key material (ADR-0001), and every method on it is keyset-shaped:
-`blind_sign`, `verify_proofs`, `keysets`, `subscribe_keysets`,
-`rotate_keyset`. A mint that needs to attest to something that is not ecash,
-for example a statement about itself or a payload another party must attribute
-to this mint, has no way to ask for it. Producing such a signature outside the
-signatory would put a private key back inside the mint process, which is
-exactly what ADR-0001 removed.
+`blind_sign`, `verify_proofs`, `keysets`, `subscribe_keysets`, `rotate_keyset`.
+A mint that needs to attest to something that is not ecash, starting with a
+statement about itself, has no way to ask for it. Producing such a signature
+outside the signatory would put a private key back inside the mint process,
+which is exactly what ADR-0001 removed.
 
-The signatory already holds a non-keyset key: the master key from
-`Xpriv::new_master(seed)`, whose public half it publishes as
-`SignatoryKeysets::pubkey` and the mint persists into `MintInfo.pubkey`. Its
-private half signs nothing today. How does the signatory sign arbitrary bytes
-with it without that signature colliding with the Cashu protocol signatures the
-same curve and hash already carry?
+NUT-06 (cashubtc/nuts#416) settles what that signature has to be. It specifies
+both halves: the mint has an identity key derived from its seed, and it signs
+with BIP-340 over the SHA-256 of the payload.
+
+```
+identity_key = HMAC_SHA256(key = seed, msg = b"Cashu_Mint_Identity_v1" || ctr)
+sig          = schnorr_sign(identity_key, SHA256(payload))
+```
+
+`ctr` starts at zero and increments while the candidate falls outside
+`1..n-1`. The mint publishes the public half as `GetInfoResponse.pubkey`.
+
+CDK already published a pubkey there, but a different one: the BIP-32 master
+key from `Xpriv::new_master(seed)`, whose private half signed nothing. So the
+question is not only how the signatory signs, but which key it signs with and
+what happens to the key deployments already advertise.
 
 ## Decision Drivers
 
 * The signing key must stay inside the signatory, like every other key.
-* The signature must be verifiable by anyone holding the mint's published
-  pubkey, with no signatory round trip.
-* A signature over arbitrary bytes must not be reusable as a Cashu protocol
-  signature, and vice versa.
-* Existing deployments advertise a `MintInfo.pubkey`; whatever signs should be
-  the key they already advertise, not a second one.
+* A wallet holding the mint's published pubkey must verify with nothing but a
+  NUT-06 implementation, and with no signatory round trip.
+* Whatever is built here should carry the mint info signature later without
+  changing again.
 
 ## Considered Options
 
-#### Sign the payload directly
-
-Call `SecretKey::sign(payload)`, which SHA-256s the input and Schnorr-signs the
-digest, the same path NUT-11 and NUT-20 use.
+#### Sign in the mint with a key the mint holds
 
 **Pros:**
 
-* Good, because it is one line and reuses an existing helper.
+* Good, because it needs no change to the signatory boundary at all.
 
 **Cons:**
 
-* Bad, because it is the identical construction NUT-11 and NUT-20 use. Anything
-  that can steer the payload can obtain a signature that is also valid as one
-  of those, and the mint is a signing oracle for arbitrary bytes. There is
-  nothing in the signed material naming what it is for.
+* Bad, because it puts private-key material back in the mint process. ADR-0001
+  exists to prevent exactly this.
 
-#### Derive a separate key for arbitrary payloads
+#### Sign with the published BIP-32 master key over a domain-separated digest
 
-Derive a dedicated signing key from the seed and publish its pubkey next to the
-existing one, so the master key never signs attacker-chosen bytes.
-
-**Pros:**
-
-* Good, because a leak of the signing key reveals nothing about the master key.
-
-**Cons:**
-
-* Bad, because it adds a second public key to the signatory boundary, the proto
-  message, and everything downstream that has to discover which key to verify
-  against.
-* Bad, because `MintInfo.pubkey` already exists as the mint's identity and
-  nothing verifies against it yet; introducing a rival key before the first one
-  has a consumer splits the identity for no gain today.
-
-#### Sign a domain-separated HMAC-SHA256 digest with the published key
-
-Sign with the key behind `SignatoryKeysets::pubkey`, but over
-`HMAC_SHA256(key = domain_tag, msg = payload)` rather than over the payload
-itself, following the HMAC-SHA256 construction NUT-12 and NUT-13 already use in
-this codebase.
+Keep advertising the master pubkey and sign
+`HMAC_SHA256(key = b"Cashu_Signatory_Sign_v1", msg = payload)`, following the
+HMAC-SHA256 construction NUT-12 and NUT-13 already use in this codebase.
 
 **Pros:**
 
-* Good, because the domain tag is the HMAC key and is a public constant, so any
-  verifier recomputes the digest with no secret.
+* Good, because no deployment sees its advertised pubkey change.
 * Good, because the digest differs from `SHA256(payload)`, so a signature here
-  is not valid as a NUT-11 or NUT-20 signature over the same bytes, and one of
-  those is not valid here.
-* Good, because it keeps one identity key: the pubkey the mint already
-  advertises is the one that verifies.
+  is not also valid as a NUT-11 or NUT-20 signature over the same bytes.
 
 **Cons:**
 
-* Bad, because the master key now signs caller-supplied material. Callers must
-  still treat `sign` as privileged.
+* Bad, because no NUT-06 wallet could verify it. Neither the key nor the digest
+  is the one the spec names, and the reason to sign at all is that someone else
+  checks the signature.
+* Bad, because the master key is the ancestor of every keyset key, so a `sign`
+  oracle over it is strictly worse than one over a sibling key.
+
+#### Derive the identity key per NUT-06 and sign the payload
+
+**Pros:**
+
+* Good, because the key is derived outside the BIP-32 tree, so no keyset
+  descends from it.
+* Good, because verification is `PublicKey::verify(payload, sig)`, which
+  already existed and already does SHA-256 then `verify_schnorr` against the
+  x-only key. A verifier needs nothing from `cdk-signatory`.
+* Good, because signing the canonical `GetInfoResponse` bytes becomes the only
+  remaining work for NUT-06 mint info signatures.
+
+**Cons:**
+
+* Bad, because the mint's advertised `pubkey` changes on upgrade.
+* Bad, because the digest carries no domain tag, so a `sign` caller who
+  controls the payload gets a signature over bytes of their choosing under the
+  mint's identity.
 
 ## Decision Outcome
 
-Chosen option: "Sign a domain-separated HMAC-SHA256 digest with the published
-key", because it is the only option that both keeps the mint's single
-advertised identity and stops the signature from being interchangeable with a
-Cashu protocol signature.
+Chosen option: "Derive the identity key per NUT-06 and sign the payload".
+Compliance is the whole point of the feature, and the separate derived key is
+also the better key to be signing with.
 
-The construction lives in `crates/cdk-signatory/src/identity.rs`:
-
-```
-digest = HMAC_SHA256(key = b"Cashu_Signatory_Sign_v1", msg = payload)
-sig    = schnorr_sign(identity_key, digest)
-```
-
-`identity::sign` and `identity::verify` are the pair; both are public so a
-verifier applies the same digest rather than reimplementing it. The identity
-key is `xpriv.private_key`, the private half of the already-published
-`SignatoryKeysets::pubkey`.
+The construction lives in `crates/cdk-signatory/src/identity.rs`. `DbSignatory`
+derives the key from the same seed it hands to `Xpriv::new_master`, but outside
+that tree, and publishes its public half as `SignatoryKeysets::pubkey`. Keyset
+derivation is untouched.
 
 The trait gains `sign(payload) -> Signature`. On the wire this is a new `Sign`
 RPC; `CONSTANTS_SCHEMA_VERSION` moves from 2 to 3 and the version interceptor
 rejects a mismatch, so a mint and a signatory across the bump refuse to
 connect.
 
+Signing zeroes the BIP-340 auxiliary randomness. That is not required by the
+spec, but it makes a re-served `/v1/info` byte-identical and lets the spec's
+example vector be a fixture.
+
+On the domain separation that a tagged digest would have bought: the mint
+identity key is not a keyset key and not a wallet key, so it signs in no other
+Cashu context, and the only payload NUT-06 defines is a self-describing JSON
+object. `sign` is a privileged operation and must not be reachable by untrusted
+callers.
+
+### Migration
+
+Every existing mint's advertised pubkey changes, because CDK previously
+published the BIP-32 master key. Three places had to learn about it:
+
+* `cdk-mintd` derives its expected identity the same way, so its startup guard
+  compares like with like.
+* A configuration that pins `mint_info.pubkey` to the old master key starts
+  with a warning instead of `SigningIdentityChange`, on the local-seed path
+  where the old value can be recomputed. With a remote signatory there is no
+  seed to check against and the operator must update the configuration.
+* `Mint` rewrites a persisted `MintInfo.pubkey` that disagrees with the
+  signatory. Previously it only filled the field when absent, which would have
+  left an upgraded mint advertising one key while signing with another.
+
 ### Positive Consequences
 
 * The mint can obtain a signature over arbitrary bytes without ever holding a
   private key.
-* Verification uses the pubkey the mint already advertises, so nothing new has
-  to be discovered or persisted.
-* Domain separation is enforced in one place that both signer and verifier go
-  through.
+* A NUT-06 wallet can verify the mint with no CDK-specific code.
+* The identity key is no longer the root of the keyset derivation tree.
 
 ### Negative Consequences
 
+* The advertised pubkey changes on upgrade, and operators who pinned it with a
+  remote signatory must edit their configuration.
 * A mint and a signatory must be upgraded together: the schema version bump
   makes a mixed pair refuse to connect.
-* The key at the root of the keyset derivation tree now signs caller-supplied
-  material. The domain separation keeps those signatures out of the Cashu
-  protocol, but `sign` is still a privileged operation and should not be
-  exposed to untrusted callers.
-* Nothing consumes `sign` yet. There is no `Mint::sign` pass-through; the first
-  caller adds it.
+* A signature is a plain BIP-340 signature over `SHA256(payload)`, with no tag
+  in the digest saying what it is for.
+* Nothing consumes `sign` yet. There is no `Mint::sign` pass-through; the mint
+  info signature is the first caller.
 
 ## Links
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,3 +10,4 @@ than editing an old one.
 | [0002](0002-signatory-keyset-subscription.md) | Signatory keyset subscription and push injection | Accepted |
 | [0003](0003-signatory-database-persistence-only.md) | Signatory database as persistence only | Accepted |
 | [0004](0004-signatory-multi-instance-sharing.md) | Multiple signatory instances sharing one database | Accepted |
+| [0005](0005-signatory-identity-signing-key.md) | Signatory signing with the NUT-06 mint identity key | Accepted |


### PR DESCRIPTION


### Description

Fixes #2387

The Signatory trait only exposed keyset operations, so a mint with something to attest to that is not ecash had no way to get it signed without holding a private key itself.

Add sign(payload), backed by the key whose public half is already published as SignatoryKeysets::pubkey. The payload is not signed bare: it goes through HMAC_SHA256 keyed by a domain tag first, so a signature here is not interchangeable with a NUT-11 or NUT-20 signature over the same bytes. The tag is a public constant, so verifiers recompute the digest with no secret.

Bumps the signatory schema version, so mint and signatory must be upgraded together.

This is an attempt to comply with https://github.com/cashubtc/nuts/pull/416

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
