### PR TITLE
Backport: feat(mint-rpc): add operator deposit addresses

### DIFF
--- a/crates/cdk-bdk/src/lib.rs
+++ b/crates/cdk-bdk/src/lib.rs
@@ -891,6 +891,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn operator_deposit_address_is_not_associated_with_a_quote() {
+        let (backend, _tmp) = build_test_instance_with_tempdir(1).await;
+
+        let operator_address = backend
+            .create_operator_deposit_address()
+            .await
+            .expect("create operator deposit address");
+        let quote_request = backend
+            .create_incoming_payment_request(IncomingPaymentOptions::Onchain(
+                OnchainIncomingPaymentOptions {
+                    quote_id: cdk_common::QuoteId::new(),
+                },
+            ))
+            .await
+            .expect("create quote receive request");
+
+        assert_ne!(operator_address, quote_request.request);
+        assert!(backend
+            .storage
+            .get_quote_id_by_receive_address(&operator_address)
+            .await
+            .expect("look up operator address")
+            .is_none());
+        assert!(!backend
+            .storage
+            .get_tracked_receive_addresses()
+            .await
+            .expect("list quote receive addresses")
+            .contains(&operator_address));
+    }
+
+    #[tokio::test]
     async fn wallet_info_lists_revealed_addresses_without_revealing_more() {
         let (backend, _tmp) = build_test_instance_with_tempdir(1).await;
 

--- a/crates/cdk-bdk/src/wallet_info.rs
+++ b/crates/cdk-bdk/src/wallet_info.rs
@@ -116,6 +116,23 @@ pub struct WalletPage<T> {
 }
 
 impl CdkBdk {
+    /// Creates and returns a fresh external address for operator deposits.
+    pub async fn create_operator_deposit_address(&self) -> Result<String, Error> {
+        let mut wallet_with_db = self.wallet_with_db.lock().await;
+        let address = wallet_with_db
+            .wallet
+            .reveal_next_address(KeychainKind::External)
+            .address
+            .to_string();
+
+        wallet_with_db.persist().map_err(|err| {
+            tracing::warn!("Could not persist to bdk db: {}", err);
+            Error::BdkPersist
+        })?;
+
+        Ok(address)
+    }
+
     /// Returns the wallet balance split by confirmation status.
     pub async fn wallet_balance(&self) -> WalletBalance {
         let wallet_with_db = self.wallet_with_db.lock().await;

--- a/crates/cdk-mint-rpc/build.rs
+++ b/crates/cdk-mint-rpc/build.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::unwrap_used)]
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("cargo:rerun-if-changed=src/proto/cdk-mint-rpc.proto");
+    println!("cargo:rerun-if-changed=src/proto");
 
     // Tell cargo to tell rustc to allow missing docs in generated code
     println!("cargo:rustc-env=RUSTDOC_ARGS=--allow-missing-docs");

--- a/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
+++ b/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
@@ -107,6 +107,8 @@ enum Commands {
     RotateNextKeyset(subcommands::RotateNextKeysetCommand),
     /// Get the BDK on-chain wallet balance
     GetWalletBalance,
+    /// Create an on-chain address for operator wallet deposits
+    CreateWalletDepositAddress,
     /// List BDK on-chain wallet transactions
     ListWalletTransactions(subcommands::WalletPaginationCommand),
     /// List addresses revealed by the BDK on-chain wallet
@@ -250,6 +252,9 @@ async fn main() -> Result<()> {
         }
         Commands::GetWalletBalance => {
             subcommands::get_wallet_balance(&mut wallet_client).await?;
+        }
+        Commands::CreateWalletDepositAddress => {
+            subcommands::create_wallet_deposit_address(&mut wallet_client).await?;
         }
         Commands::ListWalletTransactions(args) => {
             subcommands::list_wallet_transactions(&mut wallet_client, &args).await?;

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
@@ -43,5 +43,6 @@ pub use update_tos_url::{update_tos_url, UpdateTosUrlCommand};
 pub use update_ttl::{get_quote_ttl, update_quote_ttl, UpdateQuoteTtlCommand};
 pub use update_urls::{add_url, remove_url, AddUrlCommand, RemoveUrlCommand};
 pub use wallet::{
-    get_wallet_balance, list_wallet_addresses, list_wallet_transactions, WalletPaginationCommand,
+    create_wallet_deposit_address, get_wallet_balance, list_wallet_addresses,
+    list_wallet_transactions, WalletPaginationCommand,
 };

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/wallet.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/wallet.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use clap::Args;
 use tonic::Request;
 
-use crate::wallet::{GetBalanceRequest, ListAddressesRequest, ListTransactionsRequest};
+use crate::wallet::{
+    CreateDepositAddressRequest, GetBalanceRequest, ListAddressesRequest, ListTransactionsRequest,
+};
 use crate::InterceptedWalletServiceClient;
 
 /// Pagination arguments for wallet list commands.
@@ -14,6 +16,20 @@ pub struct WalletPaginationCommand {
     /// Records to skip.
     #[arg(long, default_value_t = 0)]
     offset: u32,
+}
+
+/// Creates and prints an address for operator deposits.
+pub async fn create_wallet_deposit_address(
+    client: &mut InterceptedWalletServiceClient,
+) -> Result<()> {
+    let response = client
+        .create_deposit_address(Request::new(CreateDepositAddressRequest {}))
+        .await?
+        .into_inner();
+
+    println!("address: {}", response.address);
+
+    Ok(())
 }
 
 /// Prints the BDK on-chain wallet balance.

--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -76,7 +76,7 @@ impl MintRPCServer {
         })
     }
 
-    /// Configures the read-only on-chain wallet information provider.
+    /// Configures the on-chain wallet management provider.
     pub fn with_wallet_info_provider(mut self, provider: DynWalletInfoProvider) -> Self {
         self.wallet_info_provider = Some(provider);
         self
@@ -852,6 +852,22 @@ impl CdkMint for MintRPCServer {
 
 #[tonic::async_trait]
 impl WalletService for MintRPCServer {
+    /// Creates an on-chain address for operator deposits.
+    async fn create_deposit_address(
+        &self,
+        _request: Request<crate::wallet::CreateDepositAddressRequest>,
+    ) -> Result<Response<crate::wallet::CreateDepositAddressResponse>, Status> {
+        let address = self
+            .wallet_info_provider()?
+            .create_deposit_address()
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
+
+        Ok(Response::new(crate::wallet::CreateDepositAddressResponse {
+            address,
+        }))
+    }
+
     /// Gets the on-chain wallet balance.
     async fn get_balance(
         &self,
@@ -949,6 +965,10 @@ mod tests {
 
     #[async_trait::async_trait]
     impl crate::WalletInfoProvider for TestWalletInfoProvider {
+        async fn create_deposit_address(&self) -> Result<String, crate::WalletInfoError> {
+            Ok("bcrt1qoperatordeposit".to_string())
+        }
+
         async fn get_balance(
             &self,
         ) -> Result<crate::wallet::GetBalanceResponse, crate::WalletInfoError> {
@@ -1076,6 +1096,13 @@ mod tests {
         let server = create_test_rpc_server()
             .await
             .with_wallet_info_provider(Arc::new(TestWalletInfoProvider));
+
+        let deposit_address = server
+            .create_deposit_address(Request::new(crate::wallet::CreateDepositAddressRequest {}))
+            .await
+            .expect("create deposit address")
+            .into_inner();
+        assert_eq!(deposit_address.address, "bcrt1qoperatordeposit");
 
         let balance = server
             .get_balance(Request::new(crate::wallet::GetBalanceRequest {}))

--- a/crates/cdk-mint-rpc/src/proto/wallet.proto
+++ b/crates/cdk-mint-rpc/src/proto/wallet.proto
@@ -2,14 +2,25 @@ syntax = "proto3";
 
 package cdk_mint_wallet_v1;
 
-// Read-only information about the mint's on-chain wallet.
+// Operator management of the mint's on-chain wallet.
 service WalletService {
+    // Creates a fresh address for operator deposits. Funds sent to this
+    // address are wallet capital and do not satisfy a mint quote.
+    rpc CreateDepositAddress(CreateDepositAddressRequest) returns (CreateDepositAddressResponse) {}
     // Returns the wallet balance split by confirmation status.
     rpc GetBalance(GetBalanceRequest) returns (GetBalanceResponse) {}
     // Returns wallet transactions, newest first.
     rpc ListTransactions(ListTransactionsRequest) returns (ListTransactionsResponse) {}
     // Returns addresses that the wallet has revealed, in derivation order.
     rpc ListAddresses(ListAddressesRequest) returns (ListAddressesResponse) {}
+}
+
+message CreateDepositAddressRequest {
+}
+
+message CreateDepositAddressResponse {
+    // Bitcoin address in network-specific display encoding.
+    string address = 1;
 }
 
 message GetBalanceRequest {

--- a/crates/cdk-mint-rpc/src/wallet_info.rs
+++ b/crates/cdk-mint-rpc/src/wallet_info.rs
@@ -1,4 +1,4 @@
-//! Read-only on-chain wallet information provider.
+//! On-chain wallet management provider.
 
 use std::sync::Arc;
 
@@ -7,7 +7,7 @@ use thiserror::Error;
 
 use crate::wallet::{GetBalanceResponse, WalletAddress, WalletTransaction};
 
-/// Error returned while reading the configured on-chain wallet.
+/// Error returned while managing the configured on-chain wallet.
 #[derive(Debug, Error)]
 #[error("{message}")]
 pub struct WalletInfoError {
@@ -41,9 +41,12 @@ pub struct WalletAddressPage {
     pub total: u64,
 }
 
-/// Supplies read-only information for the management wallet service.
+/// Supplies operations for the management wallet service.
 #[async_trait]
 pub trait WalletInfoProvider {
+    /// Creates a fresh address for operator deposits.
+    async fn create_deposit_address(&self) -> Result<String, WalletInfoError>;
+
     /// Returns the wallet balance.
     async fn get_balance(&self) -> Result<GetBalanceResponse, WalletInfoError>;
 

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -79,6 +79,15 @@ struct BdkWalletInfoProvider {
 #[cfg(all(feature = "management-rpc", feature = "bdk"))]
 #[async_trait::async_trait]
 impl cdk_mint_rpc::WalletInfoProvider for BdkWalletInfoProvider {
+    async fn create_deposit_address(
+        &self,
+    ) -> std::result::Result<String, cdk_mint_rpc::WalletInfoError> {
+        self.bdk
+            .create_operator_deposit_address()
+            .await
+            .map_err(|err| cdk_mint_rpc::WalletInfoError::new(err.to_string()))
+    }
+
     async fn get_balance(
         &self,
     ) -> std::result::Result<cdk_mint_rpc::wallet::GetBalanceResponse, cdk_mint_rpc::WalletInfoError>
@@ -2493,11 +2502,32 @@ mod tests {
             .iter()
             .any(|method| method.method == PaymentMethod::Known(KnownMethod::Onchain)));
 
-        let balance = provider
-            .expect("wallet info provider")
-            .get_balance()
+        let provider = provider.expect("wallet info provider");
+        let first_address = provider
+            .create_deposit_address()
             .await
-            .expect("get wallet balance");
+            .expect("create first operator deposit address");
+        let second_address = provider
+            .create_deposit_address()
+            .await
+            .expect("create second operator deposit address");
+        assert_ne!(first_address, second_address);
+
+        let addresses = provider
+            .list_addresses(0, 20)
+            .await
+            .expect("list wallet addresses");
+        assert_eq!(addresses.total, 2);
+        assert!(addresses
+            .addresses
+            .iter()
+            .any(|address| address.address == first_address));
+        assert!(addresses
+            .addresses
+            .iter()
+            .any(|address| address.address == second_address));
+
+        let balance = provider.get_balance().await.expect("get wallet balance");
         assert_eq!(balance.network, "regtest");
         assert_eq!(balance.total_sat, 0);
 


### PR DESCRIPTION
Expose a wallet management RPC and CLI command that derives fresh BDK external addresses for operator deposits without associating them with mint quotes.

Wire the BDK provider through mintd and cover address generation and RPC behavior.

(cherry picked from commit 437cc35764e4dc1d1af3f60e60ccfec9e9f47955)

closes https://github.com/cashubtc/cdk/issues/2399

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
