### PR TITLE
fix(hygiene): escape untrusted terminal and log output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,6 +1299,7 @@ dependencies = [
  "axum",
  "bip39",
  "cdk",
+ "cdk-common",
  "cdk-fake-wallet",
  "cdk-http-client",
  "cdk-prometheus",

--- a/crates/cdk-axum/Cargo.toml
+++ b/crates/cdk-axum/Cargo.toml
@@ -23,6 +23,7 @@ axum = { workspace = true, features = ["ws"] }
 cdk = { workspace = true, features = [
     "mint",
 ]}
+cdk-common.workspace = true
 cdk-http-client = { workspace = true, features = ["bitreq"] }
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/cdk-axum/src/ws/mod.rs
+++ b/crates/cdk-axum/src/ws/mod.rs
@@ -9,6 +9,7 @@ use cdk::ws::{
     notification_to_ws_message, NotificationInner, WsErrorBody, WsMessageOrResponse,
     WsMethodRequest, WsRequest,
 };
+use cdk_common::terminal::escape_control;
 use futures::StreamExt;
 use tokio::sync::mpsc;
 
@@ -110,7 +111,10 @@ pub async fn main_websocket(mut socket: WebSocket, state: MintState) {
                     },
                     Ok(Message::Close(frame)) => {
                         if let Some(CloseFrame { code, reason }) = frame {
-                            tracing::info!("ws-close: code={code:?} reason='{reason}'");
+                            tracing::info!(
+                                "ws-close: code={code:?} reason='{}'",
+                                escape_control(&reason)
+                            );
                         } else {
                             tracing::info!("ws-close: no frame");
                         }

--- a/crates/cdk-cli/src/main.rs
+++ b/crates/cdk-cli/src/main.rs
@@ -112,7 +112,7 @@ enum Commands {
     /// Update Mint Url
     UpdateMintUrl(sub_commands::update_mint_url::UpdateMintUrlSubCommand),
     /// Get proofs from mint.
-    ListMintProofs,
+    ListMintProofs(sub_commands::list_mint_proofs::ListMintProofsSubCommand),
     /// Decode a payment request
     DecodeRequest(sub_commands::decode_request::DecodePaymentRequestSubCommand),
     /// Pay a payment request
@@ -334,8 +334,8 @@ async fn main() -> Result<()> {
             )
             .await
         }
-        Commands::ListMintProofs => {
-            sub_commands::list_mint_proofs::proofs(&wallet_repository).await
+        Commands::ListMintProofs(sub_command_args) => {
+            sub_commands::list_mint_proofs::proofs(&wallet_repository, sub_command_args).await
         }
         Commands::DecodeRequest(sub_command_args) => {
             sub_commands::decode_request::decode_payment_request(sub_command_args)

--- a/crates/cdk-cli/src/sub_commands/decode_request.rs
+++ b/crates/cdk-cli/src/sub_commands/decode_request.rs
@@ -5,6 +5,8 @@ use cdk::nuts::PaymentRequest;
 use cdk::util::serialize_to_cbor_diag;
 use clap::Args;
 
+use crate::terminal::escape_cbor_diag;
+
 #[derive(Args)]
 pub struct DecodePaymentRequestSubCommand {
     /// Payment request
@@ -14,6 +16,9 @@ pub struct DecodePaymentRequestSubCommand {
 pub fn decode_payment_request(sub_command_args: &DecodePaymentRequestSubCommand) -> Result<()> {
     let payment_request = PaymentRequest::from_str(&sub_command_args.payment_request)?;
 
-    println!("{:}", serialize_to_cbor_diag(&payment_request)?);
+    println!(
+        "{}",
+        escape_cbor_diag(&serialize_to_cbor_diag(&payment_request)?)
+    );
     Ok(())
 }

--- a/crates/cdk-cli/src/sub_commands/decode_token.rs
+++ b/crates/cdk-cli/src/sub_commands/decode_token.rs
@@ -5,7 +5,7 @@ use cdk::nuts::Token;
 use cdk::util::serialize_to_cbor_diag;
 use clap::Args;
 
-use crate::terminal::escape_control;
+use crate::terminal::escape_cbor_diag;
 
 #[derive(Args)]
 pub struct DecodeTokenSubCommand {
@@ -18,6 +18,6 @@ pub fn decode_token(sub_command_args: &DecodeTokenSubCommand) -> Result<()> {
 
     // Token contents (unit, memo, secrets) are attacker-controlled; escape
     // control characters before printing.
-    println!("{:}", escape_control(&serialize_to_cbor_diag(&token)?));
+    println!("{}", escape_cbor_diag(&serialize_to_cbor_diag(&token)?));
     Ok(())
 }

--- a/crates/cdk-cli/src/sub_commands/list_mint_proofs.rs
+++ b/crates/cdk-cli/src/sub_commands/list_mint_proofs.rs
@@ -2,16 +2,30 @@ use anyhow::Result;
 use cdk::mint_url::MintUrl;
 use cdk::nuts::{CurrencyUnit, Proof};
 use cdk::wallet::WalletRepository;
+use clap::Args;
 
 use crate::terminal::escape_control;
 
-pub async fn proofs(wallet_repository: &WalletRepository) -> Result<()> {
-    list_proofs(wallet_repository).await?;
+const REDACTED_SECRET: &str = "<redacted>";
+
+#[derive(Debug, Args)]
+pub struct ListMintProofsSubCommand {
+    /// Print proof secrets. Treat the output as sensitive export material.
+    #[arg(long)]
+    show_secrets: bool,
+}
+
+pub async fn proofs(
+    wallet_repository: &WalletRepository,
+    sub_command_args: &ListMintProofsSubCommand,
+) -> Result<()> {
+    list_proofs(wallet_repository, sub_command_args.show_secrets).await?;
     Ok(())
 }
 
 async fn list_proofs(
     wallet_repository: &WalletRepository,
+    show_secrets: bool,
 ) -> Result<Vec<(MintUrl, (Vec<Proof>, CurrencyUnit))>> {
     let mut proofs_vec = Vec::new();
 
@@ -31,7 +45,7 @@ async fn list_proofs(
                 proof.amount,
                 escape_control(&wallet.unit.to_string()),
                 "unspent",
-                escape_control(&proof.secret.to_string()),
+                render_secret(&proof.secret.to_string(), show_secrets),
                 proof.dleq.is_some()
             );
         }
@@ -44,7 +58,7 @@ async fn list_proofs(
                 proof.amount,
                 escape_control(&wallet.unit.to_string()),
                 "pending",
-                escape_control(&proof.secret.to_string()),
+                render_secret(&proof.secret.to_string(), show_secrets),
                 proof.dleq.is_some()
             );
         }
@@ -57,7 +71,7 @@ async fn list_proofs(
                 proof.amount,
                 escape_control(&wallet.unit.to_string()),
                 "reserved",
-                escape_control(&proof.secret.to_string()),
+                render_secret(&proof.secret.to_string(), show_secrets),
                 proof.dleq.is_some()
             );
         }
@@ -66,4 +80,30 @@ async fn list_proofs(
         proofs_vec.push((mint_url, (unspent_proofs, wallet.unit.clone())));
     }
     Ok(proofs_vec)
+}
+
+fn render_secret(secret: &str, show_secrets: bool) -> String {
+    if show_secrets {
+        escape_control(secret)
+    } else {
+        REDACTED_SECRET.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secrets_are_redacted_by_default() {
+        assert_eq!(render_secret("sensitive-secret", false), REDACTED_SECRET);
+    }
+
+    #[test]
+    fn explicitly_shown_secrets_are_terminal_safe() {
+        assert_eq!(
+            render_secret("secret\u{1b}]52;evil\u{07}", true),
+            "secret\\e]52;evil\\a"
+        );
+    }
 }

--- a/crates/cdk-cli/src/sub_commands/mint.rs
+++ b/crates/cdk-cli/src/sub_commands/mint.rs
@@ -204,7 +204,10 @@ pub async fn mint(
             }
             // The stream surfaced an error.
             Ok(Some(Err(err))) => {
-                tracing::error!("Proof streams ended with {:?}", err);
+                tracing::error!(
+                    "Proof streams ended with {}",
+                    escape_control(&format!("{err:?}"))
+                );
                 break;
             }
             // The stream ended normally.
@@ -229,7 +232,10 @@ pub async fn mint(
         bail!("Timed out after {wait_duration}s waiting for the mint quote to be paid");
     }
 
-    println!("Received {amount_minted} from mint {mint_url}");
+    println!(
+        "Received {amount_minted} from mint {}",
+        escape_control(&mint_url.to_string())
+    );
 
     Ok(())
 }
@@ -260,7 +266,10 @@ async fn spawn_progress_task(
     let mut subscription = match wallet.subscribe(subscription_filter).await {
         Ok(sub) => sub,
         Err(err) => {
-            tracing::warn!("Failed to subscribe to mint quote updates: {}", err);
+            tracing::warn!(
+                "Failed to subscribe to mint quote updates: {}",
+                escape_control(&err.to_string())
+            );
             return None;
         }
     };

--- a/crates/cdk-cli/src/sub_commands/mint_info.rs
+++ b/crates/cdk-cli/src/sub_commands/mint_info.rs
@@ -5,7 +5,7 @@ use cdk::mint_url::MintUrl;
 use cdk::wallet::{Wallet, WalletRepository};
 use clap::Args;
 
-use crate::terminal::escape_control;
+use crate::terminal::{escape_control, escape_json};
 
 #[derive(Args)]
 pub struct MintInfoSubcommand {
@@ -21,7 +21,7 @@ pub async fn mint_info(
             Ok(info) => {
                 // Mint info is entirely mint-controlled (URLs, custom currency units,
                 // descriptions); escape control characters before printing.
-                println!("{}", escape_control(&serde_json::to_string_pretty(&info)?));
+                println!("{}", escape_json(&serde_json::to_string_pretty(&info)?));
             }
             Err(fetch_err) => {
                 let wallets: Vec<Wallet> = wallet_repository.get_wallets_for_mint(mint_url).await;
@@ -31,7 +31,7 @@ pub async fn mint_info(
                         Ok(mint_info) => {
                             println!(
                                 "{}",
-                                escape_control(&serde_json::to_string_pretty(&mint_info)?)
+                                escape_json(&serde_json::to_string_pretty(&mint_info)?)
                             );
                         }
                         Err(e) => {
@@ -58,7 +58,7 @@ pub async fn mint_info(
             match wallet.load_mint_info().await {
                 Ok(info) => {
                     println!("{i}: {}", escape_control(&mint_url.to_string()));
-                    println!("{}", escape_control(&serde_json::to_string_pretty(&info)?));
+                    println!("{}", escape_json(&serde_json::to_string_pretty(&info)?));
                 }
                 Err(e) => {
                     return Err(anyhow::anyhow!("Cannot fetch mint info {mint_url}: {e}"));

--- a/crates/cdk-cli/src/terminal.rs
+++ b/crates/cdk-cli/src/terminal.rs
@@ -1,40 +1,81 @@
-//! Terminal-safe rendering of potentially attacker-controlled strings.
-//!
-//! Values supplied by mints, tokens, or OIDC providers may contain terminal
-//! control characters (ESC, BEL, C1 controls, CR/LF) that can forge or
-//! corrupt CLI output. Escaping renders them visibly while preserving
-//! diagnostic evidence, and is preferred over silently stripping data.
+//! Terminal-safe rendering helpers for CLI output formats.
 
 use std::fmt::Write as _;
 
-/// Escapes control characters in `input` so the result is safe to print to a
-/// terminal.
+use cdk_common::terminal::is_bidi_control_character;
+
+pub use cdk_common::terminal::escape_control;
+
+/// Escapes terminal controls inside JSON strings without changing JSON layout.
 ///
-/// Printable characters, including printable Unicode, are preserved as-is.
-/// Common control characters use their familiar escape sequences (`\n`,
-/// `\r`, `\t`, `\a`, `\b`, `\v`, `\f`, `\e`, `\0`); all remaining control
-/// characters, including DEL and the C1 range, are rendered as `\u{XX}`.
-pub fn escape_control(input: &str) -> String {
-    let mut escaped = String::with_capacity(input.len());
+/// `input` must be valid JSON produced by a serializer. Structural whitespace
+/// is preserved, while controls and bidirectional formatting characters inside
+/// string values are replaced with JSON Unicode escapes.
+pub fn escape_json(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut in_string = false;
+    let mut previous_was_escape = false;
+
     for ch in input.chars() {
-        match ch {
-            '\0' => escaped.push_str("\\0"),
-            '\u{07}' => escaped.push_str("\\a"),
-            '\u{08}' => escaped.push_str("\\b"),
-            '\t' => escaped.push_str("\\t"),
-            '\n' => escaped.push_str("\\n"),
-            '\u{0B}' => escaped.push_str("\\v"),
-            '\u{0C}' => escaped.push_str("\\f"),
-            '\r' => escaped.push_str("\\r"),
-            '\u{1B}' => escaped.push_str("\\e"),
-            ch if ch.is_control() => {
-                write!(escaped, "\\u{{{:02x}}}", ch as u32)
-                    .expect("writing to a String cannot fail");
+        if in_string && (ch.is_control() || is_bidi_control_character(ch)) {
+            write!(output, "\\u{:04x}", ch as u32).expect("writing to a String cannot fail");
+        } else {
+            output.push(ch);
+        }
+
+        if in_string {
+            if previous_was_escape {
+                previous_was_escape = false;
+            } else {
+                match ch {
+                    '\\' => previous_was_escape = true,
+                    '"' => in_string = false,
+                    _ => {}
+                }
             }
-            ch => escaped.push(ch),
+        } else if ch == '"' {
+            in_string = true;
         }
     }
-    escaped
+
+    output
+}
+
+/// Escapes terminal controls in CBOR diagnostic text while preserving layout.
+///
+/// Newlines emitted by the diagnostic formatter are retained. Newlines and
+/// other controls inside quoted text strings are escaped visibly.
+pub fn escape_cbor_diag(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut segment_start = 0;
+    let mut in_text_string = false;
+    let mut previous_was_escape = false;
+
+    for (index, ch) in input.char_indices() {
+        if ch == '\n' && !in_text_string {
+            output.push_str(&escape_control(&input[segment_start..index]));
+            output.push('\n');
+            segment_start = index + ch.len_utf8();
+            continue;
+        }
+
+        if in_text_string {
+            if previous_was_escape {
+                previous_was_escape = false;
+            } else {
+                match ch {
+                    '\\' => previous_was_escape = true,
+                    '"' => in_text_string = false,
+                    _ => {}
+                }
+            }
+        } else if ch == '"' {
+            in_text_string = true;
+        }
+    }
+
+    output.push_str(&escape_control(&input[segment_start..]));
+    output
 }
 
 #[cfg(test)]
@@ -42,39 +83,61 @@ mod tests {
     use super::*;
 
     #[test]
-    fn printable_text_passes_through() {
-        assert_eq!(escape_control("lnbc2500u1pjexample"), "lnbc2500u1pjexample");
+    fn json_escaping_preserves_layout_and_value() {
+        let value = serde_json::json!({
+            "id": "safe\u{007f}\u{009b}\u{202e}spoof",
+            "nested": { "value": "line\nfeed" },
+        });
+        let input = serde_json::to_string_pretty(&value).expect("JSON serialization succeeds");
+        let escaped = escape_json(&input);
+
+        assert!(escaped.contains('\n'));
+        assert!(!escaped
+            .chars()
+            .any(|ch| matches!(ch, '\u{007f}' | '\u{009b}' | '\u{202e}')));
+        assert!(escaped.contains("safe\\u007f\\u009b\\u202espoof"));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&escaped).expect("escaped JSON is valid"),
+            value
+        );
     }
 
     #[test]
-    fn printable_unicode_is_preserved() {
-        assert_eq!(escape_control("₿ ünïcodé 🚀"), "₿ ünïcodé 🚀");
+    fn json_escaping_handles_escaped_quotes_and_backslashes() {
+        let value = serde_json::json!({"text": "quoted: \" path: \\\\ \u{009d}"});
+        let input = serde_json::to_string_pretty(&value).expect("JSON serialization succeeds");
+        let escaped = escape_json(&input);
+
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&escaped).expect("escaped JSON is valid"),
+            value
+        );
+        assert!(escaped.contains("\\u009d"));
     }
 
     #[test]
-    fn escapes_cr_lf_and_tabs() {
-        assert_eq!(escape_control("a\nb\rc\td"), "a\\nb\\rc\\td");
+    fn cbor_diag_escaping_preserves_only_structural_newlines() {
+        let input = "{\n    \"d\": \"line one\nline two\u{1b}]52;evil\u{07}\u{202e}\",\n}";
+        let escaped = escape_cbor_diag(input);
+
+        assert_eq!(
+            escaped,
+            "{\n    \"d\": \"line one\\nline two\\e]52;evil\\a\\u{202e}\",\n}"
+        );
     }
 
     #[test]
-    fn escapes_esc_and_csi_sequence() {
-        // CSI "clear screen" sequence loses its ESC and becomes inert text
-        assert_eq!(escape_control("\u{1b}[2Jevil"), "\\e[2Jevil");
-    }
+    fn cbor_diag_escaping_tracks_escaped_quotes_and_backslashes() {
+        let input = concat!(
+            "{\n",
+            "    \"d\": \"quoted: \\\" slash: \\\\ text",
+            "\n",
+            "unsafe\",\n",
+            "}"
+        );
+        let escaped = escape_cbor_diag(input);
 
-    #[test]
-    fn escapes_osc_sequence_with_bel_terminator() {
-        // OSC window-title sequence terminated by BEL
-        assert_eq!(escape_control("\u{1b}]0;pwned\u{07}"), "\\e]0;pwned\\a");
-    }
-
-    #[test]
-    fn escapes_c1_controls() {
-        assert_eq!(escape_control("\u{85}\u{9b}"), "\\u{85}\\u{9b}");
-    }
-
-    #[test]
-    fn escapes_del_and_null() {
-        assert_eq!(escape_control("\u{7f}\0"), "\\u{7f}\\0");
+        assert_eq!(escaped.matches('\n').count(), 2);
+        assert!(escaped.contains(r#"quoted: \" slash: \\ text\nunsafe"#));
     }
 }

--- a/crates/cdk-common/src/lib.rs
+++ b/crates/cdk-common/src/lib.rs
@@ -7,6 +7,7 @@
 #![doc = include_str!("../README.md")]
 
 pub mod task;
+pub mod terminal;
 
 /// Authentication related types and utilities
 ///

--- a/crates/cdk-common/src/terminal.rs
+++ b/crates/cdk-common/src/terminal.rs
@@ -1,0 +1,95 @@
+//! Terminal-safe rendering of potentially untrusted strings.
+
+use std::fmt::Write as _;
+
+/// Escapes control and bidirectional formatting characters in `input`.
+///
+/// The returned string is safe to include in terminal output and single-line
+/// logs. Printable characters are preserved, while C0/C1 controls, DEL, and
+/// Unicode bidirectional formatting characters are rendered visibly.
+pub fn escape_control(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '\0' => escaped.push_str("\\0"),
+            '\u{07}' => escaped.push_str("\\a"),
+            '\u{08}' => escaped.push_str("\\b"),
+            '\t' => escaped.push_str("\\t"),
+            '\n' => escaped.push_str("\\n"),
+            '\u{0B}' => escaped.push_str("\\v"),
+            '\u{0C}' => escaped.push_str("\\f"),
+            '\r' => escaped.push_str("\\r"),
+            '\u{1B}' => escaped.push_str("\\e"),
+            ch if ch.is_control() || is_bidi_control_character(ch) => {
+                write!(escaped, "\\u{{{:02x}}}", ch as u32)
+                    .expect("writing to a String cannot fail");
+            }
+            ch => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+/// Returns whether `ch` has Unicode's `Bidi_Control` property.
+pub const fn is_bidi_control_character(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{061c}'
+            | '\u{200e}'
+            | '\u{200f}'
+            | '\u{202a}'..='\u{202e}'
+            | '\u{2066}'..='\u{2069}'
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn printable_text_passes_through() {
+        assert_eq!(escape_control("lnbc2500u1pjexample"), "lnbc2500u1pjexample");
+    }
+
+    #[test]
+    fn printable_unicode_is_preserved() {
+        assert_eq!(escape_control("₿ ünïcodé 🚀"), "₿ ünïcodé 🚀");
+    }
+
+    #[test]
+    fn escapes_cr_lf_and_tabs() {
+        assert_eq!(escape_control("a\nb\rc\td"), "a\\nb\\rc\\td");
+    }
+
+    #[test]
+    fn escapes_esc_and_csi_sequence() {
+        assert_eq!(escape_control("\u{1b}[2Jevil"), "\\e[2Jevil");
+    }
+
+    #[test]
+    fn escapes_osc_sequence_with_bel_terminator() {
+        assert_eq!(escape_control("\u{1b}]0;pwned\u{07}"), "\\e]0;pwned\\a");
+    }
+
+    #[test]
+    fn escapes_c1_controls() {
+        assert_eq!(escape_control("\u{85}\u{9b}"), "\\u{85}\\u{9b}");
+    }
+
+    #[test]
+    fn escapes_del_and_null() {
+        assert_eq!(escape_control("\u{7f}\0"), "\\u{7f}\\0");
+    }
+
+    #[test]
+    fn escapes_unicode_bidi_controls() {
+        let input = "\u{061c}\u{200e}\u{200f}\u{202a}\u{202e}\u{2066}\u{2069}";
+        let output = escape_control(input);
+
+        assert_eq!(
+            output,
+            "\\u{61c}\\u{200e}\\u{200f}\\u{202a}\\u{202e}\\u{2066}\\u{2069}"
+        );
+        assert!(!output.chars().any(is_bidi_control_character));
+    }
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/rotate_next_keyset.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/rotate_next_keyset.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use cdk_common::terminal::escape_control;
 use clap::Args;
 use tonic::Request;
 
@@ -64,8 +65,8 @@ pub async fn rotate_next_keyset(
 
     println!(
         "Rotated to new keyset {} for unit {} with amounts {} and fee of {}",
-        response.id,
-        response.unit,
+        escape_control(&response.id),
+        escape_control(&response.unit),
         serde_json::to_string(&response.amounts)?,
         response.input_fee_ppk
     );

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/wallet.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/wallet.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use cdk_common::terminal::escape_control;
 use clap::Args;
 use tonic::Request;
 
@@ -39,7 +40,10 @@ pub async fn get_wallet_balance(client: &mut InterceptedWalletServiceClient) -> 
         .await?
         .into_inner();
 
-    println!("network:                {}", balance.network);
+    println!(
+        "network:                {}",
+        escape_control(&balance.network)
+    );
     println!("synced height:          {}", balance.synced_height);
     println!("confirmed:              {} sat", balance.confirmed_sat);
     println!(
@@ -77,7 +81,7 @@ pub async fn list_wallet_transactions(
     for transaction in response.transactions {
         println!(
             "txid: {}, received: {} sat, sent: {} sat, fee: {}, delta: {} sat, height: {}, confirmation_time: {}, first_seen: {}",
-            transaction.txid,
+            escape_control(&transaction.txid),
             transaction.received_sat,
             transaction.sent_sat,
             transaction
@@ -101,22 +105,22 @@ pub async fn list_wallet_transactions(
         for input in transaction.inputs {
             println!(
                 "  input: txid {}, vout {}, amount: {}, address: {}",
-                input.txid,
+                escape_control(&input.txid),
                 input.vout,
                 input
                     .amount_sat
                     .map(|amount| format!("{amount} sat"))
                     .unwrap_or_else(|| "unknown".to_string()),
-                input.address.as_deref().unwrap_or("unknown"),
+                escape_control(input.address.as_deref().unwrap_or("unknown")),
             );
         }
         for output in transaction.outputs {
             println!(
                 "  output: vout {}, address: {}, amount: {} sat, quote_id: {}",
                 output.vout,
-                output.address,
+                escape_control(&output.address),
                 output.amount_sat,
-                output.quote_id.as_deref().unwrap_or("none"),
+                escape_control(output.quote_id.as_deref().unwrap_or("none")),
             );
         }
     }
@@ -141,7 +145,7 @@ pub async fn list_wallet_addresses(
     for address in response.addresses {
         println!(
             "address: {}, keychain: {}, index: {}, used: {}, balance: {} sat, confirmed: {} sat",
-            address.address,
+            escape_control(&address.address),
             address.keychain().as_str_name(),
             address.derivation_index,
             address.used,

--- a/crates/cdk-sql-common/build.rs
+++ b/crates/cdk-sql-common/build.rs
@@ -8,6 +8,10 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+mod migration_name;
+
+use migration_name::{rust_string_literal, validate_migration_path};
+
 fn main() {
     // Step 1: Find `migrations/` folder recursively
     let root = Path::new("src");
@@ -16,6 +20,15 @@ fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR is set by Cargo"));
 
     for migration_path in find_migrations_dirs(root) {
+        let migration_relative_path = migration_path
+            .strip_prefix(root)
+            .expect("migration path is below the source directory")
+            .to_str()
+            .expect("migration paths must be valid UTF-8")
+            .replace("\\", "/");
+        validate_migration_path(&migration_relative_path)
+            .unwrap_or_else(|reason| panic!("Invalid migration path: {reason}"));
+
         // Step 3: Output file path to OUT_DIR instead of source directory
         let parent = migration_path.parent().unwrap();
 
@@ -117,9 +130,14 @@ fn main() {
 
             // Use path relative to OUT_DIR for include_str
             let relative_to_out_dir = relative_path.to_str().unwrap().replace("\\", "/");
+            validate_migration_path(&relative_to_out_dir)
+                .unwrap_or_else(|reason| panic!("Invalid migration path: {reason}"));
+            let prefix = rust_string_literal(&prefix);
+            let rel_name = rust_string_literal(rel_name);
+            let relative_to_out_dir = rust_string_literal(&relative_to_out_dir);
             writeln!(
                 out_file,
-                "    (\"{prefix}\", \"{rel_name}\", include_str!(r#\"{relative_to_out_dir}\"#)),"
+                "    ({prefix}, {rel_name}, include_str!({relative_to_out_dir})),"
             )
             .unwrap();
             println!("cargo:rerun-if-changed={}", path.display());

--- a/crates/cdk-sql-common/migration_name.rs
+++ b/crates/cdk-sql-common/migration_name.rs
@@ -1,0 +1,64 @@
+const INVALID_PATH_CHARACTER: &str =
+    "control, bidirectional formatting, and double-quote characters are not allowed";
+
+pub(crate) fn validate_migration_path(path: &str) -> Result<(), &'static str> {
+    if path
+        .chars()
+        .any(|ch| ch.is_control() || is_bidi_control(ch) || ch == '"')
+    {
+        Err(INVALID_PATH_CHARACTER)
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn rust_string_literal(value: &str) -> String {
+    format!("{value:?}")
+}
+
+const fn is_bidi_control(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{061c}'
+            | '\u{200e}'
+            | '\u{200f}'
+            | '\u{202a}'..='\u{202e}'
+            | '\u{2066}'..='\u{2069}'
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_normal_migration_paths() {
+        assert_eq!(
+            validate_migration_path("wallet/migrations/001_initialize.sql"),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn rejects_source_and_output_injection_characters() {
+        for path in [
+            "wallet/migrations/001_newline\n.sql",
+            "wallet/migrations/001_carriage\rreturn.sql",
+            "wallet/migrations/001_escape\u{1b}.sql",
+            "wallet/migrations/001_bell\u{07}.sql",
+            "wallet/migrations/001_\"#], malicious.sql",
+            "wallet/migrations/001_bidi\u{202e}.sql",
+        ] {
+            assert_eq!(
+                validate_migration_path(path),
+                Err(INVALID_PATH_CHARACTER),
+                "path should be rejected: {path:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn source_literals_are_escaped_defensively() {
+        assert_eq!(rust_string_literal("a\"b\n.sql"), "\"a\\\"b\\n.sql\"");
+    }
+}

--- a/crates/cdk-sql-common/src/lib.rs
+++ b/crates/cdk-sql-common/src/lib.rs
@@ -1,5 +1,9 @@
 //! SQLite storage backend for cdk
 
+#[cfg(test)]
+#[path = "../migration_name.rs"]
+mod migration_name;
+
 mod common;
 pub mod database;
 mod keyvalue;


### PR DESCRIPTION
Route untrusted strings from mints, NpubCash, RPC, and APIs through control-character and bidi escaping. Redact proof secrets by default and reject unsafe migration filenames before generating Rust source.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
