### PR TITLE
Support BOLT12 offer descriptions (NUT-25)

### DIFF
--- a/crates/cashu/src/nuts/nut04.rs
+++ b/crates/cashu/src/nuts/nut04.rs
@@ -125,19 +125,15 @@ impl Serialize for MintMethodSettings {
             num_fields += 1;
         }
 
-        let mut description_in_top_level = false;
-        let mut bolt12_description: Option<bool> = None;
+        let mut nested_description: Option<bool> = None;
         let mut onchain_confirmations: Option<u32> = None;
 
         match &self.options {
-            Some(MintMethodOptions::Bolt11 { description }) if *description => {
-                num_fields += 1;
-                description_in_top_level = true;
-            }
-            // BOLT12 advertises the description flag in a nested options object
-            // as defined in NUT-25.
-            Some(MintMethodOptions::Bolt12 { description }) => {
-                bolt12_description = Some(*description);
+            // NUT-23 (bolt11) and NUT-25 (bolt12) advertise description support
+            // in a nested options object.
+            Some(MintMethodOptions::Bolt11 { description })
+            | Some(MintMethodOptions::Bolt12 { description }) => {
+                nested_description = Some(*description);
                 num_fields += 1; // for the "options" field
             }
             Some(MintMethodOptions::Onchain { confirmations }) => {
@@ -164,11 +160,6 @@ impl Serialize for MintMethodSettings {
             state.serialize_field("max_amount", max_amount)?;
         }
 
-        // If there's a description flag in Bolt11 options, add it at the top level
-        if description_in_top_level {
-            state.serialize_field("description", &true)?;
-        }
-
         // Serialize onchain options as a nested "options" object
         if let Some(confirmations) = onchain_confirmations {
             #[derive(Serialize)]
@@ -178,13 +169,13 @@ impl Serialize for MintMethodSettings {
             state.serialize_field("options", &OnchainOptions { confirmations })?;
         }
 
-        // Serialize bolt12 options as a nested "options" object (NUT-25)
-        if let Some(description) = bolt12_description {
+        // Serialize bolt11/bolt12 description as a nested "options" object
+        if let Some(description) = nested_description {
             #[derive(Serialize)]
-            struct Bolt12Options {
+            struct DescriptionOptions {
                 description: bool,
             }
-            state.serialize_field("options", &Bolt12Options { description })?;
+            state.serialize_field("options", &DescriptionOptions { description })?;
         }
 
         state.end()
@@ -875,16 +866,16 @@ mod tests {
             _ => panic!("Expected Bolt11 options with description = true"),
         }
 
-        // Serialize it back
+        // Serialize it back as nested options per NUT-23
         let serialized = to_string(&settings).unwrap();
         let parsed: serde_json::Value = from_str(&serialized).unwrap();
 
-        // Verify the description is at the top level
-        assert_eq!(parsed["description"], json!(true));
+        assert_eq!(parsed["options"]["description"], json!(true));
+        assert!(parsed.get("description").is_none());
     }
 
     #[test]
-    fn test_mint_method_settings_does_not_serialize_false_description() {
+    fn test_mint_method_settings_serializes_false_description_in_options() {
         let settings = MintMethodSettings {
             method: PaymentMethod::Known(KnownMethod::Bolt11),
             unit: CurrencyUnit::Sat,
@@ -899,7 +890,35 @@ mod tests {
 
         assert_eq!(parsed["method"], json!("bolt11"));
         assert!(parsed.get("description").is_none());
-        assert!(parsed.get("options").is_none());
+        assert_eq!(parsed["options"]["description"], json!(false));
+    }
+
+    #[test]
+    fn test_bolt11_settings_nested_options_round_trip() {
+        let json_str = r#"{
+            "method": "bolt11",
+            "unit": "sat",
+            "min_amount": 0,
+            "max_amount": 10000,
+            "options": {
+                "description": true
+            }
+        }"#;
+
+        let settings: MintMethodSettings = from_str(json_str).unwrap();
+
+        match settings.options {
+            Some(MintMethodOptions::Bolt11 { description }) => {
+                assert!(description);
+            }
+            _ => panic!("Expected Bolt11 options with description = true"),
+        }
+
+        let serialized = to_string(&settings).unwrap();
+        let parsed: serde_json::Value = from_str(&serialized).unwrap();
+
+        assert_eq!(parsed["options"]["description"], json!(true));
+        assert!(parsed.get("description").is_none());
     }
 
     #[test]

--- a/crates/cashu/src/nuts/nut04.rs
+++ b/crates/cashu/src/nuts/nut04.rs
@@ -126,12 +126,19 @@ impl Serialize for MintMethodSettings {
         }
 
         let mut description_in_top_level = false;
+        let mut bolt12_description: Option<bool> = None;
         let mut onchain_confirmations: Option<u32> = None;
 
         match &self.options {
             Some(MintMethodOptions::Bolt11 { description }) if *description => {
                 num_fields += 1;
                 description_in_top_level = true;
+            }
+            // BOLT12 advertises the description flag in a nested options object
+            // as defined in NUT-25.
+            Some(MintMethodOptions::Bolt12 { description }) => {
+                bolt12_description = Some(*description);
+                num_fields += 1; // for the "options" field
             }
             Some(MintMethodOptions::Onchain { confirmations }) => {
                 onchain_confirmations = Some(*confirmations);
@@ -169,6 +176,15 @@ impl Serialize for MintMethodSettings {
                 confirmations: u32,
             }
             state.serialize_field("options", &OnchainOptions { confirmations })?;
+        }
+
+        // Serialize bolt12 options as a nested "options" object (NUT-25)
+        if let Some(description) = bolt12_description {
+            #[derive(Serialize)]
+            struct Bolt12Options {
+                description: bool,
+            }
+            state.serialize_field("options", &Bolt12Options { description })?;
         }
 
         state.end()
@@ -270,8 +286,13 @@ impl<'de> Visitor<'de> for MintMethodSettingsVisitor {
         let unit = unit.ok_or_else(|| de::Error::missing_field("unit"))?;
 
         // Create options based on the method and the description flag
+        // Note: the wire format of both bolt11 and bolt12 description options is
+        // {"description": bool}, which untagged deserialization maps to the
+        // Bolt11 variant. It is remapped here based on the method.
         let options = if method == PaymentMethod::Known(KnownMethod::Bolt11) {
             description.map(|desc| MintMethodOptions::Bolt11 { description: desc })
+        } else if method == PaymentMethod::Known(KnownMethod::Bolt12) {
+            description.map(|desc| MintMethodOptions::Bolt12 { description: desc })
         } else if method == PaymentMethod::Known(KnownMethod::Onchain) {
             confirmations.map(|conf| MintMethodOptions::Onchain {
                 confirmations: conf,
@@ -307,6 +328,11 @@ pub enum MintMethodOptions {
     /// Bolt11 Options
     Bolt11 {
         /// Mint supports setting bolt11 description
+        description: bool,
+    },
+    /// Bolt12 Options
+    Bolt12 {
+        /// Mint supports setting bolt12 description
         description: bool,
     },
     /// Onchain Options
@@ -1068,6 +1094,75 @@ mod tests {
 
         let err = from_str::<MintMethodSettings>(json_str).unwrap_err();
         assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn test_bolt12_settings_nested_options_round_trip() {
+        // NUT-25 spec format: description nested inside "options"
+        let json_str = r#"{
+            "method": "bolt12",
+            "unit": "sat",
+            "min_amount": 0,
+            "max_amount": 10000,
+            "options": {
+                "description": true
+            }
+        }"#;
+
+        let settings: MintMethodSettings = from_str(json_str).unwrap();
+
+        assert_eq!(settings.method, PaymentMethod::Known(KnownMethod::Bolt12));
+        assert_eq!(settings.unit, CurrencyUnit::Sat);
+
+        match settings.options {
+            Some(MintMethodOptions::Bolt12 { description }) => {
+                assert!(description);
+            }
+            _ => panic!("Expected Bolt12 options with description = true"),
+        }
+
+        // Serialize it back and verify the nested "options" structure
+        let serialized = to_string(&settings).unwrap();
+        let parsed: serde_json::Value = from_str(&serialized).unwrap();
+
+        assert_eq!(parsed["method"], json!("bolt12"));
+        assert_eq!(parsed["options"]["description"], json!(true));
+        // Verify description is NOT at top level
+        assert!(parsed.get("description").is_none());
+    }
+
+    #[test]
+    fn test_bolt12_settings_top_level_description_accepted() {
+        // Some mints place the description flag at the top level; it should be
+        // mapped to the Bolt12 options based on the method
+        let json_str = r#"{
+            "method": "bolt12",
+            "unit": "sat",
+            "description": true
+        }"#;
+
+        let settings: MintMethodSettings = from_str(json_str).unwrap();
+
+        assert_eq!(settings.method, PaymentMethod::Known(KnownMethod::Bolt12));
+        match settings.options {
+            Some(MintMethodOptions::Bolt12 { description }) => {
+                assert!(description);
+            }
+            _ => panic!("Expected Bolt12 options with description = true"),
+        }
+    }
+
+    #[test]
+    fn test_bolt12_settings_no_options_when_description_absent() {
+        let json_str = r#"{
+            "method": "bolt12",
+            "unit": "sat"
+        }"#;
+
+        let settings: MintMethodSettings = from_str(json_str).unwrap();
+
+        assert_eq!(settings.method, PaymentMethod::Known(KnownMethod::Bolt12));
+        assert_eq!(settings.options, None);
     }
 
     #[test]

--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -113,9 +113,10 @@ impl MintPayment for Cln {
                 amountless: true,
                 invoice_description: true,
             }),
-            bolt12: self
-                .bolt12
-                .then_some(payment::Bolt12Settings { amountless: true }),
+            bolt12: self.bolt12.then_some(payment::Bolt12Settings {
+                amountless: true,
+                invoice_description: true,
+            }),
             onchain: None,
             custom: HashMap::new(),
         })

--- a/crates/cdk-common/src/payment.rs
+++ b/crates/cdk-common/src/payment.rs
@@ -677,6 +677,8 @@ pub struct Bolt11Settings {
 pub struct Bolt12Settings {
     /// Amountless offer support
     pub amountless: bool,
+    /// Offer description supported
+    pub invoice_description: bool,
 }
 
 /// Onchain settings

--- a/crates/cdk-fake-wallet/src/lib.rs
+++ b/crates/cdk-fake-wallet/src/lib.rs
@@ -508,7 +508,10 @@ impl MintPayment for FakeWallet {
                 amountless: false,
                 invoice_description: true,
             }),
-            bolt12: Some(payment::Bolt12Settings { amountless: false }),
+            bolt12: Some(payment::Bolt12Settings {
+                amountless: false,
+                invoice_description: true,
+            }),
             onchain: Some(payment::OnchainSettings {
                 confirmations: 1,
                 min_receive_amount_sat: 1,

--- a/crates/cdk-ffi/src/types/mint.rs
+++ b/crates/cdk-ffi/src/types/mint.rs
@@ -173,7 +173,7 @@ pub struct MintMethodSettings {
     pub method_name: Option<String>,
     pub min_amount: Option<Amount>,
     pub max_amount: Option<Amount>,
-    /// For bolt11, whether mint supports setting invoice description
+    /// For bolt11/bolt12, whether mint supports setting invoice/offer description
     pub description: Option<bool>,
 }
 
@@ -181,6 +181,7 @@ impl From<cdk::nuts::nut04::MintMethodSettings> for MintMethodSettings {
     fn from(s: cdk::nuts::nut04::MintMethodSettings) -> Self {
         let description = match s.options {
             Some(cdk::nuts::nut04::MintMethodOptions::Bolt11 { description }) => Some(description),
+            Some(cdk::nuts::nut04::MintMethodOptions::Bolt12 { description }) => Some(description),
             _ => None,
         };
         Self {
@@ -202,6 +203,9 @@ impl TryFrom<MintMethodSettings> for cdk::nuts::nut04::MintMethodSettings {
             PaymentMethod::Bolt11 => s
                 .description
                 .map(|description| cdk::nuts::nut04::MintMethodOptions::Bolt11 { description }),
+            PaymentMethod::Bolt12 => s
+                .description
+                .map(|description| cdk::nuts::nut04::MintMethodOptions::Bolt12 { description }),
             PaymentMethod::Custom { .. } => Some(cdk::nuts::nut04::MintMethodOptions::Custom {}),
             _ => None,
         };

--- a/crates/cdk-ldk-node/src/lib.rs
+++ b/crates/cdk-ldk-node/src/lib.rs
@@ -853,7 +853,10 @@ impl MintPayment for CdkLdkNode {
                 amountless: true,
                 invoice_description: true,
             }),
-            bolt12: Some(payment::Bolt12Settings { amountless: true }),
+            bolt12: Some(payment::Bolt12Settings {
+                amountless: true,
+                invoice_description: true,
+            }),
             onchain: None,
             custom: std::collections::HashMap::new(),
         };

--- a/crates/cdk-mint-rpc/src/proto/payment_method.proto
+++ b/crates/cdk-mint-rpc/src/proto/payment_method.proto
@@ -51,7 +51,8 @@ message UpdateMintMethodResponse {
     optional uint64 min_amount = 3;
     // Maximum amount the method accepts, if set.
     optional uint64 max_amount = 4;
-    // Method options. Set only when the method carries bolt11 options.
+    // Method options. Set when the method carries bolt11 or bolt12 description
+    // options. Other method options are omitted.
     optional Bolt11MintMethodOptions options = 5;
     // Human-readable payment method name. When unset, wallets derive one from
     // method by replacing '_' and '-' with spaces and title-casing words.

--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -1446,7 +1446,8 @@ impl PaymentMethodService for MintRPCServer {
 impl From<MintMethodSettings> for crate::payment_method::UpdateMintMethodResponse {
     fn from(settings: MintMethodSettings) -> Self {
         let options = settings.options.and_then(|options| match options {
-            cdk::nuts::nut04::MintMethodOptions::Bolt11 { description } => {
+            cdk::nuts::nut04::MintMethodOptions::Bolt11 { description }
+            | cdk::nuts::nut04::MintMethodOptions::Bolt12 { description } => {
                 Some(crate::payment_method::Bolt11MintMethodOptions { description })
             }
             _ => None,
@@ -2227,6 +2228,30 @@ mod tests {
             .into_inner()
             .tos_url
             .is_none());
+    }
+
+    #[test]
+    fn test_update_mint_method_response_maps_bolt12_description_options() {
+        let settings = MintMethodSettings {
+            method: PaymentMethod::Known(KnownMethod::Bolt12),
+            unit: CurrencyUnit::Sat,
+            method_name: Some("Bolt12".to_string()),
+            min_amount: Some(Amount::from(1)),
+            max_amount: Some(Amount::from(1_000)),
+            options: Some(cdk::nuts::nut04::MintMethodOptions::Bolt12 { description: true }),
+        };
+
+        let response: crate::payment_method::UpdateMintMethodResponse = settings.into();
+
+        assert_eq!(response.unit, "sat");
+        assert_eq!(response.method, "bolt12");
+        assert_eq!(response.min_amount, Some(1));
+        assert_eq!(response.max_amount, Some(1_000));
+        assert_eq!(
+            response.options,
+            Some(crate::payment_method::Bolt11MintMethodOptions { description: true })
+        );
+        assert_eq!(response.method_name.as_deref(), Some("Bolt12"));
     }
 
     #[tokio::test]

--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -10,6 +10,7 @@ use cdk::nuts::{CurrencyUnit, MintQuoteState, PaymentMethod};
 use cdk::types::QuoteTTL;
 use cdk::Amount;
 use cdk_common::grpc::create_version_check_interceptor;
+use cdk_common::nut00::KnownMethod;
 use cdk_common::payment::WaitPaymentResponse;
 use thiserror::Error;
 use tokio::sync::Notify;
@@ -962,11 +963,15 @@ impl CdkMint for MintRPCServer {
     ) -> Result<Response<UpdateResponse>, Status> {
         let request = request.into_inner();
 
-        let options = request
-            .options
-            .map(|options| cdk::nuts::nut04::MintMethodOptions::Bolt11 {
-                description: options.description,
-            });
+        let options = request.options.map(|options| {
+            let description = options.description;
+            match PaymentMethod::from_str(&request.method) {
+                Ok(PaymentMethod::Known(KnownMethod::Bolt12)) => {
+                    cdk::nuts::nut04::MintMethodOptions::Bolt12 { description }
+                }
+                _ => cdk::nuts::nut04::MintMethodOptions::Bolt11 { description },
+            }
+        });
 
         self.set_mint_method(
             &request.unit,

--- a/crates/cdk-payment-processor/src/proto/client.rs
+++ b/crates/cdk-payment-processor/src/proto/client.rs
@@ -160,6 +160,7 @@ impl MintPayment for PaymentProcessorClient {
                 .bolt12
                 .map(|b| cdk_common::payment::Bolt12Settings {
                     amountless: b.amountless,
+                    invoice_description: b.invoice_description,
                 }),
             onchain: settings
                 .onchain

--- a/crates/cdk-payment-processor/src/proto/payment_processor.proto
+++ b/crates/cdk-payment-processor/src/proto/payment_processor.proto
@@ -35,6 +35,7 @@ message OnchainSettings {
 
 message Bolt12Settings {
     bool amountless = 2;
+    bool invoice_description = 3;
 }
 
 message Bolt11Settings {

--- a/crates/cdk-payment-processor/src/proto/server.rs
+++ b/crates/cdk-payment-processor/src/proto/server.rs
@@ -201,6 +201,7 @@ impl CdkPaymentProcessor for PaymentProcessorServer {
             }),
             bolt12: settings.bolt12.map(|b| super::Bolt12Settings {
                 amountless: b.amountless,
+                invoice_description: b.invoice_description,
             }),
             onchain: settings.onchain.map(|o| super::OnchainSettings {
                 confirmations: o.confirmations,

--- a/crates/cdk/src/mint/builder.rs
+++ b/crates/cdk/src/mint/builder.rs
@@ -477,15 +477,17 @@ impl MintBuilder {
             }
             // Handle bolt12 methods
             PaymentMethod::Known(KnownMethod::Bolt12) => {
-                if settings.bolt12.is_some() {
-                    // Add to NUT04 (mint) - bolt12 doesn't have specific options yet
+                if let Some(bolt12_settings) = &settings.bolt12 {
+                    // Add to NUT04 (mint)
                     let mint_method_settings = MintMethodSettings {
                         method: method.clone(),
                         unit: unit.clone(),
                         method_name: Some("Bolt12".to_string()),
                         min_amount: Some(limits.mint_min),
                         max_amount: Some(limits.mint_max),
-                        options: None, // No bolt12-specific options in NUT04 yet
+                        options: Some(MintMethodOptions::Bolt12 {
+                            description: bolt12_settings.invoice_description,
+                        }),
                     };
                     self.mint_info.nuts.nut04.methods.push(mint_method_settings);
                     self.mint_info.nuts.nut04.disabled = false;
@@ -1267,7 +1269,10 @@ mod tests {
             )
             .unwrap();
 
-        let bolt12_settings = Bolt12Settings { amountless: true };
+        let bolt12_settings = Bolt12Settings {
+            amountless: true,
+            invoice_description: true,
+        };
 
         let settings = SettingsResponse {
             unit: "sat".to_string(),
@@ -1298,7 +1303,10 @@ mod tests {
         assert_eq!(mint_method.method_name, Some("Bolt12".to_string()));
         assert_eq!(mint_method.min_amount, Some(limits.mint_min));
         assert_eq!(mint_method.max_amount, Some(limits.mint_max));
-        assert!(mint_method.options.is_none());
+        assert_eq!(
+            mint_method.options,
+            Some(MintMethodOptions::Bolt12 { description: true })
+        );
 
         // Check NUT05 (melt) settings
         assert!(!mint_info.nuts.nut05.disabled);
@@ -1630,7 +1638,10 @@ mod tests {
             .unwrap();
 
         // Add Bolt12
-        let bolt12_settings = Bolt12Settings { amountless: false };
+        let bolt12_settings = Bolt12Settings {
+            amountless: false,
+            invoice_description: true,
+        };
         let settings2 = SettingsResponse {
             unit: "sat".to_string(),
             bolt11: None,

--- a/crates/cdk/src/mint/issue/mod.rs
+++ b/crates/cdk/src/mint/issue/mod.rs
@@ -272,6 +272,16 @@ impl Mint {
 
                     let description = bolt12_request.description;
 
+                    // Check that the backend supports offer descriptions
+                    let settings = payment_backend.get_settings().await?;
+
+                    if let Some(ref bolt12_settings) = settings.bolt12 {
+                        if description.is_some() && !bolt12_settings.invoice_description {
+                            tracing::error!("Backend does not support invoice description");
+                            return Err(Error::InvoiceDescriptionUnsupported);
+                        }
+                    }
+
                     let bolt12_options = Bolt12IncomingPaymentOptions {
                         description,
                         amount: amount.map(|a| a.with_unit(unit.clone())),

--- a/crates/cdk/src/wallet/issue/mod.rs
+++ b/crates/cdk/src/wallet/issue/mod.rs
@@ -244,9 +244,20 @@ impl Wallet {
                 .get_settings(&unit, &method)
                 .ok_or(Error::UnsupportedUnit)?;
 
-            match settings.options {
-                Some(MintMethodOptions::Bolt11 { description }) if description => (),
-                _ => return Err(Error::InvoiceDescriptionUnsupported),
+            let description_supported = match (&method, settings.options) {
+                (
+                    PaymentMethod::Known(KnownMethod::Bolt11),
+                    Some(MintMethodOptions::Bolt11 { description }),
+                )
+                | (
+                    PaymentMethod::Known(KnownMethod::Bolt12),
+                    Some(MintMethodOptions::Bolt12 { description }),
+                ) => description,
+                _ => false,
+            };
+
+            if !description_supported {
+                return Err(Error::InvoiceDescriptionUnsupported);
             }
         }
 


### PR DESCRIPTION
## Summary
- Add `MintMethodOptions::Bolt12 { description }` to NUT-04 settings; serializer emits nested `options: {"description": bool}` per NUT-25, deserializer remaps the wire format by payment method and still accepts legacy top-level `description`
- Serialize bolt11 the same way (`options.description`) per NUT-23; still accept the legacy top-level `description` field on decode
- Add `invoice_description` to `Bolt12Settings` (cdk-common) and propagate it through the payment-processor proto/client/server
- Mint builder advertises bolt12 description support from backend settings; mint rejects bolt12 mint quotes with a description when unsupported; wallet checks nut04 settings before creating such quotes (fixes "mint does not support bolt12 descriptions")
- Enable `invoice_description` by default in cln, fake-wallet, ldk-node backends
- FFI + mint-rpc mappings updated for the new variant

## Review Notes
- Production-safety review passed (1 round): server-side guard mirrors the existing bolt11 pattern verbatim; no new unwraps in non-test code; proto addition is backward-compatible
- Deserializer note: untagged enum maps both bolt11/bolt12 wire formats to `Bolt11`, so remapping by method is required — covered by unit tests

## Decision Log
**Hardest decision:** keep the per-quote backend check in `mint/issue/mod.rs` (extra `get_settings()` RPC on bolt12 quotes) instead of relying on cached advertised settings, for exact parity with the existing bolt11 path — consistency over micro-optimization.

**Alternatives rejected:**
- Reuse `MintMethodOptions::Bolt11` for bolt12 wire data: silently mislabels capability and breaks exhaustive matches downstream
- Centralize method→description mapping in one helper: call sites match different shapes (owned/ref, Option/bool); not worth it at this size

**Least confident about:** backends where `settings.bolt12` is `None` skip the guard (same as bolt11); such quotes fail later at offer creation. If we want a hard early error there, that's a follow-up.

## Test plan
- [x] `cargo clippy -p cashu --all-targets -- -D warnings`
- [x] `cargo test -p cashu --lib nut04` (21 passed)
- [x] `cargo test -p cashu --lib nut06` (7 passed)
- [ ] CI passes
