### PR TITLE
fix(mint): preserve proof state for duplicate Ys

### DIFF
--- a/crates/cdk-sql-common/src/mint/proofs.rs
+++ b/crates/cdk-sql-common/src/mint/proofs.rs
@@ -505,9 +505,9 @@ where
             .get()
             .await
             .map_err(|e| Error::Database(Box::new(e)))?;
-        let mut current_states = get_current_states(&*conn, ys, false).await?;
+        let current_states = get_current_states(&*conn, ys, false).await?;
 
-        Ok(ys.iter().map(|y| current_states.remove(y)).collect())
+        Ok(ys.iter().map(|y| current_states.get(y).copied()).collect())
     }
 
     async fn get_proofs_by_keyset_id(

--- a/crates/cdk/src/mint/check_spendable.rs
+++ b/crates/cdk/src/mint/check_spendable.rs
@@ -160,4 +160,50 @@ mod tests {
     async fn test_check_state_returns_witness_for_spent_proofs() {
         assert!(check_state_witness_for_proof_state(State::Spent).await);
     }
+
+    #[tokio::test]
+    async fn test_check_state_returns_spent_for_duplicate_y() {
+        let mint = create_test_mint().await.unwrap();
+        let proofs = mint_test_proofs(&mint, Amount::from(100)).await.unwrap();
+        let ys = proofs.ys().unwrap();
+        let duplicated_y = ys[0];
+        let db = mint.localstore();
+
+        {
+            let mut tx = db.begin_transaction().await.unwrap();
+            tx.add_proofs(
+                proofs,
+                None,
+                &Operation::new_swap(Amount::ZERO, Amount::ZERO, Amount::ZERO),
+            )
+            .await
+            .unwrap();
+            tx.commit().await.unwrap();
+        }
+
+        {
+            let mut tx = db.begin_transaction().await.unwrap();
+            let mut acquired = tx.get_proofs(&ys).await.unwrap();
+            Mint::update_proofs_state(&mut tx, &mut acquired, State::Pending)
+                .await
+                .unwrap();
+            Mint::update_proofs_state(&mut tx, &mut acquired, State::Spent)
+                .await
+                .unwrap();
+            tx.commit().await.unwrap();
+        }
+
+        let response = mint
+            .check_state(&CheckStateRequest {
+                ys: vec![duplicated_y, duplicated_y],
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(response.states.len(), 2);
+        assert!(response
+            .states
+            .iter()
+            .all(|proof_state| proof_state.y == duplicated_y && proof_state.state == State::Spent));
+    }
 }


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
