### PR TITLE
feat(wallet)!: require confirmation for payment requests

### DIFF
--- a/crates/cashu/src/nuts/nut18/payment_request.rs
+++ b/crates/cashu/src/nuts/nut18/payment_request.rs
@@ -97,7 +97,9 @@ pub struct PaymentRequest {
     /// If non-empty, the payer must send ecash from a mint that supports at
     /// least one listed method. Each method can carry a fee that only applies
     /// to payments from non-preferred mints, or from any mint if no mint list is
-    /// set.
+    /// set. The advertised `mf` values are exposed as
+    /// [`SupportedMethod::fee`]; the fee that actually applies is selected by
+    /// the paying wallet based on its mint and supported methods.
     #[serde(rename = "sm")]
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub supported_methods: Vec<SupportedMethod>,

--- a/crates/cdk-cli/src/sub_commands/create_request.rs
+++ b/crates/cdk-cli/src/sub_commands/create_request.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use cdk::mint_url::MintUrl;
-use cdk::nuts::CurrencyUnit;
+use cdk::nuts::{CurrencyUnit, SupportedMethod};
 use cdk::wallet::{payment_request as pr, NostrWaitInfo, WalletRepository};
 use clap::Args;
 use serde::{Deserialize, Serialize};
@@ -74,6 +74,13 @@ pub struct CreateRequestSubCommand {
     /// Prefer the listed mints while allowing payment from other mints
     #[arg(long)]
     mint_preferred: bool,
+    /// Accepted payment method and optional fee as METHOD or METHOD:FEE; repeatable
+    #[arg(
+        long = "supported-method",
+        action = clap::ArgAction::Append,
+        value_parser = parse_supported_method
+    )]
+    supported_methods: Vec<SupportedMethod>,
     /// Use bech32 encoding (CREQ-B)
     #[arg(short, long)]
     bech32: bool,
@@ -98,6 +105,7 @@ pub async fn create_request(
         nostr_relays: sub_command_args.nostr_relay.clone(),
         mints: sub_command_args.mints.clone(),
         mint_preferred: sub_command_args.mint_preferred.then_some(true),
+        supported_methods: sub_command_args.supported_methods.clone(),
     };
 
     let (req, nostr_wait) = wallet_repository.create_request(params).await?;
@@ -128,6 +136,27 @@ pub async fn create_request(
     }
 
     Ok(())
+}
+
+fn parse_supported_method(value: &str) -> Result<SupportedMethod, String> {
+    let (method, fee) = match value.rsplit_once(':') {
+        Some((method, fee)) => {
+            let fee = fee
+                .parse::<u64>()
+                .map_err(|err| format!("invalid method fee `{fee}`: {err}"))?;
+            (method, Some(fee))
+        }
+        None => (value, None),
+    };
+
+    if method.is_empty() {
+        return Err("payment method cannot be empty".to_string());
+    }
+
+    Ok(match fee {
+        Some(fee) => SupportedMethod::with_fee(method, fee),
+        None => SupportedMethod::new(method),
+    })
 }
 
 #[cfg(test)]
@@ -167,6 +196,19 @@ mod tests {
 
         assert!(info.mints.is_empty());
         assert!(info.mint_preferred.is_none());
+    }
+
+    #[test]
+    fn supported_method_cli_value_accepts_optional_fee() {
+        assert_eq!(
+            parse_supported_method("bolt11").expect("method"),
+            SupportedMethod::new("bolt11")
+        );
+        assert_eq!(
+            parse_supported_method("onchain:50").expect("method with fee"),
+            SupportedMethod::with_fee("onchain", 50)
+        );
+        assert!(parse_supported_method("bolt12:not-a-fee").is_err());
     }
 
     fn stored_info(mints: Vec<MintUrl>, mint_preferred: Option<bool>) -> StoredNostrWaitInfo {

--- a/crates/cdk-cli/src/sub_commands/pay_request.rs
+++ b/crates/cdk-cli/src/sub_commands/pay_request.rs
@@ -1,10 +1,11 @@
 use anyhow::{anyhow, Result};
 use cdk::nuts::PaymentRequest;
-use cdk::wallet::WalletRepository;
-use cdk::Amount;
+use cdk::wallet::{PayRequestOptions, WalletRepository};
+use cdk::{Amount, Error};
 use clap::Args;
 
-use crate::utils::get_number_input;
+use crate::terminal::escape_control;
+use crate::utils::{get_number_input, get_user_input};
 
 #[derive(Args)]
 pub struct PayRequestSubCommand {
@@ -12,6 +13,18 @@ pub struct PayRequestSubCommand {
     /// Amount to pay (required for amountless requests)
     #[arg(short, long)]
     amount: Option<u64>,
+    /// Maximum receiver-selected method fee (`mf`) to accept
+    #[arg(long)]
+    max_method_fee: Option<u64>,
+    /// Maximum total wallet debit, including method and mint input fees
+    #[arg(long)]
+    max_total_amount: Option<u64>,
+    /// Confirm without prompting; requires explicit method-fee and total-debit limits
+    #[arg(
+        long,
+        requires_all = ["max_method_fee", "max_total_amount"]
+    )]
+    yes: bool,
 }
 
 pub async fn pay_request(
@@ -31,10 +44,93 @@ pub async fn pay_request(
         },
     };
 
-    wallet_repository
-        .pay_request(payment_request.clone(), None, Some(amount))
+    let prepared = wallet_repository
+        .prepare_pay_request(payment_request.clone(), None, Some(amount))
         .await
-        .map_err(|e| anyhow!(e.to_string()))
+        .map_err(|e| anyhow!(e.to_string()))?;
+
+    println!("Payment request:");
+    if let Some(description) = &payment_request.description {
+        println!("  Description: {}", escape_control(description));
+    }
+    if let Some(payment_id) = &payment_request.payment_id {
+        println!("  Payment ID: {}", escape_control(payment_id));
+    }
+    println!("  Mint: {}", prepared.mint_url());
+    println!(
+        "  Requested amount: {} {}",
+        prepared.requested_amount(),
+        prepared.unit()
+    );
+    match prepared.method() {
+        Some(method) => println!("  Selected method: {method}"),
+        None => println!("  Selected method: unrestricted"),
+    }
+    println!(
+        "  Method fee (mf): {} {}",
+        prepared.method_fee(),
+        prepared.unit()
+    );
+    println!(
+        "  Mint input fee: {} {}",
+        prepared.input_fee(),
+        prepared.unit()
+    );
+    println!(
+        "  Total wallet debit: {} {}",
+        prepared.total_amount(),
+        prepared.unit()
+    );
+    if payment_request.nut10.is_some() {
+        println!("  NUT-10 spending condition: required");
+    }
+
+    let limits = PayRequestOptions {
+        max_method_fee: sub_command_args.max_method_fee.map(Amount::from),
+        max_total_amount: sub_command_args.max_total_amount.map(Amount::from),
+    };
+    if let Err(err) = prepared.check_limits(limits) {
+        prepared
+            .cancel()
+            .await
+            .map_err(|cancel_err| anyhow!(cancel_err.to_string()))?;
+        return Err(anyhow!(err.to_string()));
+    }
+
+    if !sub_command_args.yes {
+        let response = match get_user_input("Confirm payment? [y/N]") {
+            Ok(response) => response,
+            Err(err) => {
+                prepared
+                    .cancel()
+                    .await
+                    .map_err(|cancel_err| anyhow!(cancel_err.to_string()))?;
+                return Err(err);
+            }
+        };
+
+        if !matches!(response.to_ascii_lowercase().as_str(), "y" | "yes") {
+            prepared
+                .cancel()
+                .await
+                .map_err(|e| anyhow!(e.to_string()))?;
+            println!("Payment canceled");
+            return Ok(());
+        }
+    }
+
+    match prepared.confirm().await {
+        Ok(()) => Ok(()),
+        Err(Error::PaymentRequestDeliveryFailed {
+            operation_id,
+            source,
+        }) => Err(anyhow!(
+            "Payment token was created but delivery failed: {source}. \
+             Pending send operation: {operation_id}. Do not pay the request again; \
+             reclaim it with Wallet::revoke_send if the receiver has not claimed it."
+        )),
+        Err(error) => Err(anyhow!(error.to_string())),
+    }
 }
 
 #[cfg(test)]
@@ -72,6 +168,9 @@ mod tests {
         let sub_command_args = PayRequestSubCommand {
             payment_request,
             amount: None,
+            max_method_fee: None,
+            max_total_amount: None,
+            yes: false,
         };
 
         let result = pay_request(&wallet_repository, &sub_command_args)

--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -42,6 +42,18 @@ pub enum Error {
     /// Invalid payment request
     #[error("Invalid payment request")]
     InvalidPaymentRequest,
+    /// A payment-request token was created but transport delivery failed.
+    ///
+    /// The token remains a pending send. Callers can pass `operation_id` to
+    /// `Wallet::revoke_send` to reclaim it if the receiver has not claimed it.
+    #[error("Payment token created but delivery failed for operation {operation_id}: {source}")]
+    PaymentRequestDeliveryFailed {
+        /// Pending send operation that can be passed to `Wallet::revoke_send`.
+        operation_id: uuid::Uuid,
+        /// Transport error returned while delivering the created token.
+        #[source]
+        source: Box<Error>,
+    },
     /// Bolt11 invoice does not have amount
     #[error("Invoice Amount undefined")]
     InvoiceAmountUndefined,
@@ -603,6 +615,11 @@ mod tests {
         assert!(!Error::ConcurrentUpdate.is_definitive_failure());
         assert!(!Error::BlindedMessageAlreadySigned.is_definitive_failure());
         assert!(!Error::TokenAlreadySpent.is_definitive_failure());
+        assert!(!Error::PaymentRequestDeliveryFailed {
+            operation_id: uuid::Uuid::new_v4(),
+            source: Box::new(Error::Timeout),
+        }
+        .is_definitive_failure());
 
         // Test HTTP server errors (5xx)
         assert!(
@@ -759,6 +776,7 @@ impl Error {
             // Ambiguous Errors (Unsafe to revert)
             Self::Timeout
             | Self::Internal
+            | Self::PaymentRequestDeliveryFailed { .. }
             | Self::UnknownPaymentState
             | Self::PendingQuote
             | Self::TokenPending

--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -9,7 +9,6 @@ use bitcoin::bip32::DerivationPath;
 use bitcoin::hashes::{sha256, Hash, HashEngine};
 use cashu::amount::{FeeAndAmounts, KeysetFeeAndAmounts, SplitTarget};
 use cashu::nuts::nut07::ProofState;
-use cashu::nuts::nut18::PaymentRequest;
 use cashu::nuts::AuthProof;
 use cashu::util::hex;
 use cashu::{nut00, PaymentMethod, Proof, Proofs, PublicKey};
@@ -1242,13 +1241,6 @@ pub trait Wallet: Send + Sync {
 
     /// Verify DLEQ proofs in a token
     async fn verify_token_dleq(&self, token_str: &str) -> Result<(), Self::Error>;
-
-    /// Pay a NUT-18 payment request
-    async fn pay_request(
-        &self,
-        request: PaymentRequest,
-        custom_amount: Option<Self::Amount>,
-    ) -> Result<(), Self::Error>;
 
     /// Subscribe to mint quote state updates
     ///

--- a/crates/cdk-ffi/src/error.rs
+++ b/crates/cdk-ffi/src/error.rs
@@ -27,6 +27,20 @@ pub enum FfiError {
         /// Human-readable error message
         error_message: String,
     },
+
+    /// A payment token was created but transport delivery failed.
+    ///
+    /// The token remains pending. Pass `operation_id` to `Wallet.revoke_send`
+    /// to reclaim it if the receiver has not already claimed it.
+    #[error(
+        "Payment token created but delivery failed for operation {operation_id}: {error_message}"
+    )]
+    PaymentRequestDeliveryFailed {
+        /// Pending send operation that can be passed to `Wallet.revoke_send`.
+        operation_id: String,
+        /// Transport delivery failure.
+        error_message: String,
+    },
 }
 
 impl FfiError {
@@ -48,6 +62,19 @@ impl FfiError {
 
 impl From<CdkError> for FfiError {
     fn from(err: CdkError) -> Self {
+        let err = match err {
+            CdkError::PaymentRequestDeliveryFailed {
+                operation_id,
+                source,
+            } => {
+                return Self::PaymentRequestDeliveryFailed {
+                    operation_id: operation_id.to_string(),
+                    error_message: source.to_string(),
+                }
+            }
+            err => err,
+        };
+
         let response = ErrorResponse::from(err);
         Self::Cdk {
             code: response.code.to_code() as u32,

--- a/crates/cdk-ffi/src/types/payment_request.rs
+++ b/crates/cdk-ffi/src/types/payment_request.rs
@@ -49,7 +49,7 @@ pub struct Transport {
 }
 
 /// Supported payment method for a NUT-18 payment request
-#[derive(Debug, Clone, Serialize, Deserialize, uniffi::Record)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
 pub struct SupportedMethod {
     /// Payment method name, such as "bolt11", "bolt12", or "onchain"
     pub method: String,
@@ -218,6 +218,122 @@ impl PaymentRequest {
     }
 }
 
+/// FFI-compatible prepared NUT-18 payment request.
+#[derive(uniffi::Object)]
+pub struct PreparedPaymentRequest {
+    inner: std::sync::Mutex<Option<cdk::wallet::PreparedPaymentRequest>>,
+    operation_id: String,
+    mint_url: String,
+    unit: CurrencyUnit,
+    requested_amount: Amount,
+    method: Option<String>,
+    method_fee: Amount,
+    payment_amount: Amount,
+    input_fee: Amount,
+    total_amount: Amount,
+}
+
+impl fmt::Debug for PreparedPaymentRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PreparedPaymentRequest")
+            .field("operation_id", &self.operation_id)
+            .field("mint_url", &self.mint_url)
+            .field("total_amount", &self.total_amount)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PreparedPaymentRequest {
+    /// Wrap a prepared CDK payment request for FFI callers.
+    pub(crate) fn new(inner: cdk::wallet::PreparedPaymentRequest) -> Self {
+        Self {
+            operation_id: inner.operation_id().to_string(),
+            mint_url: inner.mint_url().to_string(),
+            unit: inner.unit().clone().into(),
+            requested_amount: inner.requested_amount().into(),
+            method: inner.method().map(str::to_owned),
+            method_fee: inner.method_fee().into(),
+            payment_amount: inner.payment_amount().into(),
+            input_fee: inner.input_fee().into(),
+            total_amount: inner.total_amount().into(),
+            inner: std::sync::Mutex::new(Some(inner)),
+        }
+    }
+
+    fn take(&self) -> Result<cdk::wallet::PreparedPaymentRequest, FfiError> {
+        self.inner
+            .lock()
+            .map_err(|_| FfiError::internal("Prepared payment lock poisoned"))?
+            .take()
+            .ok_or_else(|| FfiError::internal("Prepared payment already completed or canceled"))
+    }
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl PreparedPaymentRequest {
+    /// Operation ID of the reserved send.
+    pub fn operation_id(&self) -> String {
+        self.operation_id.clone()
+    }
+
+    /// Mint selected for the payment.
+    pub fn mint_url(&self) -> String {
+        self.mint_url.clone()
+    }
+
+    /// Currency unit of the payment.
+    pub fn unit(&self) -> CurrencyUnit {
+        self.unit.clone()
+    }
+
+    /// Amount requested before the receiver-selected method fee.
+    pub fn requested_amount(&self) -> Amount {
+        self.requested_amount
+    }
+
+    /// Selected payment method, when restricted by the request.
+    pub fn method(&self) -> Option<String> {
+        self.method.clone()
+    }
+
+    /// Applicable receiver-selected method fee (`mf`).
+    pub fn method_fee(&self) -> Amount {
+        self.method_fee
+    }
+
+    /// Requested amount plus the applicable method fee.
+    pub fn payment_amount(&self) -> Amount {
+        self.payment_amount
+    }
+
+    /// Total mint input fee.
+    pub fn input_fee(&self) -> Amount {
+        self.input_fee
+    }
+
+    /// Total wallet debit.
+    pub fn total_amount(&self) -> Amount {
+        self.total_amount
+    }
+
+    /// Confirm and deliver the prepared payment.
+    ///
+    /// If delivery fails after token creation, this returns
+    /// `FfiError::PaymentRequestDeliveryFailed` with the pending operation ID.
+    /// Do not prepare the payment again. Call `Wallet.revoke_send(operation_id)`
+    /// to reclaim it if it remains unclaimed.
+    pub async fn confirm(&self) -> Result<(), FfiError> {
+        self.take()?.confirm().await?;
+        Ok(())
+    }
+
+    /// Cancel the prepared payment and release reserved proofs.
+    pub async fn cancel(&self) -> Result<(), FfiError> {
+        self.take()?.cancel().await?;
+        Ok(())
+    }
+}
+
 /// Parameters for creating a NUT-18 payment request
 #[derive(Clone, Serialize, Deserialize, uniffi::Record)]
 pub struct CreateRequestParams {
@@ -241,10 +357,13 @@ pub struct CreateRequestParams {
     pub http_url: Option<String>,
     /// Nostr relay URLs (required if transport is "nostr")
     pub nostr_relays: Option<Vec<String>>,
-    /// Optional list of mint URLs the receiver trusts. If not provided, the wallet's current mints for the requested unit will be used.
+    /// Optional list of mint URLs the receiver accepts or prefers; `None` emits no mint list
     pub mints: Option<Vec<String>>,
     /// Whether the mint list is preferred rather than required
     pub mint_preferred: Option<bool>,
+    /// Payment methods the payer's mint must support, with optional per-method fees
+    #[serde(default)]
+    pub supported_methods: Vec<SupportedMethod>,
 }
 
 impl fmt::Debug for CreateRequestParams {
@@ -262,6 +381,7 @@ impl fmt::Debug for CreateRequestParams {
             .field("nostr_relays", &self.nostr_relays)
             .field("mints", &self.mints)
             .field("mint_preferred", &self.mint_preferred)
+            .field("supported_methods", &self.supported_methods)
             .finish()
     }
 }
@@ -281,6 +401,7 @@ impl Default for CreateRequestParams {
             nostr_relays: None,
             mints: None,
             mint_preferred: None,
+            supported_methods: vec![],
         }
     }
 }
@@ -300,6 +421,11 @@ impl From<CreateRequestParams> for cdk::wallet::payment_request::CreateRequestPa
             nostr_relays: params.nostr_relays,
             mints: params.mints,
             mint_preferred: params.mint_preferred,
+            supported_methods: params
+                .supported_methods
+                .into_iter()
+                .map(Into::into)
+                .collect(),
         }
     }
 }
@@ -319,6 +445,11 @@ impl From<cdk::wallet::payment_request::CreateRequestParams> for CreateRequestPa
             nostr_relays: params.nostr_relays,
             mints: params.mints,
             mint_preferred: params.mint_preferred,
+            supported_methods: params
+                .supported_methods
+                .into_iter()
+                .map(Into::into)
+                .collect(),
         }
     }
 }
@@ -573,6 +704,24 @@ mod tests {
     }
 
     #[test]
+    fn payment_request_delivery_failure_exposes_revoke_operation_id() {
+        let operation_id = uuid::Uuid::new_v4();
+        let error = FfiError::from(cdk::Error::PaymentRequestDeliveryFailed {
+            operation_id,
+            source: Box::new(cdk::Error::Custom("transport failed".to_string())),
+        });
+
+        assert_eq!(
+            error.to_string(),
+            FfiError::PaymentRequestDeliveryFailed {
+                operation_id: operation_id.to_string(),
+                error_message: "`transport failed`".to_string(),
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
     fn test_transport_conversion() {
         let ffi_transport = Transport {
             transport_type: TransportType::Nostr,
@@ -597,6 +746,7 @@ mod tests {
         assert_eq!(params.transport, "none");
         assert!(params.amount.is_none());
         assert!(params.mint_preferred.is_none());
+        assert!(params.supported_methods.is_empty());
     }
 
     #[test]
@@ -608,6 +758,10 @@ mod tests {
             transport: "http".to_string(),
             http_url: Some("https://example.com/callback".to_string()),
             mint_preferred: Some(true),
+            supported_methods: vec![SupportedMethod {
+                method: "bolt11".to_string(),
+                fee: Some(Amount::new(5)),
+            }],
             ..Default::default()
         };
 
@@ -618,9 +772,12 @@ mod tests {
         assert_eq!(params.unit, decoded.unit);
         assert_eq!(params.description, decoded.description);
         assert_eq!(params.mint_preferred, decoded.mint_preferred);
+        assert_eq!(params.supported_methods.len(), 1);
+        assert_eq!(params.supported_methods[0].fee, Some(Amount::new(5)));
 
         let cdk_params: cdk::wallet::payment_request::CreateRequestParams = decoded.into();
         let ffi_params: CreateRequestParams = cdk_params.into();
         assert_eq!(ffi_params.mint_preferred, Some(true));
+        assert_eq!(ffi_params.supported_methods, params.supported_methods);
     }
 }

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -12,7 +12,7 @@ use crate::npubcash::NpubCashUserResponse;
 use crate::token::Token;
 #[cfg(all(feature = "bip353", not(target_arch = "wasm32")))]
 use crate::types::bip321::BitcoinNetwork;
-use crate::types::payment_request::PaymentRequest;
+use crate::types::payment_request::{PaymentRequest, PreparedPaymentRequest};
 use crate::types::*;
 
 /// FFI-compatible wallet.
@@ -846,27 +846,22 @@ impl Wallet {
         Ok(fee.into())
     }
 
-    /// Pay a NUT-18 payment request
+    /// Prepare a NUT-18 payment request so its method and input fees can be reviewed.
     ///
-    /// This method prepares and sends a payment for the given payment request.
-    /// It will use the Nostr or HTTP transport specified in the request.
-    ///
-    /// # Arguments
-    ///
-    /// * `payment_request` - The NUT-18 payment request to pay
-    /// * `custom_amount` - Optional amount to pay (required if request has no amount)
-    pub async fn pay_request(
+    /// Call `confirm` or `cancel` on the returned object to complete the flow.
+    pub async fn prepare_pay_request(
         &self,
         payment_request: std::sync::Arc<PaymentRequest>,
         custom_amount: Option<Amount>,
-    ) -> Result<(), FfiError> {
-        self.inner
-            .pay_request(
+    ) -> Result<std::sync::Arc<PreparedPaymentRequest>, FfiError> {
+        let prepared = self
+            .inner
+            .prepare_pay_request(
                 payment_request.inner().clone(),
                 custom_amount.map(Into::into),
             )
             .await?;
-        Ok(())
+        Ok(std::sync::Arc::new(PreparedPaymentRequest::new(prepared)))
     }
 }
 

--- a/crates/cdk-ffi/src/wallet_trait.rs
+++ b/crates/cdk-ffi/src/wallet_trait.rs
@@ -430,20 +430,6 @@ impl WalletTraitDef for Wallet {
         Ok(())
     }
 
-    async fn pay_request(
-        &self,
-        request: cdk_common::nuts::nut18::PaymentRequest,
-        custom_amount: Option<Self::Amount>,
-    ) -> Result<(), Self::Error> {
-        WalletTraitDef::pay_request(
-            self.inner().as_ref(),
-            request,
-            custom_amount.map(Into::into),
-        )
-        .await?;
-        Ok(())
-    }
-
     async fn subscribe_mint_quote_state(
         &self,
         quote_ids: Vec<String>,

--- a/crates/cdk/examples/payment_request.rs
+++ b/crates/cdk/examples/payment_request.rs
@@ -132,6 +132,7 @@ async fn main() -> anyhow::Result<()> {
         ]),
         mints: None,
         mint_preferred: None,
+        supported_methods: vec![],
     };
 
     let (payment_request, nostr_wait_info) = wallet.create_request(nostr_params).await?;
@@ -189,6 +190,7 @@ async fn main() -> anyhow::Result<()> {
         nostr_relays: None,
         mints: None,
         mint_preferred: None,
+        supported_methods: vec![],
     };
 
     let (http_request, _) = wallet.create_request(http_params).await?;
@@ -234,6 +236,7 @@ async fn main() -> anyhow::Result<()> {
         nostr_relays: Some(vec!["wss://relay.damus.io".to_string()]),
         mints: None,
         mint_preferred: None,
+        supported_methods: vec![],
     };
 
     let (p2pk_request, _) = wallet.create_request(p2pk_params).await?;
@@ -261,16 +264,29 @@ async fn main() -> anyhow::Result<()> {
     println!("// Decode the payment request");
     println!("let request = PaymentRequest::from_str(\"creqA...\")?;");
     println!();
-    println!("// Pay the request (sends tokens via the specified transport)");
-    println!("let result = wallet.pay_request(request).await?;");
+    println!("// Prepare the request and inspect its exact fees");
+    println!("let prepared = wallet.prepare_pay_request(request, None).await?;");
+    println!("println!(\"Method fee: {{}}\", prepared.method_fee());");
+    println!("println!(\"Input fee: {{}}\", prepared.input_fee());");
+    println!("println!(\"Total debit: {{}}\", prepared.total_amount());");
     println!();
-    println!("println!(\"Sent {{}} sats\", result.amount_sent);");
+    println!("// Explicitly approve and deliver the payment");
+    println!("match prepared.confirm().await {{");
+    println!("    Ok(()) => {{}}");
+    println!("    Err(Error::PaymentRequestDeliveryFailed {{ operation_id, source }}) => {{");
+    println!("        eprintln!(\"Delivery failed: {{source}}\");");
+    println!("        // Do not pay again: reclaim the pending token if it is unclaimed.");
+    println!("        wallet.revoke_send(operation_id).await?;");
+    println!("    }}");
+    println!("    Err(error) => return Err(error.into()),");
+    println!("}}");
     println!("```\n");
 
-    println!("The pay_request method will:");
+    println!("The prepare/confirm flow will:");
     println!("  1. Select proofs matching the requested amount and unit");
     println!("  2. Apply any spending conditions from the request");
-    println!("  3. Deliver the token via the request's transport (Nostr/HTTP)");
+    println!("  3. Expose method, input, and total fees before payment");
+    println!("  4. Deliver the token via the request's transport only after confirm");
 
     println!("\n✓ Example complete!");
 

--- a/crates/cdk/examples/resolve_human_readable.rs
+++ b/crates/cdk/examples/resolve_human_readable.rs
@@ -6,7 +6,7 @@
 //!
 //! This example demonstrates two wallet-level paths after resolution:
 //! - If the instruction contains a Cashu payment request and this wallet's mint is accepted,
-//!   pay it directly with `wallet.pay_request(...)`
+//!   prepare it, inspect the fees, and explicitly confirm it
 //! - Otherwise, if the instruction contains a BOLT12 offer, request a melt quote with
 //!   `wallet.melt_bip353_quote(...)`
 //!
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use cdk::mint_url::MintUrl;
 use cdk::nuts::CurrencyUnit;
 use cdk::wallet::{resolve_bip353_payment_instruction, Wallet};
-use cdk::Amount;
+use cdk::{Amount, Error};
 use cdk_sqlite::wallet::memory;
 use rand::random;
 
@@ -100,11 +100,25 @@ async fn main() -> anyhow::Result<()> {
                 );
 
                 if accepted_by_wallet {
-                    println!(
-                        "\nThis wallet's mint is accepted, proceeding with wallet.pay_request(...)"
-                    );
-                    wallet.pay_request(request.clone(), None).await?;
-                    println!("Cashu payment request paid successfully.");
+                    println!("\nThis wallet's mint is accepted, preparing the payment request...");
+                    let prepared = wallet.prepare_pay_request(request.clone(), None).await?;
+                    println!("  Method fee: {}", prepared.method_fee());
+                    println!("  Mint input fee: {}", prepared.input_fee());
+                    println!("  Total wallet debit: {}", prepared.total_amount());
+                    match prepared.confirm().await {
+                        Ok(()) => {
+                            println!("Cashu payment request paid successfully.");
+                        }
+                        Err(Error::PaymentRequestDeliveryFailed {
+                            operation_id,
+                            source,
+                        }) => {
+                            println!("Token created, but delivery failed: {source}");
+                            println!("Reclaiming pending send {operation_id}...");
+                            wallet.revoke_send(operation_id).await?;
+                        }
+                        Err(error) => return Err(error.into()),
+                    }
                 } else {
                     println!("\nThis wallet cannot pay the Cashu request.");
                     println!(

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -98,9 +98,9 @@ pub use nostr_backup::{BackupOptions, BackupResult, RestoreOptions, RestoreResul
 pub use npubcash::derive_npubcash_secret_key_from_seed;
 #[cfg(feature = "nwc")]
 pub use nwc::{derive_nwc_secret_key_from_seed, WalletNwcHandler};
-pub use payment_request::CreateRequestParams;
 #[cfg(feature = "nostr")]
 pub use payment_request::NostrWaitInfo;
+pub use payment_request::{CreateRequestParams, PayRequestOptions, PreparedPaymentRequest};
 pub use recovery::RecoveryReport;
 pub use send::PreparedSend;
 #[cfg(all(feature = "npubcash", not(target_arch = "wasm32")))]

--- a/crates/cdk/src/wallet/payment_request.rs
+++ b/crates/cdk/src/wallet/payment_request.rs
@@ -18,6 +18,7 @@ use nostr_sdk::nips::nip19::Nip19Profile;
 use nostr_sdk::prelude::*;
 #[cfg(feature = "nostr")]
 use nostr_sdk::{Client as NostrClient, EventBuilder, FromBech32, Keys, ToBech32};
+use tracing::instrument;
 
 use crate::error::Error;
 use crate::mint_url::MintUrl;
@@ -31,19 +32,207 @@ use crate::wallet::ReceiveOptions;
 use crate::wallet::{SendOptions, WalletRepository};
 use crate::Wallet;
 
-impl Wallet {
-    /// Pay a NUT-18 PaymentRequest using a specific wallet.
+/// Optional limits that callers can check before confirming a prepared NUT-18
+/// payment request.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PayRequestOptions {
+    /// Maximum receiver-selected method fee (`mf`) that may be paid.
     ///
-    /// - If the request contains a Nostr or HttpPost transport, it will try those (preferring Nostr).
-    /// - If no usable transport is present, this returns an error.
-    /// - If the request has no amount, a `custom_amount` must be provided.
-    pub async fn pay_request(
+    /// `None` accepts any method fee.
+    pub max_method_fee: Option<Amount>,
+    /// Maximum total wallet debit, including method and mint input fees.
+    pub max_total_amount: Option<Amount>,
+}
+
+/// A prepared NUT-18 payment request with its exact fees frozen for review.
+///
+/// Call [`Self::confirm`] to send and deliver the payment, or [`Self::cancel`]
+/// to release the proofs reserved during preparation.
+#[must_use = "must be confirmed or canceled to release reserved proofs"]
+pub struct PreparedPaymentRequest {
+    wallet: Wallet,
+    payment_request: PaymentRequest,
+    transport: Transport,
+    operation_id: uuid::Uuid,
+    requested_amount: Amount,
+    method: Option<String>,
+    method_fee: Amount,
+    payment_amount: Amount,
+    swap_fee: Amount,
+    send_fee: Amount,
+    input_fee: Amount,
+    total_amount: Amount,
+    send_options: SendOptions,
+    proofs_to_swap: crate::nuts::Proofs,
+    proofs_to_send: crate::nuts::Proofs,
+}
+
+impl std::fmt::Debug for PreparedPaymentRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PreparedPaymentRequest")
+            .field("operation_id", &self.operation_id)
+            .field("mint_url", &self.wallet.mint_url)
+            .field("requested_amount", &self.requested_amount)
+            .field("method", &self.method)
+            .field("method_fee", &self.method_fee)
+            .field("swap_fee", &self.swap_fee)
+            .field("send_fee", &self.send_fee)
+            .field("input_fee", &self.input_fee)
+            .field("total_amount", &self.total_amount)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PreparedPaymentRequest {
+    /// Operation ID of the reserved send.
+    pub fn operation_id(&self) -> uuid::Uuid {
+        self.operation_id
+    }
+
+    /// Mint selected for the payment.
+    pub fn mint_url(&self) -> &MintUrl {
+        &self.wallet.mint_url
+    }
+
+    /// Currency unit of the payment.
+    pub fn unit(&self) -> &CurrencyUnit {
+        &self.wallet.unit
+    }
+
+    /// Amount requested by the receiver, before the method fee.
+    pub fn requested_amount(&self) -> Amount {
+        self.requested_amount
+    }
+
+    /// Selected payment method, when the request restricts methods.
+    pub fn method(&self) -> Option<&str> {
+        self.method.as_deref()
+    }
+
+    /// Receiver-selected method fee (`mf`) that applies to this mint.
+    pub fn method_fee(&self) -> Amount {
+        self.method_fee
+    }
+
+    /// Requested amount plus the applicable method fee.
+    pub fn payment_amount(&self) -> Amount {
+        self.payment_amount
+    }
+
+    /// Mint input fee paid while swapping proofs into the required denominations.
+    pub fn swap_fee(&self) -> Amount {
+        self.swap_fee
+    }
+
+    /// Mint input fee added so the receiver obtains the full payment amount.
+    pub fn send_fee(&self) -> Amount {
+        self.send_fee
+    }
+
+    /// Total mint input fee for the payment.
+    pub fn input_fee(&self) -> Amount {
+        self.input_fee
+    }
+
+    /// Total amount deducted from the wallet.
+    pub fn total_amount(&self) -> Amount {
+        self.total_amount
+    }
+
+    /// Check this prepared payment against caller-provided fee limits.
+    pub fn check_limits(&self, options: PayRequestOptions) -> Result<(), Error> {
+        check_payment_request_limits(self.method_fee, self.total_amount, options)
+    }
+
+    /// Confirm and deliver the prepared payment.
+    ///
+    /// If token creation succeeds but transport delivery fails, this returns
+    /// [`Error::PaymentRequestDeliveryFailed`]. The token remains a pending
+    /// send: do not prepare the payment again. Use the error's operation ID
+    /// with [`Wallet::revoke_send`] to reclaim the token if it has not already
+    /// been claimed by the receiver.
+    #[instrument(skip_all)]
+    pub async fn confirm(self) -> Result<(), Error> {
+        let operation_id = self.operation_id;
+        let token = self
+            .wallet
+            .confirm_send(
+                operation_id,
+                self.payment_amount,
+                self.send_options,
+                self.proofs_to_swap,
+                self.proofs_to_send,
+                self.swap_fee,
+                self.send_fee,
+                None,
+            )
+            .await?;
+
+        let delivery_result = self
+            .wallet
+            .deliver_payment_request(&self.payment_request, &self.transport, &token)
+            .await;
+
+        payment_request_delivery_result(operation_id, delivery_result)
+    }
+
+    /// Cancel the prepared payment and release its reserved proofs.
+    #[instrument(skip_all)]
+    pub async fn cancel(self) -> Result<(), Error> {
+        self.wallet
+            .cancel_send(self.operation_id, self.proofs_to_swap, self.proofs_to_send)
+            .await
+    }
+}
+
+fn payment_request_delivery_result(
+    operation_id: uuid::Uuid,
+    delivery_result: Result<(), Error>,
+) -> Result<(), Error> {
+    delivery_result.map_err(|source| Error::PaymentRequestDeliveryFailed {
+        operation_id,
+        source: Box::new(source),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SelectedPaymentMethod {
+    method: Option<String>,
+    fee: Amount,
+}
+
+fn check_payment_request_limits(
+    method_fee: Amount,
+    total_amount: Amount,
+    options: PayRequestOptions,
+) -> Result<(), Error> {
+    if options
+        .max_method_fee
+        .is_some_and(|max_fee| method_fee > max_fee)
+        || options
+            .max_total_amount
+            .is_some_and(|max_amount| total_amount > max_amount)
+    {
+        return Err(Error::MaxFeeExceeded);
+    }
+
+    Ok(())
+}
+
+impl Wallet {
+    /// Prepare a NUT-18 payment request and freeze its selected mint fees.
+    ///
+    /// The returned payment must be explicitly completed with
+    /// [`PreparedPaymentRequest::confirm`] or released with
+    /// [`PreparedPaymentRequest::cancel`].
+    #[instrument(skip_all)]
+    pub async fn prepare_pay_request(
         &self,
         payment_request: PaymentRequest,
         custom_amount: Option<Amount>,
-    ) -> Result<(), Error> {
+    ) -> Result<PreparedPaymentRequest, Error> {
         let unit = payment_request_unit(&payment_request)?;
-        let base_amount = match payment_request.amount {
+        let requested_amount = match payment_request.amount {
             Some(amount) => amount,
             None => match custom_amount {
                 Some(a) => a,
@@ -55,8 +244,26 @@ impl Wallet {
             return Err(Error::UnsupportedUnit);
         }
 
-        let amount =
-            payment_request_amount_for_wallet(base_amount, &payment_request, self, &unit).await?;
+        if payment_request_mint_list_is_strict(&payment_request)
+            && payment_request_uses_unlisted_mint(&payment_request, &self.mint_url)
+        {
+            return Err(Error::Custom(format!(
+                "Mint {} is not accepted by this payment request. Accepted mints: {:?}",
+                self.mint_url, payment_request.mints
+            )));
+        }
+
+        let selected_method = wallet_payment_request_method(self, &payment_request, &unit)
+            .await?
+            .ok_or(Error::UnsupportedPaymentMethod)?;
+        let method_fee = if payment_request_method_fee_applies(&payment_request, &self.mint_url) {
+            selected_method.fee
+        } else {
+            Amount::ZERO
+        };
+        let payment_amount = requested_amount
+            .checked_add(method_fee)
+            .ok_or(Error::AmountOverflow)?;
 
         // Extract optional NUT-10 spending conditions from the payment request.
         //
@@ -72,21 +279,17 @@ impl Wallet {
             None
         };
 
-        let transports = payment_request.transports.clone();
-
-        // Prefer Nostr to avoid revealing IP, fall back to HTTP POST.
-        let transport = transports
-            .iter()
-            .find(|t| t._type == TransportType::Nostr)
-            .or_else(|| {
-                transports
-                    .iter()
-                    .find(|t| t._type == TransportType::HttpPost)
-            });
+        // Prefer Nostr to avoid revealing the payer's IP address, then fall back
+        // to HTTP POST when Nostr is unavailable in this build or request.
+        let transport = payment_request_transport(&payment_request.transports)
+            .cloned()
+            .ok_or_else(|| {
+                Error::Custom("No transport available in payment request".to_string())
+            })?;
 
         let prepared_send = self
             .prepare_send(
-                amount,
+                payment_amount,
                 SendOptions {
                     conditions,
                     include_fee: true,
@@ -95,107 +298,142 @@ impl Wallet {
             )
             .await?;
 
-        let token = prepared_send.confirm(None).await?;
+        let input_fee = match prepared_send
+            .swap_fee()
+            .checked_add(prepared_send.send_fee())
+        {
+            Some(input_fee) => input_fee,
+            None => {
+                prepared_send.cancel().await?;
+                return Err(Error::AmountOverflow);
+            }
+        };
+        let total_amount = match payment_amount.checked_add(input_fee) {
+            Some(total_amount) => total_amount,
+            None => {
+                prepared_send.cancel().await?;
+                return Err(Error::AmountOverflow);
+            }
+        };
 
+        Ok(PreparedPaymentRequest {
+            wallet: self.clone(),
+            payment_request,
+            transport,
+            operation_id: prepared_send.operation_id(),
+            requested_amount,
+            method: selected_method.method,
+            method_fee,
+            payment_amount,
+            swap_fee: prepared_send.swap_fee(),
+            send_fee: prepared_send.send_fee(),
+            input_fee,
+            total_amount,
+            send_options: prepared_send.options().clone(),
+            proofs_to_swap: prepared_send.proofs_to_swap().clone(),
+            proofs_to_send: prepared_send.proofs_to_send().clone(),
+        })
+    }
+
+    #[instrument(skip_all)]
+    async fn deliver_payment_request(
+        &self,
+        payment_request: &PaymentRequest,
+        transport: &Transport,
+        token: &crate::nuts::Token,
+    ) -> Result<(), Error> {
         // We need the keysets information to properly convert from token proof to proof
-        let proofs = self.token_proofs(&token).await?;
+        let proofs = self.token_proofs(token).await?;
 
-        if let Some(transport) = transport {
-            let payload = PaymentRequestPayload {
-                id: payment_request.payment_id.clone(),
-                memo: None,
-                mint: self.mint_url.clone(),
-                unit: self.unit.clone(),
-                proofs,
-            };
+        let payload = PaymentRequestPayload {
+            id: payment_request.payment_id.clone(),
+            memo: None,
+            mint: self.mint_url.clone(),
+            unit: self.unit.clone(),
+            proofs,
+        };
 
-            match transport._type {
-                TransportType::Nostr => {
-                    #[cfg(feature = "nostr")]
-                    {
-                        let keys = Keys::generate();
-                        let client = NostrClient::new(keys.clone());
-                        let nprofile = Nip19Profile::from_bech32(&transport.target)
-                            .map_err(|e| Error::Custom(format!("Invalid nprofile: {e}")))?;
+        match transport._type {
+            TransportType::Nostr => {
+                #[cfg(feature = "nostr")]
+                {
+                    let keys = Keys::generate();
+                    let client = NostrClient::new(keys.clone());
+                    let nprofile = Nip19Profile::from_bech32(&transport.target)
+                        .map_err(|e| Error::Custom(format!("Invalid nprofile: {e}")))?;
 
-                        let rumor = EventBuilder::new(
-                            nostr_sdk::Kind::from_u16(14),
-                            serde_json::to_string(&payload)
-                                .map_err(|e| Error::Custom(format!("Serialize payload: {e}")))?,
-                        )
-                        .build(keys.public_key);
-                        let relays = nprofile.relays;
+                    let rumor = EventBuilder::new(
+                        nostr_sdk::Kind::from_u16(14),
+                        serde_json::to_string(&payload)
+                            .map_err(|e| Error::Custom(format!("Serialize payload: {e}")))?,
+                    )
+                    .build(keys.public_key);
+                    let relays = nprofile.relays;
 
-                        for relay in relays.iter() {
-                            client
-                                .add_write_relay(relay)
-                                .await
-                                .map_err(|e| Error::Custom(format!("Add relay {relay}: {e}")))?;
-                        }
-
-                        client.connect().await;
-
-                        let gift_wrap = client
-                            .gift_wrap_to(relays, &nprofile.public_key, rumor, None)
+                    for relay in relays.iter() {
+                        client
+                            .add_write_relay(relay)
                             .await
-                            .map_err(|e| Error::Custom(format!("Publish Nostr event: {e}")))?;
+                            .map_err(|e| Error::Custom(format!("Add relay {relay}: {e}")))?;
+                    }
 
-                        tracing::info!(
-                            "Published event {} successfully to {}",
-                            gift_wrap.val,
+                    client.connect().await;
+
+                    let gift_wrap = client
+                        .gift_wrap_to(relays, &nprofile.public_key, rumor, None)
+                        .await
+                        .map_err(|e| Error::Custom(format!("Publish Nostr event: {e}")))?;
+
+                    tracing::info!(
+                        "Published event {} successfully to {}",
+                        gift_wrap.val,
+                        gift_wrap
+                            .success
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    );
+
+                    if !gift_wrap.failed.is_empty() {
+                        tracing::warn!(
+                            "Could not publish to {}",
                             gift_wrap
-                                .success
-                                .iter()
-                                .map(|s| s.to_string())
+                                .failed
+                                .keys()
+                                .map(|relay| relay.to_string())
                                 .collect::<Vec<_>>()
                                 .join(", ")
                         );
-
-                        if !gift_wrap.failed.is_empty() {
-                            tracing::warn!(
-                                "Could not publish to {}",
-                                gift_wrap
-                                    .failed
-                                    .keys()
-                                    .map(|relay| relay.to_string())
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            );
-                        }
-
-                        Ok(())
                     }
-                    #[cfg(not(feature = "nostr"))]
-                    Err(Error::Custom(
-                        "Nostr is not enabled in this build".to_string(),
-                    ))
+
+                    Ok(())
                 }
+                #[cfg(not(feature = "nostr"))]
+                Err(Error::Custom(
+                    "Nostr is not enabled in this build".to_string(),
+                ))
+            }
 
-                TransportType::HttpPost => {
-                    let client = HttpClient::new();
+            TransportType::HttpPost => {
+                let client = HttpClient::new();
 
-                    let res = client
-                        .post(&transport.target)
-                        .json(&payload)
-                        .send()
-                        .await
-                        .map_err(|e| Error::HttpError(None, e.to_string()))?;
+                let res = client
+                    .post(&transport.target)
+                    .json(&payload)
+                    .send()
+                    .await
+                    .map_err(|e| Error::HttpError(None, e.to_string()))?;
 
-                    if res.is_success() {
-                        tracing::info!("Successfully posted payment");
-                        Ok(())
-                    } else {
-                        let status = res.status();
-                        let body = res.text().await.unwrap_or_default();
-                        Err(Error::HttpError(Some(status), body))
-                    }
+                if res.is_success() {
+                    tracing::info!("Successfully posted payment");
+                    Ok(())
+                } else {
+                    let status = res.status();
+                    let body = res.text().await.unwrap_or_default();
+                    Err(Error::HttpError(Some(status), body))
                 }
             }
-        } else {
-            // If no transport is available, return an error instead of printing the token
-            Err(Error::Custom(
-                "No transport available in payment request".to_string(),
-            ))
         }
     }
 }
@@ -263,6 +501,57 @@ mod tests {
         assert_eq!(params.transport, "none");
         assert!(params.amount.is_none());
         assert!(params.mint_preferred.is_none());
+        assert!(params.supported_methods.is_empty());
+    }
+
+    #[test]
+    fn create_request_rejects_invalid_mint_urls() {
+        let result = parse_payment_request_mints(Some(&["not a URL".to_string()]));
+
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "nostr")]
+    #[tokio::test]
+    async fn create_request_exposes_supported_method_fees() {
+        let params = CreateRequestParams {
+            amount: Some(100),
+            supported_methods: vec![SupportedMethod::with_fee("bolt11", 5)],
+            ..Default::default()
+        };
+
+        let (request, wait_info) = test_repository()
+            .await
+            .create_request(params)
+            .await
+            .expect("create request");
+
+        assert_eq!(
+            request.supported_methods,
+            vec![SupportedMethod::with_fee("bolt11", 5)]
+        );
+        assert!(wait_info.is_none());
+    }
+
+    #[cfg(not(feature = "nostr"))]
+    #[tokio::test]
+    async fn create_request_exposes_supported_method_fees() {
+        let params = CreateRequestParams {
+            amount: Some(100),
+            supported_methods: vec![SupportedMethod::with_fee("bolt11", 5)],
+            ..Default::default()
+        };
+
+        let request = test_repository()
+            .await
+            .create_request(params)
+            .await
+            .expect("create request");
+
+        assert_eq!(
+            request.supported_methods,
+            vec![SupportedMethod::with_fee("bolt11", 5)]
+        );
     }
 
     #[test]
@@ -343,7 +632,8 @@ mod tests {
     #[test]
     fn method_fee_defaults_to_zero_when_request_has_no_method_restriction() {
         let fee = payment_request_method_fee_from_melt_methods(&[], &[], false, &CurrencyUnit::Sat)
-            .expect("fee");
+            .expect("fee")
+            .map(|selection| selection.fee);
 
         assert_eq!(fee, Some(Amount::ZERO));
     }
@@ -371,7 +661,8 @@ mod tests {
             false,
             &CurrencyUnit::Sat,
         )
-        .expect("fee");
+        .expect("fee")
+        .map(|selection| selection.fee);
 
         assert_eq!(fee, Some(Amount::from(2)));
     }
@@ -390,7 +681,8 @@ mod tests {
             false,
             &CurrencyUnit::Sat,
         )
-        .expect("fee");
+        .expect("fee")
+        .map(|selection| selection.fee);
 
         assert_eq!(fee, None);
     }
@@ -409,7 +701,8 @@ mod tests {
             false,
             &CurrencyUnit::Sat,
         )
-        .expect("fee");
+        .expect("fee")
+        .map(|selection| selection.fee);
 
         assert_eq!(fee, None);
     }
@@ -428,9 +721,189 @@ mod tests {
             true,
             &CurrencyUnit::Sat,
         )
-        .expect("fee");
+        .expect("fee")
+        .map(|selection| selection.fee);
 
         assert_eq!(fee, None);
+    }
+
+    #[test]
+    fn method_fee_selection_includes_the_selected_method() {
+        let supported_methods = vec![
+            SupportedMethod::with_fee(PaymentMethod::BOLT11.to_string(), Amount::from(5)),
+            SupportedMethod::with_fee(PaymentMethod::BOLT12.to_string(), Amount::from(2)),
+        ];
+        let melt_methods = vec![
+            melt_method(PaymentMethod::BOLT11, CurrencyUnit::Sat),
+            melt_method(PaymentMethod::BOLT12, CurrencyUnit::Sat),
+        ];
+
+        let selected = payment_request_method_fee_from_melt_methods(
+            &supported_methods,
+            &melt_methods,
+            false,
+            &CurrencyUnit::Sat,
+        )
+        .expect("method selection")
+        .expect("supported method");
+
+        assert_eq!(selected.method.as_deref(), Some("bolt12"));
+        assert_eq!(selected.fee, Amount::from(2));
+    }
+
+    #[test]
+    fn default_limits_allow_reviewed_fees() {
+        let result = check_payment_request_limits(
+            Amount::from(1),
+            Amount::from(101),
+            PayRequestOptions::default(),
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn explicit_limits_accept_fees_at_the_boundary() {
+        let result = check_payment_request_limits(
+            Amount::from(500),
+            Amount::from(602),
+            PayRequestOptions {
+                max_method_fee: Some(Amount::from(500)),
+                max_total_amount: Some(Amount::from(602)),
+            },
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn total_amount_limit_includes_method_and_input_fees() {
+        let result = check_payment_request_limits(
+            Amount::from(500),
+            Amount::from(602),
+            PayRequestOptions {
+                max_method_fee: Some(Amount::from(500)),
+                max_total_amount: Some(Amount::from(601)),
+            },
+        );
+
+        assert!(matches!(result, Err(Error::MaxFeeExceeded)));
+    }
+
+    #[test]
+    fn delivery_failure_error_preserves_the_pending_send_operation_id() {
+        let operation_id = uuid::Uuid::new_v4();
+        let error = payment_request_delivery_result(
+            operation_id,
+            Err(Error::Custom("transport failed".to_string())),
+        )
+        .expect_err("delivery failure");
+
+        match error {
+            Error::PaymentRequestDeliveryFailed {
+                operation_id: failed_operation_id,
+                source,
+            } => {
+                assert_eq!(failed_operation_id, operation_id);
+                assert_eq!(source.to_string(), "`transport failed`");
+            }
+            error => panic!("unexpected error: {error}"),
+        }
+    }
+
+    #[test]
+    fn method_fee_only_applies_to_nonpreferred_mints() {
+        let listed = MintUrl::from_str("https://listed.example.com").expect("valid URL");
+        let unlisted = MintUrl::from_str("https://unlisted.example.com").expect("valid URL");
+        let mut request = payment_request(Some(CurrencyUnit::Sat), Some(Amount::from(1)), vec![]);
+
+        assert!(payment_request_method_fee_applies(&request, &listed));
+
+        request.mints.push(listed.clone());
+        assert!(!payment_request_method_fee_applies(&request, &listed));
+        assert!(payment_request_method_fee_applies(&request, &unlisted));
+    }
+
+    #[test]
+    fn payment_request_prefers_nostr_transport_for_privacy() {
+        let http = Transport {
+            _type: TransportType::HttpPost,
+            target: "https://receiver.example.com".to_string(),
+            tags: vec![],
+        };
+        let nostr = Transport {
+            _type: TransportType::Nostr,
+            target: "nprofile1example".to_string(),
+            tags: vec![vec!["n".to_string(), "17".to_string()]],
+        };
+
+        #[cfg(feature = "nostr")]
+        {
+            assert_eq!(
+                payment_request_transport(&[http.clone(), nostr.clone()]),
+                Some(&nostr)
+            );
+            assert_eq!(
+                payment_request_transport(&[nostr.clone(), http.clone()]),
+                Some(&nostr)
+            );
+        }
+        #[cfg(not(feature = "nostr"))]
+        {
+            assert_eq!(
+                payment_request_transport(&[http.clone(), nostr.clone()]),
+                Some(&http)
+            );
+            assert_eq!(
+                payment_request_transport(&[nostr, http.clone()]),
+                Some(&http)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn prepared_payment_exposes_exact_fee_breakdown_and_cancel_releases_proofs() {
+        use crate::wallet::test_utils::{
+            create_test_db, create_test_wallet_with_mock, test_keyset_id, test_mint_url,
+            test_proof_info, MockMintConnector,
+        };
+
+        let db = create_test_db().await;
+        db.update_proofs(
+            vec![test_proof_info(test_keyset_id(), 1024, test_mint_url())],
+            vec![],
+        )
+        .await
+        .expect("store proof");
+        let wallet = create_test_wallet_with_mock(db, Arc::new(MockMintConnector::new())).await;
+        let request = payment_request_with_http_transport(Amount::from(100), Amount::from(500));
+
+        let prepared = wallet
+            .prepare_pay_request(request, None)
+            .await
+            .expect("prepare payment request");
+
+        assert_eq!(prepared.requested_amount(), Amount::from(100));
+        assert_eq!(prepared.method(), Some("bolt11"));
+        assert_eq!(prepared.method_fee(), Amount::from(500));
+        assert_eq!(prepared.payment_amount(), Amount::from(600));
+        assert_eq!(
+            prepared.total_amount(),
+            prepared.payment_amount() + prepared.input_fee()
+        );
+        assert!(prepared.input_fee() > Amount::ZERO);
+        assert!(wallet.total_reserved_balance().await.expect("balance") > Amount::ZERO);
+
+        prepared.cancel().await.expect("cancel prepared payment");
+
+        assert_eq!(
+            wallet.total_reserved_balance().await.expect("balance"),
+            Amount::ZERO
+        );
+        assert_eq!(
+            wallet.total_balance().await.expect("balance"),
+            Amount::from(1024)
+        );
     }
 
     fn payment_request(
@@ -448,6 +921,28 @@ mod tests {
             supported_methods,
             description: None,
             transports: vec![],
+            nut10: None,
+        }
+    }
+
+    fn payment_request_with_http_transport(amount: Amount, method_fee: Amount) -> PaymentRequest {
+        PaymentRequest {
+            payment_id: None,
+            amount: Some(amount),
+            unit: Some(CurrencyUnit::Sat),
+            single_use: None,
+            mints: vec![],
+            mint_preferred: None,
+            supported_methods: vec![SupportedMethod::with_fee(
+                PaymentMethod::BOLT11.to_string(),
+                method_fee,
+            )],
+            description: None,
+            transports: vec![Transport {
+                _type: TransportType::HttpPost,
+                target: "https://receiver.example.com".to_string(),
+                tags: vec![],
+            }],
             nut10: None,
         }
     }
@@ -515,9 +1010,10 @@ async fn payment_request_amount_for_wallet(
         )));
     }
 
-    let method_fee = wallet_payment_request_method_fee(wallet, payment_request, unit)
+    let method_fee = wallet_payment_request_method(wallet, payment_request, unit)
         .await?
-        .ok_or(Error::UnsupportedPaymentMethod)?;
+        .ok_or(Error::UnsupportedPaymentMethod)?
+        .fee;
 
     if payment_request_method_fee_applies(payment_request, &wallet.mint_url) {
         return amount.checked_add(method_fee).ok_or(Error::AmountOverflow);
@@ -533,13 +1029,41 @@ fn payment_request_method_fee_applies(
     payment_request.mints.is_empty() || !payment_request.mints.contains(mint_url)
 }
 
-async fn wallet_payment_request_method_fee(
+fn payment_request_transport(transports: &[Transport]) -> Option<&Transport> {
+    #[cfg(feature = "nostr")]
+    if let Some(nostr) = transports
+        .iter()
+        .find(|transport| transport._type == TransportType::Nostr)
+    {
+        return Some(nostr);
+    }
+
+    transports
+        .iter()
+        .find(|transport| transport._type == TransportType::HttpPost)
+}
+
+fn parse_payment_request_mints(mints: Option<&[String]>) -> Result<Vec<MintUrl>, Error> {
+    mints
+        .unwrap_or_default()
+        .iter()
+        .map(|url| {
+            MintUrl::from_str(url)
+                .map_err(|err| Error::Custom(format!("Invalid mint URL `{url}`: {err}")))
+        })
+        .collect()
+}
+
+async fn wallet_payment_request_method(
     wallet: &Wallet,
     payment_request: &PaymentRequest,
     unit: &CurrencyUnit,
-) -> Result<Option<Amount>, Error> {
+) -> Result<Option<SelectedPaymentMethod>, Error> {
     if payment_request.supported_methods.is_empty() {
-        return Ok(Some(Amount::ZERO));
+        return Ok(Some(SelectedPaymentMethod {
+            method: None,
+            fee: Amount::ZERO,
+        }));
     }
 
     let mint_info = wallet.load_mint_info().await?;
@@ -557,9 +1081,12 @@ fn payment_request_method_fee_from_melt_methods(
     melt_methods: &[MeltMethodSettings],
     melting_disabled: bool,
     unit: &CurrencyUnit,
-) -> Result<Option<Amount>, Error> {
+) -> Result<Option<SelectedPaymentMethod>, Error> {
     if supported_methods.is_empty() {
-        return Ok(Some(Amount::ZERO));
+        return Ok(Some(SelectedPaymentMethod {
+            method: None,
+            fee: Amount::ZERO,
+        }));
     }
 
     if melting_disabled {
@@ -569,26 +1096,34 @@ fn payment_request_method_fee_from_melt_methods(
     let requested_methods = supported_methods
         .iter()
         .map(|method| {
-            PaymentMethod::from_str(&method.method)
-                .map(|payment_method| (payment_method, method.fee.unwrap_or(Amount::ZERO)))
+            PaymentMethod::from_str(&method.method).map(|payment_method| {
+                (
+                    payment_method,
+                    method.method.clone(),
+                    method.fee.unwrap_or(Amount::ZERO),
+                )
+            })
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    let mut lowest_fee: Option<Amount> = None;
-    for (method, fee) in requested_methods {
+    let mut selected_method: Option<SelectedPaymentMethod> = None;
+    for (method, method_name, fee) in requested_methods {
         let melt_supports_method = melt_methods
             .iter()
             .any(|settings| settings.unit == *unit && settings.method == method);
 
         if melt_supports_method {
-            lowest_fee = match lowest_fee {
-                Some(current) if current <= fee => Some(current),
-                _ => Some(fee),
+            selected_method = match selected_method {
+                Some(current) if current.fee <= fee => Some(current),
+                _ => Some(SelectedPaymentMethod {
+                    method: Some(method_name),
+                    fee,
+                }),
             };
         }
     }
 
-    Ok(lowest_fee)
+    Ok(selected_method)
 }
 
 /// Parameters for creating a PaymentRequest
@@ -618,10 +1153,12 @@ pub struct CreateRequestParams {
     pub http_url: Option<String>, // when transport == http
     /// List of Nostr relay URLs to include in the nprofile (used if `transport == nostr`)
     pub nostr_relays: Option<Vec<String>>, // when transport == nostr
-    /// Optional list of mint URLs the receiver trusts. If not provided, the wallet's current mints for the requested unit will be used.
+    /// Optional list of mint URLs the receiver accepts or prefers; `None` emits no mint list
     pub mints: Option<Vec<String>>,
     /// Whether the mint list is preferred rather than required
     pub mint_preferred: Option<bool>,
+    /// Payment methods the payer's mint must support, with optional per-method fees
+    pub supported_methods: Vec<SupportedMethod>,
 }
 
 impl Default for CreateRequestParams {
@@ -639,6 +1176,7 @@ impl Default for CreateRequestParams {
             nostr_relays: None,
             mints: None,
             mint_preferred: None,
+            supported_methods: vec![],
         }
     }
 }
@@ -664,9 +1202,9 @@ pub struct NostrWaitInfo {
 }
 
 impl WalletRepository {
-    /// Pay a NUT-18 PaymentRequest using the WalletRepository.
+    /// Select a wallet and prepare a NUT-18 payment request for review.
     ///
-    /// This method handles paying a payment request by selecting an appropriate mint:
+    /// This method selects an appropriate mint:
     /// - If `mint_url` is provided, it verifies the payment request accepts that mint
     ///   and uses it to pay.
     /// - If `mint_url` is None, it automatically selects the mint that:
@@ -686,12 +1224,17 @@ impl WalletRepository {
     /// - The specified mint is not accepted by the payment request
     /// - No matching mint has sufficient balance
     /// - No transport is available in the payment request
-    pub async fn pay_request(
+    ///
+    /// The returned payment must be explicitly completed with
+    /// [`PreparedPaymentRequest::confirm`] or released with
+    /// [`PreparedPaymentRequest::cancel`].
+    #[instrument(skip_all)]
+    pub async fn prepare_pay_request(
         &self,
         payment_request: PaymentRequest,
         mint_url: Option<MintUrl>,
         custom_amount: Option<Amount>,
-    ) -> Result<(), Error> {
+    ) -> Result<PreparedPaymentRequest, Error> {
         let unit = payment_request_unit(&payment_request)?;
         let amount = match payment_request.amount {
             Some(amount) => amount,
@@ -793,9 +1336,9 @@ impl WalletRepository {
                 .ok_or(Error::InsufficientFunds)?
         };
 
-        // Use the selected wallet to pay the request
+        // Freeze the selected wallet, applicable method fee, and exact input fees.
         selected_wallet
-            .pay_request(payment_request, custom_amount)
+            .prepare_pay_request(payment_request, custom_amount)
             .await
     }
 
@@ -935,15 +1478,8 @@ impl WalletRepository {
         &self,
         params: CreateRequestParams,
     ) -> Result<(PaymentRequest, Option<NostrWaitInfo>), Error> {
-        // Collect available mints for the selected unit
-        // Filter by the requested unit and extract unique mint URLs
-        let mints: Vec<MintUrl> = params
-            .mints
-            .clone()
-            .unwrap_or_default()
-            .into_iter()
-            .filter_map(|url| MintUrl::from_str(&url).ok())
-            .collect();
+        // Parse the explicitly configured mint policy. No list means any mint.
+        let mints = parse_payment_request_mints(params.mints.as_deref())?;
 
         // Transports
         let transport_type = params.transport.to_lowercase();
@@ -998,12 +1534,18 @@ impl WalletRepository {
                         };
                         (vec![http_transport], None)
                     } else {
-                        // No URL provided, skip transport
-                        (vec![], None)
+                        return Err(Error::Custom(
+                            "HTTP transport requires an HTTP URL".to_string(),
+                        ));
                     }
                 }
                 "none" => (vec![], None),
-                _ => (vec![], None),
+                _ => {
+                    return Err(Error::Custom(format!(
+                        "Unsupported payment request transport `{}`",
+                        params.transport
+                    )))
+                }
             };
 
         let nut10 = self
@@ -1018,7 +1560,7 @@ impl WalletRepository {
             single_use: Some(true),
             mints,
             mint_preferred: params.mint_preferred,
-            supported_methods: vec![],
+            supported_methods: params.supported_methods,
             description: params.description,
             transports,
             nut10,
@@ -1044,15 +1586,8 @@ impl WalletRepository {
         &self,
         params: CreateRequestParams,
     ) -> Result<PaymentRequest, Error> {
-        // Collect available mints for the selected unit
-        // Filter by the requested unit and extract unique mint URLs
-        let mints: Vec<MintUrl> = params
-            .mints
-            .clone()
-            .unwrap_or_default()
-            .into_iter()
-            .filter_map(|url| MintUrl::from_str(&url).ok())
-            .collect();
+        // Parse the explicitly configured mint policy. No list means any mint.
+        let mints = parse_payment_request_mints(params.mints.as_deref())?;
 
         // Transports
         let transport_type = params.transport.to_lowercase();
@@ -1071,11 +1606,18 @@ impl WalletRepository {
                     };
                     vec![http_transport]
                 } else {
-                    // No URL provided, skip transport
-                    vec![]
+                    return Err(Error::Custom(
+                        "HTTP transport requires an HTTP URL".to_string(),
+                    ));
                 }
             }
-            _ => vec![],
+            "none" => vec![],
+            _ => {
+                return Err(Error::Custom(format!(
+                    "Unsupported payment request transport `{}`",
+                    params.transport
+                )))
+            }
         };
 
         let nut10 = self
@@ -1090,7 +1632,7 @@ impl WalletRepository {
             single_use: Some(true),
             mints,
             mint_preferred: params.mint_preferred,
-            supported_methods: vec![],
+            supported_methods: params.supported_methods,
             description: params.description,
             transports,
             nut10,

--- a/crates/cdk/src/wallet/wallet_trait.rs
+++ b/crates/cdk/src/wallet/wallet_trait.rs
@@ -7,7 +7,6 @@ use async_trait::async_trait;
 use cdk_common::amount::{FeeAndAmounts, KeysetFeeAndAmounts, SplitTarget};
 use cdk_common::mint_url::MintUrl;
 use cdk_common::nuts::nut07::ProofState;
-use cdk_common::nuts::nut18::PaymentRequest;
 use cdk_common::nuts::{
     AuthProof, CurrencyUnit, Id, MeltOptions, MintInfo, PaymentMethod, Proofs, SpendingConditions,
 };
@@ -362,15 +361,6 @@ impl WalletTrait for super::Wallet {
     async fn verify_token_dleq(&self, token_str: &str) -> Result<(), Self::Error> {
         let token = cdk_common::nuts::nut00::token::Token::from_str(token_str)?;
         self.verify_token_dleq(&token).await
-    }
-
-    #[instrument(skip(self, request))]
-    async fn pay_request(
-        &self,
-        request: PaymentRequest,
-        custom_amount: Option<Amount>,
-    ) -> Result<(), Self::Error> {
-        self.pay_request(request, custom_amount).await
     }
 
     #[instrument(skip(self, method))]


### PR DESCRIPTION
Expose NUT-18 method and input fees through a prepared payment request. Require callers to inspect and explicitly confirm or cancel the reserved payment instead of using an atomic pay_request API.

Return a structured delivery error when token creation succeeds but transport delivery fails. Preserve the pending operation ID so callers can revoke an unclaimed send instead of paying the request again.

Add method-fee publishing to request creation, preserve advertised transport order, and expose the prepared flow through the CLI and FFI.

BREAKING CHANGE: Remove atomic pay_request methods from Wallet, WalletRepository, wallet traits, and FFI. Call prepare_pay_request and then confirm or cancel the returned PreparedPaymentRequest.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
