### PR TITLE
fix(mintd): harden environment config and exports

### DIFF
--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -1060,7 +1060,7 @@ impl std::str::FromStr for AuthType {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Auth {
     #[serde(default)]
@@ -1093,6 +1093,27 @@ pub struct Auth {
 
 fn default_blind() -> AuthType {
     AuthType::Blind
+}
+
+impl Default for Auth {
+    fn default() -> Self {
+        Self {
+            auth_enabled: false,
+            openid_discovery: String::new(),
+            openid_client_id: String::new(),
+            mint_max_bat: 0,
+            mint: default_blind(),
+            get_mint_quote: AuthType::default(),
+            check_mint_quote: AuthType::default(),
+            melt: AuthType::default(),
+            get_melt_quote: AuthType::default(),
+            check_melt_quote: AuthType::default(),
+            swap: default_blind(),
+            restore: default_blind(),
+            check_proof_state: AuthType::default(),
+            websocket_auth: default_blind(),
+        }
+    }
 }
 
 /// CDK settings, derived from `config.toml`

--- a/crates/cdk-mintd/src/env_vars/lnd.rs
+++ b/crates/cdk-mintd/src/env_vars/lnd.rs
@@ -3,6 +3,8 @@
 use std::env;
 use std::path::PathBuf;
 
+use anyhow::{bail, Context, Result};
+
 use crate::config::Lnd;
 
 // LND environment variables
@@ -13,7 +15,7 @@ pub const ENV_LND_FEE_PERCENT: &str = "CDK_MINTD_LND_FEE_PERCENT";
 pub const ENV_LND_RESERVE_FEE_MIN: &str = "CDK_MINTD_LND_RESERVE_FEE_MIN";
 
 impl Lnd {
-    pub fn from_env(mut self) -> Self {
+    pub fn from_env(mut self) -> Result<Self> {
         if let Ok(address) = env::var(ENV_LND_ADDRESS) {
             self.address = address;
         }
@@ -27,9 +29,15 @@ impl Lnd {
         }
 
         if let Ok(fee_str) = env::var(ENV_LND_FEE_PERCENT) {
-            if let Ok(fee) = fee_str.parse() {
-                self.fee_percent = fee;
+            let fee = fee_str.parse::<f32>().with_context(|| {
+                format!("{ENV_LND_FEE_PERCENT} must be a floating-point number")
+            })?;
+            if !fee.is_finite() || !(0.0..=1.0).contains(&fee) {
+                bail!(
+                    "{ENV_LND_FEE_PERCENT} must be finite and between 0.0 and 1.0 inclusive (0.02 means 2%)"
+                );
             }
+            self.fee_percent = fee;
         }
 
         if let Ok(reserve_fee_str) = env::var(ENV_LND_RESERVE_FEE_MIN) {
@@ -38,6 +46,6 @@ impl Lnd {
             }
         }
 
-        self
+        Ok(self)
     }
 }

--- a/crates/cdk-mintd/src/env_vars/mod.rs
+++ b/crates/cdk-mintd/src/env_vars/mod.rs
@@ -173,7 +173,7 @@ impl Settings {
 
         #[cfg(feature = "lnd")]
         {
-            let lnd = self.lnd.clone().unwrap_or_default().from_env();
+            let lnd = self.lnd.clone().unwrap_or_default().from_env()?;
             if lnd.address.is_empty() {
                 self.lnd = None;
             } else {

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -3968,14 +3968,27 @@ backend = "fakewallet"
             "CDK_MINTD_AUTH_ENABLED",
             "CDK_MINTD_AUTH_OPENID_DISCOVERY",
             "CDK_MINTD_AUTH_OPENID_CLIENT_ID",
+            "CDK_MINTD_AUTH_MINT_MAX_BAT",
+            "CDK_MINTD_AUTH_MINT",
+            "CDK_MINTD_AUTH_GET_MINT_QUOTE",
+            "CDK_MINTD_AUTH_CHECK_MINT_QUOTE",
+            "CDK_MINTD_AUTH_MELT",
+            "CDK_MINTD_AUTH_GET_MELT_QUOTE",
+            "CDK_MINTD_AUTH_CHECK_MELT_QUOTE",
+            "CDK_MINTD_AUTH_SWAP",
+            "CDK_MINTD_AUTH_RESTORE",
+            "CDK_MINTD_AUTH_CHECK_PROOF_STATE",
+            "CDK_MINTD_AUTH_WEBSOCKET",
             "CDK_MINTD_AUTH_POSTGRES_URL",
             "CDK_MINTD_AUTH_POSTGRES_TLS_MODE",
             "CDK_MINTD_AUTH_POSTGRES_MAX_CONNECTIONS",
             "CDK_MINTD_AUTH_POSTGRES_CONNECTION_TIMEOUT_SECONDS",
             "CDK_MINTD_CLN_RPC_PATH",
+            "CDK_MINTD_CLN_FEE_PERCENT",
             "CDK_MINTD_LND_ADDRESS",
             "CDK_MINTD_LND_CERT_FILE",
             "CDK_MINTD_LND_MACAROON_FILE",
+            "CDK_MINTD_LND_FEE_PERCENT",
             "CDK_MINTD_FAKE_WALLET_SUPPORTED_UNITS",
             "CDK_MINTD_FAKE_WALLET_FEE_PERCENT",
             "CDK_MINTD_FAKE_WALLET_RESERVE_FEE_MIN",
@@ -4756,6 +4769,79 @@ openid_client_id = "mintd"
         let _ = fs::remove_dir_all(&temp_dir);
         clear_mintd_env();
         result
+    }
+
+    #[cfg(feature = "fakewallet")]
+    #[test]
+    fn env_only_auth_preserves_protected_endpoint_defaults() {
+        let settings = load_settings_with_env(
+            "cdk_mintd_env_auth_defaults",
+            &format!(
+                r#"
+[info]
+mnemonic = "{TEST_MNEMONIC}"
+
+[database]
+engine = "sqlite"
+
+[payment_backend]
+backend = "fakewallet"
+"#
+            ),
+            || {
+                std::env::set_var("CDK_MINTD_AUTH_ENABLED", "true");
+                std::env::set_var(
+                    "CDK_MINTD_AUTH_OPENID_DISCOVERY",
+                    "https://issuer.example.com/.well-known/openid-configuration",
+                );
+                std::env::set_var("CDK_MINTD_AUTH_OPENID_CLIENT_ID", "mintd");
+            },
+        )
+        .expect("environment-only auth configuration should load");
+
+        let auth = settings.auth.expect("auth should be enabled");
+        assert_eq!(auth.mint, config::AuthType::Blind);
+        assert_eq!(auth.swap, config::AuthType::Blind);
+        assert_eq!(auth.restore, config::AuthType::Blind);
+        assert_eq!(auth.websocket_auth, config::AuthType::Blind);
+    }
+
+    #[cfg(feature = "lnd")]
+    #[test]
+    fn invalid_lnd_fee_percent_from_env_is_rejected() {
+        for (name, fee_percent) in [
+            ("nan", "NaN"),
+            ("negative", "-1"),
+            ("not-a-number", "invalid"),
+        ] {
+            let error = load_settings_with_env(
+                &format!("cdk_mintd_lnd_fee_percent_{name}"),
+                &format!(
+                    r#"
+[info]
+mnemonic = "{TEST_MNEMONIC}"
+
+[database]
+engine = "sqlite"
+
+[payment_backend]
+backend = "lnd"
+"#
+                ),
+                || {
+                    std::env::set_var("CDK_MINTD_LND_ADDRESS", "https://127.0.0.1:10009");
+                    std::env::set_var("CDK_MINTD_LND_CERT_FILE", "/certs/tls.cert");
+                    std::env::set_var("CDK_MINTD_LND_MACAROON_FILE", "/data/admin.macaroon");
+                    std::env::set_var("CDK_MINTD_LND_FEE_PERCENT", fee_percent);
+                },
+            )
+            .expect_err("invalid LND fee percentage should fail startup validation");
+
+            assert!(
+                error.to_string().contains("CDK_MINTD_LND_FEE_PERCENT"),
+                "unexpected error for {fee_percent}: {error}"
+            );
+        }
     }
 
     #[cfg(feature = "fakewallet")]

--- a/crates/cdk-mintd/src/main.rs
+++ b/crates/cdk-mintd/src/main.rs
@@ -167,6 +167,7 @@ fn export_document(path: &std::path::Path, document: &str, force: bool) -> Resul
     } else {
         options.create_new(true);
     }
+    set_export_creation_mode(&mut options);
 
     let mut file = match options.open(path) {
         Ok(file) => file,
@@ -186,20 +187,36 @@ fn export_document(path: &std::path::Path, document: &str, force: bool) -> Resul
         .with_context(|| format!("could not export configuration to {}", path.display()))
 }
 
+#[cfg(unix)]
+fn set_export_creation_mode(options: &mut std::fs::OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    options.mode(0o600);
+}
+
+#[cfg(not(unix))]
+fn set_export_creation_mode(_options: &mut std::fs::OpenOptions) {}
+
 #[cfg(test)]
 mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
 
-    #[test]
-    fn export_requires_force_to_replace_existing_file() {
+    fn export_test_directory(name: &str) -> std::path::PathBuf {
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system time should follow the Unix epoch")
             .as_nanos();
-        let directory =
-            std::env::temp_dir().join(format!("cdk-mintd-export-{}-{nonce}", std::process::id()));
+        std::env::temp_dir().join(format!(
+            "cdk-mintd-export-{name}-{}-{nonce}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn export_requires_force_to_replace_existing_file() {
+        let directory = export_test_directory("replace");
         std::fs::create_dir(&directory).expect("create test directory");
         let path = directory.join("config.toml");
         std::fs::write(&path, "existing").expect("create existing export");
@@ -216,6 +233,28 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(&path).expect("read replacement export"),
             "replacement"
+        );
+
+        std::fs::remove_dir_all(directory).expect("remove test directory");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_uses_owner_only_permissions_for_new_files() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = export_test_directory("permissions");
+        std::fs::create_dir(&directory).expect("create test directory");
+        let path = directory.join("config.toml");
+
+        export_document(&path, "first", false).expect("create export");
+        assert_eq!(
+            std::fs::metadata(&path)
+                .expect("read export metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
         );
 
         std::fs::remove_dir_all(directory).expect("remove test directory");


### PR DESCRIPTION
Preserve protected endpoint policies when auth is configured only through environment variables. Reject malformed, non-finite, or out-of-range LND fee percentages instead of silently ignoring or accepting them.

Create new configuration exports with owner-only permissions on Unix while preserving the existing --force replacement behavior.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
