### PR TITLE
fix: escape untrusted strings before terminal and log output

### DIFF
--- a/crates/cashu/src/nuts/auth/nut21.rs
+++ b/crates/cashu/src/nuts/auth/nut21.rs
@@ -43,6 +43,18 @@ impl Settings {
     }
 }
 
+fn is_disallowed_path_character(ch: char) -> bool {
+    ch.is_control()
+        || matches!(
+            ch,
+            '\u{061c}'
+                | '\u{200e}'
+                | '\u{200f}'
+                | '\u{202a}'..='\u{202e}'
+                | '\u{2066}'..='\u{2069}'
+        )
+}
+
 // Custom deserializer for Settings to expand patterns in protected endpoints
 impl<'de> Deserialize<'de> for Settings {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -70,6 +82,12 @@ impl<'de> Deserialize<'de> for Settings {
         let mut protected_endpoints = HashSet::new();
 
         for raw_endpoint in raw.protected_endpoints {
+            if raw_endpoint.path.chars().any(is_disallowed_path_character) {
+                return Err(serde::de::Error::custom(
+                    "Invalid protected endpoint path: control and bidirectional formatting characters are not allowed",
+                ));
+            }
+
             let expanded_paths = matching_route_paths(&raw_endpoint.path).map_err(|e| {
                 serde::de::Error::custom(format!("Invalid pattern '{}': {}", raw_endpoint.path, e))
             })?;
@@ -818,6 +836,27 @@ mod tests {
 
         let result = serde_json::from_str::<Settings>(json);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_settings_deserialize_rejects_controls_with_safe_error() {
+        let path = "/invalid/\u{1b}]52;c;clipboard\u{07}\r\u{85}\u{202e}";
+        let value = serde_json::json!({
+            "openid_discovery": "https://example.com/.well-known/openid-configuration",
+            "client_id": "client123",
+            "protected_endpoints": [{
+                "method": "GET",
+                "path": path,
+            }],
+        });
+
+        let error = serde_json::from_value::<Settings>(value)
+            .expect_err("invalid path should fail")
+            .to_string();
+
+        assert!(!error.chars().any(is_disallowed_path_character));
+        assert!(error.contains("control and bidirectional formatting characters are not allowed"));
+        assert!(!error.contains("clipboard"));
     }
 
     #[test]

--- a/crates/cdk-cli/src/sub_commands/cat_device_login.rs
+++ b/crates/cdk-cli/src/sub_commands/cat_device_login.rs
@@ -9,6 +9,7 @@ use clap::Args;
 use serde::{Deserialize, Serialize};
 use tokio::time::sleep;
 
+use super::cat_login::token_display_line;
 use crate::terminal::escape_control;
 use crate::token_storage;
 
@@ -47,8 +48,8 @@ pub async fn cat_device_login(
     // Print a cute ASCII cat
     println!("\nAuthentication successful! 🎉\n");
     println!("\nYour tokens:");
-    println!("access_token: {access_token}");
-    println!("refresh_token: {refresh_token}");
+    println!("{}", token_display_line("access_token", &access_token));
+    println!("{}", token_display_line("refresh_token", &refresh_token));
 
     Ok(())
 }

--- a/crates/cdk-cli/src/sub_commands/cat_login.rs
+++ b/crates/cdk-cli/src/sub_commands/cat_login.rs
@@ -7,7 +7,12 @@ use cdk::wallet::WalletRepository;
 use clap::Args;
 use serde::{Deserialize, Serialize};
 
+use crate::terminal::escape_control;
 use crate::token_storage;
+
+pub(super) fn token_display_line(label: &str, token: &str) -> String {
+    format!("{label}: {}", escape_control(token))
+}
 
 #[derive(Args, Serialize, Deserialize)]
 pub struct CatLoginSubCommand {
@@ -53,8 +58,8 @@ pub async fn cat_login(
 
     println!("\nAuthentication successful! 🎉\n");
     println!("\nYour tokens:");
-    println!("access_token: {access_token}");
-    println!("refresh_token: {refresh_token}");
+    println!("{}", token_display_line("access_token", &access_token));
+    println!("{}", token_display_line("refresh_token", &refresh_token));
 
     Ok(())
 }
@@ -110,4 +115,23 @@ async fn get_access_token(
         .to_string();
 
     Ok((access_token, refresh_token))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_display_escapes_terminal_controls() {
+        let token = "token\u{1b}]52;c;clipboard\u{07}\r\u{85}\u{202e}";
+        let output = token_display_line("access_token", token);
+
+        assert_eq!(
+            output,
+            "access_token: token\\e]52;c;clipboard\\a\\r\\u{85}\\u{202e}"
+        );
+        assert!(!output
+            .chars()
+            .any(|ch| { ch.is_control() || cdk_common::terminal::is_bidi_control_character(ch) }));
+    }
 }

--- a/crates/cdk-cli/src/sub_commands/check_pending.rs
+++ b/crates/cdk-cli/src/sub_commands/check_pending.rs
@@ -1,13 +1,24 @@
 use anyhow::Result;
+use cdk::nuts::CurrencyUnit;
 use cdk::wallet::WalletRepository;
 use cdk::Amount;
+
+use crate::terminal::escape_control;
+
+fn pending_proofs_status(pending_amount: Amount, unit: &CurrencyUnit) -> String {
+    format!(
+        "Checked pending proofs: {} {} still pending",
+        pending_amount,
+        escape_control(&unit.to_string())
+    )
+}
 
 pub async fn check_pending(wallet_repository: &WalletRepository) -> Result<()> {
     let wallets = wallet_repository.get_wallets().await;
 
     for (i, wallet) in wallets.iter().enumerate() {
         let mint_url = wallet.mint_url.clone();
-        println!("{i}: {mint_url}");
+        println!("{i}: {}", escape_control(&mint_url.to_string()));
 
         // Check all orphaned pending proofs (not managed by active sagas)
         // This function queries the mint and marks spent proofs accordingly
@@ -16,14 +27,33 @@ pub async fn check_pending(wallet_repository: &WalletRepository) -> Result<()> {
                 if pending_amount == Amount::ZERO {
                     println!("No orphaned pending proofs found");
                 } else {
-                    println!(
-                        "Checked pending proofs: {} {} still pending",
-                        pending_amount, wallet.unit
-                    );
+                    println!("{}", pending_proofs_status(pending_amount, &wallet.unit));
                 }
             }
-            Err(e) => println!("Error checking pending proofs: {e}"),
+            Err(e) => println!(
+                "Error checking pending proofs: {}",
+                escape_control(&e.to_string())
+            ),
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_status_escapes_custom_currency_unit() {
+        let unit = CurrencyUnit::custom("usd\u{1b}]52;c;clipboard\u{07}\r\u{85}\u{202e}");
+        let output = pending_proofs_status(Amount::from(7), &unit);
+
+        assert_eq!(
+            output,
+            "Checked pending proofs: 7 usd\\e]52;c;clipboard\\a\\r\\u{85}\\u{202e} still pending"
+        );
+        assert!(!output
+            .chars()
+            .any(|ch| { ch.is_control() || cdk_common::terminal::is_bidi_control_character(ch) }));
+    }
 }

--- a/crates/cdk-cli/src/sub_commands/check_requests.rs
+++ b/crates/cdk-cli/src/sub_commands/check_requests.rs
@@ -2,13 +2,23 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::Result;
+use cdk::mint_url::MintUrl;
 use cdk::nuts::Token;
 use cdk::wallet::{ReceiveOptions, WalletRepository};
 use cdk_common::PaymentRequestPayload;
 use nostr_sdk::{Filter, Keys, Kind, PublicKey, SecretKey};
 
 use super::create_request::StoredNostrWaitInfo;
+use crate::terminal::escape_control;
 use crate::utils::get_or_create_wallet;
+
+fn unaccepted_mint_warning(request_id: &str, mint_url: &MintUrl) -> String {
+    format!(
+        "Ignoring payment for request {} from unaccepted mint {}",
+        escape_control(request_id),
+        escape_control(&mint_url.to_string())
+    )
+}
 
 pub async fn check_requests(wallet_repository: &WalletRepository) -> Result<()> {
     let wallets = wallet_repository.get_wallets().await;
@@ -53,11 +63,7 @@ pub async fn check_requests(wallet_repository: &WalletRepository) -> Result<()> 
                             serde_json::from_str::<PaymentRequestPayload>(&unwrapped.rumor.content)
                         {
                             if !info.accepts_mint(&payload.mint) {
-                                tracing::warn!(
-                                    "Ignoring payment for request {} from unaccepted mint {}",
-                                    key,
-                                    payload.mint
-                                );
+                                tracing::warn!("{}", unaccepted_mint_warning(&key, &payload.mint));
                                 continue;
                             }
 
@@ -86,7 +92,11 @@ pub async fn check_requests(wallet_repository: &WalletRepository) -> Result<()> 
                                     // Silently ignore already claimed proofs if that's what the error is
                                     // or print if it's something else.
                                     // For now, let's just log it.
-                                    tracing::debug!("Failed to receive token for {}: {}", key, e);
+                                    tracing::debug!(
+                                        "Failed to receive token for {}: {}",
+                                        escape_control(&key),
+                                        escape_control(&e.to_string())
+                                    );
                                 }
                             }
                         }
@@ -97,4 +107,26 @@ pub async fn check_requests(wallet_repository: &WalletRepository) -> Result<()> 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unaccepted_mint_warning_escapes_terminal_controls() {
+        let mint =
+            MintUrl::from_str("https://example.com/\u{1b}]52;c;clipboard\u{07}\r\u{85}\u{202e}")
+                .expect("mint URL should parse");
+        let output = unaccepted_mint_warning("request", &mint);
+
+        assert_eq!(
+            output,
+            "Ignoring payment for request request from unaccepted mint \
+             https://example.com/\\e]52;c;clipboard\\a\\r\\u{85}\\u{202e}"
+        );
+        assert!(!output
+            .chars()
+            .any(|ch| { ch.is_control() || cdk_common::terminal::is_bidi_control_character(ch) }));
+    }
 }

--- a/crates/cdk/src/wallet/bip321.rs
+++ b/crates/cdk/src/wallet/bip321.rs
@@ -53,6 +53,8 @@ use crate::bip353::Bip353Address;
 use crate::error::Error;
 use crate::nuts::PaymentRequest;
 #[cfg(all(feature = "bip353", not(target_arch = "wasm32")))]
+use crate::wallet::util::escape_log_value;
+#[cfg(all(feature = "bip353", not(target_arch = "wasm32")))]
 use crate::wallet::MintConnector;
 
 /// Parsed payment instruction with all available payment methods.
@@ -215,18 +217,25 @@ pub async fn resolve_bip353_payment_instruction(
     network: bitcoin::Network,
 ) -> Result<ParsedPaymentInstruction, Error> {
     let address = Bip353Address::from_str(bip353_address).map_err(|e| {
-        tracing::error!("Failed to parse BIP353 address '{}': {}", bip353_address, e);
+        tracing::error!(
+            "Failed to parse BIP353 address '{}': {}",
+            escape_log_value(bip353_address),
+            escape_log_value(&e)
+        );
         Error::Bip353Parse(e.to_string())
     })?;
 
-    tracing::debug!("Resolving BIP353 address: {}", address);
     let address_string = address.to_string();
+    tracing::debug!(
+        "Resolving BIP353 address: {}",
+        escape_log_value(&address_string)
+    );
 
     let resolved_uri = address.resolve(client).await.map_err(|e| {
         tracing::error!(
             "Failed to resolve BIP353 address '{}': {}",
-            address_string,
-            e
+            escape_log_value(&address_string),
+            escape_log_value(&e)
         );
         Error::Bip353Resolve(e.to_string())
     })?;
@@ -236,8 +245,8 @@ pub async fn resolve_bip353_payment_instruction(
         .map_err(|e| {
             tracing::error!(
                 "Failed to parse resolved BIP353 payment instruction '{}': {}",
-                resolved_uri,
-                e
+                escape_log_value(&resolved_uri),
+                escape_log_value(&e)
             );
             Error::Bip321Parse(format!("Invalid resolved bitcoin URI: {e}"))
         })
@@ -394,6 +403,21 @@ fn format_btc_amount_from_sats(sats: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(all(feature = "bip353", not(target_arch = "wasm32")))]
+    #[test]
+    fn bip353_log_values_escape_terminal_controls() {
+        let value = "alice\u{1b}]52;c;clipboard\u{07}\r\u{85}\u{202e}@example.com";
+        let escaped = escape_log_value(value);
+
+        assert_eq!(
+            escaped,
+            "alice\\e]52;c;clipboard\\a\\r\\u{85}\\u{202e}@example.com"
+        );
+        assert!(!escaped
+            .chars()
+            .any(|ch| { ch.is_control() || cdk_common::terminal::is_bidi_control_character(ch) }));
+    }
 
     const TEST_CREQ: &str = "CREQB1QYQQWER9D4HNZV3NQGQQSQQQQQQQQQQRAQPSQQGQQSQQZQG9QQVXSAR5WPEN5TE0D45KUAPWV4UXZMTSD3JJUCM0D5RQQRJRDANXVET9YPCXZ7TDV4H8GXHR3TQ";
     const TEST_BOLT11: &str = "lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq9qrsgq357wnc5r2ueh7ck6q93dj32dlqnls087fxdwk8qakdyafkq3yap9us6v52vjjsrvywa6rt52cm9r9zqt8r2t7mlcwspyetp5h2tztugp9lfyql";

--- a/crates/cdk/src/wallet/issue/saga/resume.rs
+++ b/crates/cdk/src/wallet/issue/saga/resume.rs
@@ -29,6 +29,7 @@ use crate::wallet::issue::saga::compensation::ReleaseMintQuote;
 use crate::wallet::issue::saga::state::PreparedMintRequest;
 use crate::wallet::recovery::{OutputRecoveryResult, RecoveryAction};
 use crate::wallet::saga::CompensatingAction;
+use crate::wallet::util::escape_log_value;
 use crate::{Error, Wallet};
 
 fn is_mint_limit_error(error: &Error) -> bool {
@@ -301,11 +302,14 @@ impl Wallet {
                     if let Err(e) = self.check_state(&mut quote).await {
                         tracing::warn!(
                             "Failed to check quote state for transaction recording: {}",
-                            e
+                            escape_log_value(&e)
                         );
                     }
                     if let Err(e) = self.localstore.add_mint_quote(quote.clone()).await {
-                        tracing::warn!("Failed to save updated quote state: {}", e);
+                        tracing::warn!(
+                            "Failed to save updated quote state: {}",
+                            escape_log_value(&e)
+                        );
                     }
                     quote
                 }
@@ -464,7 +468,7 @@ impl Wallet {
                         tracing::warn!(
                             "Issue saga {} - batch replay failed with mint limit: {}",
                             saga_id,
-                            e
+                            escape_log_value(&e)
                         );
                         return Err(e);
                     }
@@ -472,7 +476,7 @@ impl Wallet {
                     tracing::info!(
                         "Issue saga {} - batch replay failed ({}), falling back to restore",
                         saga_id,
-                        e
+                        escape_log_value(&e)
                     );
                     return Ok(None);
                 }
@@ -556,7 +560,7 @@ impl Wallet {
                 tracing::warn!(
                     "Issue saga {} - failed to sign mint request: {}, cannot replay",
                     saga_id,
-                    e
+                    escape_log_value(&e)
                 );
                 return Ok(None);
             }
@@ -587,7 +591,7 @@ impl Wallet {
                     tracing::warn!(
                         "Issue saga {} - replay failed with mint limit: {}",
                         saga_id,
-                        e
+                        escape_log_value(&e)
                     );
                     return Err(e);
                 }
@@ -595,7 +599,7 @@ impl Wallet {
                 tracing::info!(
                     "Issue saga {} - replay failed ({}), falling back to restore",
                     saga_id,
-                    e
+                    escape_log_value(&e)
                 );
                 return Ok(None);
             }
@@ -667,7 +671,7 @@ impl Wallet {
             tracing::warn!(
                 "Failed to release mint quote for saga {}: {}. Continuing with saga cleanup.",
                 saga_id,
-                e
+                escape_log_value(&e)
             );
         }
 

--- a/crates/cdk/src/wallet/melt/saga/resume.rs
+++ b/crates/cdk/src/wallet/melt/saga/resume.rs
@@ -18,6 +18,7 @@ use crate::wallet::melt::saga::compensation::ReleaseMeltQuote;
 use crate::wallet::melt::MeltQuoteStatusResponse;
 use crate::wallet::recovery::OutputRecoveryResult;
 use crate::wallet::saga::{CompensatingAction, RevertProofReservation};
+use crate::wallet::util::escape_log_value;
 use crate::{Error, Wallet};
 
 impl Wallet {
@@ -196,7 +197,7 @@ impl Wallet {
                 tracing::warn!(
                     "Melt saga {} - can't check quote state ({}), skipping",
                     saga_id,
-                    e
+                    escape_log_value(&e)
                 );
                 Ok(None)
             }
@@ -276,7 +277,7 @@ impl Wallet {
                     tracing::warn!(
                         "Failed to release melt quote for saga {} after recovery finalization: {}",
                         saga_id,
-                        e
+                        escape_log_value(&e)
                     );
                 }
 
@@ -347,7 +348,7 @@ impl Wallet {
                                 "Melt saga {} - failed to recover change: {}. \
                                  Skipping final transaction recording until change can be recovered.",
                                 saga_id,
-                                e
+                                escape_log_value(&e)
                             );
                             return Err(e);
                         }
@@ -424,7 +425,7 @@ impl Wallet {
             tracing::warn!(
                 "Failed to release melt quote for saga {} after recovery finalization: {}",
                 saga_id,
-                e
+                escape_log_value(&e)
             );
         }
 
@@ -455,7 +456,7 @@ impl Wallet {
             tracing::warn!(
                 "Failed to release melt quote for saga {}: {}. Continuing with saga cleanup.",
                 saga_id,
-                e
+                escape_log_value(&e)
             );
         }
 

--- a/crates/cdk/src/wallet/mint_metadata_cache.rs
+++ b/crates/cdk/src/wallet/mint_metadata_cache.rs
@@ -39,6 +39,7 @@ use tokio::sync::Mutex;
 use web_time::Instant;
 
 use crate::nuts::Id;
+use crate::wallet::util::escape_log_value;
 use crate::wallet::{AuthMintConnector, AuthWallet, MintConnector};
 use crate::{Error, Wallet};
 
@@ -665,7 +666,10 @@ impl MintMetadataCache {
         client: Option<&Arc<dyn MintConnector + Send + Sync>>,
         auth_client: Option<&Arc<dyn AuthMintConnector + Send + Sync>>,
     ) -> Result<Arc<MintMetadata>, Error> {
-        tracing::debug!("Fetching mint metadata from HTTP for {}", self.mint_url);
+        tracing::debug!(
+            "Fetching mint metadata from HTTP for {}",
+            escape_log_value(&self.mint_url)
+        );
 
         // Start with current cache to preserve data from other sources
         let mut new_metadata = (*self.metadata.load().clone()).clone();
@@ -675,7 +679,11 @@ impl MintMetadataCache {
         if let Some(client) = client.as_ref() {
             // Get mint information
             new_metadata.mint_info = client.get_mint_info().await.inspect_err(|err| {
-                tracing::error!("Failed to fetch mint info for {}: {}", self.mint_url, err);
+                tracing::error!(
+                    "Failed to fetch mint info for {}: {}",
+                    escape_log_value(&self.mint_url),
+                    escape_log_value(err)
+                );
             })?;
 
             // Get list of keysets
@@ -684,7 +692,11 @@ impl MintMetadataCache {
                     .get_mint_keysets()
                     .await
                     .inspect_err(|err| {
-                        tracing::error!("Failed to fetch keysets for {}: {}", self.mint_url, err);
+                        tracing::error!(
+                            "Failed to fetch keysets for {}: {}",
+                            escape_log_value(&self.mint_url),
+                            escape_log_value(err)
+                        );
                     })?
                     .keysets,
             );
@@ -698,7 +710,7 @@ impl MintMetadataCache {
         tracing::debug!(
             "Fetched {} keysets for {}",
             keysets_to_fetch.len(),
-            self.mint_url
+            escape_log_value(&self.mint_url)
         );
 
         // Fetch keys for each keyset

--- a/crates/cdk/src/wallet/receive/saga/resume.rs
+++ b/crates/cdk/src/wallet/receive/saga/resume.rs
@@ -24,6 +24,7 @@ use crate::util::unix_time;
 use crate::wallet::receive::saga::compensation::RemovePendingProofs;
 use crate::wallet::recovery::{RecoveryAction, RecoveryHelpers};
 use crate::wallet::saga::CompensatingAction;
+use crate::wallet::util::escape_log_value;
 use crate::{Error, Wallet};
 
 impl Wallet {
@@ -119,7 +120,7 @@ impl Wallet {
                         "Receive saga {} - couldn't reconstruct the historical fee ({}), \
                          recording the pending transaction with zero fee",
                         saga_id,
-                        error
+                        escape_log_value(&error)
                     );
                     Amount::ZERO
                 }
@@ -192,7 +193,7 @@ impl Wallet {
                 tracing::warn!(
                     "Receive saga {} - can't check proof states ({}), skipping",
                     saga_id,
-                    e
+                    escape_log_value(&e)
                 );
                 Ok(RecoveryAction::Skipped)
             }

--- a/crates/cdk/src/wallet/recovery.rs
+++ b/crates/cdk/src/wallet/recovery.rs
@@ -26,6 +26,7 @@ use crate::nuts::{CheckStateRequest, PreMintSecrets, Proofs, RestoreRequest, Sta
 use crate::wallet::blind_signature::{
     validate_mint_response_signatures, SignatureAmountValidation,
 };
+use crate::wallet::util::escape_log_value;
 use crate::{Error, Wallet};
 
 /// Parameters for recovering outputs using stored blinded messages.
@@ -250,7 +251,7 @@ impl RecoveryHelpers for Wallet {
                     "{} saga {} - replay failed ({}), falling back to other recovery",
                     saga_type,
                     saga_id,
-                    e
+                    escape_log_value(&e)
                 );
                 return Ok(None);
             }
@@ -395,7 +396,11 @@ impl Wallet {
                     report.skipped += 1;
                 }
                 Err(e) => {
-                    tracing::error!("Failed to recover saga {}: {}", saga.id, e);
+                    tracing::error!(
+                        "Failed to recover saga {}: {}",
+                        saga.id,
+                        escape_log_value(&e)
+                    );
                     report.failed += 1;
                 }
             }
@@ -451,7 +456,7 @@ impl Wallet {
                          Run wallet.restore() to recover any missing proofs.",
                         saga_type,
                         saga_id,
-                        e
+                        escape_log_value(&e)
                     );
                     return Ok(OutputRecoveryResult::Unavailable);
                 } else {
@@ -460,7 +465,7 @@ impl Wallet {
                          Skipping recovery to retry later.",
                         saga_type,
                         saga_id,
-                        e
+                        escape_log_value(&e)
                     );
                     return Err(e);
                 }
@@ -639,23 +644,23 @@ impl Wallet {
                             // No saga found - this is an orphaned reservation
                             tracing::warn!(
                                 "Found orphaned melt quote reservation: quote={}, operation={}. Releasing.",
-                                quote.id,
+                                escape_log_value(&quote.id),
                                 operation_id
                             );
                             if let Err(e) = self.localstore.release_melt_quote(&operation_id).await
                             {
                                 tracing::error!(
                                     "Failed to release orphaned melt quote {}: {}",
-                                    quote.id,
-                                    e
+                                    escape_log_value(&quote.id),
+                                    escape_log_value(&e)
                                 );
                             }
                         }
                         Err(e) => {
                             tracing::warn!(
                                 "Failed to check saga for melt quote {}: {}",
-                                quote.id,
-                                e
+                                escape_log_value(&quote.id),
+                                escape_log_value(&e)
                             );
                         }
                     }
@@ -682,23 +687,23 @@ impl Wallet {
                             // No saga found - this is an orphaned reservation
                             tracing::warn!(
                                 "Found orphaned mint quote reservation: quote={}, operation={}. Releasing.",
-                                quote.id,
+                                escape_log_value(&quote.id),
                                 operation_id
                             );
                             if let Err(e) = self.localstore.release_mint_quote(&operation_id).await
                             {
                                 tracing::error!(
                                     "Failed to release orphaned mint quote {}: {}",
-                                    quote.id,
-                                    e
+                                    escape_log_value(&quote.id),
+                                    escape_log_value(&e)
                                 );
                             }
                         }
                         Err(e) => {
                             tracing::warn!(
                                 "Failed to check saga for mint quote {}: {}",
-                                quote.id,
-                                e
+                                escape_log_value(&quote.id),
+                                escape_log_value(&e)
                             );
                         }
                     }

--- a/crates/cdk/src/wallet/send/saga/resume.rs
+++ b/crates/cdk/src/wallet/send/saga/resume.rs
@@ -10,6 +10,7 @@ use tracing::instrument;
 use crate::nuts::State;
 use crate::wallet::recovery::{RecoveryAction, RecoveryHelpers};
 use crate::wallet::saga::{CompensatingAction, RevertProofReservation};
+use crate::wallet::util::escape_log_value;
 use crate::{Error, Wallet};
 
 impl Wallet {
@@ -129,7 +130,7 @@ impl Wallet {
                 tracing::warn!(
                     "Send saga {} (RollingBack) - can't check proof states ({}), skipping",
                     saga_id,
-                    e
+                    escape_log_value(&e)
                 );
                 Ok(RecoveryAction::Skipped)
             }
@@ -181,7 +182,7 @@ impl Wallet {
                 tracing::warn!(
                     "Send saga {} - can't check proof states ({}), skipping",
                     saga_id,
-                    e
+                    escape_log_value(&e)
                 );
                 Ok(RecoveryAction::Skipped)
             }

--- a/crates/cdk/src/wallet/swap/saga/resume.rs
+++ b/crates/cdk/src/wallet/swap/saga/resume.rs
@@ -18,6 +18,7 @@ use crate::dhke::hash_to_curve;
 use crate::nuts::{PreMintSecrets, State};
 use crate::wallet::recovery::{RecoveryAction, RecoveryHelpers};
 use crate::wallet::saga::{CompensatingAction, RevertProofReservation};
+use crate::wallet::util::escape_log_value;
 use crate::{Error, Wallet};
 
 impl Wallet {
@@ -144,7 +145,7 @@ impl Wallet {
                     tracing::warn!(
                         "Swap saga {} - can't check proof states ({}), skipping",
                         saga_id,
-                        e
+                        escape_log_value(&e)
                     );
                     return Ok(RecoveryAction::Skipped);
                 }
@@ -162,7 +163,7 @@ impl Wallet {
                         tracing::warn!(
                             "Restore failed for orphaned saga {} ({}). Cleaning up.",
                             saga_id,
-                            e
+                            escape_log_value(&e)
                         );
                         self.localstore.delete_saga(saga_id).await?;
                         Ok(RecoveryAction::Recovered)

--- a/crates/cdk/src/wallet/util.rs
+++ b/crates/cdk/src/wallet/util.rs
@@ -1,13 +1,23 @@
 //! Wallet Utility Functions
 
 use std::collections::HashMap;
+use std::fmt;
 use std::str::FromStr;
 
 use bitcoin::XOnlyPublicKey;
+use cdk_common::terminal::escape_control;
 
 use crate::nuts::nut10::Kind;
 use crate::nuts::{Conditions, Proof, Proofs, PublicKey, SecretKey};
 use crate::{Error, SECP256K1};
+
+/// Render a value without allowing terminal controls to reach a log sink.
+pub(crate) fn escape_log_value<T>(value: &T) -> String
+where
+    T: fmt::Display + ?Sized,
+{
+    escape_control(&value.to_string())
+}
 
 /// Returns `true` if the proof has a P2PK (NUT-11) spending condition.
 ///
@@ -186,6 +196,23 @@ mod tests {
     use crate::nuts::nut28::{blind_public_key, ecdh_kdf};
     use crate::nuts::{CurrencyUnit, Id, Proof, SpendingConditions, Token};
     use crate::Amount;
+
+    #[test]
+    fn escape_log_value_neutralizes_terminal_and_bidi_controls() {
+        let error = Error::HttpError(
+            Some(500),
+            "safe\u{1b}]52;c;clipboard\u{07}\r\u{85}\u{202e}".to_string(),
+        );
+        let escaped = escape_log_value(&error);
+
+        assert_eq!(
+            escaped,
+            "Http transport error Some(500): safe\\e]52;c;clipboard\\a\\r\\u{85}\\u{202e}"
+        );
+        assert!(!escaped
+            .chars()
+            .any(|ch| { ch.is_control() || cdk_common::terminal::is_bidi_control_character(ch) }));
+    }
 
     fn make_p2pk_proof(pubkey: PublicKey) -> Proof {
         let spending_conditions = SpendingConditions::new_p2pk(pubkey, None);


### PR DESCRIPTION
Route remaining peer- and server-controlled strings (NUT-21 endpoint paths, BIP353 resolver values, mint error bodies in startup recovery, currency units in check-pending, OIDC token display, and gift-wrap mint URLs) through control-character and bidi escaping. Use the shared cdk-common helper for non-CLI sinks, and reject unsafe NUT-21 endpoint paths before formatting deserialization errors.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
