### PR TITLE
feat(cdk-mint-rpc): expose transaction output quote details

### DIFF
--- a/crates/cdk-bdk/src/lib.rs
+++ b/crates/cdk-bdk/src/lib.rs
@@ -57,6 +57,7 @@ pub mod wallet_info;
 
 pub use crate::wallet_info::{
     WalletAddress, WalletBalance, WalletKeychain, WalletPage, WalletTransaction,
+    WalletTransactionInput, WalletTransactionOutput,
 };
 
 /// Wrapper struct that combines wallet and database to prevent deadlocks
@@ -446,6 +447,7 @@ impl MintPayment for CdkBdk {
 
         self.recover_receive_saga().await?;
         self.recover_send_saga().await?;
+        self.storage.ensure_send_outpoint_quote_id_index().await?;
 
         let cancel = CancellationToken::new();
 
@@ -1032,6 +1034,15 @@ mod tests {
         assert_eq!(transactions.items[0].balance_delta_sat, 42_000);
         assert_eq!(transactions.items[0].confirmation_height, None);
         assert_eq!(transactions.items[0].first_seen, Some(0));
+        assert_eq!(
+            transactions.items[0].inputs,
+            vec![WalletTransactionInput {
+                txid: Txid::all_zeros().to_string(),
+                vout: 0,
+                amount_sat: None,
+                address: None,
+            }]
+        );
 
         let addresses = backend
             .wallet_addresses(0, 20)
@@ -1039,6 +1050,15 @@ mod tests {
             .expect("list addresses");
         assert_eq!(addresses.total, 1);
         assert!(addresses.items[0].used);
+        assert_eq!(
+            transactions.items[0].outputs,
+            vec![WalletTransactionOutput {
+                vout: 0,
+                address: addresses.items[0].address.clone(),
+                amount_sat: 42_000,
+                quote_id: None,
+            }]
+        );
         assert_eq!(addresses.items[0].balance_sat, 42_000);
         assert_eq!(addresses.items[0].confirmed_balance_sat, 0);
 
@@ -1048,6 +1068,259 @@ mod tests {
             .expect("list empty transaction page");
         assert_eq!(empty_page.total, 1);
         assert!(empty_page.items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn wallet_info_pairs_unconfirmed_incoming_output_with_quote_id() {
+        let (backend, _tmp) = build_test_instance_with_tempdir(1).await;
+        fund_backend_wallet(&backend, 42_000).await;
+        let address = backend
+            .wallet_addresses(0, 20)
+            .await
+            .expect("list addresses")
+            .items[0]
+            .address
+            .clone();
+        backend
+            .storage
+            .track_receive_address(&address, "mint-quote")
+            .await
+            .expect("track receive address");
+
+        let transactions = backend
+            .wallet_transactions(0, 20)
+            .await
+            .expect("list transactions");
+        assert_eq!(
+            transactions.items[0].outputs,
+            vec![WalletTransactionOutput {
+                vout: 0,
+                address,
+                amount_sat: 42_000,
+                quote_id: Some("mint-quote".to_string()),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn wallet_info_pairs_batched_outputs_with_quote_ids() {
+        let (backend, _tmp) = build_test_instance_with_tempdir(1).await;
+        let funding_txids = fund_backend_wallet_transactions(&backend, &[20_000, 22_000]).await;
+        let funding_address = backend
+            .wallet_addresses(0, 20)
+            .await
+            .expect("list funding address")
+            .items[0]
+            .address
+            .clone();
+        let first_address = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string();
+        let second_address = "bcrt1q6rhpng9evdsfnn833a4f4vej0asu6dk5srld6x".to_string();
+
+        let mut wallet_with_db = backend.wallet_with_db.lock().await;
+        let first_recipient_script = bdk_wallet::bitcoin::Address::from_str(&first_address)
+            .expect("valid address")
+            .require_network(Network::Regtest)
+            .expect("regtest address")
+            .script_pubkey();
+        let second_recipient_script = bdk_wallet::bitcoin::Address::from_str(&second_address)
+            .expect("valid address")
+            .require_network(Network::Regtest)
+            .expect("regtest address")
+            .script_pubkey();
+        let change_script = wallet_with_db
+            .wallet
+            .reveal_next_address(KeychainKind::Internal)
+            .address
+            .script_pubkey();
+        let spending_transaction = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: funding_txids
+                .iter()
+                .rev()
+                .map(|txid| TxIn {
+                    previous_output: OutPoint::new(*txid, 0),
+                    script_sig: Default::default(),
+                    sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                    witness: Witness::new(),
+                })
+                .collect(),
+            output: vec![
+                TxOut {
+                    value: bdk_wallet::bitcoin::Amount::from_sat(20_000),
+                    script_pubkey: first_recipient_script,
+                },
+                TxOut {
+                    value: bdk_wallet::bitcoin::Amount::from_sat(10_000),
+                    script_pubkey: second_recipient_script,
+                },
+                TxOut {
+                    value: bdk_wallet::bitcoin::Amount::from_sat(11_900),
+                    script_pubkey: change_script,
+                },
+            ],
+        };
+        let spending_txid = spending_transaction.compute_txid();
+        wallet_with_db
+            .wallet
+            .apply_unconfirmed_txs([(spending_transaction, 1)]);
+        wallet_with_db
+            .persist()
+            .expect("persist spending transaction");
+        drop(wallet_with_db);
+
+        let batch_id = Uuid::new_v4();
+        let intents = [
+            (Uuid::new_v4(), "quote-first", &first_address, 20_000, 0),
+            (Uuid::new_v4(), "quote-second", &second_address, 10_000, 1),
+        ];
+        for (intent_id, quote_id, address, amount_sat, vout) in &intents {
+            backend
+                .storage
+                .create_send_intent_if_absent(
+                    &crate::send::payment_intent::record::SendIntentRecord {
+                        intent_id: *intent_id,
+                        quote_id: quote_id.to_string(),
+                        address: address.to_string(),
+                        amount_sat: *amount_sat,
+                        max_fee_amount_sat: 1_000,
+                        tier: PaymentTier::Immediate,
+                        metadata: PaymentMetadata::default(),
+                        state: crate::send::payment_intent::record::SendIntentState::AwaitingConfirmation {
+                            batch_id,
+                            txid: spending_txid.to_string(),
+                            outpoint: format!("{spending_txid}:{vout}"),
+                            fee_contribution_sat: 50,
+                            created_at: 0,
+                        },
+                    },
+                )
+                .await
+                .expect("store send intent");
+        }
+
+        let transactions = backend
+            .wallet_transactions(0, 20)
+            .await
+            .expect("list transactions");
+
+        assert_eq!(transactions.total, 3);
+        assert_eq!(
+            transactions.items[0].inputs,
+            vec![
+                WalletTransactionInput {
+                    txid: funding_txids[1].to_string(),
+                    vout: 0,
+                    amount_sat: Some(22_000),
+                    address: Some(funding_address.clone()),
+                },
+                WalletTransactionInput {
+                    txid: funding_txids[0].to_string(),
+                    vout: 0,
+                    amount_sat: Some(20_000),
+                    address: Some(funding_address),
+                },
+            ]
+        );
+        assert_eq!(
+            transactions.items[0].outputs,
+            vec![
+                WalletTransactionOutput {
+                    vout: 0,
+                    address: first_address.clone(),
+                    amount_sat: 20_000,
+                    quote_id: Some("quote-first".to_string()),
+                },
+                WalletTransactionOutput {
+                    vout: 1,
+                    address: second_address.clone(),
+                    amount_sat: 10_000,
+                    quote_id: Some("quote-second".to_string()),
+                },
+            ]
+        );
+        assert_eq!(transactions.items[0].sent_sat, 42_000);
+        assert_eq!(transactions.items[0].received_sat, 11_900);
+
+        for (intent_id, quote_id, _, amount_sat, vout) in &intents {
+            backend
+                .storage
+                .finalize_send_intent(
+                    intent_id,
+                    &FinalizedSendIntentRecord {
+                        intent_id: *intent_id,
+                        quote_id: quote_id.to_string(),
+                        total_spent_sat: *amount_sat + 50,
+                        outpoint: format!("{spending_txid}:{vout}"),
+                        finalized_at: 0,
+                    },
+                )
+                .await
+                .expect("finalize send intent");
+        }
+
+        let finalized_transactions = backend
+            .wallet_transactions(0, 20)
+            .await
+            .expect("list transactions after intent finalization");
+        assert_eq!(
+            finalized_transactions.items[0]
+                .outputs
+                .iter()
+                .map(|output| output.quote_id.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("quote-first"), Some("quote-second")]
+        );
+    }
+
+    #[tokio::test]
+    async fn wallet_info_reports_multiple_incoming_outputs_in_vout_order() {
+        let (backend, _tmp) = build_test_instance_with_tempdir(1).await;
+        let mut wallet_with_db = backend.wallet_with_db.lock().await;
+        let output_script = wallet_with_db
+            .wallet
+            .reveal_next_address(KeychainKind::External)
+            .address
+            .script_pubkey();
+        let funding_transaction = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::new(Txid::all_zeros(), 0),
+                script_sig: Default::default(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![
+                TxOut {
+                    value: bdk_wallet::bitcoin::Amount::from_sat(21_000),
+                    script_pubkey: output_script.clone(),
+                },
+                TxOut {
+                    value: bdk_wallet::bitcoin::Amount::from_sat(21_000),
+                    script_pubkey: output_script,
+                },
+            ],
+        };
+        wallet_with_db
+            .wallet
+            .apply_unconfirmed_txs([(funding_transaction, 0)]);
+        wallet_with_db
+            .persist()
+            .expect("persist funding transaction");
+        drop(wallet_with_db);
+
+        let transactions = backend
+            .wallet_transactions(0, 20)
+            .await
+            .expect("list transactions");
+
+        assert_eq!(transactions.total, 1);
+        assert_eq!(transactions.items[0].outputs.len(), 2);
+        assert_eq!(transactions.items[0].outputs[0].vout, 0);
+        assert_eq!(transactions.items[0].outputs[0].amount_sat, 21_000);
+        assert_eq!(transactions.items[0].outputs[1].vout, 1);
+        assert_eq!(transactions.items[0].outputs[1].amount_sat, 21_000);
     }
 
     #[tokio::test]

--- a/crates/cdk-bdk/src/storage/mod.rs
+++ b/crates/cdk-bdk/src/storage/mod.rs
@@ -26,6 +26,15 @@ pub const SEND_INTENT_NAMESPACE: &str = "send_intent";
 /// Secondary namespace for send intent quote id index
 pub const SEND_INTENT_QUOTE_ID_NAMESPACE: &str = "send_intent_quote_id";
 
+/// Secondary namespace for send output quote id index (outpoint -> quote_id)
+pub const SEND_OUTPOINT_QUOTE_ID_NAMESPACE: &str = "send_outpoint_quote_id";
+
+/// Secondary namespace for one-time BDK storage migrations.
+pub const STORAGE_MIGRATION_NAMESPACE: &str = "storage_migration";
+
+/// Marker for the send output quote id index backfill.
+pub const SEND_OUTPOINT_QUOTE_ID_BACKFILL_KEY: &str = "send_outpoint_quote_id_v1";
+
 /// Secondary namespace for send batches
 pub const SEND_BATCH_NAMESPACE: &str = "send_batch";
 
@@ -675,6 +684,13 @@ mod tests {
             .await
             .expect("get tombstone")
             .is_some());
+        assert_eq!(
+            storage
+                .get_quote_id_by_send_outpoint("txid:0")
+                .await
+                .expect("lookup finalized output quote"),
+            Some(quote_id.clone())
+        );
 
         // A new intent for the SAME quote ID should NOT be allowed
         let mut second = make_pending_intent(Uuid::new_v4());
@@ -910,6 +926,124 @@ mod tests {
             }
             other => panic!("Expected AwaitingConfirmation, got {:?}", other),
         }
+        assert_eq!(
+            storage
+                .get_quote_id_by_send_outpoint("abc123:0")
+                .await
+                .expect("lookup output quote"),
+            Some("quote-confirm".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_outpoint_quote_index_tracks_state_changes() {
+        let storage = test_storage().await;
+        let intent_id = Uuid::new_v4();
+        let intent = make_pending_intent(intent_id);
+        storage
+            .create_send_intent_if_absent(&intent)
+            .await
+            .expect("store intent");
+
+        storage
+            .update_send_intent(
+                &intent_id,
+                &SendIntentState::AwaitingConfirmation {
+                    batch_id: Uuid::new_v4(),
+                    txid: "indexed-txid".to_string(),
+                    outpoint: "indexed-txid:2".to_string(),
+                    fee_contribution_sat: 300,
+                    created_at: 1_700_000_000,
+                },
+            )
+            .await
+            .expect("mark intent awaiting confirmation");
+        assert_eq!(
+            storage
+                .get_quote_id_by_send_outpoint("indexed-txid:2")
+                .await
+                .expect("lookup indexed output"),
+            Some(intent.quote_id.clone())
+        );
+
+        storage
+            .update_send_intent(
+                &intent_id,
+                &SendIntentState::Pending {
+                    created_at: 1_700_000_000,
+                },
+            )
+            .await
+            .expect("revert intent to pending");
+        assert_eq!(
+            storage
+                .get_quote_id_by_send_outpoint("indexed-txid:2")
+                .await
+                .expect("lookup removed output index"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn test_backfill_send_outpoint_quote_id_index() {
+        let storage = test_storage().await;
+        let active_intent = SendIntentRecord {
+            intent_id: Uuid::new_v4(),
+            quote_id: "active-legacy-quote".to_string(),
+            address: "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            amount_sat: 75_000,
+            max_fee_amount_sat: 2_000,
+            tier: PaymentTier::Standard,
+            metadata: PaymentMetadata::default(),
+            state: SendIntentState::AwaitingConfirmation {
+                batch_id: Uuid::new_v4(),
+                txid: "active-legacy-txid".to_string(),
+                outpoint: "active-legacy-txid:0".to_string(),
+                fee_contribution_sat: 300,
+                created_at: 1_700_000_000,
+            },
+        };
+        let finalized_intent = FinalizedSendIntentRecord {
+            intent_id: Uuid::new_v4(),
+            quote_id: "finalized-legacy-quote".to_string(),
+            total_spent_sat: 76_000,
+            outpoint: "finalized-legacy-txid:1".to_string(),
+            finalized_at: 1_700_000_001,
+        };
+        storage
+            .put_record(&active_intent)
+            .await
+            .expect("store legacy active intent");
+        storage
+            .put_record(&finalized_intent)
+            .await
+            .expect("store legacy finalized intent");
+
+        assert_eq!(
+            storage
+                .get_quote_id_by_send_outpoint("active-legacy-txid:0")
+                .await
+                .expect("lookup missing active index"),
+            None
+        );
+        storage
+            .ensure_send_outpoint_quote_id_index()
+            .await
+            .expect("backfill output quote index");
+        assert_eq!(
+            storage
+                .get_quote_id_by_send_outpoint("active-legacy-txid:0")
+                .await
+                .expect("lookup active index"),
+            Some(active_intent.quote_id)
+        );
+        assert_eq!(
+            storage
+                .get_quote_id_by_send_outpoint("finalized-legacy-txid:1")
+                .await
+                .expect("lookup finalized index"),
+            Some(finalized_intent.quote_id)
+        );
     }
 
     #[tokio::test]

--- a/crates/cdk-bdk/src/storage/send.rs
+++ b/crates/cdk-bdk/src/storage/send.rs
@@ -3,9 +3,10 @@ use std::str::FromStr;
 use uuid::Uuid;
 
 use super::{
-    BdkStorage, FailedSendAttemptRecord, FinalizedSendIntentRecord, BDK_NAMESPACE,
+    outpoint_to_key, BdkStorage, FailedSendAttemptRecord, FinalizedSendIntentRecord, BDK_NAMESPACE,
     FINALIZED_INTENT_NAMESPACE, FINALIZED_SEND_INTENT_QUOTE_ID_NAMESPACE, SEND_INTENT_NAMESPACE,
-    SEND_INTENT_QUOTE_ID_NAMESPACE,
+    SEND_INTENT_QUOTE_ID_NAMESPACE, SEND_OUTPOINT_QUOTE_ID_BACKFILL_KEY,
+    SEND_OUTPOINT_QUOTE_ID_NAMESPACE, STORAGE_MIGRATION_NAMESPACE,
 };
 use crate::error::Error;
 use crate::send::batch_transaction::record::{SendBatchRecord, SendBatchState};
@@ -70,6 +71,16 @@ impl BdkStorage {
         )
         .await
         .map_err(Error::from)?;
+        if let SendIntentState::AwaitingConfirmation { outpoint, .. } = &intent.state {
+            tx.kv_write(
+                BDK_NAMESPACE,
+                SEND_OUTPOINT_QUOTE_ID_NAMESPACE,
+                &outpoint_to_key(outpoint),
+                intent.quote_id.as_bytes(),
+            )
+            .await
+            .map_err(Error::from)?;
+        }
         tx.commit().await.map_err(Error::from)?;
         Ok(())
     }
@@ -157,6 +168,16 @@ impl BdkStorage {
         )
         .await
         .map_err(Error::from)?;
+        if let SendIntentState::AwaitingConfirmation { outpoint, .. } = &record.state {
+            tx.kv_write(
+                BDK_NAMESPACE,
+                SEND_OUTPOINT_QUOTE_ID_NAMESPACE,
+                &outpoint_to_key(outpoint),
+                record.quote_id.as_bytes(),
+            )
+            .await
+            .map_err(Error::from)?;
+        }
         tx.commit().await.map_err(Error::from)?;
         Ok(record)
     }
@@ -176,13 +197,55 @@ impl BdkStorage {
         intent_id: &Uuid,
         new_state: &SendIntentState,
     ) -> Result<(), Error> {
-        let key = intent_id.to_string();
-        if self.get_send_intent(intent_id).await?.is_none() {
+        let Some(mut intent) = self.get_send_intent(intent_id).await? else {
             return Err(Error::SendIntentNotFound(*intent_id));
-        }
+        };
+        let previous_outpoint = match &intent.state {
+            SendIntentState::AwaitingConfirmation { outpoint, .. } => Some(outpoint.clone()),
+            _ => None,
+        };
+        let new_outpoint = match new_state {
+            SendIntentState::AwaitingConfirmation { outpoint, .. } => Some(outpoint.clone()),
+            _ => None,
+        };
+        intent.state = new_state.clone();
 
-        self.update_record_state::<SendIntentRecord, SendIntentState>(&key, new_state)
+        let serialized = serde_json::to_vec(&intent)?;
+        let mut tx = self
+            .kv_store
+            .begin_transaction()
             .await
+            .map_err(Error::from)?;
+        tx.kv_write(
+            BDK_NAMESPACE,
+            SEND_INTENT_NAMESPACE,
+            &intent_id.to_string(),
+            &serialized,
+        )
+        .await
+        .map_err(Error::from)?;
+        if let Some(outpoint) =
+            previous_outpoint.filter(|outpoint| Some(outpoint) != new_outpoint.as_ref())
+        {
+            tx.kv_remove(
+                BDK_NAMESPACE,
+                SEND_OUTPOINT_QUOTE_ID_NAMESPACE,
+                &outpoint_to_key(&outpoint),
+            )
+            .await
+            .map_err(Error::from)?;
+        }
+        if let Some(outpoint) = new_outpoint {
+            tx.kv_write(
+                BDK_NAMESPACE,
+                SEND_OUTPOINT_QUOTE_ID_NAMESPACE,
+                &outpoint_to_key(&outpoint),
+                intent.quote_id.as_bytes(),
+            )
+            .await
+            .map_err(Error::from)?;
+        }
+        tx.commit().await.map_err(Error::from)
     }
 
     /// Delete a send intent
@@ -206,6 +269,15 @@ impl BdkStorage {
         )
         .await
         .map_err(Error::from)?;
+        if let SendIntentState::AwaitingConfirmation { outpoint, .. } = intent.state {
+            tx.kv_remove(
+                BDK_NAMESPACE,
+                SEND_OUTPOINT_QUOTE_ID_NAMESPACE,
+                &outpoint_to_key(&outpoint),
+            )
+            .await
+            .map_err(Error::from)?;
+        }
         tx.commit().await.map_err(Error::from)?;
         Ok(())
     }
@@ -294,6 +366,95 @@ impl BdkStorage {
             .await
     }
 
+    /// Get all finalized send intent tombstones.
+    pub async fn get_all_finalized_send_intents(
+        &self,
+    ) -> Result<Vec<FinalizedSendIntentRecord>, Error> {
+        self.list_records::<FinalizedSendIntentRecord>().await
+    }
+
+    /// Look up a quote ID by the transaction output assigned to a send intent.
+    pub async fn get_quote_id_by_send_outpoint(
+        &self,
+        outpoint: &str,
+    ) -> Result<Option<String>, Error> {
+        let quote_id_bytes = self
+            .kv_store
+            .kv_read(
+                BDK_NAMESPACE,
+                SEND_OUTPOINT_QUOTE_ID_NAMESPACE,
+                &outpoint_to_key(outpoint),
+            )
+            .await
+            .map_err(Error::from)?;
+
+        match quote_id_bytes {
+            Some(quote_id_bytes) => String::from_utf8(quote_id_bytes)
+                .map(Some)
+                .map_err(|e| Error::Wallet(format!("Invalid quote-id index entry: {}", e))),
+            None => Ok(None),
+        }
+    }
+
+    /// Populate the send output quote index for records written by older versions.
+    pub(crate) async fn ensure_send_outpoint_quote_id_index(&self) -> Result<(), Error> {
+        if self
+            .kv_store
+            .kv_read(
+                BDK_NAMESPACE,
+                STORAGE_MIGRATION_NAMESPACE,
+                SEND_OUTPOINT_QUOTE_ID_BACKFILL_KEY,
+            )
+            .await
+            .map_err(Error::from)?
+            .is_some()
+        {
+            return Ok(());
+        }
+
+        let (send_intents, finalized_send_intents) = tokio::try_join!(
+            self.get_all_send_intents(),
+            self.get_all_finalized_send_intents(),
+        )?;
+        let mut tx = self
+            .kv_store
+            .begin_transaction()
+            .await
+            .map_err(Error::from)?;
+
+        for intent in send_intents {
+            if let SendIntentState::AwaitingConfirmation { outpoint, .. } = intent.state {
+                tx.kv_write(
+                    BDK_NAMESPACE,
+                    SEND_OUTPOINT_QUOTE_ID_NAMESPACE,
+                    &outpoint_to_key(&outpoint),
+                    intent.quote_id.as_bytes(),
+                )
+                .await
+                .map_err(Error::from)?;
+            }
+        }
+        for intent in finalized_send_intents {
+            tx.kv_write(
+                BDK_NAMESPACE,
+                SEND_OUTPOINT_QUOTE_ID_NAMESPACE,
+                &outpoint_to_key(&intent.outpoint),
+                intent.quote_id.as_bytes(),
+            )
+            .await
+            .map_err(Error::from)?;
+        }
+        tx.kv_write(
+            BDK_NAMESPACE,
+            STORAGE_MIGRATION_NAMESPACE,
+            SEND_OUTPOINT_QUOTE_ID_BACKFILL_KEY,
+            b"complete",
+        )
+        .await
+        .map_err(Error::from)?;
+        tx.commit().await.map_err(Error::from)
+    }
+
     /// Look up a finalized intent tombstone by quote ID.
     pub async fn get_finalized_intent_by_quote_id(
         &self,
@@ -374,6 +535,14 @@ impl BdkStorage {
             FINALIZED_SEND_INTENT_QUOTE_ID_NAMESPACE,
             &intent.quote_id,
             record.intent_id.to_string().as_bytes(),
+        )
+        .await
+        .map_err(Error::from)?;
+        tx.kv_write(
+            BDK_NAMESPACE,
+            SEND_OUTPOINT_QUOTE_ID_NAMESPACE,
+            &outpoint_to_key(&record.outpoint),
+            record.quote_id.as_bytes(),
         )
         .await
         .map_err(Error::from)?;

--- a/crates/cdk-bdk/src/wallet_info.rs
+++ b/crates/cdk-bdk/src/wallet_info.rs
@@ -34,6 +34,10 @@ pub struct WalletBalance {
 pub struct WalletTransaction {
     /// Transaction ID.
     pub txid: String,
+    /// Inputs spent by this transaction in input order.
+    pub inputs: Vec<WalletTransactionInput>,
+    /// Non-change payment outputs in transaction output order.
+    pub outputs: Vec<WalletTransactionOutput>,
     /// Value received by wallet scripts in satoshis.
     pub received_sat: u64,
     /// Value spent from wallet inputs in satoshis.
@@ -48,6 +52,32 @@ pub struct WalletTransaction {
     pub confirmation_time: Option<u64>,
     /// First-seen timestamp, when known for an unconfirmed transaction.
     pub first_seen: Option<u64>,
+}
+
+/// An input spent by a wallet transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalletTransactionInput {
+    /// Transaction ID containing the previous output.
+    pub txid: String,
+    /// Index of the previous output.
+    pub vout: u32,
+    /// Value of the previous output in satoshis, when known.
+    pub amount_sat: Option<u64>,
+    /// Address of the previous output, when it belongs to the wallet.
+    pub address: Option<String>,
+}
+
+/// A payment output belonging to a wallet transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalletTransactionOutput {
+    /// Transaction output index.
+    pub vout: u32,
+    /// Bitcoin address in network-specific display encoding.
+    pub address: String,
+    /// Output value in satoshis.
+    pub amount_sat: u64,
+    /// Quote associated with this output, when managed by the payment backend.
+    pub quote_id: Option<String>,
 }
 
 /// BDK keychain containing a revealed address.
@@ -109,6 +139,7 @@ impl CdkBdk {
         offset: usize,
         limit: usize,
     ) -> Result<WalletPage<WalletTransaction>, Error> {
+        self.storage.ensure_send_outpoint_quote_id_index().await?;
         let wallet_with_db = self.wallet_with_db.lock().await;
         let wallet = &wallet_with_db.wallet;
         let transactions = wallet.transactions_sort_by(|left, right| {
@@ -120,7 +151,7 @@ impl CdkBdk {
         let total = u64::try_from(transactions.len())
             .map_err(|_| Error::Wallet("Transaction count exceeds u64".to_string()))?;
 
-        let items = transactions
+        let mut items = transactions
             .into_iter()
             .skip(offset)
             .take(limit)
@@ -133,6 +164,56 @@ impl CdkBdk {
                     .map_err(|_| Error::Wallet("Received value exceeds i64".to_string()))?;
                 let sent_signed = i64::try_from(sent_sat)
                     .map_err(|_| Error::Wallet("Sent value exceeds i64".to_string()))?;
+                let is_outgoing = sent_sat > 0;
+                let inputs = tx
+                    .input
+                    .iter()
+                    .map(|input| {
+                        let outpoint = input.previous_output;
+                        let previous_output = wallet.tx_graph().get_txout(outpoint);
+                        let amount_sat = previous_output.map(|output| output.value.to_sat());
+                        let address = previous_output
+                            .filter(|output| wallet.is_mine(output.script_pubkey.clone()))
+                            .and_then(|output| {
+                                Address::from_script(output.script_pubkey.as_script(), self.network)
+                                    .ok()
+                            })
+                            .map(|address| address.to_string());
+
+                        WalletTransactionInput {
+                            txid: outpoint.txid.to_string(),
+                            vout: outpoint.vout,
+                            amount_sat,
+                            address,
+                        }
+                    })
+                    .collect();
+                let outputs = tx
+                    .output
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, output)| {
+                        let is_wallet_output = wallet.is_mine(output.script_pubkey.clone());
+                        is_outgoing != is_wallet_output
+                    })
+                    .filter_map(|(vout, output)| {
+                        Address::from_script(output.script_pubkey.as_script(), self.network)
+                            .ok()
+                            .map(|address| (vout, output, address))
+                    })
+                    .map(|(vout, output, address)| {
+                        let vout = u32::try_from(vout).map_err(|_| {
+                            Error::Wallet("Transaction output index exceeds u32".to_string())
+                        })?;
+                        let address = address.to_string();
+                        Ok(WalletTransactionOutput {
+                            vout,
+                            address,
+                            amount_sat: output.value.to_sat(),
+                            quote_id: None,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, Error>>()?;
 
                 let (confirmation_height, confirmation_time, first_seen) =
                     match transaction.chain_position {
@@ -146,6 +227,8 @@ impl CdkBdk {
 
                 Ok(WalletTransaction {
                     txid: transaction.tx_node.txid.to_string(),
+                    inputs,
+                    outputs,
                     received_sat,
                     sent_sat,
                     fee_sat: wallet.calculate_fee(tx).ok().map(|fee| fee.to_sat()),
@@ -156,6 +239,25 @@ impl CdkBdk {
                 })
             })
             .collect::<Result<Vec<_>, Error>>()?;
+        drop(wallet_with_db);
+
+        for transaction in &mut items {
+            for output in &mut transaction.outputs {
+                output.quote_id = match transaction.sent_sat > 0 {
+                    true => {
+                        let outpoint = format!("{}:{}", transaction.txid, output.vout);
+                        self.storage
+                            .get_quote_id_by_send_outpoint(&outpoint)
+                            .await?
+                    }
+                    false => {
+                        self.storage
+                            .get_quote_id_by_receive_address(&output.address)
+                            .await?
+                    }
+                };
+            }
+        }
 
         Ok(WalletPage { items, total })
     }

--- a/crates/cdk-mint-rpc/build.rs
+++ b/crates/cdk-mint-rpc/build.rs
@@ -12,6 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_prost_build::configure()
         .protoc_arg("--experimental_allow_proto3_optional")
         .type_attribute(".", "#[allow(missing_docs)]")
+        .type_attribute("cdk_mint_wallet_v1.WalletTransaction", "#[derive(Eq)]")
         .field_attribute(".", "#[allow(missing_docs)]")
         .compile_protos(
             &["src/proto/cdk-mint-rpc.proto", "src/proto/wallet.proto"],

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/wallet.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/wallet.rs
@@ -82,6 +82,27 @@ pub async fn list_wallet_transactions(
                 .map(|timestamp| timestamp.to_string())
                 .unwrap_or_else(|| "none".to_string()),
         );
+        for input in transaction.inputs {
+            println!(
+                "  input: txid {}, vout {}, amount: {}, address: {}",
+                input.txid,
+                input.vout,
+                input
+                    .amount_sat
+                    .map(|amount| format!("{amount} sat"))
+                    .unwrap_or_else(|| "unknown".to_string()),
+                input.address.as_deref().unwrap_or("unknown"),
+            );
+        }
+        for output in transaction.outputs {
+            println!(
+                "  output: vout {}, address: {}, amount: {} sat, quote_id: {}",
+                output.vout,
+                output.address,
+                output.amount_sat,
+                output.quote_id.as_deref().unwrap_or("none"),
+            );
+        }
     }
 
     Ok(())

--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -972,6 +972,18 @@ mod tests {
             Ok(crate::WalletTransactionPage {
                 transactions: vec![crate::wallet::WalletTransaction {
                     txid: format!("{offset}:{limit}"),
+                    inputs: vec![crate::wallet::WalletTransactionInput {
+                        txid: "previous-txid".to_string(),
+                        vout: 1,
+                        amount_sat: Some(42_000),
+                        address: Some("bcrt1qinput".to_string()),
+                    }],
+                    outputs: vec![crate::wallet::WalletTransactionOutput {
+                        vout: 2,
+                        address: "bcrt1qoutput".to_string(),
+                        amount_sat: 21_000,
+                        quote_id: Some("quote-id".to_string()),
+                    }],
                     ..Default::default()
                 }],
                 total: 7,
@@ -1085,6 +1097,16 @@ mod tests {
             .into_inner();
         assert_eq!(transactions.total, 7);
         assert_eq!(transactions.transactions[0].txid, "2:20");
+        let input = &transactions.transactions[0].inputs[0];
+        assert_eq!(input.txid, "previous-txid");
+        assert_eq!(input.vout, 1);
+        assert_eq!(input.amount_sat, Some(42_000));
+        assert_eq!(input.address.as_deref(), Some("bcrt1qinput"));
+        let output = &transactions.transactions[0].outputs[0];
+        assert_eq!(output.vout, 2);
+        assert_eq!(output.address, "bcrt1qoutput");
+        assert_eq!(output.amount_sat, 21_000);
+        assert_eq!(output.quote_id.as_deref(), Some("quote-id"));
 
         let addresses = server
             .list_addresses(Request::new(crate::wallet::ListAddressesRequest {

--- a/crates/cdk-mint-rpc/src/proto/wallet.proto
+++ b/crates/cdk-mint-rpc/src/proto/wallet.proto
@@ -45,6 +45,10 @@ message ListTransactionsRequest {
 message WalletTransaction {
     // Transaction ID in display encoding.
     string txid = 1;
+    // Inputs spent by this transaction, in input order.
+    repeated WalletTransactionInput inputs = 10;
+    // Non-change payment outputs in transaction output order.
+    repeated WalletTransactionOutput outputs = 9;
     // Value sent to wallet scripts, including change.
     uint64 received_sat = 2;
     // Value consumed from wallet inputs.
@@ -59,6 +63,28 @@ message WalletTransaction {
     optional uint64 confirmation_time = 7;
     // First-seen timestamp, when known for an unconfirmed transaction.
     optional uint64 first_seen = 8;
+}
+
+message WalletTransactionInput {
+    // Previous outpoint transaction ID in display encoding.
+    string txid = 1;
+    // Previous outpoint output index.
+    uint32 vout = 2;
+    // Value of the previous output, when known to the wallet.
+    optional uint64 amount_sat = 3;
+    // Address of the previous output, when it belongs to the wallet.
+    optional string address = 4;
+}
+
+message WalletTransactionOutput {
+    // Transaction output index.
+    uint32 vout = 1;
+    // Bitcoin address in network-specific display encoding.
+    string address = 2;
+    // Output value in satoshis.
+    uint64 amount_sat = 3;
+    // Quote associated with this output, when managed by the payment backend.
+    optional string quote_id = 4;
 }
 
 message ListTransactionsResponse {

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -115,6 +115,26 @@ impl cdk_mint_rpc::WalletInfoProvider for BdkWalletInfoProvider {
                 .into_iter()
                 .map(|transaction| cdk_mint_rpc::wallet::WalletTransaction {
                     txid: transaction.txid,
+                    inputs: transaction
+                        .inputs
+                        .into_iter()
+                        .map(|input| cdk_mint_rpc::wallet::WalletTransactionInput {
+                            txid: input.txid,
+                            vout: input.vout,
+                            amount_sat: input.amount_sat,
+                            address: input.address,
+                        })
+                        .collect(),
+                    outputs: transaction
+                        .outputs
+                        .into_iter()
+                        .map(|output| cdk_mint_rpc::wallet::WalletTransactionOutput {
+                            vout: output.vout,
+                            address: output.address,
+                            amount_sat: output.amount_sat,
+                            quote_id: output.quote_id,
+                        })
+                        .collect(),
                     received_sat: transaction.received_sat,
                     sent_sat: transaction.sent_sat,
                     fee_sat: transaction.fee_sat,
@@ -941,8 +961,6 @@ async fn configure_onchain_backend_with_wallet_info(
 
     #[cfg(all(feature = "management-rpc", feature = "bdk"))]
     let mut wallet_info_provider = no_wallet_info_provider();
-    #[cfg(not(all(feature = "management-rpc", feature = "bdk")))]
-    let wallet_info_provider = no_wallet_info_provider();
 
     if let Some(onchain_settings) = &settings.onchain {
         match onchain_settings.onchain_backend {
@@ -1035,7 +1053,14 @@ async fn configure_onchain_backend_with_wallet_info(
         }
     }
 
-    Ok((mint_builder, wallet_info_provider))
+    #[cfg(all(feature = "management-rpc", feature = "bdk"))]
+    {
+        Ok((mint_builder, wallet_info_provider))
+    }
+    #[cfg(not(all(feature = "management-rpc", feature = "bdk")))]
+    {
+        Ok((mint_builder, no_wallet_info_provider()))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add ordered non-change outputs to wallet transaction records with each output's vout, address, amount, and associated quote ID kept together. Resolve incoming quotes from tracked addresses before confirmation and preserve outgoing quote associations after batched sends are finalized.

Include each input's previous outpoint in BDK wallet transaction results. Populate optional amount and wallet-owned address metadata when BDK retains the referenced output.

closes: https://github.com/cashubtc/cdk/issues/2384

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
