### PR TITLE
Collapse duplicate P2PK keys when building spending conditions

### DIFF
--- a/crates/cashu/src/amount.rs
+++ b/crates/cashu/src/amount.rs
@@ -2541,4 +2541,16 @@ mod tests {
             Amount::from(5)
         );
     }
+
+    /// A keyset may advertise a zero denomination. Dividing by it panics, so
+    /// the split rejects the keyset instead of trusting it.
+    #[test]
+    fn test_split_rejects_zero_denomination() {
+        let fee_and_amounts: FeeAndAmounts = (0, vec![0, 1, 2]).into();
+
+        assert!(matches!(
+            Amount::from(3).split(&fee_and_amounts),
+            Err(Error::InvalidAmount(_))
+        ));
+    }
 }

--- a/crates/cashu/src/nuts/nut00/mod.rs
+++ b/crates/cashu/src/nuts/nut00/mod.rs
@@ -1074,9 +1074,19 @@ impl PreMintSecrets {
         ephemeral_keys: &[crate::nuts::nut01::SecretKey],
         fee_and_amounts: &FeeAndAmounts,
     ) -> Result<Self, Error> {
+        use crate::nuts::nut10::spending_conditions::{check_locking_slots, validate_p2pk};
         use crate::nuts::nut28::{blind_public_key, ecdh_kdf};
 
         let amount_split = amount.split_targeted(amount_split_target, fee_and_amounts)?;
+
+        validate_p2pk(receiver_pubkey, conditions.as_ref())?;
+
+        if let Some(conditions) = conditions.as_ref() {
+            check_locking_slots(
+                conditions.pubkeys.as_ref().map(Vec::len).unwrap_or(0),
+                conditions.refund_keys.as_deref(),
+            )?;
+        }
 
         let mut output = Vec::with_capacity(amount_split.len());
 
@@ -1128,7 +1138,7 @@ impl PreMintSecrets {
                 conditions: blinded_conditions,
             };
 
-            let secret: crate::nuts::nut10::Secret = p2pk_conditions.into();
+            let secret: crate::nuts::nut10::Secret = p2pk_conditions.try_into()?;
             let secret: Secret = secret.try_into()?;
             let (blinded, rs) = blind_message(&secret.to_bytes(), None)?;
 
@@ -1161,7 +1171,7 @@ impl PreMintSecrets {
         let mut output = Vec::with_capacity(amount_split.len());
 
         for amount in amount_split {
-            let secret: nut10::Secret = conditions.clone().into();
+            let secret: nut10::Secret = conditions.clone().try_into()?;
 
             let secret: Secret = secret.try_into()?;
             let (blinded, r) = blind_message(&secret.to_bytes(), None)?;
@@ -2011,7 +2021,7 @@ mod tests {
         let refund_key_1 = crate::nuts::nut01::SecretKey::generate().public_key();
         let refund_key_2 = crate::nuts::nut01::SecretKey::generate().public_key();
         let conditions = Conditions::new(
-            None,
+            Some(crate::util::unix_time() + 3600),
             Some(vec![additional_key_1, additional_key_2]),
             Some(vec![refund_key_1, refund_key_2]),
             Some(1),
@@ -2077,6 +2087,147 @@ mod tests {
             }
             SpendingConditions::HTLCConditions { .. } => panic!("expected P2PK conditions"),
         }
+    }
+
+    /// Each key is blinded under its own slot, so a repeated key would blind
+    /// into two different keys and hide the duplicate from verification. The
+    /// rejection has to land before any output is built.
+    #[test]
+    fn test_with_p2bk_rejects_duplicate_pubkeys_before_blinding() {
+        use crate::amount::{FeeAndAmounts, SplitTarget};
+        use crate::nuts::nut11::SigFlag;
+        use crate::Conditions;
+
+        let keyset_id = Id::from_str("009a1f293253e41e").unwrap();
+        let receiver_secret_key = crate::nuts::nut01::SecretKey::generate();
+        let mut bytes = receiver_secret_key.public_key().to_bytes();
+        bytes[0] = 0x02;
+        let pk_02 = PublicKey::from_slice(&bytes).unwrap();
+        bytes[0] = 0x03;
+        let pk_03 = PublicKey::from_slice(&bytes).unwrap();
+
+        let conditions = Conditions {
+            locktime: None,
+            pubkeys: Some(vec![pk_03]),
+            refund_keys: None,
+            num_sigs: None,
+            sig_flag: SigFlag::SigAll,
+            num_sigs_refund: None,
+        };
+        let ephemeral_key = crate::nuts::nut01::SecretKey::generate();
+        let fee_and_amounts = FeeAndAmounts::from((0, (0..32).map(|x| 2u64.pow(x)).collect()));
+
+        let err = PreMintSecrets::with_p2bk(
+            keyset_id,
+            Amount::from(1_u64),
+            &SplitTarget::default(),
+            pk_02,
+            Some(conditions),
+            std::slice::from_ref(&ephemeral_key),
+            &fee_and_amounts,
+        )
+        .expect_err("duplicate key should be rejected before blinding");
+
+        assert!(
+            matches!(
+                err,
+                Error::NUT10(crate::nuts::nut10::Error::NUT11(
+                    crate::nuts::nut11::Error::DuplicatePubkey
+                ))
+            ),
+            "Expected DuplicatePubkey, got: {err:?}"
+        );
+    }
+
+    /// Every output in the batch carries the same conditions, so the batch has
+    /// to be rejected before the first secret is built.
+    #[test]
+    fn test_with_conditions_rejects_duplicate_pubkeys() {
+        use crate::amount::{FeeAndAmounts, SplitTarget};
+        use crate::nuts::nut11::SigFlag;
+        use crate::{Conditions, SpendingConditions};
+
+        let keyset_id = Id::from_str("009a1f293253e41e").unwrap();
+        let pubkey = crate::nuts::nut01::SecretKey::generate().public_key();
+
+        let conditions = Conditions {
+            locktime: None,
+            pubkeys: Some(vec![pubkey]),
+            refund_keys: None,
+            num_sigs: None,
+            sig_flag: SigFlag::SigInputs,
+            num_sigs_refund: None,
+        };
+        let fee_and_amounts = FeeAndAmounts::from((0, (0..32).map(|x| 2u64.pow(x)).collect()));
+
+        let err = PreMintSecrets::with_conditions(
+            keyset_id,
+            Amount::from(2_u64),
+            &SplitTarget::default(),
+            &SpendingConditions::P2PKConditions {
+                data: pubkey,
+                conditions: Some(conditions),
+            },
+            &fee_and_amounts,
+        )
+        .expect_err("duplicate key should be rejected for the whole batch");
+
+        assert!(
+            matches!(
+                err,
+                Error::NUT10(crate::nuts::nut10::Error::NUT11(
+                    crate::nuts::nut11::Error::DuplicatePubkey
+                ))
+            ),
+            "Expected DuplicatePubkey, got: {err:?}"
+        );
+    }
+
+    /// Twelve slots have to fail as TooManyPubkeys, not as the
+    /// InvalidCanonicalSlot the key derivation would raise on its own.
+    #[test]
+    fn test_with_p2bk_rejects_more_slots_than_nut28_allows() {
+        use crate::amount::{FeeAndAmounts, SplitTarget};
+        use crate::nuts::nut11::SigFlag;
+        use crate::Conditions;
+
+        let keyset_id = Id::from_str("009a1f293253e41e").unwrap();
+        let receiver_pubkey = crate::nuts::nut01::SecretKey::generate().public_key();
+        let pubkeys: Vec<PublicKey> = (0..11)
+            .map(|_| crate::nuts::nut01::SecretKey::generate().public_key())
+            .collect();
+
+        let conditions = Conditions {
+            locktime: None,
+            pubkeys: Some(pubkeys),
+            refund_keys: None,
+            num_sigs: Some(1),
+            sig_flag: SigFlag::SigAll,
+            num_sigs_refund: None,
+        };
+        let ephemeral_key = crate::nuts::nut01::SecretKey::generate();
+        let fee_and_amounts = FeeAndAmounts::from((0, (0..32).map(|x| 2u64.pow(x)).collect()));
+
+        let err = PreMintSecrets::with_p2bk(
+            keyset_id,
+            Amount::from(1_u64),
+            &SplitTarget::default(),
+            receiver_pubkey,
+            Some(conditions),
+            std::slice::from_ref(&ephemeral_key),
+            &fee_and_amounts,
+        )
+        .expect_err("twelve slots should be rejected");
+
+        assert!(
+            matches!(
+                err,
+                Error::NUT10(crate::nuts::nut10::Error::NUT11(
+                    crate::nuts::nut11::Error::TooManyPubkeys { slots: 12 }
+                ))
+            ),
+            "Expected TooManyPubkeys, got: {err:?}"
+        );
     }
 
     #[test]

--- a/crates/cashu/src/nuts/nut10/mod.rs
+++ b/crates/cashu/src/nuts/nut10/mod.rs
@@ -100,6 +100,17 @@ impl SecretData {
     }
 }
 
+/// NUT-28 locking slots available across `data`, `pubkeys` and refund keys.
+///
+/// Slot indices are carried in a single `i_byte` (0x00..=0x0A), so eleven is a
+/// hard ceiling rather than a policy choice.
+pub const MAX_LOCKING_SLOTS: usize = 11;
+
+/// Reject a key repeated within one signing pathway, comparing x-coordinates.
+///
+/// NUT-11 counts two keys sharing an x-coordinate as one, so a repetition can
+/// never add a signer. Construction and verification both run this, so a lock
+/// that is built is a lock that can be spent.
 fn check_duplicate_pubkeys(pubkeys: &[PublicKey]) -> Result<(), Error> {
     let mut x_coords = std::collections::HashSet::with_capacity(pubkeys.len());
     for pk in pubkeys {
@@ -561,7 +572,8 @@ mod tests {
                 ..Default::default()
             }),
         )
-        .into();
+        .try_into()
+        .unwrap();
 
         assert_eq!(
             get_pubkeys_and_required_sigs(&secret, 100)
@@ -580,18 +592,22 @@ mod tests {
         );
     }
 
+    /// The secret is built from raw parts rather than through
+    /// [`SpendingConditions`], which rejects the duplicate: a hostile token can
+    /// still carry both keys, and verification has to reject it.
     #[test]
     fn test_htlc_rejects_duplicate_receiver_pubkeys() {
         let pubkey = SecretKey::generate().public_key();
-        let secret: Secret = SpendingConditions::new_htlc_hash(
-            "5c23fc3aec9d985bd5fc88ca8bceaccc52cf892715dd94b42b84f1b43350751e",
-            Some(Conditions {
-                pubkeys: Some(vec![pubkey, pubkey]),
-                ..Default::default()
-            }),
-        )
-        .unwrap()
-        .into();
+        let secret = Secret::new(
+            Kind::HTLC,
+            SecretData::new(
+                "5c23fc3aec9d985bd5fc88ca8bceaccc52cf892715dd94b42b84f1b43350751e",
+                Some(Conditions {
+                    pubkeys: Some(vec![pubkey, pubkey]),
+                    ..Default::default()
+                }),
+            ),
+        );
 
         assert!(matches!(
             get_pubkeys_and_required_sigs(&secret, 0),

--- a/crates/cashu/src/nuts/nut10/spending_conditions.rs
+++ b/crates/cashu/src/nuts/nut10/spending_conditions.rs
@@ -294,6 +294,7 @@ impl Conditions {
 /// the blinded `data` key plus the `pubkeys` and refund tags cannot occupy more
 /// than [`MAX_LOCKING_SLOTS`] entries. Plain NUT-11 and NUT-14 locks have no
 /// such limit, and verification never counts slots.
+#[cfg(feature = "wallet")]
 pub(crate) fn check_locking_slots(
     pubkeys: usize,
     refund_keys: Option<&[PublicKey]>,

--- a/crates/cashu/src/nuts/nut10/spending_conditions.rs
+++ b/crates/cashu/src/nuts/nut10/spending_conditions.rs
@@ -2,7 +2,6 @@
 //!
 //! <https://github.com/cashubtc/nuts/blob/main/10.md>
 
-use std::collections::HashSet;
 use std::str::FromStr;
 
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
@@ -63,9 +62,7 @@ impl SpendingConditions {
                 if let Some(conditions) = conditions {
                     pubkeys.extend(conditions.pubkeys.clone().unwrap_or_default());
                 }
-                // Remove duplicates
-                let unique_pubkeys: HashSet<_> = pubkeys.into_iter().collect();
-                Some(unique_pubkeys.into_iter().collect())
+                Some(pubkeys)
             }
             Self::HTLCConditions { conditions, .. } => conditions.clone().and_then(|c| c.pubkeys),
         }
@@ -128,9 +125,14 @@ impl TryFrom<Nut10Secret> for SpendingConditions {
     }
 }
 
-impl From<SpendingConditions> for super::Secret {
-    fn from(conditions: SpendingConditions) -> super::Secret {
-        match conditions {
+/// The only door from an author-supplied lock to wire bytes, so the
+/// construction rules are enforced here instead of at each caller.
+impl TryFrom<SpendingConditions> for super::Secret {
+    type Error = Error;
+    fn try_from(conditions: SpendingConditions) -> Result<super::Secret, Self::Error> {
+        conditions.validate()?;
+
+        Ok(match conditions {
             SpendingConditions::P2PKConditions { data, conditions } => super::Secret::new(
                 Kind::P2PK,
                 super::SecretData::new(data.to_hex(), conditions),
@@ -139,16 +141,14 @@ impl From<SpendingConditions> for super::Secret {
                 Kind::HTLC,
                 super::SecretData::new(data.to_string(), conditions),
             ),
-        }
+        })
     }
 }
 
 impl TryFrom<SpendingConditions> for Secret {
     type Error = Error;
     fn try_from(conditions: SpendingConditions) -> Result<Secret, Self::Error> {
-        conditions.validate()?;
-        let secret: Nut10Secret = conditions.into();
-        Secret::try_from(secret)
+        Secret::try_from(Nut10Secret::try_from(conditions)?)
     }
 }
 
@@ -237,6 +237,12 @@ impl Conditions {
     }
 
     /// Create new Spending [`Conditions`]
+    ///
+    /// A key repeated within either list is rejected: verification counts keys
+    /// by x-coordinate, so the repetition can never add a signer. On top of the
+    /// protocol rules this constructor applies authoring policy, refusing a
+    /// locktime already in the past and refund keys with no locktime, since
+    /// both describe a branch the author cannot have meant to leave dead.
     pub fn new(
         locktime: Option<u64>,
         pubkeys: Option<Vec<PublicKey>>,
@@ -252,6 +258,13 @@ impl Conditions {
             );
         }
 
+        if let Some(pubkeys) = pubkeys.as_deref() {
+            super::check_duplicate_pubkeys(pubkeys)?;
+        }
+        if let Some(refund_keys) = refund_keys.as_deref() {
+            super::check_duplicate_pubkeys(refund_keys)?;
+        }
+
         let conditions = Self {
             locktime,
             pubkeys,
@@ -262,26 +275,86 @@ impl Conditions {
         };
         conditions.validate(1)?;
 
+        if conditions
+            .refund_keys
+            .as_ref()
+            .is_some_and(|keys| !keys.is_empty())
+            && conditions.locktime.is_none()
+        {
+            return Err(Error::NUT11(crate::nut11::Error::RefundKeysRequireLocktime));
+        }
+
         Ok(conditions)
     }
 }
 
+/// Reject a key set that P2BK cannot blind.
+///
+/// Only NUT-28 assigns slot indices, and it carries them in a single byte, so
+/// the blinded `data` key plus the `pubkeys` and refund tags cannot occupy more
+/// than [`MAX_LOCKING_SLOTS`] entries. Plain NUT-11 and NUT-14 locks have no
+/// such limit, and verification never counts slots.
+pub(crate) fn check_locking_slots(
+    pubkeys: usize,
+    refund_keys: Option<&[PublicKey]>,
+) -> Result<(), Error> {
+    let slots = 1 + pubkeys + refund_keys.map(<[PublicKey]>::len).unwrap_or(0);
+    if slots > super::MAX_LOCKING_SLOTS {
+        return Err(Error::NUT11(crate::nut11::Error::TooManyPubkeys { slots }));
+    }
+    Ok(())
+}
+
+/// Enforce the P2PK construction rules over a key set.
+///
+/// `data` and the `pubkeys` tag are one signing pathway, so a key repeated
+/// across the two is a duplicate; the refund tag is checked as its own set.
+/// Shared with the P2BK path, which has to reject before blinding: each key is
+/// blinded under its own slot index, so a repeated key would blind into two
+/// different keys and hide the duplicate.
+pub(crate) fn validate_p2pk(data: PublicKey, conditions: Option<&Conditions>) -> Result<(), Error> {
+    let Some(conditions) = conditions else {
+        return Ok(());
+    };
+
+    let mut primary = vec![data];
+    primary.extend(conditions.pubkeys.clone().unwrap_or_default());
+    super::check_duplicate_pubkeys(&primary)?;
+
+    if let Some(refund_keys) = conditions.refund_keys.as_deref() {
+        super::check_duplicate_pubkeys(refund_keys)?;
+    }
+
+    conditions.validate(1)
+}
+
 impl SpendingConditions {
-    fn validate(&self) -> Result<(), Error> {
+    /// Enforce the NUT-10/11 construction rules, rejecting duplicate keys.
+    ///
+    /// Keys are compared by x-coordinate within a signing pathway, the way
+    /// verification compares them, so a lock that validates here is one the
+    /// mint will accept. The duplicate check runs before the signature
+    /// thresholds so a repeated key always reports the repetition. Only
+    /// protocol rules are enforced; the authoring policy in
+    /// [`Conditions::new`] is not applied here.
+    pub fn validate(&self) -> Result<(), Error> {
         match self {
-            Self::P2PKConditions { conditions, .. } => {
-                if let Some(conditions) = conditions {
-                    conditions.validate(1)?;
-                }
-            }
+            Self::P2PKConditions { data, conditions } => validate_p2pk(*data, conditions.as_ref()),
             Self::HTLCConditions { conditions, .. } => {
-                if let Some(conditions) = conditions {
-                    conditions.validate(0)?;
+                let Some(conditions) = conditions else {
+                    return Ok(());
+                };
+
+                if let Some(pubkeys) = conditions.pubkeys.as_deref() {
+                    super::check_duplicate_pubkeys(pubkeys)?;
                 }
+                if let Some(refund_keys) = conditions.refund_keys.as_deref() {
+                    super::check_duplicate_pubkeys(refund_keys)?;
+                }
+
+                conditions.validate(0)
             }
         }
-
-        Ok(())
     }
 }
 
@@ -584,6 +657,61 @@ mod tests {
         assert!(matches!(
             result,
             Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired))
+        ));
+    }
+
+    /// Without a locktime the refund branch never opens, but the primary
+    /// pathway stays spendable, so NUT-11 still accepts the lock. Only
+    /// `Conditions::new` refuses it.
+    #[test]
+    fn test_refund_keys_without_locktime_build_a_secret() {
+        let key = PublicKey::from_str(
+            "033281c37677ea273eb7183b783067f5244933ef78d8c3f15b1a77cb246099c26e",
+        )
+        .unwrap();
+        let data = PublicKey::from_str(
+            "026562efcfadc8e86d44da6a8adf80633d974302e62c850774db1fb36ff4cc7198",
+        )
+        .unwrap();
+
+        let conditions = SpendingConditions::P2PKConditions {
+            data,
+            conditions: Some(Conditions {
+                refund_keys: Some(vec![key]),
+                locktime: None,
+                ..Default::default()
+            }),
+        };
+
+        let result: Result<Secret, _> = conditions.try_into();
+
+        assert!(
+            result.is_ok(),
+            "refund keys without a locktime should build: {:?}",
+            result.err()
+        );
+    }
+
+    /// Wire bytes are only reachable through this conversion, so a lock
+    /// verification would refuse can never be serialized.
+    #[test]
+    fn test_nut10_secret_rejects_duplicate_p2pk_key() {
+        let key = PublicKey::from_str(
+            "026562efcfadc8e86d44da6a8adf80633d974302e62c850774db1fb36ff4cc7198",
+        )
+        .unwrap();
+
+        let result = Nut10Secret::try_from(SpendingConditions::P2PKConditions {
+            data: key,
+            conditions: Some(Conditions {
+                pubkeys: Some(vec![key]),
+                ..Default::default()
+            }),
+        });
+
+        assert!(matches!(
+            result,
+            Err(Error::NUT11(crate::nut11::Error::DuplicatePubkey))
         ));
     }
 

--- a/crates/cashu/src/nuts/nut11/mod.rs
+++ b/crates/cashu/src/nuts/nut11/mod.rs
@@ -15,7 +15,9 @@ use super::nut00::Witness;
 use super::nut01::PublicKey;
 use super::nut05::MeltRequest;
 use super::{Kind, Nut10Secret, Proof, Proofs, SecretKey};
-use crate::nut10::{get_pubkeys_and_required_sigs, Conditions, SpendingConditionVerification};
+use crate::nut10::{
+    get_pubkeys_and_required_sigs, Conditions, SpendingConditionVerification, MAX_LOCKING_SLOTS,
+};
 use crate::nuts::nut00::BlindedMessage;
 use crate::util::unix_time;
 use crate::{SpendingConditions, SwapRequest};
@@ -58,6 +60,17 @@ pub enum Error {
     /// Duplicate public key in multisig (same x-coordinate)
     #[error("Duplicate public key in multisig (same x-coordinate)")]
     DuplicatePubkey,
+    /// More locking slots requested than NUT-28 allows
+    #[error(
+        "Too many pubkeys, {slots} slots provided, maximum allowed is {MAX_LOCKING_SLOTS} in total"
+    )]
+    TooManyPubkeys {
+        /// Slots the conditions would occupy
+        slots: usize,
+    },
+    /// Refund keys given without a locktime, so the refund path is unreachable
+    #[error("refund keys require a locktime")]
+    RefundKeysRequireLocktime,
     /// Impossible multisig configuration: num_sigs exceeds available pubkeys
     #[error(
         "Impossible multisig: required {required} signatures but only {available} keys available"
@@ -631,7 +644,9 @@ mod tests {
             num_sigs_refund: None,
         };
 
-        let secret: Nut10Secret = SpendingConditions::new_p2pk(data, Some(conditions)).into();
+        let secret: Nut10Secret = SpendingConditions::new_p2pk(data, Some(conditions))
+            .try_into()
+            .unwrap();
 
         let secret_str = serde_json::to_string(&secret).unwrap();
 
@@ -844,6 +859,9 @@ mod tests {
         );
     }
 
+    /// The secret is built directly rather than through `SpendingConditions`,
+    /// which now rejects the duplicate: a hostile token can still carry both
+    /// keys, and verification has to reject it.
     #[test]
     fn test_duplicate_key_in_main_pathway() {
         let secret_key = SecretKey::generate();
@@ -864,9 +882,12 @@ mod tests {
             num_sigs_refund: None,
         };
 
-        let secret: Secret = SpendingConditions::new_p2pk(pk_02, Some(conditions))
-            .try_into()
-            .unwrap();
+        let secret: Secret = Nut10Secret::new(
+            Kind::P2PK,
+            crate::nuts::SecretData::new(pk_02.to_hex(), Some(conditions)),
+        )
+        .try_into()
+        .unwrap();
 
         let mut proof = Proof {
             keyset_id: Id::from_str("009a1f293253e41e").unwrap(),
@@ -918,10 +939,12 @@ mod tests {
             num_sigs_refund: Some(2),
         };
 
-        let secret: Secret =
-            SpendingConditions::new_p2pk(secret_key.public_key(), Some(conditions))
-                .try_into()
-                .unwrap();
+        let secret: Secret = Nut10Secret::new(
+            Kind::P2PK,
+            crate::nuts::SecretData::new(secret_key.public_key().to_hex(), Some(conditions)),
+        )
+        .try_into()
+        .unwrap();
 
         let proof = Proof {
             keyset_id: Id::from_str("009a1f293253e41e").unwrap(),
@@ -1102,10 +1125,10 @@ mod tests {
                 .unwrap();
         let pubkey = secret_key.public_key();
 
-        // Create conditions with explicit authorized pubkey
+        // The data key is the authorized key; repeating it in the tag would be a duplicate
         let conditions = Conditions {
             sig_flag: SigFlag::SigAll,
-            pubkeys: Some(vec![pubkey]),
+            pubkeys: None,
             ..Default::default()
         };
 
@@ -1137,7 +1160,7 @@ mod tests {
         // Create conditions with SIG_INPUTS instead of SIG_ALL
         let conditions = Conditions {
             sig_flag: SigFlag::SigInputs,
-            pubkeys: Some(vec![pubkey]),
+            pubkeys: None,
             ..Default::default()
         };
 
@@ -1290,7 +1313,7 @@ mod tests {
 
         let conditions = Conditions {
             sig_flag: SigFlag::SigAll,
-            pubkeys: Some(vec![pubkey]),
+            pubkeys: None,
             ..Default::default()
         };
 
@@ -2266,7 +2289,7 @@ mod tests {
 
         // 2 refund keys, requiring 2 should succeed
         let result = Conditions::new(
-            None,
+            Some(crate::util::unix_time() + 3600),
             None,
             Some(vec![refund_key1, refund_key2]),
             None,
@@ -2274,6 +2297,315 @@ mod tests {
             Some(2),
         );
         assert!(result.is_ok(), "2-of-2 refund multisig should be valid");
+    }
+
+    /// Two keys sharing an x-coordinate, the way a caller repeating a key
+    /// with the other parity byte would supply them.
+    fn duplicate_x_only_pair() -> (PublicKey, PublicKey) {
+        let secret_key = SecretKey::generate();
+        let mut bytes = secret_key.public_key().to_bytes();
+        bytes[0] = 0x02;
+        let pk_02 = PublicKey::from_slice(&bytes).unwrap();
+        bytes[0] = 0x03;
+        let pk_03 = PublicKey::from_slice(&bytes).unwrap();
+        (pk_02, pk_03)
+    }
+
+    fn assert_duplicate_pubkey(err: crate::nut10::Error) {
+        assert!(
+            matches!(err, crate::nut10::Error::NUT11(Error::DuplicatePubkey)),
+            "Expected DuplicatePubkey, got: {err:?}"
+        );
+    }
+
+    /// A key repeated between `data` and the `pubkeys` tag is malformed under
+    /// NUT-11. Collapsing it silently would change the signer set the caller
+    /// asked for, so construction rejects it instead.
+    #[test]
+    fn test_duplicate_key_rejected_at_construction() {
+        let (pk_02, pk_03) = duplicate_x_only_pair();
+
+        let conditions = Conditions {
+            locktime: None,
+            pubkeys: Some(vec![pk_03]),
+            refund_keys: None,
+            num_sigs: None,
+            sig_flag: SigFlag::SigInputs,
+            num_sigs_refund: None,
+        };
+
+        let result: Result<Secret, _> =
+            SpendingConditions::new_p2pk(pk_02, Some(conditions)).try_into();
+
+        assert_duplicate_pubkey(result.expect_err("duplicate key should be rejected"));
+    }
+
+    /// The threshold must not change which error a repeated key produces:
+    /// 1-of-[A, A] and 2-of-[A, A] are the same malformed input.
+    #[test]
+    fn test_duplicate_key_multisig_reports_the_duplicate() {
+        let (pk_02, pk_03) = duplicate_x_only_pair();
+
+        let conditions = Conditions {
+            locktime: None,
+            pubkeys: Some(vec![pk_03]),
+            refund_keys: None,
+            num_sigs: Some(2),
+            sig_flag: SigFlag::SigInputs,
+            num_sigs_refund: None,
+        };
+
+        let result: Result<Secret, _> =
+            SpendingConditions::new_p2pk(pk_02, Some(conditions)).try_into();
+
+        assert_duplicate_pubkey(result.expect_err("2-of-2 over one key should be rejected"));
+    }
+
+    /// A threshold above the number of distinct keys is still its own error.
+    #[test]
+    fn test_impossible_multisig_is_still_reported() {
+        let data = SecretKey::generate().public_key();
+        let other = SecretKey::generate().public_key();
+
+        let conditions = Conditions {
+            locktime: None,
+            pubkeys: Some(vec![other]),
+            refund_keys: None,
+            num_sigs: Some(3),
+            sig_flag: SigFlag::SigInputs,
+            num_sigs_refund: None,
+        };
+
+        let result: Result<Secret, _> =
+            SpendingConditions::new_p2pk(data, Some(conditions)).try_into();
+        let err = result.expect_err("3-of-2 should be rejected");
+
+        assert!(
+            matches!(
+                err,
+                crate::nut10::Error::NUT11(Error::ImpossibleMultisigConfiguration {
+                    required: 3,
+                    available: 2,
+                })
+            ),
+            "Expected ImpossibleMultisigConfiguration, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_duplicate_refund_key_rejected_at_construction() {
+        let (pk_02, pk_03) = duplicate_x_only_pair();
+
+        let conditions = Conditions {
+            locktime: Some(unix_time() + 3600),
+            pubkeys: None,
+            refund_keys: Some(vec![pk_02, pk_03]),
+            num_sigs: None,
+            sig_flag: SigFlag::SigInputs,
+            num_sigs_refund: None,
+        };
+
+        let result: Result<Secret, _> =
+            SpendingConditions::new_p2pk(SecretKey::generate().public_key(), Some(conditions))
+                .try_into();
+
+        assert_duplicate_pubkey(result.expect_err("duplicate refund key should be rejected"));
+    }
+
+    /// The primary and refund pathways are checked separately, so a key that
+    /// can sign before the locktime and reclaim after it stays legal.
+    #[test]
+    fn test_key_may_appear_in_both_pathways() {
+        let pubkey = SecretKey::generate().public_key();
+
+        let conditions = Conditions {
+            locktime: Some(unix_time() + 3600),
+            pubkeys: None,
+            refund_keys: Some(vec![pubkey]),
+            num_sigs: None,
+            sig_flag: SigFlag::SigInputs,
+            num_sigs_refund: None,
+        };
+
+        let secret: Result<Secret, _> =
+            SpendingConditions::new_p2pk(pubkey, Some(conditions)).try_into();
+
+        assert!(
+            secret.is_ok(),
+            "a key in both pathways is not a duplicate: {secret:?}"
+        );
+    }
+
+    #[test]
+    fn test_htlc_duplicate_pubkeys_rejected_at_construction() {
+        use bitcoin::hashes::{sha256, Hash};
+
+        let (pk_02, pk_03) = duplicate_x_only_pair();
+
+        let conditions = Conditions {
+            locktime: None,
+            pubkeys: Some(vec![pk_02, pk_03]),
+            refund_keys: None,
+            num_sigs: None,
+            sig_flag: SigFlag::SigInputs,
+            num_sigs_refund: None,
+        };
+
+        let result: Result<Secret, _> = SpendingConditions::HTLCConditions {
+            data: sha256::Hash::hash(b"preimage"),
+            conditions: Some(conditions),
+        }
+        .try_into();
+
+        assert_duplicate_pubkey(result.expect_err("duplicate HTLC key should be rejected"));
+    }
+
+    #[test]
+    fn test_htlc_duplicate_refund_key_rejected_at_construction() {
+        use bitcoin::hashes::{sha256, Hash};
+
+        let (pk_02, pk_03) = duplicate_x_only_pair();
+
+        let conditions = Conditions {
+            locktime: Some(unix_time() + 3600),
+            pubkeys: None,
+            refund_keys: Some(vec![pk_02, pk_03]),
+            num_sigs: None,
+            sig_flag: SigFlag::SigInputs,
+            num_sigs_refund: None,
+        };
+
+        let result: Result<Secret, _> = SpendingConditions::HTLCConditions {
+            data: sha256::Hash::hash(b"preimage"),
+            conditions: Some(conditions),
+        }
+        .try_into();
+
+        assert_duplicate_pubkey(result.expect_err("duplicate refund key should be rejected"));
+    }
+
+    /// `Conditions::new` cannot see the P2PK `data` key, but it still owns the
+    /// two lists it is given.
+    #[test]
+    fn test_conditions_new_rejects_duplicates_in_each_list() {
+        let (pk_02, pk_03) = duplicate_x_only_pair();
+
+        let err = Conditions::new(None, Some(vec![pk_02, pk_03]), None, None, None, None)
+            .expect_err("duplicate pubkeys should be rejected");
+        assert_duplicate_pubkey(err);
+
+        let err = Conditions::new(
+            Some(unix_time() + 3600),
+            None,
+            Some(vec![pk_02, pk_03]),
+            None,
+            None,
+            None,
+        )
+        .expect_err("duplicate refund keys should be rejected");
+        assert_duplicate_pubkey(err);
+    }
+
+    /// Slot indices exist only for P2BK blinding. A plain lock is bounded by
+    /// what verification accepts, and verification never counts slots.
+    #[test]
+    fn test_plain_p2pk_is_not_slot_capped() {
+        let data = SecretKey::generate().public_key();
+        let pubkeys: Vec<PublicKey> = (0..11)
+            .map(|_| SecretKey::generate().public_key())
+            .collect();
+
+        let conditions = Conditions {
+            locktime: None,
+            pubkeys: Some(pubkeys),
+            refund_keys: None,
+            num_sigs: Some(1),
+            sig_flag: SigFlag::SigInputs,
+            num_sigs_refund: None,
+        };
+
+        let secret: Secret = SpendingConditions::new_p2pk(data, Some(conditions))
+            .try_into()
+            .expect("twelve keys are a valid NUT-11 lock");
+
+        let nut10: Nut10Secret = secret.try_into().unwrap();
+        let requirements = get_pubkeys_and_required_sigs(&nut10, unix_time()).unwrap();
+
+        assert_eq!(requirements.pubkeys.len(), 12);
+    }
+
+    /// The HTLC `data` is a preimage hash, not a key, so it never occupies a
+    /// slot and the P2BK ceiling must not reach this path.
+    #[test]
+    fn test_plain_htlc_is_not_slot_capped() {
+        use bitcoin::hashes::{sha256, Hash};
+
+        let pubkeys: Vec<PublicKey> = (0..11)
+            .map(|_| SecretKey::generate().public_key())
+            .collect();
+        let refund_key = SecretKey::generate().public_key();
+
+        let conditions = Conditions {
+            locktime: None,
+            pubkeys: Some(pubkeys.clone()),
+            refund_keys: None,
+            num_sigs: Some(1),
+            sig_flag: SigFlag::SigInputs,
+            num_sigs_refund: None,
+        };
+        let hash = sha256::Hash::hash(b"preimage");
+
+        let result: Result<Secret, _> = SpendingConditions::HTLCConditions {
+            data: hash,
+            conditions: Some(conditions),
+        }
+        .try_into();
+        assert!(
+            result.is_ok(),
+            "eleven pubkeys should build: {:?}",
+            result.err()
+        );
+
+        let conditions = Conditions {
+            locktime: Some(unix_time() + 3600),
+            pubkeys: Some(pubkeys[..10].to_vec()),
+            refund_keys: Some(vec![refund_key]),
+            num_sigs: Some(1),
+            sig_flag: SigFlag::SigInputs,
+            num_sigs_refund: Some(1),
+        };
+
+        let result: Result<Secret, _> = SpendingConditions::HTLCConditions {
+            data: hash,
+            conditions: Some(conditions),
+        }
+        .try_into();
+        assert!(
+            result.is_ok(),
+            "ten pubkeys plus a refund key should build: {:?}",
+            result.err()
+        );
+    }
+
+    /// Refund keys only become spendable once the locktime passes, so omitting
+    /// it would lock the funds behind a path that never opens.
+    #[test]
+    fn test_conditions_refund_keys_require_locktime() {
+        let refund_key = PublicKey::from_str(
+            "033281c37677ea273eb7183b783067f5244933ef78d8c3f15b1a77cb246099c26e",
+        )
+        .unwrap();
+
+        let err = Conditions::new(None, None, Some(vec![refund_key]), None, None, None)
+            .expect_err("refund keys without a locktime should be rejected");
+
+        assert!(
+            matches!(
+                err,
+                crate::nut10::Error::NUT11(Error::RefundKeysRequireLocktime)
+            ),
+            "Expected RefundKeysRequireLocktime, got: {err:?}"
+        );
     }
 
     #[test]

--- a/crates/cashu/src/nuts/nut18/payment_request.rs
+++ b/crates/cashu/src/nuts/nut18/payment_request.rs
@@ -581,7 +581,7 @@ mod tests {
         let payment_request = PaymentRequestBuilder::default()
             .unit(CurrencyUnit::Sat)
             .amount(10)
-            .nut10(nut10.into())
+            .nut10(nut10.try_into().unwrap())
             .build();
 
         let payment_request_str = payment_request.to_string();
@@ -608,7 +608,7 @@ mod tests {
             .amount(10)
             .payment_id("test-p2pk-id")
             .description("P2PK locked payment")
-            .nut10(nut10.into())
+            .nut10(nut10.try_into().unwrap())
             .build();
 
         // Convert to string representation

--- a/crates/cashu/src/nuts/nut18/secret.rs
+++ b/crates/cashu/src/nuts/nut18/secret.rs
@@ -1,7 +1,7 @@
 //! Secret types for NUT-18: Payment Requests
 use serde::{Deserialize, Serialize};
 
-use crate::nuts::nut10::{Kind, SpendingConditions};
+use crate::nuts::nut10::{Error as Nut10Error, Kind, SpendingConditions};
 use crate::nuts::Nut10Secret;
 use crate::SecretData;
 
@@ -50,16 +50,21 @@ impl From<Nut10SecretRequest> for Nut10Secret {
     }
 }
 
-impl From<SpendingConditions> for Nut10SecretRequest {
-    fn from(conditions: SpendingConditions) -> Self {
-        match conditions {
+/// A request advertises a lock the payer will build, so it has to pass the same
+/// construction rules the secret itself would.
+impl TryFrom<SpendingConditions> for Nut10SecretRequest {
+    type Error = Nut10Error;
+    fn try_from(conditions: SpendingConditions) -> Result<Self, Self::Error> {
+        conditions.validate()?;
+
+        Ok(match conditions {
             SpendingConditions::P2PKConditions { data, conditions } => {
                 Self::new(Kind::P2PK, data.to_hex(), conditions)
             }
             SpendingConditions::HTLCConditions { data, conditions } => {
                 Self::new(Kind::HTLC, data.to_string(), conditions)
             }
-        }
+        })
     }
 }
 
@@ -95,6 +100,35 @@ mod tests {
         let decoded: Nut10SecretRequest = serde_json::from_str(&json).unwrap();
 
         assert_eq!(original, decoded);
+    }
+
+    /// A request advertises a lock the payer will go on to build, so it cannot
+    /// carry one the payer would refuse.
+    #[test]
+    fn test_request_rejects_duplicate_p2pk_key() {
+        use std::str::FromStr;
+
+        use crate::nuts::nut10::Conditions;
+        use crate::nuts::nut11::Error as Nut11Error;
+        use crate::PublicKey;
+
+        let key = PublicKey::from_str(
+            "026562efcfadc8e86d44da6a8adf80633d974302e62c850774db1fb36ff4cc7198",
+        )
+        .unwrap();
+
+        let result = Nut10SecretRequest::try_from(SpendingConditions::P2PKConditions {
+            data: key,
+            conditions: Some(Conditions {
+                pubkeys: Some(vec![key]),
+                ..Default::default()
+            }),
+        });
+
+        assert!(matches!(
+            result,
+            Err(Nut10Error::NUT11(Nut11Error::DuplicatePubkey))
+        ));
     }
 
     #[test]

--- a/crates/cdk-ffi/src/lib.rs
+++ b/crates/cdk-ffi/src/lib.rs
@@ -320,7 +320,7 @@ mod tests {
         assert!(encoded.contains(&secret_hex));
         assert!(encoded.contains("p2pk_signing_keys"));
         assert!(!debug.contains(&secret_hex));
-        assert!(debug.contains("[redacted]"));
+        assert!(debug.contains("[REDACTED]"));
 
         let decoded = crate::types::wallet::decode_send_options(encoded).unwrap();
 
@@ -377,7 +377,7 @@ mod tests {
         assert!(encoded.contains(&secret_hex));
         assert!(encoded.contains("p2pk_signing_keys"));
         assert!(!debug.contains(&secret_hex));
-        assert!(debug.contains("[redacted]"));
+        assert!(debug.contains("[REDACTED]"));
 
         let decoded = crate::types::wallet::decode_receive_options(encoded).unwrap();
 

--- a/crates/cdk-ffi/src/types/wallet.rs
+++ b/crates/cdk-ffi/src/types/wallet.rs
@@ -331,7 +331,7 @@ pub struct SecretKey {
 impl fmt::Debug for SecretKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SecretKey")
-            .field("hex", &"[redacted]")
+            .field("hex", &"[REDACTED]")
             .finish()
     }
 }

--- a/crates/cdk/src/test_helpers/nut10.rs
+++ b/crates/cdk/src/test_helpers/nut10.rs
@@ -103,7 +103,10 @@ impl TestMintHelper {
         amount: Amount,
         spending_conditions: &SpendingConditions,
     ) -> (BlindedMessage, SecretKey, Secret) {
-        let nut10_secret: Nut10Secret = spending_conditions.clone().into();
+        let nut10_secret: Nut10Secret = spending_conditions
+            .clone()
+            .try_into()
+            .expect("test spending conditions must be valid");
         let secret: Secret = nut10_secret.try_into().unwrap();
         let (blinded_point, blinding_factor) = blind_message(&secret.to_bytes(), None).unwrap();
         let blinded_msg = BlindedMessage::new(amount, self.active_sat_keyset_id, blinded_point);

--- a/crates/cdk/src/wallet/payment_request.rs
+++ b/crates/cdk/src/wallet/payment_request.rs
@@ -206,6 +206,54 @@ mod tests {
 
     use super::*;
 
+    async fn test_repository() -> WalletRepository {
+        use cdk_common::database::{Error as DatabaseError, WalletDatabase};
+
+        let localstore: Arc<dyn WalletDatabase<DatabaseError> + Send + Sync> = Arc::new(
+            cdk_sqlite::wallet::memory::empty()
+                .await
+                .expect("in-memory database"),
+        );
+
+        crate::wallet::WalletRepositoryBuilder::new()
+            .localstore(localstore)
+            .seed([0u8; 64])
+            .build()
+            .await
+            .expect("repository")
+    }
+
+    /// A request advertising the same key twice would build a lock the payer
+    /// cannot satisfy, so it has to fail on the requester's side. Mirrors what
+    /// `create_request` does with the parsed conditions.
+    #[tokio::test]
+    async fn get_pr_spending_conditions_rejects_duplicate_pubkey() {
+        let pubkey = crate::nuts::SecretKey::generate().public_key().to_hex();
+        let params = CreateRequestParams {
+            pubkeys: Some(vec![pubkey.clone(), pubkey]),
+            ..Default::default()
+        };
+
+        let conditions = test_repository()
+            .await
+            .get_pr_spending_conditions(&params)
+            .expect("params should parse")
+            .expect("conditions should be present");
+
+        let err = Error::from(
+            Nut10SecretRequest::try_from(conditions)
+                .expect_err("duplicate pubkey should be rejected"),
+        );
+
+        assert!(
+            matches!(
+                err,
+                Error::NUT11(crate::nuts::nut11::Error::DuplicatePubkey)
+            ),
+            "Expected DuplicatePubkey, got: {err:?}"
+        );
+    }
+
     #[test]
     fn create_request_params_default_is_strict_by_default() {
         let params = CreateRequestParams::default();
@@ -757,7 +805,7 @@ impl WalletRepository {
     /// - Centralizes translation of CLI/SDK inputs (P2PK multisig and HTLC variants) into
     ///   a single, canonical `SpendingConditions` shape so requests are consistent.
     /// - Prevents ambiguous construction by capping `num_sigs` to the number of provided keys
-    ///   and rejecting malformed hashes/inputs early.
+    ///   and rejecting malformed hashes/inputs early. Repeated keys are an error, not a cap.
     /// - Encourages safe defaults by selecting `SigFlag::SigInputs` and composing conditions
     ///   that can be verified by recipients and mints.
     ///
@@ -772,6 +820,9 @@ impl WalletRepository {
     /// Errors:
     /// - Invalid SHA-256 `hash` strings or invalid HTLC/P2PK parameterizations surface as errors
     ///   from parsing and `SpendingConditions` constructors.
+    /// - Conditions are validated here, so a request advertising a key twice within one
+    ///   signing pathway fails at creation with `DuplicatePubkey` rather than on the
+    ///   payer's side.
     fn get_pr_spending_conditions(
         &self,
         params: &CreateRequestParams,
@@ -852,6 +903,7 @@ impl WalletRepository {
             } else {
                 None
             };
+
         Ok(spending_conditions)
     }
 
@@ -956,7 +1008,8 @@ impl WalletRepository {
 
         let nut10 = self
             .get_pr_spending_conditions(&params)?
-            .map(Nut10SecretRequest::from);
+            .map(Nut10SecretRequest::try_from)
+            .transpose()?;
 
         let req = PaymentRequest {
             payment_id: None,
@@ -1027,7 +1080,8 @@ impl WalletRepository {
 
         let nut10 = self
             .get_pr_spending_conditions(&params)?
-            .map(Nut10SecretRequest::from);
+            .map(Nut10SecretRequest::try_from)
+            .transpose()?;
 
         let req = PaymentRequest {
             payment_id: None,

--- a/crates/cdk/src/wallet/send/saga/mod.rs
+++ b/crates/cdk/src/wallet/send/saga/mod.rs
@@ -1226,7 +1226,7 @@ mod tests {
     fn test_p2pk_proof(keyset_id: crate::nuts::Id, amount: u64) -> Proof {
         let secret_key = SecretKey::generate();
         let spending_conditions = SpendingConditions::new_p2pk(secret_key.public_key(), None);
-        let nut10_secret: crate::nuts::nut10::Secret = spending_conditions.into();
+        let nut10_secret: crate::nuts::nut10::Secret = spending_conditions.try_into().unwrap();
         let secret: crate::secret::Secret = nut10_secret.try_into().unwrap();
         let mut proof = test_proof(keyset_id, amount);
         proof.secret = secret;

--- a/crates/cdk/src/wallet/util.rs
+++ b/crates/cdk/src/wallet/util.rs
@@ -179,7 +179,7 @@ mod tests {
 
     fn make_p2pk_proof(pubkey: PublicKey) -> Proof {
         let spending_conditions = SpendingConditions::new_p2pk(pubkey, None);
-        let nut10_secret: crate::nuts::nut10::Secret = spending_conditions.into();
+        let nut10_secret: crate::nuts::nut10::Secret = spending_conditions.try_into().unwrap();
         let secret: crate::secret::Secret = nut10_secret.try_into().unwrap();
         Proof::new(
             Amount::from(1),

--- a/fuzz/fuzz_targets/fuzz_htlc_verify.rs
+++ b/fuzz/fuzz_targets/fuzz_htlc_verify.rs
@@ -147,7 +147,7 @@ fuzz_target!(|input: Input| {
             };
             let spending = SpendingConditions::new_htlc(preimage.clone(), conditions)
                 .expect("32-byte preimage must create HTLC conditions");
-            let nut10: Nut10Secret = spending.into();
+            let nut10: Nut10Secret = cdk_fuzz::nut10_secret_unchecked(spending);
             let secret: SecretString = nut10
                 .try_into()
                 .expect("generated valid HTLC conditions must serialize");
@@ -206,7 +206,7 @@ fuzz_target!(|input: Input| {
             };
             let spending = SpendingConditions::new_htlc(preimage, Some(conditions))
                 .expect("valid refund conditions must create an HTLC");
-            let nut10: Nut10Secret = spending.into();
+            let nut10: Nut10Secret = cdk_fuzz::nut10_secret_unchecked(spending);
             let secret: SecretString = nut10
                 .try_into()
                 .expect("generated valid HTLC refund conditions must serialize");

--- a/fuzz/fuzz_targets/fuzz_p2pk_verify.rs
+++ b/fuzz/fuzz_targets/fuzz_p2pk_verify.rs
@@ -140,7 +140,7 @@ fuzz_target!(|input: Input| {
             num_sigs_refund: None,
         };
         let spending = SpendingConditions::new_p2pk(receiver_pk, Some(conditions));
-        let nut10: Nut10Secret = spending.into();
+        let nut10: Nut10Secret = cdk_fuzz::nut10_secret_unchecked(spending);
         let secret: SecretString = nut10
             .try_into()
             .expect("generated valid P2PK conditions must serialize");
@@ -215,7 +215,7 @@ fuzz_target!(|input: Input| {
     let spending = SpendingConditions::new_p2pk(receiver_pk, Some(conditions));
 
     // Convert to a Nut10Secret, then to the JSON-encoded plaintext `Secret`.
-    let mut nut10: Nut10Secret = spending.into();
+    let mut nut10: Nut10Secret = cdk_fuzz::nut10_secret_unchecked(spending);
 
     // Optionally mutate the data field to a fuzz-provided string so we can
     // feed malformed hex into the pubkey parser inside `verify_p2pk`.

--- a/fuzz/src/arbitrary_ext.rs
+++ b/fuzz/src/arbitrary_ext.rs
@@ -221,7 +221,7 @@ impl<'a> Arbitrary<'a> for SecretStringArb {
                 let pk = PublicKeyArb::arbitrary(u)?.into_inner();
                 let cond = ConditionsArb::arbitrary(u)?.into_inner();
                 let sc = SpendingConditions::new_p2pk(pk, Some(cond));
-                let nut10: Nut10Secret = sc.into();
+                let nut10 = crate::nut10_secret_unchecked(sc);
                 match SecretString::try_from(nut10) {
                     Ok(s) => s,
                     Err(_) => SecretString::generate(),

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -8,7 +8,26 @@
 
 pub mod arbitrary_ext;
 
-use cashu::{PublicKey, SecretKey};
+use cashu::nuts::nut10::{Kind, SecretData};
+use cashu::nuts::SpendingConditions;
+use cashu::{Nut10Secret, PublicKey, SecretKey};
+
+/// Build a NUT-10 secret without the construction checks the public
+/// conversion applies.
+///
+/// Verifier fuzzing needs malformed locks (duplicate keys, impossible
+/// thresholds) to reach the verifier at all, and the validating `TryFrom` would
+/// reject them before they got there.
+pub fn nut10_secret_unchecked(conditions: SpendingConditions) -> Nut10Secret {
+    match conditions {
+        SpendingConditions::P2PKConditions { data, conditions } => {
+            Nut10Secret::new(Kind::P2PK, SecretData::new(data.to_hex(), conditions))
+        }
+        SpendingConditions::HTLCConditions { data, conditions } => {
+            Nut10Secret::new(Kind::HTLC, SecretData::new(data.to_string(), conditions))
+        }
+    }
+}
 
 /// Deterministic `SecretKey` from 32 fuzz bytes.
 ///


### PR DESCRIPTION
### Description

Fixes #2389. This fix was extracted from #1982

Spending validation counts pubkeys by x-coordinate and rejects repeats, but construction counted them naively. A caller could build a nominal 2-of-2 whose two keys are the same key, mint the output, and only find out at spend time that nothing can satisfy it.

Dedupe on the same x-only view verification uses, with the P2PK data key sharing the set with the pubkeys tag, and validate the threshold after the collapse rather than before. While here: enforce the NUT-28 slot ceiling, reject refund keys with no locktime since that path never opens, and route with_conditions through the validating conversion it was bypassing.

Amount::split already rejects a keyset advertising a zero denomination. Say so on the function and pin it with a test.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
