### PR TITLE
feat(payjoin): add backend-independent NUT-31 plumbing

### DIFF
--- a/crates/cashu/src/nuts/mod.rs
+++ b/crates/cashu/src/nuts/mod.rs
@@ -33,6 +33,7 @@ pub mod nut27;
 pub mod nut28;
 pub mod nut29;
 pub mod nut30;
+pub mod nut31;
 
 mod auth;
 
@@ -95,3 +96,4 @@ pub use nut30::{
     MeltOnchainRequest, MeltQuoteOnchainRequest, MeltQuoteOnchainResponse, MintQuoteOnchainRequest,
     MintQuoteOnchainResponse,
 };
+pub use nut31::PayjoinV2;

--- a/crates/cashu/src/nuts/nut17/mod.rs
+++ b/crates/cashu/src/nuts/nut17/mod.rs
@@ -502,6 +502,7 @@ mod tests {
             amount_paid: Amount::from(100_000),
             amount_issued: Amount::from(0),
             updated_at: 0,
+            payjoin: None,
         };
         let payload: NotificationPayload<String> =
             NotificationPayload::MintQuoteOnchainResponse(resp.clone());
@@ -614,6 +615,7 @@ mod tests {
             selected_fee_index: Some(0),
             outpoint: Some("3b7f3b85:2".to_string()),
             change: None,
+            payjoin: None,
         };
         let payload: NotificationPayload<String> =
             NotificationPayload::MeltQuoteOnchainResponse(resp.clone());

--- a/crates/cashu/src/nuts/nut30.rs
+++ b/crates/cashu/src/nuts/nut30.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use super::nut00::{BlindSignature, BlindedMessage, CurrencyUnit, KnownMethod, PaymentMethod};
 use super::nut01::PublicKey;
 use super::nut05::MeltRequest;
+use super::nut31::PayjoinV2;
 use super::MeltQuoteState;
 #[cfg(feature = "mint")]
 use crate::quote_id::QuoteId;
@@ -58,6 +59,9 @@ pub struct MintQuoteOnchainResponse<Q> {
     /// Unix timestamp indicating when the quote was last updated
     #[serde(default)]
     pub updated_at: u64,
+    /// Optional Payjoin instructions. `request` remains the fallback address.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payjoin: Option<PayjoinV2>,
 }
 
 impl<Q: ToString> MintQuoteOnchainResponse<Q> {
@@ -73,6 +77,7 @@ impl<Q: ToString> MintQuoteOnchainResponse<Q> {
             amount_paid: self.amount_paid,
             amount_issued: self.amount_issued,
             updated_at: self.updated_at,
+            payjoin: self.payjoin.clone(),
         }
     }
 }
@@ -90,6 +95,7 @@ impl From<MintQuoteOnchainResponse<QuoteId>> for MintQuoteOnchainResponse<String
             amount_paid: value.amount_paid,
             amount_issued: value.amount_issued,
             updated_at: value.updated_at,
+            payjoin: value.payjoin,
         }
     }
 }
@@ -105,6 +111,9 @@ pub struct MeltQuoteOnchainRequest {
     pub unit: CurrencyUnit,
     /// Amount to send in the specified unit
     pub amount: Amount,
+    /// Optional Payjoin instructions for the destination.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payjoin: Option<PayjoinV2>,
 }
 
 /// Melt onchain request
@@ -197,6 +206,9 @@ pub struct MeltQuoteOnchainResponse<Q> {
     /// Blind signatures for overpaid onchain fee reserve
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub change: Option<Vec<BlindSignature>>,
+    /// Optional confirmation that Payjoin v2 was accepted for this quote.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payjoin: Option<PayjoinV2>,
 }
 
 impl<Q: ToString> MeltQuoteOnchainResponse<Q> {
@@ -214,6 +226,7 @@ impl<Q: ToString> MeltQuoteOnchainResponse<Q> {
             selected_fee_index: self.selected_fee_index,
             outpoint: self.outpoint.clone(),
             change: self.change.clone(),
+            payjoin: self.payjoin.clone(),
         }
     }
 }
@@ -233,6 +246,7 @@ impl From<MeltQuoteOnchainResponse<QuoteId>> for MeltQuoteOnchainResponse<String
             selected_fee_index: value.selected_fee_index,
             outpoint: value.outpoint,
             change: value.change,
+            payjoin: value.payjoin,
         }
     }
 }
@@ -264,6 +278,7 @@ mod tests {
             request: "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh".to_string(),
             unit: CurrencyUnit::Sat,
             amount: Amount::from(1000),
+            payjoin: None,
         };
 
         let serialized = serde_json::to_string(&request).unwrap();
@@ -294,6 +309,7 @@ mod tests {
                 "3b7f3b85c5f1a3c4d2b8e9f6a7c5d8e9f1a2b3c4d5e6f7a8b9c1d2e3f4a5b6c7:2".to_string(),
             ),
             change: None,
+            payjoin: None,
         };
 
         let serialized = serde_json::to_string(&response).unwrap();
@@ -357,6 +373,7 @@ mod tests {
             selected_fee_index: None,
             outpoint: None,
             change: None,
+            payjoin: None,
         };
 
         let serialized = serde_json::to_string(&response).unwrap();
@@ -369,8 +386,8 @@ mod tests {
 
     #[test]
     fn test_mint_quote_onchain_response_tolerates_unknown_fields() {
-        // Responses from newer mints may carry additional optional fields
-        // (e.g. payjoin instructions); released wallets must not reject them.
+        // Responses from newer mints may carry additional optional fields;
+        // released wallets must not reject them.
         let encoded = r#"{
             "quote": "DSGLX9kevM...",
             "request": "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
@@ -379,7 +396,7 @@ mod tests {
             "pubkey": "03d56ce4e446a85bbdaa547b4ec2b073d40ff802831352b8272b7dd7a4de5a7cac",
             "amount_paid": 100000,
             "amount_issued": 0,
-            "payjoin": {"endpoint": "https://payjoin.example/pj"}
+            "future_extension": {"enabled": true}
         }"#;
 
         let deserialized: MintQuoteOnchainResponse<String> = serde_json::from_str(encoded).unwrap();
@@ -399,7 +416,7 @@ mod tests {
             "fee_options": [{"fee_index": 0, "fee_reserve": 5000, "estimated_blocks": 1}],
             "selected_fee_index": null,
             "outpoint": null,
-            "payjoin": {"endpoint": "https://payjoin.example/pj"}
+            "future_extension": {"enabled": true}
         }"#;
 
         let deserialized: MeltQuoteOnchainResponse<String> = serde_json::from_str(encoded).unwrap();
@@ -426,6 +443,7 @@ mod tests {
             amount_paid: Amount::from(100000),
             amount_issued: Amount::from(0),
             updated_at: 0,
+            payjoin: None,
         };
 
         let string_id_response = response.to_string_id();
@@ -472,9 +490,56 @@ mod tests {
                 "3b7f3b85c5f1a3c4d2b8e9f6a7c5d8e9f1a2b3c4d5e6f7a8b9c1d2e3f4a5b6c7:2".to_string(),
             ),
             change: None,
+            payjoin: None,
         };
 
         let string_id_response = response.to_string_id();
         assert_eq!(string_id_response.quote, "TRmjduhIsPxd...");
+    }
+
+    #[test]
+    fn test_old_onchain_json_deserializes_without_payjoin() {
+        let request = r#"{
+            "request": "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+            "unit": "sat",
+            "amount": 1000
+        }"#;
+
+        let request: MeltQuoteOnchainRequest = serde_json::from_str(request).unwrap();
+        assert_eq!(request.payjoin, None);
+    }
+
+    #[test]
+    fn test_onchain_payjoin_response_serialization() {
+        let payjoin = PayjoinV2::new(
+            "https://payjoin.example/pj".to_string(),
+            "QYPFLM8XL59R0XV4VGPLS7FRDSSM4TUXL07TXCWC4S0GLVLNK2SE4NQ",
+            "QV6WSX0UQPAEA0RH54430D0UVZWS8CZ6FEGZF4RGFCDKJLPGMYEJG",
+            1_701_704_757,
+        )
+        .expect("valid Payjoin keys");
+        let response = MintQuoteOnchainResponse {
+            quote: "DSGLX9kevM...".to_string(),
+            request: "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh".to_string(),
+            unit: CurrencyUnit::Sat,
+            method: PaymentMethod::Known(KnownMethod::Onchain),
+            expiry: Some(1_701_704_757),
+            pubkey: PublicKey::from_hex(
+                "03d56ce4e446a85bbdaa547b4ec2b073d40ff802831352b8272b7dd7a4de5a7cac",
+            )
+            .unwrap(),
+            amount_paid: Amount::ZERO,
+            amount_issued: Amount::ZERO,
+            updated_at: 0,
+            payjoin: Some(payjoin.clone()),
+        };
+
+        let serialized = serde_json::to_string(&response).unwrap();
+        assert!(serialized.contains(r#""expires_at":1701704757"#));
+        assert!(!serialized.contains("EX1"));
+
+        let deserialized: MintQuoteOnchainResponse<String> =
+            serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.payjoin, Some(payjoin));
     }
 }

--- a/crates/cashu/src/nuts/nut31.rs
+++ b/crates/cashu/src/nuts/nut31.rs
@@ -1,0 +1,279 @@
+//! Payjoin for onchain payment method
+
+use core::fmt;
+use core::str::FromStr;
+
+use bitcoin::bech32::primitives::decode::{
+    CharError, CheckedHrpstring, CheckedHrpstringError, UncheckedHrpstringError,
+};
+use bitcoin::bech32::{self, Hrp, NoChecksum};
+use bitcoin::secp256k1;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const OHTTP_KEYS_PREFIX: &str = "OH1";
+const OHTTP_KEYS_HRP: &str = "OH";
+const OHTTP_KEYS_BYTES: usize = 34;
+const RECEIVER_KEY_PREFIX: &str = "RK1";
+const RECEIVER_KEY_HRP: &str = "RK";
+const RECEIVER_KEY_BYTES: usize = 33;
+
+/// Implement Display/FromStr/Serialize/Deserialize for a prefixless BIP77
+/// fragment key newtype. Only the per-type public-key offset validation
+/// differs between the key types.
+macro_rules! impl_prefixless_key {
+    ($ty:ident, $field:literal, $hrp:expr, $prefix:expr, $bytes:expr, $pubkey_offset:expr) => {
+        impl fmt::Display for $ty {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write_prefixless_key(f, $field, $hrp, $prefix, &self.0)
+            }
+        }
+
+        impl FromStr for $ty {
+            type Err = PayjoinV2KeyError;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                let bytes = decode_prefixless_key::<{ $bytes }>(value, $field, $hrp, $prefix)?;
+                validate_compressed_pubkey($field, &bytes[$pubkey_offset..])?;
+                Ok(Self(bytes))
+            }
+        }
+
+        impl Serialize for $ty {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $ty {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                value.parse().map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+/// Encoded OHTTP key material needed by the sender.
+///
+/// The wire representation is the BIP77 `OH` fragment value without the
+/// `OH1` prefix. Internally this stores the decoded key identifier and
+/// compressed secp256k1 public key bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PayjoinOhttpKeys([u8; OHTTP_KEYS_BYTES]);
+
+impl PayjoinOhttpKeys {
+    /// Return decoded OHTTP key bytes.
+    pub fn as_bytes(&self) -> &[u8; OHTTP_KEYS_BYTES] {
+        &self.0
+    }
+}
+
+// The first byte is the OHTTP key identifier; the pubkey follows it.
+impl_prefixless_key!(
+    PayjoinOhttpKeys,
+    "ohttp_keys",
+    OHTTP_KEYS_HRP,
+    OHTTP_KEYS_PREFIX,
+    OHTTP_KEYS_BYTES,
+    1
+);
+
+/// Encoded receiver session key.
+///
+/// The wire representation is the BIP77 `RK` fragment value without the
+/// `RK1` prefix. Internally this stores the decoded compressed secp256k1
+/// public key bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PayjoinReceiverKey([u8; RECEIVER_KEY_BYTES]);
+
+impl PayjoinReceiverKey {
+    /// Return decoded receiver public key bytes.
+    pub fn as_bytes(&self) -> &[u8; RECEIVER_KEY_BYTES] {
+        &self.0
+    }
+}
+
+impl_prefixless_key!(
+    PayjoinReceiverKey,
+    "receiver_key",
+    RECEIVER_KEY_HRP,
+    RECEIVER_KEY_PREFIX,
+    RECEIVER_KEY_BYTES,
+    0
+);
+
+/// Errors for Payjoin v2 key encoding.
+#[derive(Debug, Error)]
+pub enum PayjoinV2KeyError {
+    /// Key string included the BIP77 fragment prefix.
+    #[error("{field} must not include the {prefix} prefix")]
+    HasPrefix {
+        /// Field name.
+        field: &'static str,
+        /// Disallowed prefix.
+        prefix: &'static str,
+    },
+    /// Key string has an invalid bech32 prefix.
+    #[error("{field} has invalid bech32 prefix")]
+    InvalidPrefix {
+        /// Field name.
+        field: &'static str,
+    },
+    /// Key string has an invalid bech32 character.
+    #[error("{field} has invalid bech32 character: {character}")]
+    InvalidCharacter {
+        /// Field name.
+        field: &'static str,
+        /// Invalid character.
+        character: char,
+    },
+    /// Key string decodes to the wrong byte length.
+    #[error("{field} has invalid decoded length: {actual}, expected {expected}")]
+    InvalidLength {
+        /// Field name.
+        field: &'static str,
+        /// Actual decoded byte length.
+        actual: usize,
+        /// Expected decoded byte length.
+        expected: usize,
+    },
+    /// Key string contains non-zero padding bits.
+    #[error("{field} has invalid bech32 padding")]
+    InvalidPadding {
+        /// Field name.
+        field: &'static str,
+    },
+    /// Key string does not contain a valid compressed secp256k1 public key.
+    #[error("{field} does not contain a valid compressed secp256k1 public key")]
+    InvalidPublicKey {
+        /// Field name.
+        field: &'static str,
+    },
+}
+
+/// Payjoin v2 parameters for an onchain payment.
+///
+/// Cashu uses Unix timestamp; BIP77 URI fragments use encoded `EX1`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PayjoinV2 {
+    /// BIP77 mailbox endpoint URL without receiver fragment parameters.
+    ///
+    /// When assembled into a `pj` URI parameter, the endpoint value must be
+    /// encoded according to BIP77.
+    pub endpoint: String,
+    /// Encoded OHTTP key material needed by the sender, without the `OH1` prefix.
+    pub ohttp_keys: PayjoinOhttpKeys,
+    /// Encoded receiver session key, without the `RK1` prefix.
+    pub receiver_key: PayjoinReceiverKey,
+    /// Unix timestamp until the Payjoin parameters are valid.
+    pub expires_at: u64,
+}
+
+impl PayjoinV2 {
+    /// Construct Payjoin v2 parameters from encoded key strings.
+    pub fn new<O, R>(
+        endpoint: String,
+        ohttp_keys: O,
+        receiver_key: R,
+        expires_at: u64,
+    ) -> Result<Self, PayjoinV2KeyError>
+    where
+        O: AsRef<str>,
+        R: AsRef<str>,
+    {
+        Ok(Self {
+            endpoint,
+            ohttp_keys: ohttp_keys.as_ref().parse()?,
+            receiver_key: receiver_key.as_ref().parse()?,
+            expires_at,
+        })
+    }
+}
+
+/// Decode an uppercase bech32 (`NoChecksum`) BIP77 fragment value like
+/// `OH1…`/`RK1…`/`EX1…`, checking the HRP and expecting exactly `N` data bytes.
+pub fn decode_bech32_fragment<const N: usize>(
+    encoded: &str,
+    field: &'static str,
+    hrp: &'static str,
+) -> Result<[u8; N], PayjoinV2KeyError> {
+    let hrp_string = CheckedHrpstring::new::<NoChecksum>(encoded)
+        .map_err(|error| map_bech32_error(field, error))?;
+    let expected_hrp = Hrp::parse(hrp).map_err(|_| PayjoinV2KeyError::InvalidPrefix { field })?;
+    if hrp_string.hrp() != expected_hrp {
+        return Err(PayjoinV2KeyError::InvalidPrefix { field });
+    }
+
+    let bytes = hrp_string.byte_iter().collect::<Vec<u8>>();
+    bytes
+        .try_into()
+        .map_err(|bytes: Vec<u8>| PayjoinV2KeyError::InvalidLength {
+            field,
+            actual: bytes.len(),
+            expected: N,
+        })
+}
+
+/// Encode bytes as an uppercase bech32 (`NoChecksum`) BIP77 fragment value
+/// like `EX1…`, including the HRP prefix.
+pub fn encode_bech32_fragment(
+    field: &'static str,
+    hrp: &'static str,
+    bytes: &[u8],
+) -> Result<String, PayjoinV2KeyError> {
+    let hrp = Hrp::parse(hrp).map_err(|_| PayjoinV2KeyError::InvalidPrefix { field })?;
+    bech32::encode_upper::<NoChecksum>(hrp, bytes)
+        .map_err(|_| PayjoinV2KeyError::InvalidPrefix { field })
+}
+
+fn decode_prefixless_key<const N: usize>(
+    value: &str,
+    field: &'static str,
+    hrp: &'static str,
+    prefix: &'static str,
+) -> Result<[u8; N], PayjoinV2KeyError> {
+    if value.starts_with(prefix) {
+        return Err(PayjoinV2KeyError::HasPrefix { field, prefix });
+    }
+
+    decode_bech32_fragment::<N>(&format!("{prefix}{value}"), field, hrp)
+}
+
+fn write_prefixless_key(
+    f: &mut fmt::Formatter<'_>,
+    field: &'static str,
+    hrp: &'static str,
+    prefix: &'static str,
+    bytes: &[u8],
+) -> fmt::Result {
+    let encoded = encode_bech32_fragment(field, hrp, bytes).map_err(|_| fmt::Error)?;
+    let value = encoded.strip_prefix(prefix).ok_or(fmt::Error)?;
+    f.write_str(value)
+}
+
+fn validate_compressed_pubkey(field: &'static str, bytes: &[u8]) -> Result<(), PayjoinV2KeyError> {
+    secp256k1::PublicKey::from_slice(bytes)
+        .map(|_| ())
+        .map_err(|_| PayjoinV2KeyError::InvalidPublicKey { field })
+}
+
+fn map_bech32_error(field: &'static str, error: CheckedHrpstringError) -> PayjoinV2KeyError {
+    match error {
+        CheckedHrpstringError::Parse(UncheckedHrpstringError::Char(CharError::InvalidChar(
+            character,
+        ))) => PayjoinV2KeyError::InvalidCharacter { field, character },
+        CheckedHrpstringError::Parse(UncheckedHrpstringError::Char(
+            CharError::MissingSeparator | CharError::NothingAfterSeparator | CharError::MixedCase,
+        ))
+        | CheckedHrpstringError::Parse(UncheckedHrpstringError::Hrp(_))
+        | CheckedHrpstringError::Checksum(_) => PayjoinV2KeyError::InvalidPrefix { field },
+        _ => PayjoinV2KeyError::InvalidPadding { field },
+    }
+}

--- a/crates/cdk-common/src/lib.rs
+++ b/crates/cdk-common/src/lib.rs
@@ -32,6 +32,7 @@ pub mod melt;
 #[cfg(feature = "mint")]
 pub mod mint;
 pub mod mint_quote;
+pub mod payjoin;
 #[cfg(feature = "mint")]
 pub mod payment;
 pub mod pub_sub;

--- a/crates/cdk-common/src/melt.rs
+++ b/crates/cdk-common/src/melt.rs
@@ -317,6 +317,7 @@ where
                     selected_fee_index: value.selected_fee_index,
                     outpoint: value.payment_proof.clone(),
                     change: None,
+                    payjoin: None,
                 })
             }
             ref method => Self::Custom((
@@ -394,6 +395,7 @@ mod tests {
             selected_fee_index: Some(0),
             outpoint: Some("abcd...ef:0".to_string()),
             change: None,
+            payjoin: None,
         }
     }
 

--- a/crates/cdk-common/src/mint.rs
+++ b/crates/cdk-common/src/mint.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 use crate::common::IssuerVersion;
 use crate::mint_quote::MintQuoteResponse;
 use crate::nuts::{MeltQuoteState, MintQuoteState};
+use crate::payjoin::payjoin_v2_from_extra_json;
 use crate::payment::PaymentIdentifier;
 use crate::{Amount, CurrencyUnit, Error, Id, KeySetInfo, PublicKey};
 
@@ -1221,6 +1222,7 @@ impl From<MeltQuote> for MeltQuoteOnchainResponse<QuoteId> {
             selected_fee_index: quote.selected_fee_index,
             outpoint: quote.payment_proof.clone(),
             change: None,
+            payjoin: payjoin_v2_from_extra_json(quote.extra_json.as_ref()),
         }
     }
 }
@@ -1238,6 +1240,7 @@ impl TryFrom<MintQuote> for MintQuoteOnchainResponse<QuoteId> {
             amount_paid: quote.amount_paid().into(),
             amount_issued: quote.amount_issued().into(),
             updated_at: quote.updated_at(),
+            payjoin: payjoin_v2_from_extra_json(quote.extra_json.as_ref()),
         })
     }
 }
@@ -1935,6 +1938,47 @@ mod tests {
         assert_eq!(response.pubkey, pubkey);
         assert_eq!(response.amount_paid, Amount::from(10_000));
         assert_eq!(response.amount_issued, Amount::from(1_000));
+    }
+
+    #[test]
+    fn test_mint_quote_onchain_response_exposes_payjoin_from_extra_json() {
+        use cashu::nuts::nut31::PayjoinV2;
+
+        let quote_id = QuoteId::new();
+        let pubkey = PublicKey::from_hex(
+            "03d56ce4e446a85bbdaa547b4ec2b073d40ff802831352b8272b7dd7a4de5a7cac",
+        )
+        .expect("valid test public key");
+        let payjoin = PayjoinV2::new(
+            "https://payjoin.example/pj".to_string(),
+            "QYPFLM8XL59R0XV4VGPLS7FRDSSM4TUXL07TXCWC4S0GLVLNK2SE4NQ",
+            "QV6WSX0UQPAEA0RH54430D0UVZWS8CZ6FEGZF4RGFCDKJLPGMYEJG",
+            unix_time() + 3_600,
+        )
+        .expect("valid Payjoin parameters");
+        let now = unix_time();
+        let mint_quote = MintQuote::new(
+            Some(quote_id),
+            "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh".to_string(),
+            CurrencyUnit::Sat,
+            None,
+            now + 3_600,
+            PaymentIdentifier::CustomId("payjoin-session".to_string()),
+            Some(pubkey),
+            Amount::new(0, CurrencyUnit::Sat),
+            Amount::new(0, CurrencyUnit::Sat),
+            PaymentMethod::Known(cashu::nuts::nut00::KnownMethod::Onchain),
+            now,
+            now,
+            vec![],
+            vec![],
+            Some(serde_json::json!({ "payjoin": payjoin.clone() })),
+        );
+
+        let response = MintQuoteOnchainResponse::try_from(mint_quote)
+            .expect("onchain quote should convert");
+
+        assert_eq!(response.payjoin, Some(payjoin));
     }
 
     fn dummy_bolt12_mint_quote(expiry: u64) -> (MintQuote, QuoteId, PublicKey) {

--- a/crates/cdk-common/src/payjoin.rs
+++ b/crates/cdk-common/src/payjoin.rs
@@ -1,0 +1,490 @@
+//! Payjoin helper functions for CDK integrations.
+//!
+//! Cashu uses Unix timestamp; BIP77 URI fragments use encoded `EX1`.
+
+use bitcoin::{Amount, Denomination};
+use thiserror::Error;
+
+use crate::nuts::nut31::{
+    decode_bech32_fragment, encode_bech32_fragment, PayjoinV2, PayjoinV2KeyError,
+};
+
+/// Extra JSON key used for Payjoin v2 parameters.
+pub const ONCHAIN_PAYJOIN_EXTRA_KEY: &str = "payjoin";
+/// Internal extra JSON key used to persist destination Payjoin v2 parameters
+/// for onchain melt recovery.
+pub const ONCHAIN_PAYJOIN_DESTINATION_EXTRA_KEY: &str = "payjoin_destination";
+
+/// Error for converting BIP21 BTC amount strings to satoshis.
+#[derive(Debug, Error)]
+#[error("invalid BIP21 amount '{amount}': {source}")]
+pub struct Bip21AmountError {
+    /// Original BIP21 amount string.
+    amount: String,
+    /// Underlying amount parsing error.
+    source: bitcoin::amount::ParseAmountError,
+}
+
+/// Parsed BIP21 payment URI with optional Payjoin v2 parameters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Bip21PayjoinUri {
+    /// Normalized onchain address.
+    pub address: String,
+    /// Optional BIP21 amount in satoshis.
+    pub amount_sat: Option<u64>,
+    /// Optional Payjoin v2 receiver parameters.
+    pub payjoin: Option<PayjoinV2>,
+    /// Optional BIP21 `pjos` output-substitution preference.
+    pub pjos: Option<bool>,
+}
+
+/// Errors while building or parsing a BIP21 Payjoin URI.
+#[derive(Debug, Error)]
+pub enum Bip21PayjoinUriError {
+    /// URI parsing failed.
+    #[error("invalid BIP21 URI: {0}")]
+    InvalidUri(#[from] url::ParseError),
+    /// URI scheme is not `bitcoin`.
+    #[error("expected bitcoin URI scheme, found '{0}'")]
+    InvalidScheme(String),
+    /// URI has no onchain address.
+    #[error("bitcoin URI is missing an onchain address")]
+    MissingAddress,
+    /// BIP21 amount is invalid.
+    #[error(transparent)]
+    InvalidAmount(#[from] Bip21AmountError),
+    /// BIP21 `pjos` is not `0` or `1`.
+    #[error("invalid pjos value '{0}', expected 0 or 1")]
+    InvalidPjos(String),
+    /// Payjoin v2 endpoint conversion failed.
+    #[error(transparent)]
+    InvalidPayjoin(#[from] PayjoinV2Error),
+}
+
+/// Errors for BIP77 Payjoin v2 parameter conversion.
+#[derive(Debug, Error)]
+pub enum PayjoinV2Error {
+    /// Endpoint URL failed to parse.
+    #[error("invalid Payjoin endpoint URL: {0}")]
+    InvalidEndpoint(#[from] url::ParseError),
+    /// Endpoint fragment contains both `+` and `-` delimiters.
+    #[error("ambiguous Payjoin fragment delimiter")]
+    AmbiguousFragmentDelimiter,
+    /// Endpoint fragment parameter is missing.
+    #[error("Payjoin URI is missing {prefix} fragment parameter")]
+    MissingFragmentParam {
+        /// Missing fragment parameter prefix.
+        prefix: &'static str,
+    },
+    /// Fragment value is missing the expected prefix.
+    #[error("Payjoin fragment value is missing {prefix} prefix")]
+    MissingFragmentPrefix {
+        /// Missing fragment parameter prefix.
+        prefix: &'static str,
+    },
+    /// Expiry fragment has the wrong HRP.
+    #[error("invalid EX1 expiry prefix")]
+    InvalidExpiryPrefix,
+    /// Expiry fragment has an invalid character.
+    #[error("invalid EX1 expiry character: {0}")]
+    InvalidExpiryCharacter(char),
+    /// Expiry fragment decodes to the wrong number of bytes.
+    #[error("invalid EX1 expiry length: {0}")]
+    InvalidExpiryLength(usize),
+    /// Expiry fragment contains non-zero padding bits.
+    #[error("invalid EX1 expiry padding")]
+    InvalidExpiryPadding,
+    /// Expiry timestamp cannot fit in the BIP77 u32 timestamp encoding.
+    #[error("Payjoin expiry exceeds BIP77 u32 range: {0}")]
+    ExpiryOutOfRange(u64),
+    /// Payjoin key material is invalid.
+    #[error("{0}")]
+    InvalidKey(#[from] PayjoinV2KeyError),
+}
+
+/// Read Cashu Payjoin v2 parameters from an `extra_json` object.
+pub fn payjoin_v2_from_extra_json(extra_json: Option<&serde_json::Value>) -> Option<PayjoinV2> {
+    extra_json
+        .and_then(|extra| extra.get(ONCHAIN_PAYJOIN_EXTRA_KEY))
+        .cloned()
+        .and_then(|payjoin| serde_json::from_value(payjoin).ok())
+}
+
+/// Format a satoshi amount as a BIP21 BTC decimal string.
+pub fn format_bip21_amount_from_sats(amount_sat: u64) -> String {
+    Amount::from_sat(amount_sat).to_string_in(Denomination::Bitcoin)
+}
+
+/// Parse a BIP21 BTC decimal amount string into satoshis.
+pub fn parse_bip21_amount_to_sats(amount: &str) -> Result<u64, Bip21AmountError> {
+    Amount::from_str_in(amount, Denomination::Bitcoin)
+        .map(Amount::to_sat)
+        .map_err(|source| Bip21AmountError {
+            amount: amount.to_string(),
+            source,
+        })
+}
+
+/// Build a BIP21 URI containing Payjoin v2 receiver parameters.
+pub fn build_bip21_payjoin_uri(
+    address: &str,
+    amount_sat: Option<u64>,
+    payjoin: &PayjoinV2,
+    pjos: Option<bool>,
+) -> Result<String, Bip21PayjoinUriError> {
+    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+    if let Some(amount_sat) = amount_sat {
+        serializer.append_pair("amount", &format_bip21_amount_from_sats(amount_sat));
+    }
+    if let Some(pjos) = pjos {
+        serializer.append_pair("pjos", if pjos { "1" } else { "0" });
+    }
+    serializer.append_pair("pj", &payjoin_v2_to_bip77_endpoint(payjoin)?);
+
+    Ok(format!(
+        "BITCOIN:{}?{}",
+        uppercase_bip21_address(address),
+        serializer.finish()
+    ))
+}
+
+/// Parse a BIP21 URI and its optional Payjoin v2 receiver parameters.
+pub fn parse_bip21_payjoin_uri(value: &str) -> Result<Bip21PayjoinUri, Bip21PayjoinUriError> {
+    let uri = url::Url::parse(value)?;
+    if !uri.scheme().eq_ignore_ascii_case("bitcoin") {
+        return Err(Bip21PayjoinUriError::InvalidScheme(
+            uri.scheme().to_string(),
+        ));
+    }
+
+    let address = normalize_bip21_address(uri.path());
+    if address.is_empty() {
+        return Err(Bip21PayjoinUriError::MissingAddress);
+    }
+
+    let mut amount_sat = None;
+    let mut endpoint = None;
+    let mut pjos = None;
+    for (key, value) in uri.query_pairs() {
+        match key.as_ref() {
+            "amount" => amount_sat = Some(parse_bip21_amount_to_sats(&value)?),
+            "pj" => endpoint = Some(value.into_owned()),
+            "pjos" => {
+                pjos = Some(match value.as_ref() {
+                    "0" => false,
+                    "1" => true,
+                    invalid => {
+                        return Err(Bip21PayjoinUriError::InvalidPjos(invalid.to_string()));
+                    }
+                });
+            }
+            _ => {}
+        }
+    }
+
+    let payjoin = endpoint
+        .as_deref()
+        .map(payjoin_v2_from_bip77_endpoint)
+        .transpose()?;
+
+    Ok(Bip21PayjoinUri {
+        address,
+        amount_sat,
+        payjoin,
+        pjos,
+    })
+}
+
+fn normalize_bip21_address(address: &str) -> String {
+    let lowercase = address.to_ascii_lowercase();
+    if is_bech32_address(&lowercase) {
+        lowercase
+    } else {
+        address.to_string()
+    }
+}
+
+fn uppercase_bip21_address(address: &str) -> String {
+    let lowercase = address.to_ascii_lowercase();
+    if is_bech32_address(&lowercase) {
+        address.to_ascii_uppercase()
+    } else {
+        address.to_string()
+    }
+}
+
+fn is_bech32_address(address: &str) -> bool {
+    address.starts_with("bc1") || address.starts_with("tb1") || address.starts_with("bcrt1")
+}
+
+/// Parse Cashu Payjoin v2 parameters from a BIP77 mailbox endpoint.
+///
+/// BIP77 encodes expiry in the `EX1...` fragment. Cashu uses Unix timestamp;
+/// BIP77 URI fragments use encoded `EX1`, so this normalizes `EX1...` into
+/// [`PayjoinV2::expires_at`].
+pub fn payjoin_v2_from_bip77_endpoint(endpoint: &str) -> Result<PayjoinV2, PayjoinV2Error> {
+    let mut endpoint_url = url::Url::parse(endpoint)?;
+    let ohttp_keys = extract_payjoin_fragment_value(&endpoint_url, "OH1")?;
+    let receiver_key = extract_payjoin_fragment_value(&endpoint_url, "RK1")?;
+    let expires_at = extract_payjoin_fragment_value(&endpoint_url, "EX1")?;
+    let expires_at = decode_bip77_expiry(&expires_at)?;
+    endpoint_url.set_fragment(None);
+
+    PayjoinV2::new(
+        endpoint_url.to_string(),
+        strip_fragment_prefix(&ohttp_keys, "OH1")?,
+        strip_fragment_prefix(&receiver_key, "RK1")?,
+        expires_at,
+    )
+    .map_err(Into::into)
+}
+
+/// Build a BIP77 mailbox endpoint with `EX1`, `OH1`, and `RK1` fragment parameters.
+///
+/// Cashu uses Unix timestamp; BIP77 URI fragments use encoded `EX1`. This
+/// conversion is for payjoin-library sender/integration calls that require a
+/// BIP21/BIP77-style `pj` URI.
+pub fn payjoin_v2_to_bip77_endpoint(payjoin: &PayjoinV2) -> Result<String, PayjoinV2Error> {
+    let mut endpoint = url::Url::parse(&payjoin.endpoint)?;
+    endpoint.set_fragment(Some(&format!(
+        "{}-OH1{}-RK1{}",
+        encode_bip77_expiry(payjoin.expires_at)?,
+        payjoin.ohttp_keys,
+        payjoin.receiver_key
+    )));
+    Ok(endpoint.to_string())
+}
+
+/// Returns true when the Payjoin parameters are expired at `now`.
+pub fn payjoin_v2_is_expired_at(payjoin: &PayjoinV2, now: u64) -> bool {
+    payjoin_expires_at_is_expired(payjoin.expires_at, now)
+}
+
+/// Returns true when a Payjoin expiry timestamp has been reached.
+pub fn payjoin_expires_at_is_expired(expires_at: u64, now: u64) -> bool {
+    now >= expires_at
+}
+
+/// Decode a BIP77 `EX1` expiry fragment parameter into a Unix timestamp.
+fn decode_bip77_expiry(value: &str) -> Result<u64, PayjoinV2Error> {
+    let bytes = decode_bech32_fragment::<4>(value, "expiry", "EX").map_err(expiry_key_error)?;
+    Ok(u32::from_le_bytes(bytes) as u64)
+}
+
+/// Encode a Unix timestamp as a BIP77 `EX1` expiry fragment parameter.
+fn encode_bip77_expiry(expires_at: u64) -> Result<String, PayjoinV2Error> {
+    let expires_at =
+        u32::try_from(expires_at).map_err(|_| PayjoinV2Error::ExpiryOutOfRange(expires_at))?;
+
+    encode_bech32_fragment("expiry", "EX", &expires_at.to_le_bytes()).map_err(expiry_key_error)
+}
+
+fn expiry_key_error(error: PayjoinV2KeyError) -> PayjoinV2Error {
+    match error {
+        PayjoinV2KeyError::InvalidCharacter { character, .. } => {
+            PayjoinV2Error::InvalidExpiryCharacter(character)
+        }
+        PayjoinV2KeyError::InvalidLength { actual, .. } => {
+            PayjoinV2Error::InvalidExpiryLength(actual)
+        }
+        PayjoinV2KeyError::InvalidPadding { .. } => PayjoinV2Error::InvalidExpiryPadding,
+        _ => PayjoinV2Error::InvalidExpiryPrefix,
+    }
+}
+
+fn extract_payjoin_fragment_value(
+    endpoint_url: &url::Url,
+    prefix: &'static str,
+) -> Result<String, PayjoinV2Error> {
+    let fragment = endpoint_url
+        .fragment()
+        .ok_or(PayjoinV2Error::MissingFragmentParam { prefix })?;
+    if fragment.contains('+') && fragment.contains('-') {
+        return Err(PayjoinV2Error::AmbiguousFragmentDelimiter);
+    }
+    let delimiter = if fragment.contains('+') { '+' } else { '-' };
+
+    fragment
+        .split(delimiter)
+        .find(|part| part.starts_with(prefix))
+        .map(|part| part.to_string())
+        .ok_or(PayjoinV2Error::MissingFragmentParam { prefix })
+}
+
+fn strip_fragment_prefix<'a>(
+    value: &'a str,
+    prefix: &'static str,
+) -> Result<&'a str, PayjoinV2Error> {
+    value
+        .strip_prefix(prefix)
+        .ok_or(PayjoinV2Error::MissingFragmentPrefix { prefix })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_bip21_payjoin_uri, decode_bip77_expiry, encode_bip77_expiry,
+        format_bip21_amount_from_sats, parse_bip21_amount_to_sats, parse_bip21_payjoin_uri,
+        payjoin_v2_from_bip77_endpoint, payjoin_v2_from_extra_json, payjoin_v2_is_expired_at,
+        payjoin_v2_to_bip77_endpoint, Bip21PayjoinUriError, ONCHAIN_PAYJOIN_EXTRA_KEY,
+    };
+    use crate::nuts::nut31::PayjoinV2;
+
+    const OHTTP_KEYS: &str = "QYPFLM8XL59R0XV4VGPLS7FRDSSM4TUXL07TXCWC4S0GLVLNK2SE4NQ";
+    const RECEIVER_KEY: &str = "QV6WSX0UQPAEA0RH54430D0UVZWS8CZ6FEGZF4RGFCDKJLPGMYEJG";
+
+    #[test]
+    fn bip77_expiry_roundtrips() {
+        assert_eq!(encode_bip77_expiry(1_720_547_781).unwrap(), "EX1C4UC6ES");
+        assert_eq!(decode_bip77_expiry("EX1C4UC6ES").unwrap(), 1_720_547_781);
+    }
+
+    #[test]
+    fn rejects_malformed_bip77_expiry() {
+        assert!(matches!(
+            decode_bip77_expiry("EY1C4UC6ES"),
+            Err(super::PayjoinV2Error::InvalidExpiryPrefix)
+        ));
+        assert!(matches!(
+            decode_bip77_expiry("EX1*"),
+            Err(super::PayjoinV2Error::InvalidExpiryCharacter('*'))
+        ));
+        assert!(matches!(
+            decode_bip77_expiry("EX1Q"),
+            Err(super::PayjoinV2Error::InvalidExpiryLength(0))
+        ));
+        assert!(matches!(
+            encode_bip77_expiry(u64::from(u32::MAX) + 1),
+            Err(super::PayjoinV2Error::ExpiryOutOfRange(value)) if value == u64::from(u32::MAX) + 1
+        ));
+    }
+
+    #[test]
+    fn parses_bip77_endpoint_into_cashu_fields() {
+        let payjoin = payjoin_v2_from_bip77_endpoint(
+            "HTTPS://PAYJO.IN/E73HSW759WNES#EX12XHZ26S-OH1QYPFLM8XL59R0XV4VGPLS7FRDSSM4TUXL07TXCWC4S0GLVLNK2SE4NQ-RK1QV6WSX0UQPAEA0RH54430D0UVZWS8CZ6FEGZF4RGFCDKJLPGMYEJG",
+        )
+        .unwrap();
+
+        assert_eq!(payjoin.endpoint, "https://payjo.in/E73HSW759WNES");
+        assert_eq!(payjoin.ohttp_keys.to_string(), OHTTP_KEYS);
+        assert_eq!(payjoin.receiver_key.to_string(), RECEIVER_KEY);
+        assert_eq!(payjoin.expires_at, 1_780_854_353);
+    }
+
+    #[test]
+    fn builds_bip77_endpoint_from_cashu_fields() {
+        let payjoin = PayjoinV2::new(
+            "https://payjoin.example/pj".to_string(),
+            OHTTP_KEYS,
+            RECEIVER_KEY,
+            1_720_547_781,
+        )
+        .expect("valid Payjoin keys");
+
+        assert_eq!(
+            payjoin_v2_to_bip77_endpoint(&payjoin).unwrap(),
+            "https://payjoin.example/pj#EX1C4UC6ES-OH1QYPFLM8XL59R0XV4VGPLS7FRDSSM4TUXL07TXCWC4S0GLVLNK2SE4NQ-RK1QV6WSX0UQPAEA0RH54430D0UVZWS8CZ6FEGZF4RGFCDKJLPGMYEJG"
+        );
+    }
+
+    #[test]
+    fn reads_payjoin_from_extra_json() {
+        let payjoin = PayjoinV2::new(
+            "https://payjoin.example/pj".to_string(),
+            OHTTP_KEYS,
+            RECEIVER_KEY,
+            1_720_547_781,
+        )
+        .expect("valid Payjoin keys");
+        let extra = serde_json::json!({ ONCHAIN_PAYJOIN_EXTRA_KEY: payjoin.clone() });
+
+        assert_eq!(payjoin_v2_from_extra_json(Some(&extra)).unwrap(), payjoin);
+        assert_eq!(payjoin_v2_from_extra_json(None), None);
+    }
+
+    #[test]
+    fn formats_bip21_amount_from_sats() {
+        assert_eq!(format_bip21_amount_from_sats(0), "0");
+        assert_eq!(format_bip21_amount_from_sats(1), "0.00000001");
+        assert_eq!(format_bip21_amount_from_sats(100_000_000), "1");
+        assert_eq!(format_bip21_amount_from_sats(123_456_780), "1.2345678");
+    }
+
+    #[test]
+    fn parses_bip21_amount_to_sats() {
+        assert_eq!(parse_bip21_amount_to_sats("0").unwrap(), 0);
+        assert_eq!(parse_bip21_amount_to_sats("0.00000001").unwrap(), 1);
+        assert_eq!(parse_bip21_amount_to_sats("1").unwrap(), 100_000_000);
+        assert_eq!(
+            parse_bip21_amount_to_sats("1.2345678").unwrap(),
+            123_456_780
+        );
+        assert!(
+            parse_bip21_amount_to_sats("1.000000001").is_err(),
+            "sub-satoshi precision must be rejected"
+        );
+    }
+
+    #[test]
+    fn detects_expired_payjoin() {
+        let payjoin = PayjoinV2::new(
+            "https://payjoin.example/pj".to_string(),
+            OHTTP_KEYS,
+            RECEIVER_KEY,
+            10,
+        )
+        .expect("valid Payjoin keys");
+
+        assert!(!payjoin_v2_is_expired_at(&payjoin, 9));
+        assert!(payjoin_v2_is_expired_at(&payjoin, 10));
+    }
+
+    #[test]
+    fn bip21_payjoin_uri_roundtrips() {
+        let payjoin = PayjoinV2::new(
+            "https://payjoin.example/pj".to_string(),
+            OHTTP_KEYS,
+            RECEIVER_KEY,
+            1_720_547_781,
+        )
+        .expect("valid Payjoin keys");
+        let uri = build_bip21_payjoin_uri(
+            "bcrt1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4",
+            Some(50_000),
+            &payjoin,
+            Some(false),
+        )
+        .expect("build Payjoin URI");
+
+        assert!(uri.starts_with("BITCOIN:BCRT1Q6D3A2W975YNY0ASUVD9A67NER4NKS58FF0Q8G4?"));
+        assert_eq!(
+            parse_bip21_payjoin_uri(&uri).expect("parse Payjoin URI"),
+            super::Bip21PayjoinUri {
+                address: "bcrt1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4".to_string(),
+                amount_sat: Some(50_000),
+                payjoin: Some(payjoin),
+                pjos: Some(false),
+            }
+        );
+    }
+
+    #[test]
+    fn bip21_uri_without_payjoin_is_supported() {
+        let parsed = parse_bip21_payjoin_uri("bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=1")
+            .expect("parse BIP21 URI");
+
+        assert_eq!(parsed.address, "12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX");
+        assert_eq!(parsed.amount_sat, Some(100_000_000));
+        assert_eq!(parsed.payjoin, None);
+        assert_eq!(parsed.pjos, None);
+    }
+
+    #[test]
+    fn bip21_uri_rejects_invalid_pjos() {
+        let err = parse_bip21_payjoin_uri("bitcoin:bc1qexample?pjos=2")
+            .expect_err("invalid pjos must fail");
+
+        assert!(matches!(err, Bip21PayjoinUriError::InvalidPjos(value) if value == "2"));
+    }
+}

--- a/crates/cdk-common/src/payment.rs
+++ b/crates/cdk-common/src/payment.rs
@@ -19,6 +19,7 @@ use thiserror::Error;
 use crate::mint::{MeltPaymentRequest, MeltQuote};
 use crate::nuts::nut30::MeltQuoteOnchainFeeOption;
 use crate::nuts::{CurrencyUnit, MeltQuoteState, PublicKey};
+use crate::payjoin::{ONCHAIN_PAYJOIN_DESTINATION_EXTRA_KEY, ONCHAIN_PAYJOIN_EXTRA_KEY};
 use crate::{Amount, QuoteId};
 
 /// CDK Payment Error
@@ -427,11 +428,18 @@ impl OutgoingPaymentOptions {
                     max_fee_amount: Some(fee_reserve),
                     quote_id: melt_quote.id,
                     fee_index: melt_quote.selected_fee_index,
-                    metadata: None,
+                    metadata: onchain_melt_payment_metadata(melt_quote.extra_json),
                 }),
             )),
         }
     }
+}
+
+fn onchain_melt_payment_metadata(extra_json: Option<Value>) -> Option<String> {
+    let extra_json = extra_json?;
+    extra_json
+        .get(ONCHAIN_PAYJOIN_DESTINATION_EXTRA_KEY)
+        .map(|payjoin| serde_json::json!({ ONCHAIN_PAYJOIN_EXTRA_KEY: payjoin }).to_string())
 }
 
 /// Mint payment trait
@@ -880,6 +888,7 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
+    use crate::payjoin::{ONCHAIN_PAYJOIN_DESTINATION_EXTRA_KEY, ONCHAIN_PAYJOIN_EXTRA_KEY};
     use crate::QuoteId;
 
     #[test]
@@ -958,6 +967,70 @@ mod tests {
         // Invalid length for bolt12_payment_hash
         let result_bolt12 = PaymentIdentifier::new("bolt12_payment_hash", "00");
         assert!(matches!(result_bolt12, Err(Error::InvalidHash)));
+    }
+
+    #[test]
+    fn onchain_melt_payment_metadata_uses_persisted_payjoin_destination() {
+        let destination = serde_json::json!({
+            "endpoint": "https://payjoin.example/pj",
+            "ohttp_keys": "QYPFLM8XL59R0XV4VGPLS7FRDSSM4TUXL07TXCWC4S0GLVLNK2SE4NQ",
+            "receiver_key": "QV6WSX0UQPAEA0RH54430D0UVZWS8CZ6FEGZF4RGFCDKJLPGMYEJG",
+            "expires_at": 1_741_276_520,
+        });
+        let extra_json = serde_json::json!({
+            ONCHAIN_PAYJOIN_EXTRA_KEY: destination.clone(),
+            ONCHAIN_PAYJOIN_DESTINATION_EXTRA_KEY: destination.clone(),
+        });
+        let mut quote = MeltQuote::new_onchain(
+            Some(QuoteId::new()),
+            MeltPaymentRequest::Onchain {
+                address: "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq".to_string(),
+            },
+            CurrencyUnit::Sat,
+            Amount::new(4_000, CurrencyUnit::Sat),
+            1_701_704_757,
+            None,
+            Some(extra_json),
+            vec![MeltQuoteOnchainFeeOption {
+                fee_index: 0,
+                fee_reserve: Amount::from(1_000),
+                estimated_blocks: 1,
+            }],
+        )
+        .expect("well-formed onchain quote must construct");
+        quote
+            .select_onchain_fee_option(0)
+            .expect("known fee option must select");
+
+        let options = OutgoingPaymentOptions::from_melt_quote_with_fee(quote)
+            .expect("onchain quote must convert to outgoing payment options");
+        let OutgoingPaymentOptions::Onchain(options) = options else {
+            panic!("expected onchain payment options");
+        };
+        let metadata: Value = serde_json::from_str(
+            options
+                .metadata
+                .as_deref()
+                .expect("Payjoin metadata must be present"),
+        )
+        .expect("metadata must be valid JSON");
+
+        assert_eq!(
+            metadata,
+            serde_json::json!({ ONCHAIN_PAYJOIN_EXTRA_KEY: destination })
+        );
+        assert!(metadata
+            .get(ONCHAIN_PAYJOIN_DESTINATION_EXTRA_KEY)
+            .is_none());
+    }
+
+    #[test]
+    fn onchain_melt_payment_metadata_ignores_unrelated_extra_json() {
+        let metadata = onchain_melt_payment_metadata(Some(serde_json::json!({
+            "internal_note": "must not reach payment backend",
+        })));
+
+        assert_eq!(metadata, None);
     }
 }
 

--- a/crates/cdk-payment-processor/src/proto/mod.rs
+++ b/crates/cdk-payment-processor/src/proto/mod.rs
@@ -472,7 +472,13 @@ mod tests {
             extra_json: Some(serde_json::json!({
                 "method": "custom",
                 "redirect_url": "https://example.com/pay",
-                "nested": { "attempt": 1 }
+                "nested": { "attempt": 1 },
+                "payjoin": {
+                    "endpoint": "https://payjoin.example/pj",
+                    "ohttp_keys": "QYPFLM8XL59R0XV4VGPLS7FRDSSM4TUXL07TXCWC4S0GLVLNK2SE4NQ",
+                    "receiver_key": "QV6WSX0UQPAEA0RH54430D0UVZWS8CZ6FEGZF4RGFCDKJLPGMYEJG",
+                    "expires_at": 1780000000
+                }
             })),
             fee_options: Some(vec![MeltQuoteOnchainFeeOption {
                 fee_index: 0,

--- a/crates/cdk/src/mint/melt/mod.rs
+++ b/crates/cdk/src/mint/melt/mod.rs
@@ -10,6 +10,10 @@ use cdk_common::mint::MeltPaymentRequest;
 use cdk_common::nut00::KnownMethod;
 use cdk_common::nut05::MeltMethodOptions;
 use cdk_common::nuts::nut17::{Kind, NotificationPayload};
+use cdk_common::payjoin::{
+    payjoin_v2_from_extra_json, payjoin_v2_is_expired_at, payjoin_v2_to_bip77_endpoint,
+    ONCHAIN_PAYJOIN_DESTINATION_EXTRA_KEY, ONCHAIN_PAYJOIN_EXTRA_KEY,
+};
 use cdk_common::payment::{
     Bolt11OutgoingPaymentOptions, Bolt12OutgoingPaymentOptions, CustomOutgoingPaymentOptions,
     OutgoingPaymentOptions, PaymentIdentifier,
@@ -40,6 +44,24 @@ pub(crate) mod shared;
 mod tests;
 
 use melt_saga::{MeltSaga, PaymentOutcome};
+
+fn onchain_melt_quote_extra_json(
+    payment_extra_json: Option<serde_json::Value>,
+    destination_payjoin: Option<&cdk_common::nuts::nut31::PayjoinV2>,
+) -> Option<serde_json::Value> {
+    let mut extra = payment_extra_json?;
+    if let Some(payjoin) = destination_payjoin {
+        if payjoin_v2_from_extra_json(Some(&extra)).is_some() {
+            if let Some(object) = extra.as_object_mut() {
+                object.insert(
+                    ONCHAIN_PAYJOIN_DESTINATION_EXTRA_KEY.to_string(),
+                    serde_json::to_value(payjoin).ok()?,
+                );
+            }
+        }
+    }
+    Some(extra)
+}
 
 fn pending_melt_wait_timeout() -> Duration {
     if cfg!(test) {
@@ -502,6 +524,21 @@ impl Mint {
             // no longer self-referential via the backend response.
             let quote_id = QuoteId::new();
 
+            if let Some(payjoin) = melt_request.payjoin.as_ref() {
+                if payjoin_v2_is_expired_at(payjoin, unix_time()) {
+                    return Err(Error::Custom("Payjoin parameters are expired".to_string()));
+                }
+                payjoin_v2_to_bip77_endpoint(payjoin)
+                    .map_err(|err| Error::Custom(format!("Invalid Payjoin parameters: {err}")))?;
+            }
+
+            let payjoin_metadata = melt_request.payjoin.as_ref().map(|payjoin| {
+                serde_json::json!({
+                    ONCHAIN_PAYJOIN_EXTRA_KEY: payjoin,
+                })
+                .to_string()
+            });
+
             let outgoing_payment_options = cdk_common::payment::OnchainOutgoingPaymentOptions {
                 address: melt_request.request.clone(),
                 amount: melt_request.amount.with_unit(unit.clone()),
@@ -511,7 +548,7 @@ impl Mint {
                 // available `fee_options` and the wallet picks one (echoed back
                 // as `fee_index`) when executing the melt.
                 fee_index: None,
-                metadata: None,
+                metadata: payjoin_metadata,
             };
 
             let payment_quote = payment_backend
@@ -574,6 +611,11 @@ impl Mint {
             // `MeltQuote::new_onchain` applies the NUT validation. Failures are
             // returned before the quote is persisted, so a backend that violates
             // the contract never leaves state behind in the mint.
+            let extra_json = onchain_melt_quote_extra_json(
+                payment_quote.extra_json,
+                melt_request.payjoin.as_ref(),
+            );
+
             let quote = MeltQuote::new_onchain(
                 Some(quote_id),
                 MeltPaymentRequest::Onchain {
@@ -583,7 +625,7 @@ impl Mint {
                 payment_quote.amount,
                 unix_time() + melt_ttl,
                 request_lookup_id,
-                payment_quote.extra_json,
+                extra_json,
                 fee_options,
             )?;
 

--- a/crates/cdk/src/mint/melt/tests/onchain_quote_id_tests.rs
+++ b/crates/cdk/src/mint/melt/tests/onchain_quote_id_tests.rs
@@ -7,7 +7,9 @@ use async_trait::async_trait;
 use cdk_common::melt::MeltQuoteRequest;
 use cdk_common::nut00::KnownMethod;
 use cdk_common::nuts::nut30::MeltQuoteOnchainFeeOption;
+use cdk_common::nuts::nut31::PayjoinV2;
 use cdk_common::nuts::{CurrencyUnit, MeltQuoteState};
+use cdk_common::payjoin::{ONCHAIN_PAYJOIN_DESTINATION_EXTRA_KEY, ONCHAIN_PAYJOIN_EXTRA_KEY};
 use cdk_common::payment::{
     self, CreateIncomingPaymentResponse, Event, IncomingPaymentOptions, MakePaymentResponse,
     MintPayment, OnchainSettings, OutgoingPaymentOptions, PaymentIdentifier, PaymentQuoteResponse,
@@ -20,6 +22,9 @@ use futures::Stream;
 use crate::mint::{Mint, MintBuilder, MintMeltLimits};
 use crate::types::QuoteTTL;
 use crate::Error;
+
+const PAYJOIN_OHTTP_KEYS: &str = "QYPFLM8XL59R0XV4VGPLS7FRDSSM4TUXL07TXCWC4S0GLVLNK2SE4NQ";
+const PAYJOIN_RECEIVER_KEY: &str = "QV6WSX0UQPAEA0RH54430D0UVZWS8CZ6FEGZF4RGFCDKJLPGMYEJG";
 
 /// What to put in [`PaymentQuoteResponse::request_lookup_id`] when the test
 /// backend is asked for an onchain quote.
@@ -59,6 +64,7 @@ struct OnchainQuoteMock {
     confirmations: u32,
     echo: EchoBehavior,
     fee_options: FeeOptionsBehavior,
+    accept_payjoin: bool,
 }
 
 impl OnchainQuoteMock {
@@ -71,7 +77,13 @@ impl OnchainQuoteMock {
             confirmations: 1,
             echo,
             fee_options,
+            accept_payjoin: false,
         }
+    }
+
+    fn with_payjoin_acceptance(mut self) -> Self {
+        self.accept_payjoin = true;
+        self
     }
 }
 
@@ -124,12 +136,23 @@ impl MintPayment for OnchainQuoteMock {
             FeeOptionsBehavior::Explicit(options) => (None, Some(options.clone())),
         };
 
+        let extra_json = if self.accept_payjoin {
+            onchain_options
+                .metadata
+                .as_deref()
+                .and_then(|metadata| serde_json::from_str::<serde_json::Value>(metadata).ok())
+                .and_then(|value| value.get(ONCHAIN_PAYJOIN_EXTRA_KEY).cloned())
+                .map(|payjoin| serde_json::json!({ ONCHAIN_PAYJOIN_EXTRA_KEY: payjoin }))
+        } else {
+            None
+        };
+
         Ok(PaymentQuoteResponse {
             request_lookup_id,
             amount: self.amount.clone(),
             fee: self.fee.clone(),
             state: MeltQuoteState::Unpaid,
-            extra_json: None,
+            extra_json,
             estimated_blocks,
             fee_options,
         })
@@ -186,9 +209,12 @@ async fn create_onchain_test_mint_with_fee_options(
     echo: EchoBehavior,
     fee_options: FeeOptionsBehavior,
 ) -> Result<Mint, Error> {
-    let backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync> =
-        Arc::new(OnchainQuoteMock::with_fee_options(echo, fee_options));
+    create_onchain_test_mint_with_backend(OnchainQuoteMock::with_fee_options(echo, fee_options))
+        .await
+}
 
+async fn create_onchain_test_mint_with_backend(backend: OnchainQuoteMock) -> Result<Mint, Error> {
+    let backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync> = Arc::new(backend);
     let db = Arc::new(cdk_sqlite::mint::memory::empty().await?);
     let mut mint_builder = MintBuilder::new(db.clone());
 
@@ -220,7 +246,28 @@ fn onchain_melt_request() -> MeltQuoteRequest {
         request: "bcrt1qexampleaddr0000000000000000000000000000".to_string(),
         unit: CurrencyUnit::Sat,
         amount: Amount::from(1_000),
+        payjoin: None,
     })
+}
+
+fn payjoin_melt_request(endpoint: &str, expires_at: u64) -> (MeltQuoteRequest, PayjoinV2) {
+    let payjoin = PayjoinV2::new(
+        endpoint.to_string(),
+        PAYJOIN_OHTTP_KEYS,
+        PAYJOIN_RECEIVER_KEY,
+        expires_at,
+    )
+    .expect("valid Payjoin keys");
+
+    (
+        MeltQuoteRequest::Onchain(MeltQuoteOnchainRequest {
+            request: "bcrt1qexampleaddr0000000000000000000000000000".to_string(),
+            unit: CurrencyUnit::Sat,
+            amount: Amount::from(1_000),
+            payjoin: Some(payjoin.clone()),
+        }),
+        payjoin,
+    )
 }
 
 /// Happy-path: a contract-compliant backend (echoes `quote_id` verbatim)
@@ -257,6 +304,91 @@ async fn onchain_quote_uses_mint_generated_id_when_backend_echoes() {
         "request_lookup_id should be the mint-generated QuoteId, not whatever \
          variant the backend happened to return"
     );
+}
+
+#[tokio::test]
+async fn accepted_payjoin_melt_quote_persists_json_for_execution_recovery() {
+    let backend = OnchainQuoteMock::with_fee_options(
+        EchoBehavior::Echo,
+        FeeOptionsBehavior::Explicit(vec![MeltQuoteOnchainFeeOption {
+            fee_index: 0,
+            fee_reserve: Amount::from(10),
+            estimated_blocks: 6,
+        }]),
+    )
+    .with_payjoin_acceptance();
+    let mint = create_onchain_test_mint_with_backend(backend)
+        .await
+        .unwrap();
+    let (request, payjoin) = payjoin_melt_request("https://payjoin.example/pj", 4_000_000_000);
+
+    let response = mint.get_melt_quote(request).await.unwrap();
+    let options = match response {
+        cdk_common::MeltQuoteCreateResponse::Onchain(options) => options,
+        other => panic!("expected onchain quote response, got {other:?}"),
+    };
+    assert_eq!(options.payjoin, Some(payjoin.clone()));
+
+    let stored = mint
+        .localstore()
+        .get_melt_quote(&options.quote)
+        .await
+        .unwrap()
+        .expect("quote must be persisted");
+    let extra_json = stored.extra_json.expect("Payjoin JSON must persist");
+
+    assert_eq!(
+        extra_json.get(ONCHAIN_PAYJOIN_EXTRA_KEY),
+        Some(&serde_json::to_value(payjoin.clone()).expect("Payjoin must serialize"))
+    );
+    assert_eq!(
+        extra_json.get(ONCHAIN_PAYJOIN_DESTINATION_EXTRA_KEY),
+        Some(&serde_json::to_value(payjoin).expect("Payjoin must serialize"))
+    );
+}
+
+#[tokio::test]
+async fn invalid_payjoin_melt_quote_is_rejected_before_persisting() {
+    let mint = create_onchain_test_mint(EchoBehavior::Echo).await.unwrap();
+    let (request, _) = payjoin_melt_request("not a url", 4_000_000_000);
+
+    let error = mint
+        .get_melt_quote(request)
+        .await
+        .expect_err("invalid Payjoin parameters must be rejected");
+
+    assert!(matches!(
+        error,
+        Error::Custom(message) if message.contains("Invalid Payjoin parameters")
+    ));
+    assert!(mint
+        .localstore()
+        .get_melt_quotes()
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn expired_payjoin_melt_quote_is_rejected_before_persisting() {
+    let mint = create_onchain_test_mint(EchoBehavior::Echo).await.unwrap();
+    let (request, _) = payjoin_melt_request("https://payjoin.example/pj", 1);
+
+    let error = mint
+        .get_melt_quote(request)
+        .await
+        .expect_err("expired Payjoin parameters must be rejected");
+
+    assert!(matches!(
+        error,
+        Error::Custom(message) if message.contains("Payjoin parameters are expired")
+    ));
+    assert!(mint
+        .localstore()
+        .get_melt_quotes()
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 /// Backend omits `request_lookup_id` entirely — must reject with

--- a/crates/cdk/src/wallet/issue/mod.rs
+++ b/crates/cdk/src/wallet/issue/mod.rs
@@ -784,6 +784,7 @@ mod tests {
                 amount_paid: Amount::from(1_000),
                 amount_issued: Amount::from(250),
                 updated_at: 0,
+                payjoin: None,
             });
 
         assert_eq!(mint_quote_response_amount(&response), None);

--- a/crates/cdk/src/wallet/melt/onchain.rs
+++ b/crates/cdk/src/wallet/melt/onchain.rs
@@ -43,6 +43,7 @@ impl Wallet {
             request: address.to_string(),
             unit: self.unit.clone(),
             amount,
+            payjoin: None,
         };
 
         let quote_res = self

--- a/crates/cdk/src/wallet/melt/saga/mod.rs
+++ b/crates/cdk/src/wallet/melt/saga/mod.rs
@@ -1580,6 +1580,7 @@ mod tests {
                 selected_fee_index: Some(0),
                 outpoint: None,
                 change: None,
+                payjoin: None,
             },
         )));
         let wallet = create_test_wallet_with_mock(db.clone(), mock_client.clone()).await;
@@ -1651,6 +1652,7 @@ mod tests {
             selected_fee_index: quote.fee_index,
             outpoint: None,
             change: None,
+            payjoin: None,
         })
     }
 

--- a/crates/cdk/src/wallet/streams/payment.rs
+++ b/crates/cdk/src/wallet/streams/payment.rs
@@ -507,6 +507,7 @@ mod tests {
                 amount_paid: Amount::from(101u64),
                 amount_issued: Amount::from(100u64),
                 updated_at: 0,
+                payjoin: None,
             },
         ))
         .expect("positive unissued onchain amount should emit");
@@ -642,6 +643,7 @@ mod tests {
                     amount_paid: Amount::from(50u64),
                     amount_issued: Amount::from(100u64),
                     updated_at: 0,
+                    payjoin: None,
                 },
             ))
             .is_none()
@@ -752,6 +754,7 @@ mod tests {
             selected_fee_index: None,
             outpoint: None,
             change: None,
+            payjoin: None,
         }
     }
 


### PR DESCRIPTION
Expose Payjoin v2 through NUT-30 and carry negotiation data through the existing payment-processor metadata and extra_json fields.

Add shared BIP21/BIP77 conversion helpers and persist accepted destination data so non-BDK backends can negotiate and recover Payjoin payments.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
