### PR TITLE
fix(cdk-bdk): strengthen on-chain send recovery

### DIFF
--- a/crates/cdk-bdk/src/chain/electrum.rs
+++ b/crates/cdk-bdk/src/chain/electrum.rs
@@ -103,12 +103,63 @@ pub(crate) async fn sync_electrum(
                     }
                 };
 
+                let reservations = match cdk_bdk.load_broadcast_reservations().await {
+                    Ok(reservations) => reservations,
+                    Err(error) => {
+                        consecutive_failures = consecutive_failures.saturating_add(1);
+                        crate::sync::log_sync_failure(
+                            "Failed to load Broadcast transactions for Electrum sync",
+                            &error,
+                            consecutive_failures,
+                        );
+                        continue;
+                    }
+                };
                 let sync_request = {
-                    let wallet = cdk_bdk.wallet_with_db.lock().await;
+                    let sync_started_at = crate::util::unix_now();
+                    let Some(reservation_time) = sync_started_at.checked_add(1) else {
+                        let error = Error::Wallet(
+                            "Cannot construct Electrum sync request at maximum timestamp"
+                                .to_string(),
+                        );
+                        consecutive_failures = consecutive_failures.saturating_add(1);
+                        crate::sync::log_sync_failure(
+                            "Failed to reserve Broadcast transactions for Electrum sync",
+                            &error,
+                            consecutive_failures,
+                        );
+                        continue;
+                    };
+                    let mut wallet = cdk_bdk.wallet_with_db.lock().await;
+                    if let Err(error) = CdkBdk::reserve_broadcast_transactions_locked(
+                        &mut wallet.wallet,
+                        &reservations,
+                        reservation_time,
+                    ) {
+                        consecutive_failures = consecutive_failures.saturating_add(1);
+                        crate::sync::log_sync_failure(
+                            "Failed to reserve Broadcast transactions for Electrum sync",
+                            &error,
+                            consecutive_failures,
+                        );
+                        continue;
+                    }
+                    if let Err(error) = wallet.persist() {
+                        let error = Error::Database(error);
+                        consecutive_failures = consecutive_failures.saturating_add(1);
+                        crate::sync::log_sync_failure(
+                            "Failed to persist Broadcast reservations for Electrum sync",
+                            &error,
+                            consecutive_failures,
+                        );
+                        continue;
+                    }
                     client.populate_tx_cache(
                         wallet.wallet.tx_graph().full_txs().map(|tx_node| tx_node.tx),
                     );
-                    wallet.wallet.start_sync_with_revealed_spks()
+                    wallet
+                        .wallet
+                        .start_sync_with_revealed_spks_at(sync_started_at)
                 };
 
                 let sync_client = Arc::clone(&client);

--- a/crates/cdk-bdk/src/chain/esplora.rs
+++ b/crates/cdk-bdk/src/chain/esplora.rs
@@ -79,10 +79,63 @@ pub(crate) async fn sync_esplora(
                     }
                 };
 
-                // Phase A (short lock): build the sync request.
+                // Phase A (short lock): refresh durable Broadcast reservations
+                // and build the sync request atomically. BDK marks transactions
+                // missing from the backend as evicted at `sync_started_at`, so
+                // reservations must be strictly newer than that timestamp.
+                let reservations = match cdk_bdk.load_broadcast_reservations().await {
+                    Ok(reservations) => reservations,
+                    Err(err) => {
+                        consecutive_failures = consecutive_failures.saturating_add(1);
+                        crate::sync::log_sync_failure(
+                            "Failed to load Broadcast transactions for Esplora sync",
+                            &err,
+                            consecutive_failures,
+                        );
+                        continue;
+                    }
+                };
                 let sync_request = {
-                    let w = cdk_bdk.wallet_with_db.lock().await;
-                    w.wallet.start_sync_with_revealed_spks()
+                    let sync_started_at = crate::util::unix_now();
+                    let Some(reservation_time) = sync_started_at.checked_add(1) else {
+                        let err = Error::Wallet(
+                            "Cannot construct Esplora sync request at maximum timestamp"
+                                .to_string(),
+                        );
+                        consecutive_failures = consecutive_failures.saturating_add(1);
+                        crate::sync::log_sync_failure(
+                            "Failed to reserve Broadcast transactions for Esplora sync",
+                            &err,
+                            consecutive_failures,
+                        );
+                        continue;
+                    };
+                    let mut w = cdk_bdk.wallet_with_db.lock().await;
+                    if let Err(err) = CdkBdk::reserve_broadcast_transactions_locked(
+                        &mut w.wallet,
+                        &reservations,
+                        reservation_time,
+                    ) {
+                        consecutive_failures = consecutive_failures.saturating_add(1);
+                        crate::sync::log_sync_failure(
+                            "Failed to reserve Broadcast transactions for Esplora sync",
+                            &err,
+                            consecutive_failures,
+                        );
+                        continue;
+                    }
+                    if let Err(err) = w.persist() {
+                        let err = Error::Database(err);
+                        consecutive_failures = consecutive_failures.saturating_add(1);
+                        crate::sync::log_sync_failure(
+                            "Failed to persist Broadcast reservations for Esplora sync",
+                            &err,
+                            consecutive_failures,
+                        );
+                        continue;
+                    }
+                    w.wallet
+                        .start_sync_with_revealed_spks_at(sync_started_at)
                 };
 
                 // Phase B (no lock): execute the network sync.

--- a/crates/cdk-bdk/src/error.rs
+++ b/crates/cdk-bdk/src/error.rs
@@ -139,6 +139,30 @@ pub enum Error {
     #[error("Send intent already exists for quote id: {0}")]
     DuplicateQuoteId(String),
 
+    /// Send intent state changed concurrently; the transition was rejected
+    ///
+    /// The durable record no longer matches the state the caller expected,
+    /// meaning another worker advanced or rewound it. No write was performed.
+    #[error("Send intent {intent_id} is no longer in expected state {expected}")]
+    SendIntentStateConflict {
+        /// Intent whose durable state changed under the caller
+        intent_id: Uuid,
+        /// State the transition expected to find
+        expected: &'static str,
+    },
+
+    /// Send batch state changed concurrently; the transition was rejected
+    ///
+    /// The durable record no longer matches the state the caller expected,
+    /// meaning another worker advanced or removed it. No write was performed.
+    #[error("Send batch {batch_id} is no longer in expected state {expected}")]
+    SendBatchStateConflict {
+        /// Batch whose durable state changed under the caller
+        batch_id: Uuid,
+        /// State the transition expected to find
+        expected: &'static str,
+    },
+
     /// Batch fee exceeds the combined max fee of all included intents
     #[error("Batch fee {actual_fee} exceeds combined max fee {max_fee}")]
     BatchFeeTooHigh {

--- a/crates/cdk-bdk/src/lib.rs
+++ b/crates/cdk-bdk/src/lib.rs
@@ -51,6 +51,8 @@ pub(crate) mod recovery;
 pub mod send;
 pub mod storage;
 pub(crate) mod sync;
+#[cfg(test)]
+pub(crate) mod testutil;
 pub mod types;
 pub(crate) mod util;
 pub mod wallet_info;
@@ -855,6 +857,22 @@ impl MintPayment for CdkBdk {
 
         // 1. Check active intents
         if let Some(record) = self.storage.get_send_intent_by_quote_id(&quote_id).await? {
+            let has_broadcast_evidence =
+                self.storage
+                    .get_all_send_batches()
+                    .await?
+                    .iter()
+                    .any(|batch| {
+                        matches!(
+                            &batch.state,
+                            crate::send::batch_transaction::record::SendBatchState::Broadcast {
+                                assignments,
+                                ..
+                            } if assignments
+                                .iter()
+                                .any(|assignment| assignment.intent_id == record.intent_id)
+                        )
+                    });
             // `total_spent` is the actual amount spent (amount + fee) and is
             // only reported once the payment has been made. Before the batch
             // transaction has been built, the per-intent fee contribution is
@@ -879,6 +897,14 @@ impl MintPayment for CdkBdk {
                 | crate::send::payment_intent::record::SendIntentState::AwaitingConfirmation {
                     ..
                 } => MeltQuoteState::Pending,
+                crate::send::payment_intent::record::SendIntentState::Failed { .. }
+                    if has_broadcast_evidence =>
+                {
+                    // A durable Broadcast transaction may already have reached
+                    // the network. Never authorize proof compensation merely
+                    // because a stale worker left the current intent Failed.
+                    MeltQuoteState::Pending
+                }
                 crate::send::payment_intent::record::SendIntentState::Failed { .. } => {
                     MeltQuoteState::Failed
                 }
@@ -1455,6 +1481,7 @@ mod tests {
                 .create_send_intent_if_absent(
                     &crate::send::payment_intent::record::SendIntentRecord {
                         intent_id: *intent_id,
+                        attempt_id: Uuid::new_v4(),
                         quote_id: quote_id.to_string(),
                         address: address.to_string(),
                         amount_sat: *amount_sat,
@@ -1518,10 +1545,16 @@ mod tests {
         assert_eq!(transactions.items[0].received_sat, 11_900);
 
         for (intent_id, quote_id, _, amount_sat, vout) in &intents {
+            let expected = backend
+                .storage
+                .get_send_intent(intent_id)
+                .await
+                .expect("read send intent")
+                .expect("send intent exists");
             backend
                 .storage
                 .finalize_send_intent(
-                    intent_id,
+                    &expected,
                     &FinalizedSendIntentRecord {
                         intent_id: *intent_id,
                         quote_id: quote_id.to_string(),
@@ -2345,8 +2378,11 @@ mod tests {
         .await
         .expect("create Pending send intent");
 
+        let batch_id = Uuid::new_v4();
+        crate::testutil::store_test_signed_batch(&backend.storage, batch_id, &[pending.intent_id])
+            .await;
         pending
-            .assign_to_batch(&backend.storage, Uuid::new_v4())
+            .assign_to_batch(&backend.storage, batch_id)
             .await
             .expect("transition Pending → Batched");
 
@@ -2390,8 +2426,11 @@ mod tests {
         .await
         .expect("create Pending send intent");
 
+        let batch_id = Uuid::new_v4();
+        crate::testutil::store_test_signed_batch(&backend.storage, batch_id, &[pending.intent_id])
+            .await;
         let batched = pending
-            .assign_to_batch(&backend.storage, Uuid::new_v4())
+            .assign_to_batch(&backend.storage, batch_id)
             .await
             .expect("transition Pending → Batched");
 
@@ -2455,6 +2494,75 @@ mod tests {
         assert_eq!(response.status, MeltQuoteState::Failed);
         assert_eq!(response.total_spent, Amount::new(0, CurrencyUnit::Sat));
         assert_eq!(response.payment_proof, None);
+    }
+
+    #[tokio::test]
+    async fn durable_broadcast_fences_failed_intent_and_retry() {
+        use crate::send::batch_transaction::record::{
+            BatchOutputAssignment, SendBatchRecord, SendBatchState,
+        };
+        use crate::send::payment_intent::SendIntent;
+        use crate::types::{PaymentMetadata, PaymentTier};
+
+        let backend = build_test_instance(5).await;
+        let quote_id = QuoteId::UUID(Uuid::new_v4());
+        let pending = SendIntent::new(
+            &backend.storage,
+            quote_id.to_string(),
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            30_000,
+            2_000,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("create Pending send intent");
+        let intent_id = pending.intent_id;
+        let attempt_id = pending.attempt_id;
+        pending
+            .fail(&backend.storage, "stale failure".to_string())
+            .await
+            .expect("transition Pending to Failed");
+
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id: Uuid::new_v4(),
+                state: SendBatchState::Broadcast {
+                    txid: Txid::all_zeros().to_string(),
+                    tx_bytes: vec![0x01],
+                    assignments: vec![BatchOutputAssignment {
+                        intent_id,
+                        attempt_id,
+                        vout: 0,
+                        fee_contribution_sat: 500,
+                    }],
+                    fee_sat: 500,
+                },
+            })
+            .await
+            .expect("store Broadcast evidence");
+
+        let response = backend
+            .check_outgoing_payment(&PaymentIdentifier::QuoteId(quote_id.clone()))
+            .await
+            .expect("check fenced intent");
+        assert_eq!(response.status, MeltQuoteState::Pending);
+
+        let retry = SendIntent::new(
+            &backend.storage,
+            quote_id.to_string(),
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            30_000,
+            2_000,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await;
+        assert!(matches!(
+            retry,
+            Err(Error::SendIntentStateConflict { intent_id: id, .. }) if id == intent_id
+        ));
     }
 
     #[tokio::test]

--- a/crates/cdk-bdk/src/recovery.rs
+++ b/crates/cdk-bdk/src/recovery.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
 
-use bdk_wallet::bitcoin::{OutPoint, Transaction};
+use bdk_wallet::bitcoin::{Address, OutPoint, Transaction};
 use uuid::Uuid;
 
 use crate::chain::BroadcastOutcome;
@@ -23,6 +24,7 @@ fn batch_intent_ids(batch_state: &SendBatchState) -> Vec<Uuid> {
     match batch_state {
         SendBatchState::Built { intent_ids, .. } => intent_ids.clone(),
         SendBatchState::Signed { assignments, .. }
+        | SendBatchState::Cancelled { assignments, .. }
         | SendBatchState::Broadcast { assignments, .. } => {
             assignments.iter().map(|a| a.intent_id).collect()
         }
@@ -45,14 +47,214 @@ async fn load_batch_intents(
 }
 
 impl CdkBdk {
-    async fn apply_recovered_send_tx(&self, batch_id: Uuid, context: &str, tx: &Transaction) {
-        let txid = tx.compute_txid();
-        let apply_time = crate::util::unix_now();
-        let mut wallet_with_db = self.wallet_with_db.lock().await;
+    async fn cancel_invalid_signed_send_batch(
+        &self,
+        batch_id: Uuid,
+        tx_bytes: &[u8],
+        assignments: &[BatchOutputAssignment],
+        fee_sat: u64,
+    ) -> Result<(), Error> {
+        tracing::error!(%batch_id, "Cancelling Signed batch with invalid assignments");
+        let evict_at = crate::util::unix_now().saturating_add(1);
+        if !self
+            .cancel_signed_send_batch(batch_id, tx_bytes, assignments, fee_sat, evict_at)
+            .await?
+        {
+            tracing::info!(
+                %batch_id,
+                "Signed batch changed concurrently before invalid-assignment cancellation"
+            );
+        }
+        Ok(())
+    }
 
+    /// Durably cancel a signed batch, then complete its wallet and intent
+    /// compensation. Returns `false` if another worker changed the batch from
+    /// `Signed` before cancellation won the compare-and-set.
+    pub(crate) async fn cancel_signed_send_batch(
+        &self,
+        batch_id: Uuid,
+        tx_bytes: &[u8],
+        assignments: &[BatchOutputAssignment],
+        fee_sat: u64,
+        evict_at: u64,
+    ) -> Result<bool, Error> {
+        let signed_state = SendBatchState::Signed {
+            tx_bytes: tx_bytes.to_vec(),
+            assignments: assignments.to_vec(),
+            fee_sat,
+        };
+        let cancelled_state = SendBatchState::Cancelled {
+            tx_bytes: tx_bytes.to_vec(),
+            assignments: assignments.to_vec(),
+            fee_sat,
+            evict_at,
+        };
+
+        if self
+            .storage
+            .transition_send_batch(&batch_id, &signed_state, &cancelled_state)
+            .await?
+        {
+            self.finish_cancelled_send_batch(batch_id, &cancelled_state)
+                .await?;
+            return Ok(true);
+        }
+
+        // Another recovery worker may already have won the cancellation.
+        // Help finish its durable state rather than leaving compensation for
+        // another process restart.
+        let Some(current) = self.storage.get_send_batch(&batch_id).await? else {
+            return Ok(true);
+        };
+        if matches!(current.state, SendBatchState::Cancelled { .. }) {
+            self.finish_cancelled_send_batch(batch_id, &current.state)
+                .await?;
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    /// Finish a durable cancellation idempotently.
+    pub(crate) async fn finish_cancelled_send_batch(
+        &self,
+        batch_id: Uuid,
+        cancelled_state: &SendBatchState,
+    ) -> Result<(), Error> {
+        let SendBatchState::Cancelled {
+            tx_bytes,
+            assignments,
+            evict_at,
+            ..
+        } = cancelled_state
+        else {
+            return Err(Error::SendBatchStateConflict {
+                batch_id,
+                expected: "Cancelled",
+            });
+        };
+
+        let tx = bdk_wallet::bitcoin::consensus::deserialize::<Transaction>(tx_bytes)
+            .map_err(|err| Error::Wallet(err.to_string()))?;
+        let txid = tx.compute_txid();
+        let mut wallet_with_db = self.wallet_with_db.lock().await;
+        let last_seen = match wallet_with_db.wallet.get_tx(txid) {
+            Some(wallet_tx) => match wallet_tx.chain_position {
+                bdk_wallet::chain::ChainPosition::Confirmed { .. } => {
+                    return Err(Error::Wallet(format!(
+                        "Cannot cancel confirmed send-batch transaction {txid}"
+                    )));
+                }
+                bdk_wallet::chain::ChainPosition::Unconfirmed { last_seen, .. } => last_seen,
+            },
+            None => None,
+        };
+        let mut effective_evict_at = (*evict_at).max(crate::util::unix_now());
+        for timestamp in [
+            last_seen,
+            wallet_with_db.wallet.tx_graph().get_last_evicted(txid),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            effective_evict_at =
+                effective_evict_at.max(timestamp.checked_add(1).ok_or_else(|| {
+                    Error::Wallet(format!(
+                        "Cannot evict send-batch transaction {txid} after maximum timestamp"
+                    ))
+                })?);
+        }
         wallet_with_db
             .wallet
-            .apply_unconfirmed_txs([(tx.clone(), apply_time)]);
+            .apply_evicted_txs([(txid, effective_evict_at)]);
+        if wallet_with_db.wallet.get_tx(txid).is_some() {
+            return Err(Error::Wallet(format!(
+                "Send-batch transaction {txid} remained canonical after eviction"
+            )));
+        }
+        wallet_with_db.persist().map_err(Error::Database)?;
+        drop(wallet_with_db);
+
+        for assignment in assignments {
+            let Some(record) = self.storage.get_send_intent(&assignment.intent_id).await? else {
+                continue;
+            };
+            if assignment.attempt_id.is_nil() || record.attempt_id != assignment.attempt_id {
+                tracing::warn!(
+                    batch_id = %batch_id,
+                    intent_id = %assignment.intent_id,
+                    assignment_attempt_id = %assignment.attempt_id,
+                    current_attempt_id = %record.attempt_id,
+                    "Skipping cancellation compensation for an unbound or replacement send attempt"
+                );
+                continue;
+            }
+            if let SendIntentAny::Batched(intent) = payment_intent::from_record(&record) {
+                if intent.state.batch_id == batch_id {
+                    intent.revert_to_pending(&self.storage).await?;
+                }
+            }
+        }
+
+        let deleted = self
+            .storage
+            .delete_send_batch_if_state(&batch_id, cancelled_state)
+            .await?;
+        if !deleted {
+            tracing::info!(
+                batch_id = %batch_id,
+                "Cancelled batch was already cleaned up by another worker"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Retry every durable cancellation without letting one broken batch
+    /// prevent later batches from making progress.
+    pub(crate) async fn resume_cancelled_send_batches(&self) -> Result<(), Error> {
+        let batches = self.storage.get_all_send_batches().await?;
+
+        for batch in batches {
+            if !matches!(batch.state, SendBatchState::Cancelled { .. }) {
+                continue;
+            }
+
+            if let Err(err) = self
+                .finish_cancelled_send_batch(batch.batch_id, &batch.state)
+                .await
+            {
+                tracing::warn!(
+                    batch_id = %batch.batch_id,
+                    error = %err,
+                    "Could not finish durable send-batch cancellation; retrying next cycle"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn apply_recovered_send_tx(
+        &self,
+        batch_id: Uuid,
+        context: &str,
+        tx: &Transaction,
+    ) -> bool {
+        let txid = tx.compute_txid();
+        let mut wallet_with_db = self.wallet_with_db.lock().await;
+
+        if let Err(err) =
+            crate::send::service::reserve_unconfirmed_tx(&mut wallet_with_db.wallet, tx)
+        {
+            tracing::error!(
+                batch_id = %batch_id,
+                txid = %txid,
+                "{context}: could not reserve recovered transaction: {err}"
+            );
+            return false;
+        }
 
         if let Err(err) = wallet_with_db.persist() {
             tracing::warn!(
@@ -61,6 +263,70 @@ impl CdkBdk {
                 "{context}: could not persist BDK wallet after applying recovered tx: {err}"
             );
         }
+        true
+    }
+
+    /// Fence and reserve a recovered Broadcast transaction in one local wallet
+    /// critical section. The durable validation immediately precedes the BDK
+    /// mutation, so no local batch can select the inputs between those steps.
+    async fn prepare_recovered_broadcast_tx(
+        &self,
+        batch_id: Uuid,
+        state: &SendBatchState,
+    ) -> Result<Option<Transaction>, Error> {
+        let reservation = crate::send::service::decode_broadcast_reservation(&batch_id, state);
+        let eligible = self.prepare_broadcast_batch(batch_id, state).await?;
+        let Some((_reservation_batch_id, _txid, reservation_tx)) = reservation else {
+            return Ok(None);
+        };
+        let mut wallet_with_db = self.wallet_with_db.lock().await;
+        if let Err(err) = crate::send::service::reserve_unconfirmed_tx(
+            &mut wallet_with_db.wallet,
+            &reservation_tx,
+        ) {
+            tracing::error!(
+                %batch_id,
+                txid = %reservation_tx.compute_txid(),
+                error = %err,
+                "Broadcast recovery could not reserve fenced transaction"
+            );
+            return Ok(None);
+        }
+        if let Err(err) = wallet_with_db.persist() {
+            tracing::warn!(
+                %batch_id,
+                txid = %reservation_tx.compute_txid(),
+                error = %err,
+                "Could not persist BDK wallet after reserving recovered Broadcast transaction"
+            );
+        }
+        Ok(eligible.map(|(_, tx)| tx))
+    }
+
+    /// Check durable Broadcast evidence immediately before a Signed batch is
+    /// promoted. A transaction already claiming any member intent wins the
+    /// safety fence, regardless of whether that Broadcast record is eligible
+    /// for network rebroadcast.
+    async fn signed_batch_has_broadcast_conflict(
+        &self,
+        signed_batch_id: Uuid,
+        assignments: &[BatchOutputAssignment],
+    ) -> Result<bool, Error> {
+        let intent_ids: HashSet<_> = assignments
+            .iter()
+            .map(|assignment| assignment.intent_id)
+            .collect();
+        let batches = self.storage.get_all_send_batches().await?;
+        Ok(batches.into_iter().any(|batch| {
+            batch.batch_id != signed_batch_id
+                && matches!(
+                    batch.state,
+                    SendBatchState::Broadcast { assignments, .. }
+                        if assignments
+                            .iter()
+                            .any(|assignment| intent_ids.contains(&assignment.intent_id))
+                )
+        }))
     }
 
     fn log_batch_recovery_invariants(
@@ -263,6 +529,98 @@ impl CdkBdk {
                             }
                         };
 
+                    let unique_intent_ids: HashSet<_> = assignments
+                        .iter()
+                        .map(|assignment| assignment.intent_id)
+                        .collect();
+                    let unique_vouts: HashSet<_> = assignments
+                        .iter()
+                        .map(|assignment| assignment.vout)
+                        .collect();
+                    let allocated_fee = assignments.iter().try_fold(0_u64, |total, assignment| {
+                        total.checked_add(assignment.fee_contribution_sat)
+                    });
+                    if assignments.is_empty()
+                        || unique_intent_ids.len() != assignments.len()
+                        || unique_vouts.len() != assignments.len()
+                        || allocated_fee != Some(fee_sat)
+                    {
+                        self.cancel_invalid_signed_send_batch(
+                            batch_record.batch_id,
+                            &tx_bytes,
+                            &assignments,
+                            fee_sat,
+                        )
+                        .await?;
+                        continue;
+                    }
+
+                    if self
+                        .signed_batch_has_broadcast_conflict(batch_record.batch_id, &assignments)
+                        .await?
+                    {
+                        tracing::error!(
+                            batch_id = %batch_record.batch_id,
+                            "Cancelling Signed batch because another durable Broadcast batch references one of its intents"
+                        );
+                        self.cancel_invalid_signed_send_batch(
+                            batch_record.batch_id,
+                            &tx_bytes,
+                            &assignments,
+                            fee_sat,
+                        )
+                        .await?;
+                        continue;
+                    }
+
+                    let mut assignments_match_intents = true;
+                    for assignment in &assignments {
+                        let Some(record) =
+                            self.storage.get_send_intent(&assignment.intent_id).await?
+                        else {
+                            assignments_match_intents = false;
+                            break;
+                        };
+                        let state_matches = match &record.state {
+                            SendIntentState::Pending { .. } => true,
+                            SendIntentState::Batched { batch_id, .. } => {
+                                *batch_id == batch_record.batch_id
+                            }
+                            SendIntentState::AwaitingConfirmation { .. }
+                            | SendIntentState::Failed { .. } => false,
+                        };
+                        let output = usize::try_from(assignment.vout)
+                            .ok()
+                            .and_then(|vout| tx.output.get(vout));
+                        let address = Address::from_str(&record.address)
+                            .ok()
+                            .and_then(|address| address.require_network(self.network).ok());
+                        if assignment.attempt_id.is_nil()
+                            || record.attempt_id != assignment.attempt_id
+                            || !state_matches
+                            || assignment.fee_contribution_sat > record.max_fee_amount_sat
+                            || output.is_none_or(|output| {
+                                output.value.to_sat() != record.amount_sat
+                                    || address.as_ref().is_none_or(|address| {
+                                        output.script_pubkey != address.script_pubkey()
+                                    })
+                            })
+                        {
+                            assignments_match_intents = false;
+                            break;
+                        }
+                    }
+                    if !assignments_match_intents {
+                        self.cancel_invalid_signed_send_batch(
+                            batch_record.batch_id,
+                            &tx_bytes,
+                            &assignments,
+                            fee_sat,
+                        )
+                        .await?;
+                        continue;
+                    }
+
                     let expected_intent_count = assignments.len();
                     let mut batched_intents = Vec::new();
                     let mut abort_recovery = false;
@@ -271,6 +629,20 @@ impl CdkBdk {
                         let id = assignment.intent_id;
                         let record = self.storage.get_send_intent(&id).await?;
                         match record {
+                            Some(record)
+                                if assignment.attempt_id.is_nil()
+                                    || record.attempt_id != assignment.attempt_id =>
+                            {
+                                tracing::error!(
+                                    batch_id = %batch_record.batch_id,
+                                    intent_id = %id,
+                                    assignment_attempt_id = %assignment.attempt_id,
+                                    current_attempt_id = %record.attempt_id,
+                                    "Signed batch recovery aborted because a member is unbound or a replacement attempt"
+                                );
+                                abort_recovery = true;
+                                break;
+                            }
                             Some(record) => match payment_intent::from_record(&record) {
                                 SendIntentAny::Batched(intent)
                                     if intent.state.batch_id == batch_record.batch_id =>
@@ -343,9 +715,25 @@ impl CdkBdk {
 
                     if abort_recovery || batched_intents.len() != expected_intent_count {
                         tracing::error!(
-                            "Signed batch {} recovery aborted because not all members are recoverable",
+                            "Cancelling signed batch {} because not all members are recoverable",
                             batch_record.batch_id
                         );
+                        let evict_at = crate::util::unix_now().saturating_add(1);
+                        if !self
+                            .cancel_signed_send_batch(
+                                batch_record.batch_id,
+                                &tx_bytes,
+                                &assignments,
+                                fee_sat,
+                                evict_at,
+                            )
+                            .await?
+                        {
+                            tracing::info!(
+                                batch_id = %batch_record.batch_id,
+                                "Signed batch changed concurrently before recovery cancellation"
+                            );
+                        }
                         continue;
                     }
 
@@ -357,6 +745,28 @@ impl CdkBdk {
                     >::reconstruct(
                         batch_record.batch_id, batched_intents
                     );
+
+                    // Re-read immediately before promotion, after any Pending
+                    // member repairs, so a concurrent durable Broadcast cannot
+                    // be followed by a second network transaction.
+                    if self
+                        .signed_batch_has_broadcast_conflict(batch_record.batch_id, &assignments)
+                        .await?
+                    {
+                        tracing::error!(
+                            batch_id = %batch_record.batch_id,
+                            "Cancelling Signed batch after a concurrent Broadcast claim"
+                        );
+                        self.cancel_signed_send_batch(
+                            batch_record.batch_id,
+                            &tx_bytes,
+                            &assignments,
+                            fee_sat,
+                            crate::util::unix_now().saturating_add(1),
+                        )
+                        .await?;
+                        continue;
+                    }
 
                     let broadcast_result = match signed_batch
                         .mark_broadcast(
@@ -431,12 +841,16 @@ impl CdkBdk {
                         txid_str
                     );
 
-                    self.apply_recovered_send_tx(
-                        batch_record.batch_id,
-                        "Signed batch recovery",
-                        &tx,
-                    )
-                    .await;
+                    if !self
+                        .apply_recovered_send_tx(
+                            batch_record.batch_id,
+                            "Signed batch recovery",
+                            &tx,
+                        )
+                        .await
+                    {
+                        continue;
+                    }
 
                     match self.broadcast_transaction_internal(tx).await {
                         Ok(BroadcastOutcome::Accepted) => {}
@@ -457,35 +871,44 @@ impl CdkBdk {
                         }
                     }
                 }
-                SendBatchState::Broadcast { txid, tx_bytes, .. } => {
-                    if let Ok(tx) =
-                        bdk_wallet::bitcoin::consensus::deserialize::<Transaction>(&tx_bytes)
+                state @ SendBatchState::Cancelled { .. } => {
+                    if let Err(err) = self
+                        .finish_cancelled_send_batch(batch_record.batch_id, &state)
+                        .await
                     {
-                        // Broadcast state is persisted before the network send,
-                        // so recovery intentionally retries rebroadcast here if a
-                        // crash happened after persistence but before backend
-                        // acceptance was observed.
-                        tracing::info!("Re-broadcasting batch {} during recovery", txid);
-                        self.apply_recovered_send_tx(
-                            batch_record.batch_id,
-                            "Broadcast batch recovery",
-                            &tx,
-                        )
-                        .await;
+                        tracing::warn!(
+                            batch_id = %batch_record.batch_id,
+                            error = %err,
+                            "Could not finish durable send-batch cancellation during recovery; continuing"
+                        );
+                        continue;
+                    }
+                }
+                state @ SendBatchState::Broadcast { .. } => {
+                    // A durable Broadcast marker is necessary but not sufficient
+                    // authority for network I/O. Repair exact Batched members and
+                    // fence corrupt, failed, or replacement attempts first.
+                    let Some(tx) = self
+                        .prepare_recovered_broadcast_tx(batch_record.batch_id, &state)
+                        .await?
+                    else {
+                        continue;
+                    };
+                    let txid = tx.compute_txid();
+                    tracing::info!("Re-broadcasting batch {} during recovery", txid);
 
-                        match self.broadcast_transaction_internal(tx).await {
-                            Ok(BroadcastOutcome::Accepted) => {}
-                            Ok(BroadcastOutcome::AlreadyKnown) => {
-                                tracing::info!("Recovery rebroadcast tx {} already known", txid);
-                            }
-                            Err(failure) => {
-                                self.log_broadcast_failure(
-                                    "Broadcast batch recovery rebroadcast failed",
-                                    batch_record.batch_id,
-                                    &txid,
-                                    &failure,
-                                );
-                            }
+                    match self.broadcast_transaction_internal(tx).await {
+                        Ok(BroadcastOutcome::Accepted) => {}
+                        Ok(BroadcastOutcome::AlreadyKnown) => {
+                            tracing::info!("Recovery rebroadcast tx {} already known", txid);
+                        }
+                        Err(failure) => {
+                            self.log_broadcast_failure(
+                                "Broadcast batch recovery rebroadcast failed",
+                                batch_record.batch_id,
+                                &txid.to_string(),
+                                &failure,
+                            );
                         }
                     }
                 }
@@ -506,6 +929,14 @@ impl CdkBdk {
                     if let Some(batch) = batch {
                         let batch_intent_ids = batch_intent_ids(&batch.state);
                         if !batch_intent_ids.contains(&intent_id) {
+                            if matches!(batch.state, SendBatchState::Broadcast { .. }) {
+                                tracing::error!(
+                                    batch_id = %batch.batch_id,
+                                    intent_id = %intent_id,
+                                    "Retaining mismatched Broadcast intent as recovery evidence"
+                                );
+                                continue;
+                            }
                             tracing::warn!(
                                 batch_id = %batch.batch_id,
                                 intent_id = %intent_id,
@@ -521,73 +952,15 @@ impl CdkBdk {
                             continue;
                         }
 
-                        if let SendBatchState::Broadcast {
-                            txid: recorded_txid,
-                            tx_bytes,
-                            assignments,
-                            ..
-                        } = &batch.state
-                        {
-                            // Use the persisted assignment to attribute the
-                            // correct vout and fee. Re-deriving from tx outputs
-                            // here would be ambiguous when two intents in the
-                            // same batch share (address, amount).
-                            let Some(assignment) =
-                                assignments.iter().find(|a| a.intent_id == intent_id)
-                            else {
-                                tracing::error!(
-                                    batch_id = %batch.batch_id,
-                                    intent_id = %intent_id,
-                                    "Broadcast batch has no output assignment for orphan intent during recovery; skipping"
-                                );
-                                continue;
-                            };
-
-                            // Compute the txid from the persisted bytes so we
-                            // do not trust the record's txid field blindly.
-                            let computed_txid = match bdk_wallet::bitcoin::consensus::deserialize::<
-                                Transaction,
-                            >(tx_bytes)
-                            {
-                                Ok(tx) => tx.compute_txid(),
-                                Err(err) => {
-                                    tracing::error!(
-                                        batch_id = %batch.batch_id,
-                                        intent_id = %intent_id,
-                                        error = %err,
-                                        "Failed to deserialize broadcast batch tx during orphan repair"
-                                    );
-                                    continue;
-                                }
-                            };
-                            let computed_txid_str = computed_txid.to_string();
-                            if recorded_txid != &computed_txid_str {
-                                tracing::warn!(
-                                    batch_id = %batch.batch_id,
-                                    intent_id = %intent_id,
-                                    recorded_txid = %recorded_txid,
-                                    computed_txid = %computed_txid_str,
-                                    "Broadcast batch txid differs from persisted tx bytes during orphan repair"
-                                );
-                            }
-                            let outpoint =
-                                OutPoint::new(computed_txid, assignment.vout).to_string();
-
-                            if let Err(e) = intent
-                                .mark_broadcast(
-                                    &self.storage,
-                                    computed_txid_str,
-                                    outpoint,
-                                    assignment.fee_contribution_sat,
-                                )
-                                .await
-                            {
-                                tracing::error!(
-                                    "Failed to repair broadcast intent {} during recovery: {}",
-                                    intent_id,
-                                    e
-                                );
-                            }
+                        if matches!(batch.state, SendBatchState::Broadcast { .. }) {
+                            // Phase 1 repairs only a fully valid Broadcast batch
+                            // before network I/O. A Batched member still present
+                            // here was fenced; do not rewind it into eligibility.
+                            tracing::error!(
+                                batch_id = %batch.batch_id,
+                                intent_id = %intent_id,
+                                "Leaving fenced Broadcast member unchanged for operator recovery"
+                            );
                         }
                     } else {
                         tracing::info!(
@@ -646,20 +1019,17 @@ mod tests {
     use bdk_wallet::bitcoin::hashes::Hash as _;
     use bdk_wallet::bitcoin::transaction::Version;
     use bdk_wallet::bitcoin::{
-        consensus, Amount as BtcAmount, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn,
-        TxOut, Txid, Witness,
+        consensus, Amount as BtcAmount, OutPoint, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
     };
-    use bdk_wallet::keys::bip39::Mnemonic;
     use bdk_wallet::KeychainKind;
-    use cdk_common::common::FeeReserve;
-    use cdk_common::{Amount, CurrencyUnit};
 
     use super::*;
     use crate::send::batch_transaction::record::{
         BatchOutputAssignment, SendBatchRecord, SendBatchState,
     };
+    use crate::send::payment_intent::SendIntent;
+    use crate::testutil::{store_test_signed_batch, GatedKvStore, PausePoint, ReadPath};
     use crate::types::{PaymentMetadata, PaymentTier};
-    use crate::{ChainSource, EsploraConfig};
 
     const TEST_TXID: &str = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -668,51 +1038,23 @@ mod tests {
     /// BDK wallet is empty, which means `txid_has_required_confirmations`
     /// always returns `false` for any txid we ask about.
     async fn build_test_instance() -> CdkBdk {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        // Leak the tempdir so it outlives the test — CdkBdk opens a
-        // sqlite file under it and we don't want the path disappearing
-        // while recovery is running.
-        let path = tmp.keep();
-        let mnemonic = Mnemonic::from_str(
-            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-        )
-        .expect("mnemonic");
-
         let kv = cdk_sqlite::mint::memory::empty()
             .await
             .expect("in-memory kv store");
+        build_test_instance_with_kv(Arc::new(kv)).await
+    }
 
-        let chain_source = ChainSource::Esplora(EsploraConfig {
-            url: "http://127.0.0.1:1".to_string(),
-            parallel_requests: 1,
-        });
-
-        let fee_reserve = FeeReserve {
-            min_fee_reserve: Amount::new(1, CurrencyUnit::Sat).into(),
-            percent_fee_reserve: 0.02,
-        };
-
-        CdkBdk::new(
-            mnemonic,
-            Network::Regtest,
-            chain_source,
-            path.to_string_lossy().into_owned(),
-            fee_reserve,
-            Arc::new(kv),
-            None,
-            1,
-            0,
-            546,
-            60,
-            Some(5),
-            None,
-        )
-        .expect("build CdkBdk test instance")
+    /// Build a `CdkBdk` test instance backed by the given KV store.
+    async fn build_test_instance_with_kv(
+        kv: Arc<dyn cdk_common::database::KVStore<Err = cdk_common::database::Error> + Send + Sync>,
+    ) -> CdkBdk {
+        crate::testutil::build_test_backend(kv, None).await
     }
 
     fn awaiting_intent(intent_id: Uuid, batch_id: Uuid, quote_id: &str) -> SendIntentRecord {
         SendIntentRecord {
             intent_id,
+            attempt_id: intent_id,
             quote_id: quote_id.to_string(),
             address: "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
             amount_sat: 25_000,
@@ -732,6 +1074,7 @@ mod tests {
     fn pending_intent(intent_id: Uuid, quote_id: &str) -> SendIntentRecord {
         SendIntentRecord {
             intent_id,
+            attempt_id: intent_id,
             quote_id: quote_id.to_string(),
             address: "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
             amount_sat: 25_000,
@@ -745,6 +1088,11 @@ mod tests {
     }
 
     async fn wallet_relevant_send_tx_bytes(backend: &CdkBdk) -> Vec<u8> {
+        let recipient_script = Address::from_str("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080")
+            .expect("valid test address")
+            .require_network(backend.network)
+            .expect("test address matches backend network")
+            .script_pubkey();
         let mut wallet_with_db = backend.wallet_with_db.lock().await;
         let funding_script = wallet_with_db
             .wallet
@@ -783,7 +1131,7 @@ mod tests {
             }],
             output: vec![TxOut {
                 value: BtcAmount::from_sat(25_000),
-                script_pubkey: ScriptBuf::new(),
+                script_pubkey: recipient_script,
             }],
         };
 
@@ -819,6 +1167,15 @@ mod tests {
         assert!(
             wallet_with_db.wallet.get_tx(parsed_txid).is_some(),
             "recovered transaction must be applied to the BDK wallet graph"
+        );
+    }
+
+    async fn assert_wallet_does_not_know_tx(backend: &CdkBdk, txid: &str) {
+        let parsed_txid = bdk_wallet::bitcoin::Txid::from_str(txid).expect("test txid must parse");
+        let wallet_with_db = backend.wallet_with_db.lock().await;
+        assert!(
+            wallet_with_db.wallet.get_tx(parsed_txid).is_none(),
+            "cancelled transaction must be evicted from the BDK wallet graph"
         );
     }
 
@@ -882,6 +1239,7 @@ mod tests {
                 tx_bytes: vec![0x01],
                 assignments: vec![BatchOutputAssignment {
                     intent_id: other_intent_id,
+                    attempt_id: other_intent_id,
                     vout: 0,
                     fee_contribution_sat: 500,
                 }],
@@ -924,6 +1282,7 @@ mod tests {
                 tx_bytes: vec![0x01],
                 assignments: vec![BatchOutputAssignment {
                     intent_id,
+                    attempt_id: intent_id,
                     vout: 0,
                     fee_contribution_sat: 500,
                 }],
@@ -971,6 +1330,7 @@ mod tests {
                     tx_bytes: tx_bytes.clone(),
                     assignments: vec![BatchOutputAssignment {
                         intent_id,
+                        attempt_id: intent_id,
                         vout: 0,
                         fee_contribution_sat: 500,
                     }],
@@ -1010,6 +1370,699 @@ mod tests {
         assert_wallet_knows_tx(&backend, &txid).await;
     }
 
+    #[tokio::test]
+    async fn signed_recovery_cancels_assignment_to_wrong_output() {
+        let backend = build_test_instance().await;
+        let intent_id = Uuid::new_v4();
+        let batch_id = Uuid::new_v4();
+        let valid_tx_bytes = wallet_relevant_send_tx_bytes(&backend).await;
+        let mut tx: Transaction = consensus::deserialize(&valid_tx_bytes).expect("valid tx");
+        tx.output[0].script_pubkey = Default::default();
+        let tx_bytes = consensus::serialize(&tx);
+
+        backend
+            .storage
+            .create_send_intent_if_absent(&pending_intent(intent_id, "quote-wrong-output"))
+            .await
+            .expect("store pending intent");
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Signed {
+                    tx_bytes,
+                    assignments: vec![BatchOutputAssignment {
+                        intent_id,
+                        attempt_id: intent_id,
+                        vout: 0,
+                        fee_contribution_sat: 500,
+                    }],
+                    fee_sat: 500,
+                },
+            })
+            .await
+            .expect("store signed batch");
+
+        backend
+            .recover_send_saga()
+            .await
+            .expect("invalid assignment should be compensated");
+
+        let intent = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("read intent")
+            .expect("intent remains active");
+        assert!(matches!(intent.state, SendIntentState::Pending { .. }));
+        assert!(
+            backend
+                .storage
+                .get_send_batch(&batch_id)
+                .await
+                .expect("read batch")
+                .is_none(),
+            "invalid Signed batch should be cancelled and removed"
+        );
+    }
+
+    /// A Signed batch belongs to the attempt that produced its transaction,
+    /// not merely to whichever retry currently reuses the same intent ID.
+    #[tokio::test]
+    async fn signed_recovery_rejects_replacement_attempt_with_same_intent_id() {
+        let backend = build_test_instance().await;
+        let batch_id = Uuid::new_v4();
+        let tx_bytes = wallet_relevant_send_tx_bytes(&backend).await;
+        let quote_id = "quote-signed-replacement".to_string();
+        let original = SendIntent::new(
+            &backend.storage,
+            quote_id.clone(),
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            25_000,
+            500,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("store original attempt");
+        let intent_id = original.intent_id;
+        let original_attempt_id = original.attempt_id;
+
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Signed {
+                    tx_bytes,
+                    assignments: vec![BatchOutputAssignment {
+                        intent_id,
+                        attempt_id: original_attempt_id,
+                        vout: 0,
+                        fee_contribution_sat: 500,
+                    }],
+                    fee_sat: 500,
+                },
+            })
+            .await
+            .expect("store original signed batch");
+
+        original
+            .fail(&backend.storage, "retry after signing crash".to_string())
+            .await
+            .expect("fail original attempt");
+        let replacement = SendIntent::new(
+            &backend.storage,
+            quote_id,
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            25_000,
+            750,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("store replacement attempt");
+        assert_eq!(replacement.intent_id, intent_id);
+        assert_ne!(replacement.attempt_id, original_attempt_id);
+        assert!(backend
+            .storage
+            .transition_send_intent(
+                &intent_id,
+                &replacement.attempt_id,
+                &SendIntentState::Pending {
+                    created_at: replacement.created_at,
+                },
+                &SendIntentState::Batched {
+                    batch_id,
+                    created_at: replacement.created_at,
+                },
+            )
+            .await
+            .expect("persist replacement as Batched"));
+
+        backend
+            .recover_send_saga()
+            .await
+            .expect("recover send saga");
+
+        let persisted = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get replacement")
+            .expect("replacement remains");
+        assert_eq!(persisted.attempt_id, replacement.attempt_id);
+        assert!(matches!(persisted.state, SendIntentState::Pending { .. }));
+        assert!(backend
+            .storage
+            .get_send_batch(&batch_id)
+            .await
+            .expect("get cancelled batch")
+            .is_none());
+    }
+
+    /// Legacy assignments remain readable, but their missing attempt binding
+    /// is not sufficient evidence to attach an intent to a signed transaction.
+    #[tokio::test]
+    async fn signed_recovery_cancels_legacy_unbound_assignment() {
+        let backend = build_test_instance().await;
+        let intent_id = Uuid::new_v4();
+        let batch_id = Uuid::new_v4();
+        let tx_bytes = wallet_relevant_send_tx_bytes(&backend).await;
+        let mut legacy_intent = pending_intent(intent_id, "quote-legacy-signed");
+        legacy_intent.attempt_id = Uuid::nil();
+        backend
+            .storage
+            .create_send_intent_if_absent(&legacy_intent)
+            .await
+            .expect("store legacy intent");
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Signed {
+                    tx_bytes,
+                    assignments: vec![BatchOutputAssignment {
+                        intent_id,
+                        attempt_id: Uuid::nil(),
+                        vout: 0,
+                        fee_contribution_sat: 500,
+                    }],
+                    fee_sat: 500,
+                },
+            })
+            .await
+            .expect("store legacy signed batch");
+
+        backend
+            .recover_send_saga()
+            .await
+            .expect("recover legacy signed batch");
+
+        let persisted = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get legacy intent")
+            .expect("legacy intent remains");
+        assert!(matches!(persisted.state, SendIntentState::Pending { .. }));
+        assert!(backend
+            .storage
+            .get_send_batch(&batch_id)
+            .await
+            .expect("get legacy batch")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn signed_recovery_cancels_duplicate_intent_assignments() {
+        let backend = build_test_instance().await;
+        let first_intent_id = Uuid::new_v4();
+        let second_intent_id = Uuid::new_v4();
+        let batch_id = Uuid::new_v4();
+        let tx_bytes = wallet_relevant_send_tx_bytes(&backend).await;
+
+        for (intent_id, quote_id) in [
+            (first_intent_id, "quote-duplicate-first"),
+            (second_intent_id, "quote-duplicate-second"),
+        ] {
+            backend
+                .storage
+                .create_send_intent_if_absent(&pending_intent(intent_id, quote_id))
+                .await
+                .expect("store pending intent");
+        }
+
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Signed {
+                    tx_bytes,
+                    assignments: vec![
+                        BatchOutputAssignment {
+                            intent_id: first_intent_id,
+                            attempt_id: first_intent_id,
+                            vout: 0,
+                            fee_contribution_sat: 500,
+                        },
+                        BatchOutputAssignment {
+                            intent_id: first_intent_id,
+                            attempt_id: first_intent_id,
+                            vout: 1,
+                            fee_contribution_sat: 500,
+                        },
+                    ],
+                    fee_sat: 1_000,
+                },
+            })
+            .await
+            .expect("store malformed signed batch");
+
+        tokio::time::timeout(Duration::from_secs(5), backend.recover_send_saga())
+            .await
+            .expect("recovery timed out")
+            .expect("recovery should reject malformed batch without failing startup");
+
+        for intent_id in [first_intent_id, second_intent_id] {
+            let intent = backend
+                .storage
+                .get_send_intent(&intent_id)
+                .await
+                .expect("read intent")
+                .expect("intent remains active");
+            assert!(matches!(intent.state, SendIntentState::Pending { .. }));
+        }
+
+        assert!(
+            backend
+                .storage
+                .get_send_batch(&batch_id)
+                .await
+                .expect("read batch")
+                .is_none(),
+            "malformed signed batch must be durably cancelled and cleaned up"
+        );
+    }
+
+    /// Recovery must finish a durable cancellation left behind by a crash
+    /// after the signed transaction entered the wallet graph. The wallet tx,
+    /// batch record, and `Batched` intent must all be compensated.
+    #[tokio::test]
+    async fn cancelled_recovery_evicts_wallet_tx_and_reverts_intent() {
+        let backend = build_test_instance().await;
+        let intent_id = Uuid::new_v4();
+        let batch_id = Uuid::new_v4();
+        let tx_bytes = wallet_relevant_send_tx_bytes(&backend).await;
+        let tx: Transaction = consensus::deserialize(&tx_bytes).expect("valid tx");
+        let txid = tx.compute_txid().to_string();
+        let apply_at = crate::util::unix_now();
+
+        {
+            let mut wallet_with_db = backend.wallet_with_db.lock().await;
+            wallet_with_db
+                .wallet
+                .apply_unconfirmed_txs([(tx, apply_at)]);
+            wallet_with_db.persist().expect("persist signed tx");
+        }
+        assert_wallet_knows_tx(&backend, &txid).await;
+
+        let mut intent = pending_intent(intent_id, "quote-cancelled-recovery");
+        intent.state = SendIntentState::Batched {
+            batch_id,
+            created_at: apply_at,
+        };
+        backend
+            .storage
+            .create_send_intent_if_absent(&intent)
+            .await
+            .expect("store batched intent");
+
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Cancelled {
+                    tx_bytes,
+                    assignments: vec![BatchOutputAssignment {
+                        intent_id,
+                        attempt_id: intent_id,
+                        vout: 0,
+                        fee_contribution_sat: 500,
+                    }],
+                    fee_sat: 500,
+                    // Exercise recovery from a stale durable marker. Cleanup
+                    // must advance it beyond the wallet's current last_seen.
+                    evict_at: apply_at.saturating_sub(1),
+                },
+            })
+            .await
+            .expect("store cancelled batch");
+
+        tokio::time::timeout(Duration::from_secs(5), backend.recover_send_saga())
+            .await
+            .expect("recovery timed out")
+            .expect("recovery should finish cancellation");
+
+        let intent = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("read intent")
+            .expect("intent remains active");
+        assert!(matches!(intent.state, SendIntentState::Pending { .. }));
+        assert!(
+            backend
+                .storage
+                .get_send_batch(&batch_id)
+                .await
+                .expect("read batch")
+                .is_none(),
+            "completed cancellation must delete its durable marker"
+        );
+        assert_wallet_does_not_know_tx(&backend, &txid).await;
+    }
+
+    #[tokio::test]
+    async fn cancelled_recovery_failure_does_not_abort_orphan_reconciliation() {
+        let backend = build_test_instance().await;
+        let cancelled_batch_id = Uuid::new_v4();
+        let orphan_batch_id = Uuid::new_v4();
+        let orphan_intent_id = Uuid::new_v4();
+
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id: cancelled_batch_id,
+                state: SendBatchState::Cancelled {
+                    tx_bytes: vec![0xff],
+                    assignments: Vec::new(),
+                    fee_sat: 500,
+                    evict_at: crate::util::unix_now(),
+                },
+            })
+            .await
+            .expect("store malformed cancelled batch");
+
+        let mut orphan = pending_intent(orphan_intent_id, "quote-cancelled-failure-orphan");
+        orphan.state = SendIntentState::Batched {
+            batch_id: orphan_batch_id,
+            created_at: crate::util::unix_now(),
+        };
+        backend
+            .storage
+            .create_send_intent_if_absent(&orphan)
+            .await
+            .expect("store orphaned intent");
+
+        tokio::time::timeout(Duration::from_secs(5), backend.recover_send_saga())
+            .await
+            .expect("recovery timed out")
+            .expect("one malformed cancellation should not abort recovery");
+
+        let persisted = backend
+            .storage
+            .get_send_intent(&orphan_intent_id)
+            .await
+            .expect("read orphaned intent")
+            .expect("orphaned intent remains active");
+        assert!(matches!(persisted.state, SendIntentState::Pending { .. }));
+        assert!(
+            backend
+                .storage
+                .get_send_batch(&cancelled_batch_id)
+                .await
+                .expect("read malformed cancelled batch")
+                .is_some(),
+            "failed cancellation should remain durable for a later retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_batch_does_not_compensate_replacement_attempt() {
+        let backend = build_test_instance().await;
+        let intent_id = Uuid::new_v4();
+        let batch_id = Uuid::new_v4();
+        let original_attempt_id = Uuid::new_v4();
+        let replacement_attempt_id = Uuid::new_v4();
+        let tx_bytes = wallet_relevant_send_tx_bytes(&backend).await;
+        let mut replacement = pending_intent(intent_id, "quote-cancelled-replacement");
+        replacement.attempt_id = replacement_attempt_id;
+        replacement.state = SendIntentState::Batched {
+            batch_id,
+            created_at: 1_700_000_000,
+        };
+        backend
+            .storage
+            .create_send_intent_if_absent(&replacement)
+            .await
+            .expect("store replacement intent");
+        let cancelled_state = SendBatchState::Cancelled {
+            tx_bytes,
+            assignments: vec![BatchOutputAssignment {
+                intent_id,
+                attempt_id: original_attempt_id,
+                vout: 0,
+                fee_contribution_sat: 500,
+            }],
+            fee_sat: 500,
+            evict_at: crate::util::unix_now().saturating_add(1),
+        };
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: cancelled_state.clone(),
+            })
+            .await
+            .expect("store cancelled batch");
+
+        backend
+            .finish_cancelled_send_batch(batch_id, &cancelled_state)
+            .await
+            .expect("finish cancellation");
+
+        let persisted = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get replacement")
+            .expect("replacement remains");
+        assert_eq!(persisted.attempt_id, replacement_attempt_id);
+        assert!(matches!(
+            persisted.state,
+            SendIntentState::Batched {
+                batch_id: stored_batch_id,
+                ..
+            } if stored_batch_id == batch_id
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancelled_batch_rejects_late_pending_claim() {
+        let backend = build_test_instance().await;
+        let batch_id = Uuid::new_v4();
+        let pending = SendIntent::new(
+            &backend.storage,
+            "quote-cancel-wins".to_string(),
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            25_000,
+            500,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("store pending intent");
+        let intent_id = pending.intent_id;
+        let tx_bytes = wallet_relevant_send_tx_bytes(&backend).await;
+        let assignments = vec![BatchOutputAssignment {
+            intent_id,
+            attempt_id: pending.attempt_id,
+            vout: 0,
+            fee_contribution_sat: 500,
+        }];
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Signed {
+                    tx_bytes: tx_bytes.clone(),
+                    assignments: assignments.clone(),
+                    fee_sat: 500,
+                },
+            })
+            .await
+            .expect("store signed batch");
+
+        assert!(backend
+            .cancel_signed_send_batch(
+                batch_id,
+                &tx_bytes,
+                &assignments,
+                500,
+                crate::util::unix_now().saturating_add(1),
+            )
+            .await
+            .expect("cancel signed batch"));
+
+        let error = pending
+            .assign_to_batch(&backend.storage, batch_id)
+            .await
+            .expect_err("a deleted cancelled batch cannot accept a late claim");
+        assert!(matches!(
+            error,
+            Error::SendBatchStateConflict {
+                batch_id: id,
+                expected: "Signed",
+            } if id == batch_id
+        ));
+        let persisted = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("read intent")
+            .expect("intent remains active");
+        assert!(matches!(persisted.state, SendIntentState::Pending { .. }));
+    }
+
+    #[tokio::test]
+    async fn cancelled_batch_compensates_claim_that_wins_first() {
+        let backend = build_test_instance().await;
+        let batch_id = Uuid::new_v4();
+        let pending = SendIntent::new(
+            &backend.storage,
+            "quote-claim-wins".to_string(),
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            25_000,
+            500,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("store pending intent");
+        let intent_id = pending.intent_id;
+        let tx_bytes = wallet_relevant_send_tx_bytes(&backend).await;
+        let assignments = vec![BatchOutputAssignment {
+            intent_id,
+            attempt_id: pending.attempt_id,
+            vout: 0,
+            fee_contribution_sat: 500,
+        }];
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Signed {
+                    tx_bytes: tx_bytes.clone(),
+                    assignments: assignments.clone(),
+                    fee_sat: 500,
+                },
+            })
+            .await
+            .expect("store signed batch");
+
+        pending
+            .assign_to_batch(&backend.storage, batch_id)
+            .await
+            .expect("claim intent while batch is signed");
+        assert!(backend
+            .cancel_signed_send_batch(
+                batch_id,
+                &tx_bytes,
+                &assignments,
+                500,
+                crate::util::unix_now().saturating_add(1),
+            )
+            .await
+            .expect("cancel signed batch"));
+
+        let persisted = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("read intent")
+            .expect("intent remains active");
+        assert!(matches!(persisted.state, SendIntentState::Pending { .. }));
+        assert!(backend
+            .storage
+            .get_send_batch(&batch_id)
+            .await
+            .expect("read batch")
+            .is_none());
+    }
+
+    /// If recovery repairs one Pending member before finding a later member
+    /// that cannot belong to the Signed batch, durable cancellation must undo
+    /// that partial repair instead of stranding it in `Batched`.
+    #[tokio::test]
+    async fn signed_recovery_cancels_partially_repaired_members() {
+        let backend = build_test_instance().await;
+        let repaired_intent_id = Uuid::new_v4();
+        let advanced_intent_id = Uuid::new_v4();
+        let batch_id = Uuid::new_v4();
+        let replacement_batch_id = Uuid::new_v4();
+        let tx_bytes = wallet_relevant_send_tx_bytes(&backend).await;
+
+        backend
+            .storage
+            .create_send_intent_if_absent(&pending_intent(
+                repaired_intent_id,
+                "quote-partial-repair",
+            ))
+            .await
+            .expect("store pending intent");
+        backend
+            .storage
+            .create_send_intent_if_absent(&awaiting_intent(
+                advanced_intent_id,
+                replacement_batch_id,
+                "quote-advanced-member",
+            ))
+            .await
+            .expect("store advanced intent");
+
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Signed {
+                    tx_bytes,
+                    assignments: vec![
+                        BatchOutputAssignment {
+                            intent_id: repaired_intent_id,
+                            attempt_id: repaired_intent_id,
+                            vout: 0,
+                            fee_contribution_sat: 250,
+                        },
+                        BatchOutputAssignment {
+                            intent_id: advanced_intent_id,
+                            attempt_id: advanced_intent_id,
+                            vout: 1,
+                            fee_contribution_sat: 250,
+                        },
+                    ],
+                    fee_sat: 500,
+                },
+            })
+            .await
+            .expect("store signed batch");
+
+        tokio::time::timeout(Duration::from_secs(5), backend.recover_send_saga())
+            .await
+            .expect("recovery timed out")
+            .expect("recovery should cancel unrecoverable batch");
+
+        let repaired = backend
+            .storage
+            .get_send_intent(&repaired_intent_id)
+            .await
+            .expect("read repaired intent")
+            .expect("repaired intent remains active");
+        assert!(matches!(repaired.state, SendIntentState::Pending { .. }));
+
+        let advanced = backend
+            .storage
+            .get_send_intent(&advanced_intent_id)
+            .await
+            .expect("read advanced intent")
+            .expect("advanced intent remains active");
+        assert!(matches!(
+            advanced.state,
+            SendIntentState::AwaitingConfirmation {
+                batch_id: stored_batch_id,
+                ..
+            } if stored_batch_id == replacement_batch_id
+        ));
+        assert!(
+            backend
+                .storage
+                .get_send_batch(&batch_id)
+                .await
+                .expect("read batch")
+                .is_none(),
+            "unrecoverable signed batch must be cancelled"
+        );
+    }
+
     /// A persisted Broadcast batch may represent a crash after durable state
     /// was written but before the tx was accepted or before the BDK wallet
     /// graph was persisted. Recovery must apply the tx locally so its inputs
@@ -1024,13 +2077,17 @@ mod tests {
         let tx: Transaction = consensus::deserialize(&tx_bytes).expect("valid tx");
         let txid = tx.compute_txid().to_string();
 
+        let mut awaiting = awaiting_intent(intent_id, batch_id, "quote-broadcast-wallet-graph");
+        awaiting.state = SendIntentState::AwaitingConfirmation {
+            batch_id,
+            txid: txid.clone(),
+            outpoint: format!("{txid}:0"),
+            fee_contribution_sat: 500,
+            created_at: 1_700_000_000,
+        };
         backend
             .storage
-            .create_send_intent_if_absent(&awaiting_intent(
-                intent_id,
-                batch_id,
-                "quote-broadcast-wallet-graph",
-            ))
+            .create_send_intent_if_absent(&awaiting)
             .await
             .expect("store awaiting intent");
 
@@ -1043,6 +2100,7 @@ mod tests {
                     tx_bytes,
                     assignments: vec![BatchOutputAssignment {
                         intent_id,
+                        attempt_id: intent_id,
                         vout: 0,
                         fee_contribution_sat: 500,
                     }],
@@ -1062,18 +2120,16 @@ mod tests {
     }
 
     /// If a crash leaves an intent in `Batched` while its batch is already
-    /// `Broadcast`, recovery must bind the repaired intent to the txid derived
-    /// from the persisted transaction bytes, not the batch record's txid field.
+    /// `Broadcast`, recovery must repair that exact member before reserving and
+    /// rebroadcasting the transaction.
     #[tokio::test]
-    async fn test_recover_send_saga_batched_repair_uses_computed_txid() {
+    async fn test_recover_send_saga_repairs_exact_batched_broadcast_member() {
         let backend = build_test_instance().await;
         let intent_id = Uuid::new_v4();
         let batch_id = Uuid::new_v4();
         let tx_bytes = wallet_relevant_send_tx_bytes(&backend).await;
         let tx: Transaction = consensus::deserialize(&tx_bytes).expect("valid tx");
         let computed_txid = tx.compute_txid().to_string();
-
-        assert_ne!(computed_txid, TEST_TXID);
 
         let mut batched = pending_intent(intent_id, "quote-batched-repair");
         batched.state = SendIntentState::Batched {
@@ -1091,10 +2147,11 @@ mod tests {
             .store_send_batch(&SendBatchRecord {
                 batch_id,
                 state: SendBatchState::Broadcast {
-                    txid: TEST_TXID.to_string(),
+                    txid: computed_txid.clone(),
                     tx_bytes,
                     assignments: vec![BatchOutputAssignment {
                         intent_id,
+                        attempt_id: intent_id,
                         vout: 0,
                         fee_contribution_sat: 500,
                     }],
@@ -1123,5 +2180,250 @@ mod tests {
             }
             other => panic!("expected AwaitingConfirmation, got {:?}", other),
         }
+    }
+
+    /// Broadcast orphan repair must not attach a replacement attempt to a
+    /// transaction signed for an older generation of the same intent.
+    #[tokio::test]
+    async fn broadcast_recovery_rejects_replacement_attempt() {
+        let backend = build_test_instance().await;
+        let intent_id = Uuid::new_v4();
+        let original_attempt_id = Uuid::new_v4();
+        let replacement_attempt_id = Uuid::new_v4();
+        let batch_id = Uuid::new_v4();
+        let tx_bytes = wallet_relevant_send_tx_bytes(&backend).await;
+        let tx: Transaction = consensus::deserialize(&tx_bytes).expect("valid tx");
+
+        let mut replacement = pending_intent(intent_id, "quote-broadcast-replacement");
+        replacement.attempt_id = replacement_attempt_id;
+        replacement.state = SendIntentState::Batched {
+            batch_id,
+            created_at: 1_700_000_000,
+        };
+        backend
+            .storage
+            .create_send_intent_if_absent(&replacement)
+            .await
+            .expect("store replacement attempt");
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Broadcast {
+                    txid: tx.compute_txid().to_string(),
+                    tx_bytes,
+                    assignments: vec![BatchOutputAssignment {
+                        intent_id,
+                        attempt_id: original_attempt_id,
+                        vout: 0,
+                        fee_contribution_sat: 500,
+                    }],
+                    fee_sat: 500,
+                },
+            })
+            .await
+            .expect("store original broadcast batch");
+
+        backend
+            .recover_send_saga()
+            .await
+            .expect("recover broadcast batch");
+
+        let persisted = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get replacement")
+            .expect("replacement remains");
+        assert_eq!(persisted.attempt_id, replacement_attempt_id);
+        assert!(matches!(persisted.state, SendIntentState::Batched { .. }));
+        assert_wallet_knows_tx(&backend, &tx.compute_txid().to_string()).await;
+        backend
+            .cleanup_completed_batches()
+            .await
+            .expect("cleanup must retain mismatch evidence");
+        assert!(
+            backend
+                .storage
+                .get_send_batch(&batch_id)
+                .await
+                .expect("get fenced batch")
+                .is_some(),
+            "replacement mismatch evidence must be retained"
+        );
+    }
+
+    #[tokio::test]
+    async fn broadcast_recovery_fences_failed_member_and_retains_evidence() {
+        let backend = build_test_instance().await;
+        let intent_id = Uuid::new_v4();
+        let batch_id = Uuid::new_v4();
+        let tx_bytes = wallet_relevant_send_tx_bytes(&backend).await;
+        let tx: Transaction = consensus::deserialize(&tx_bytes).expect("valid tx");
+        let txid = tx.compute_txid().to_string();
+
+        let mut failed = pending_intent(intent_id, "quote-broadcast-failed");
+        failed.state = SendIntentState::Failed {
+            reason: "terminal".to_string(),
+            created_at: 1_700_000_000,
+            failed_at: 1_700_000_001,
+        };
+        backend
+            .storage
+            .create_send_intent_if_absent(&failed)
+            .await
+            .expect("store failed intent");
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Broadcast {
+                    txid: txid.clone(),
+                    tx_bytes,
+                    assignments: vec![BatchOutputAssignment {
+                        intent_id,
+                        attempt_id: intent_id,
+                        vout: 0,
+                        fee_contribution_sat: 500,
+                    }],
+                    fee_sat: 500,
+                },
+            })
+            .await
+            .expect("store Broadcast batch");
+
+        backend
+            .recover_send_saga()
+            .await
+            .expect("recover fenced Broadcast batch");
+
+        let persisted = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get failed intent")
+            .expect("failed intent remains");
+        assert!(matches!(persisted.state, SendIntentState::Failed { .. }));
+        assert_wallet_knows_tx(&backend, &txid).await;
+        assert!(
+            backend
+                .storage
+                .get_send_batch(&batch_id)
+                .await
+                .expect("get fenced batch")
+                .is_some(),
+            "failed-member evidence must be retained"
+        );
+    }
+
+    /// A Signed batch member still stored as Pending is repaired by
+    /// claiming it for the batch. If another instance advances the intent
+    /// after recovery read it, the claim must abort and cancel the old batch
+    /// instead of rewinding the record or rebroadcasting its transaction.
+    #[tokio::test]
+    async fn signed_recovery_pending_repair_rejects_stale_snapshot() {
+        let kv = GatedKvStore::default();
+        let backend = build_test_instance_with_kv(Arc::new(kv.clone())).await;
+        let intent_id = Uuid::new_v4();
+        let batch_id = Uuid::new_v4();
+        let tx_bytes = wallet_relevant_send_tx_bytes(&backend).await;
+
+        backend
+            .storage
+            .create_send_intent_if_absent(&pending_intent(intent_id, "quote-stale-repair"))
+            .await
+            .expect("store pending intent");
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Signed {
+                    tx_bytes,
+                    assignments: vec![BatchOutputAssignment {
+                        intent_id,
+                        attempt_id: intent_id,
+                        vout: 0,
+                        fee_contribution_sat: 500,
+                    }],
+                    fee_sat: 500,
+                },
+            })
+            .await
+            .expect("store signed batch");
+
+        let gate = kv.gate_read(
+            ReadPath::Direct,
+            PausePoint::AfterRead,
+            crate::storage::BDK_NAMESPACE,
+            crate::storage::SEND_INTENT_NAMESPACE,
+            2,
+        );
+
+        let recover_backend = backend.clone();
+        let recovery = tokio::spawn(async move { recover_backend.recover_send_saga().await });
+
+        tokio::time::timeout(Duration::from_secs(5), gate.wait_entered())
+            .await
+            .expect("recovery reached the gated read");
+
+        let record = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get intent")
+            .expect("intent present");
+        let pending = match payment_intent::from_record(&record) {
+            SendIntentAny::Pending(intent) => intent,
+            _ => panic!("intent should be pending"),
+        };
+        let replacement_batch = Uuid::new_v4();
+        store_test_signed_batch(&backend.storage, replacement_batch, &[intent_id]).await;
+        pending
+            .assign_to_batch(&backend.storage, replacement_batch)
+            .await
+            .expect("other instance claims intent")
+            .mark_broadcast(
+                &backend.storage,
+                TEST_TXID.to_string(),
+                format!("{TEST_TXID}:0"),
+                500,
+            )
+            .await
+            .expect("other instance broadcasts intent");
+
+        gate.release();
+        tokio::time::timeout(Duration::from_secs(5), recovery)
+            .await
+            .expect("recovery timed out")
+            .expect("join recovery task")
+            .expect("recovery should not error");
+
+        let persisted = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get intent")
+            .expect("intent present");
+        assert!(
+            matches!(
+                persisted.state,
+                SendIntentState::AwaitingConfirmation {
+                    batch_id: b,
+                    ..
+                } if b == replacement_batch
+            ),
+            "intent must remain AwaitingConfirmation under the replacement batch, got {:?}",
+            persisted.state
+        );
+
+        assert!(
+            backend
+                .storage
+                .get_send_batch(&batch_id)
+                .await
+                .expect("get batch")
+                .is_none(),
+            "stale signed batch must be cancelled"
+        );
     }
 }

--- a/crates/cdk-bdk/src/recovery.rs
+++ b/crates/cdk-bdk/src/recovery.rs
@@ -853,8 +853,11 @@ impl CdkBdk {
                     }
 
                     match self.broadcast_transaction_internal(tx).await {
-                        Ok(BroadcastOutcome::Accepted) => {}
+                        Ok(BroadcastOutcome::Accepted) => {
+                            self.note_broadcast_success(batch_record.batch_id).await;
+                        }
                         Ok(BroadcastOutcome::AlreadyKnown) => {
+                            self.note_broadcast_success(batch_record.batch_id).await;
                             tracing::info!(
                                 "Recovered signed batch {} txid {} was already known to backend",
                                 batch_record.batch_id,
@@ -867,7 +870,8 @@ impl CdkBdk {
                                 batch_record.batch_id,
                                 &txid_str,
                                 &failure,
-                            );
+                            )
+                            .await;
                         }
                     }
                 }
@@ -895,11 +899,33 @@ impl CdkBdk {
                         continue;
                     };
                     let txid = tx.compute_txid();
+                    // The reservation was already refreshed above; an
+                    // escalated batch waits for operator review instead of
+                    // retrying the backend on every restart.
+                    if self
+                        .storage
+                        .get_broadcast_rejection(&batch_record.batch_id)
+                        .await?
+                        .is_some_and(|rejection| {
+                            rejection.consecutive_rejections
+                                >= crate::send::service::MAX_CONSECUTIVE_BROADCAST_REJECTIONS
+                        })
+                    {
+                        tracing::warn!(
+                            batch_id = %batch_record.batch_id,
+                            %txid,
+                            "Skipping recovery rebroadcast of escalated batch"
+                        );
+                        continue;
+                    }
                     tracing::info!("Re-broadcasting batch {} during recovery", txid);
 
                     match self.broadcast_transaction_internal(tx).await {
-                        Ok(BroadcastOutcome::Accepted) => {}
+                        Ok(BroadcastOutcome::Accepted) => {
+                            self.note_broadcast_success(batch_record.batch_id).await;
+                        }
                         Ok(BroadcastOutcome::AlreadyKnown) => {
+                            self.note_broadcast_success(batch_record.batch_id).await;
                             tracing::info!("Recovery rebroadcast tx {} already known", txid);
                         }
                         Err(failure) => {
@@ -908,7 +934,8 @@ impl CdkBdk {
                                 batch_record.batch_id,
                                 &txid.to_string(),
                                 &failure,
-                            );
+                            )
+                            .await;
                         }
                     }
                 }

--- a/crates/cdk-bdk/src/send/batch_transaction/mod.rs
+++ b/crates/cdk-bdk/src/send/batch_transaction/mod.rs
@@ -214,18 +214,28 @@ impl SendBatch<Signed> {
         assignments: Vec<BatchOutputAssignment>,
         fee_sat: u64,
     ) -> Result<BroadcastResult, Error> {
+        let expected_state = SendBatchState::Signed {
+            tx_bytes: tx_bytes.clone(),
+            assignments: assignments.clone(),
+            fee_sat,
+        };
+        let broadcast_state = SendBatchState::Broadcast {
+            txid: txid.clone(),
+            tx_bytes,
+            assignments,
+            fee_sat,
+        };
+
         // Persist Broadcast state BEFORE actually broadcasting (crash safety)
-        storage
-            .update_send_batch(
-                &self.batch_id,
-                &SendBatchState::Broadcast {
-                    txid: txid.clone(),
-                    tx_bytes,
-                    assignments,
-                    fee_sat,
-                },
-            )
+        let transitioned = storage
+            .transition_send_batch(&self.batch_id, &expected_state, &broadcast_state)
             .await?;
+        if !transitioned {
+            return Err(Error::SendBatchStateConflict {
+                batch_id: self.batch_id,
+                expected: "Signed",
+            });
+        }
 
         Ok(BroadcastResult {
             intents: self.intents,
@@ -243,6 +253,7 @@ mod tests {
     use crate::send::payment_intent::state::Batched as IntentBatched;
     use crate::send::payment_intent::SendIntent;
     use crate::storage::BdkStorage;
+    use crate::testutil::store_test_signed_batch;
     use crate::types::{PaymentMetadata, PaymentTier};
 
     /// Helper: create an in-memory KVStore-backed BdkStorage for tests
@@ -273,6 +284,7 @@ mod tests {
         .await
         .expect("create pending intent");
 
+        store_test_signed_batch(storage, batch_id, &[pending.intent_id]).await;
         pending
             .assign_to_batch(storage, batch_id)
             .await
@@ -307,11 +319,13 @@ mod tests {
         let assignments = vec![
             BatchOutputAssignment {
                 intent_id: built_batch.intents[0].intent_id,
+                attempt_id: built_batch.intents[0].attempt_id,
                 vout: 0,
                 fee_contribution_sat: 250,
             },
             BatchOutputAssignment {
                 intent_id: built_batch.intents[1].intent_id,
+                attempt_id: built_batch.intents[1].attempt_id,
                 vout: 1,
                 fee_contribution_sat: 250,
             },
@@ -378,15 +392,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stale_signed_batch_cannot_overwrite_broadcast_batch() {
+        let storage = test_storage().await;
+        let batch_id = Uuid::new_v4();
+        let tx_bytes = vec![0xAA, 0xBB, 0xCC];
+        let assignments = Vec::new();
+        let signed_state = SendBatchState::Signed {
+            tx_bytes: tx_bytes.clone(),
+            assignments: assignments.clone(),
+            fee_sat: 500,
+        };
+        let winning_state = SendBatchState::Broadcast {
+            txid: "winning-txid".to_string(),
+            tx_bytes: tx_bytes.clone(),
+            assignments: assignments.clone(),
+            fee_sat: 500,
+        };
+
+        let signed_batch = SendBatch::new(&storage, batch_id, vec![1, 2, 3], Vec::new())
+            .await
+            .expect("new batch")
+            .sign(&storage, tx_bytes.clone(), assignments.clone(), 500)
+            .await
+            .expect("sign batch");
+        assert!(storage
+            .transition_send_batch(&batch_id, &signed_state, &winning_state)
+            .await
+            .expect("promote batch"));
+
+        let result = signed_batch
+            .mark_broadcast(
+                &storage,
+                "stale-txid".to_string(),
+                tx_bytes,
+                assignments,
+                500,
+            )
+            .await;
+        let error = match result {
+            Ok(_) => panic!("stale promotion must fail"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            Error::SendBatchStateConflict {
+                batch_id: id,
+                expected: "Signed",
+            } if id == batch_id
+        ));
+
+        let persisted = storage
+            .get_send_batch(&batch_id)
+            .await
+            .expect("get batch")
+            .expect("batch remains");
+        assert_eq!(persisted.state, winning_state);
+    }
+
+    #[tokio::test]
     async fn test_assignments_roundtrip_serde() {
         let assignment = BatchOutputAssignment {
             intent_id: Uuid::new_v4(),
+            attempt_id: Uuid::new_v4(),
             vout: 7,
             fee_contribution_sat: 1234,
         };
         let encoded = serde_json::to_vec(&assignment).expect("encode");
         let decoded: BatchOutputAssignment = serde_json::from_slice(&encoded).expect("decode");
         assert_eq!(decoded, assignment);
+
+        let mut legacy = serde_json::to_value(&assignment).expect("encode legacy assignment");
+        legacy
+            .as_object_mut()
+            .expect("assignment serializes as an object")
+            .remove("attempt_id");
+        let decoded_legacy: BatchOutputAssignment =
+            serde_json::from_value(legacy).expect("decode legacy assignment");
+        assert_eq!(decoded_legacy.attempt_id, Uuid::nil());
     }
 
     #[test]

--- a/crates/cdk-bdk/src/send/batch_transaction/record.rs
+++ b/crates/cdk-bdk/src/send/batch_transaction/record.rs
@@ -14,6 +14,13 @@ use uuid::Uuid;
 pub struct BatchOutputAssignment {
     /// The intent that owns this output.
     pub intent_id: Uuid,
+    /// Unique generation of the send attempt that owns this output.
+    ///
+    /// Assignments written before attempt generations were introduced
+    /// deserialize to the nil UUID. Signed-batch claims and recovery treat that
+    /// sentinel as unbound and cancel conservatively rather than guessing.
+    #[serde(default)]
+    pub attempt_id: Uuid,
     /// Output index in the batch transaction.
     pub vout: u32,
     /// Fee allocated to this intent in satoshis.
@@ -21,7 +28,7 @@ pub struct BatchOutputAssignment {
 }
 
 /// Durable send batch state
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SendBatchState {
     /// PSBT has been constructed but not yet signed
     Built {
@@ -39,13 +46,29 @@ pub enum SendBatchState {
         /// Total transaction fee in satoshis
         fee_sat: u64,
     },
+    /// A signed transaction that must never be broadcast.
+    ///
+    /// This state is persisted before evicting the transaction from BDK or
+    /// reverting any claimed intents. Recovery completes those operations
+    /// idempotently and deletes the batch only after compensation succeeds.
+    Cancelled {
+        /// Serialized signed transaction bytes used to derive the txid to evict.
+        tx_bytes: Vec<u8>,
+        /// Per-intent assignments retained for compensation recovery.
+        assignments: Vec<BatchOutputAssignment>,
+        /// Total transaction fee in satoshis.
+        fee_sat: u64,
+        /// BDK eviction timestamp, chosen after the original apply timestamp.
+        evict_at: u64,
+    },
     /// Transaction has been durably persisted for rebroadcast and reconciliation.
     ///
     /// This state is written before the backend/node broadcast call so recovery
     /// can safely retry the network send after a crash. It does not guarantee
     /// that the transaction was already accepted by the network.
     Broadcast {
-        /// Transaction ID
+        /// Transaction ID. Informational only: consumers must derive the
+        /// canonical txid from `tx_bytes` rather than trusting this string.
         txid: String,
         /// Serialized signed transaction bytes (kept for rebroadcast)
         tx_bytes: Vec<u8>,

--- a/crates/cdk-bdk/src/send/payment_intent/mod.rs
+++ b/crates/cdk-bdk/src/send/payment_intent/mod.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use self::record::{SendIntentRecord, SendIntentState};
 use self::state::{AwaitingConfirmation, Batched, Failed, Pending};
 use crate::error::Error;
-use crate::storage::{BdkStorage, FailedSendAttemptRecord, FinalizedSendIntentRecord};
+use crate::storage::{BdkStorage, FinalizedSendIntentRecord};
 use crate::types::{PaymentMetadata, PaymentTier};
 
 /// A send intent in a particular typestate
@@ -25,6 +25,8 @@ use crate::types::{PaymentMetadata, PaymentTier};
 pub(crate) struct SendIntent<S> {
     /// Unique identifier for this intent
     pub intent_id: Uuid,
+    /// Unique generation for the current payment attempt.
+    pub attempt_id: Uuid,
     /// Quote ID linking this intent to a melt quote
     pub quote_id: String,
     /// Destination Bitcoin address
@@ -57,10 +59,12 @@ impl SendIntent<Pending> {
         metadata: PaymentMetadata,
     ) -> Result<Self, Error> {
         let intent_id = Uuid::new_v4();
+        let attempt_id = Uuid::new_v4();
         let created_at = crate::util::unix_now();
 
         let record = SendIntentRecord {
             intent_id,
+            attempt_id,
             quote_id: quote_id.clone(),
             address: address.clone(),
             amount_sat: amount,
@@ -82,6 +86,7 @@ impl SendIntent<Pending> {
 
         Ok(Self {
             intent_id: record.intent_id,
+            attempt_id: record.attempt_id,
             quote_id: record.quote_id,
             address: record.address,
             amount: record.amount_sat,
@@ -94,23 +99,28 @@ impl SendIntent<Pending> {
     }
 
     /// Transition to Batched state
+    ///
+    /// The transition locks the durable `Signed` batch and compare-and-sets
+    /// the intent in one transaction. It fails when the batch changed or no
+    /// longer lists the intent, or when the intent is no longer the expected
+    /// `Pending` attempt.
     pub async fn assign_to_batch(
         self,
         storage: &BdkStorage,
         batch_id: Uuid,
     ) -> Result<SendIntent<Batched>, Error> {
         storage
-            .update_send_intent(
+            .claim_send_intent_for_signed_batch(
                 &self.intent_id,
-                &SendIntentState::Batched {
-                    batch_id,
-                    created_at: self.created_at,
-                },
+                &self.attempt_id,
+                self.created_at,
+                &batch_id,
             )
             .await?;
 
         Ok(SendIntent {
             intent_id: self.intent_id,
+            attempt_id: self.attempt_id,
             quote_id: self.quote_id,
             address: self.address,
             amount: self.amount,
@@ -123,15 +133,25 @@ impl SendIntent<Pending> {
     }
 
     /// Mark a pending intent as failed before a signed transaction was committed.
+    ///
+    /// The transition is a compare-and-set against the durable record: it
+    /// fails with [`Error::SendIntentStateConflict`] when the intent is no
+    /// longer stored as `Pending`, so a stale handle cannot fail an intent
+    /// another worker already batched or broadcast. The failed-attempt
+    /// tombstone is only written after the transition succeeds.
     pub async fn fail(
         self,
         storage: &BdkStorage,
         reason: String,
     ) -> Result<SendIntent<Failed>, Error> {
         let failed_at = crate::util::unix_now();
-        storage
-            .update_send_intent(
+        let failed = storage
+            .transition_send_intent(
                 &self.intent_id,
+                &self.attempt_id,
+                &SendIntentState::Pending {
+                    created_at: self.created_at,
+                },
                 &SendIntentState::Failed {
                     reason: reason.clone(),
                     created_at: self.created_at,
@@ -139,18 +159,16 @@ impl SendIntent<Pending> {
                 },
             )
             .await?;
-        storage
-            .add_failed_send_attempt(&FailedSendAttemptRecord {
-                attempt_id: Uuid::new_v4(),
+        if !failed {
+            return Err(Error::SendIntentStateConflict {
                 intent_id: self.intent_id,
-                quote_id: self.quote_id.clone(),
-                reason: reason.clone(),
-                failed_at,
-            })
-            .await?;
+                expected: "Pending",
+            });
+        }
 
         Ok(SendIntent {
             intent_id: self.intent_id,
+            attempt_id: self.attempt_id,
             quote_id: self.quote_id,
             address: self.address,
             amount: self.amount,
@@ -165,6 +183,11 @@ impl SendIntent<Pending> {
 
 impl SendIntent<Batched> {
     /// Transition to AwaitingConfirmation state after broadcast
+    ///
+    /// The transition is a compare-and-set against the durable record: it
+    /// fails with [`Error::SendIntentStateConflict`] when the intent is no
+    /// longer stored as `Batched` for this batch, so a stale handle cannot
+    /// overwrite a compensated record or a replacement transaction.
     pub async fn mark_broadcast(
         self,
         storage: &BdkStorage,
@@ -172,9 +195,14 @@ impl SendIntent<Batched> {
         outpoint: String,
         fee_contribution_sat: u64,
     ) -> Result<SendIntent<AwaitingConfirmation>, Error> {
-        storage
-            .update_send_intent(
+        let broadcast = storage
+            .transition_send_intent(
                 &self.intent_id,
+                &self.attempt_id,
+                &SendIntentState::Batched {
+                    batch_id: self.state.batch_id,
+                    created_at: self.created_at,
+                },
                 &SendIntentState::AwaitingConfirmation {
                     batch_id: self.state.batch_id,
                     txid: txid.clone(),
@@ -184,9 +212,16 @@ impl SendIntent<Batched> {
                 },
             )
             .await?;
+        if !broadcast {
+            return Err(Error::SendIntentStateConflict {
+                intent_id: self.intent_id,
+                expected: "Batched",
+            });
+        }
 
         Ok(SendIntent {
             intent_id: self.intent_id,
+            attempt_id: self.attempt_id,
             quote_id: self.quote_id,
             address: self.address,
             amount: self.amount,
@@ -204,21 +239,38 @@ impl SendIntent<Batched> {
     }
 
     /// Revert to Pending state (compensation)
+    ///
+    /// The transition is a compare-and-set against the durable record: it
+    /// fails with [`Error::SendIntentStateConflict`] when the intent is no
+    /// longer stored as `Batched` for this batch, so a stale handle cannot
+    /// rewind an intent another worker already broadcast.
     pub async fn revert_to_pending(
         self,
         storage: &BdkStorage,
     ) -> Result<SendIntent<Pending>, Error> {
-        storage
-            .update_send_intent(
+        let reverted = storage
+            .transition_send_intent(
                 &self.intent_id,
+                &self.attempt_id,
+                &SendIntentState::Batched {
+                    batch_id: self.state.batch_id,
+                    created_at: self.created_at,
+                },
                 &SendIntentState::Pending {
                     created_at: self.created_at,
                 },
             )
             .await?;
+        if !reverted {
+            return Err(Error::SendIntentStateConflict {
+                intent_id: self.intent_id,
+                expected: "Batched",
+            });
+        }
 
         Ok(SendIntent {
             intent_id: self.intent_id,
+            attempt_id: self.attempt_id,
             quote_id: self.quote_id,
             address: self.address,
             amount: self.amount,
@@ -237,8 +289,25 @@ impl SendIntent<AwaitingConfirmation> {
     /// Called after the transaction reaches the required confirmation depth.
     /// The tombstone preserves `total_spent` and `outpoint` so that
     /// `check_outgoing_payment` returns correct data after the intent is gone.
-    pub async fn finalize(self, storage: &BdkStorage) -> Result<(), Error> {
+    pub async fn finalize(self, storage: &BdkStorage) -> Result<bool, Error> {
         let total_spent_sat = self.amount + self.state.fee_contribution_sat;
+        let expected = SendIntentRecord {
+            intent_id: self.intent_id,
+            attempt_id: self.attempt_id,
+            quote_id: self.quote_id.clone(),
+            address: self.address.clone(),
+            amount_sat: self.amount,
+            max_fee_amount_sat: self.max_fee_amount,
+            tier: self.tier,
+            metadata: self.metadata.clone(),
+            state: SendIntentState::AwaitingConfirmation {
+                batch_id: self.state.batch_id,
+                txid: self.state.txid.clone(),
+                outpoint: self.state.outpoint.clone(),
+                fee_contribution_sat: self.state.fee_contribution_sat,
+                created_at: self.created_at,
+            },
+        };
 
         let tombstone = FinalizedSendIntentRecord {
             intent_id: self.intent_id,
@@ -248,10 +317,7 @@ impl SendIntent<AwaitingConfirmation> {
             finalized_at: crate::util::unix_now(),
         };
 
-        storage
-            .finalize_send_intent(&self.intent_id, &tombstone)
-            .await?;
-        Ok(())
+        storage.finalize_send_intent(&expected, &tombstone).await
     }
 }
 
@@ -260,6 +326,7 @@ pub(crate) fn from_record(record: &SendIntentRecord) -> SendIntentAny {
     match &record.state {
         SendIntentState::Pending { created_at } => SendIntentAny::Pending(SendIntent {
             intent_id: record.intent_id,
+            attempt_id: record.attempt_id,
             quote_id: record.quote_id.clone(),
             address: record.address.clone(),
             amount: record.amount_sat,
@@ -274,6 +341,7 @@ pub(crate) fn from_record(record: &SendIntentRecord) -> SendIntentAny {
             created_at,
         } => SendIntentAny::Batched(SendIntent {
             intent_id: record.intent_id,
+            attempt_id: record.attempt_id,
             quote_id: record.quote_id.clone(),
             address: record.address.clone(),
             amount: record.amount_sat,
@@ -293,6 +361,7 @@ pub(crate) fn from_record(record: &SendIntentRecord) -> SendIntentAny {
             created_at,
         } => SendIntentAny::AwaitingConfirmation(SendIntent {
             intent_id: record.intent_id,
+            attempt_id: record.attempt_id,
             quote_id: record.quote_id.clone(),
             address: record.address.clone(),
             amount: record.amount_sat,
@@ -332,287 +401,18 @@ pub(crate) enum SendIntentAny {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
-    use std::sync::{Arc, Mutex as StdMutex};
+    use std::sync::Arc;
+    use std::time::Duration;
 
-    use async_trait::async_trait;
-    use cdk_common::database::{
-        DbTransactionFinalizer, Error as DatabaseError, KVStore, KVStoreDatabase,
-        KVStoreTransaction,
-    };
     use cdk_common::payment::{MakePaymentResponse, PaymentIdentifier};
     use cdk_common::{Amount, CurrencyUnit, MeltQuoteState};
-    use tokio::sync::Barrier;
 
     use super::*;
-    use crate::storage::{BdkStorage, SEND_INTENT_QUOTE_ID_NAMESPACE};
-
-    type KvKey = (String, String, String);
-
-    /// KV store that lets two concurrent transactions both observe a missing
-    /// quote-id index entry before either writes. `kv_write_if_absent` is
-    /// atomic across transactions, mirroring the SQL backend.
-    #[derive(Clone)]
-    struct RacingKvStore {
-        data: Arc<StdMutex<HashMap<KvKey, Vec<u8>>>>,
-        reservations: Arc<StdMutex<HashSet<KvKey>>>,
-        index_read_barrier: Arc<Barrier>,
-    }
-
-    impl RacingKvStore {
-        fn new(parties: usize) -> Self {
-            Self {
-                data: Arc::new(StdMutex::new(HashMap::new())),
-                reservations: Arc::new(StdMutex::new(HashSet::new())),
-                index_read_barrier: Arc::new(Barrier::new(parties)),
-            }
-        }
-    }
-
-    struct RacingTransaction {
-        store: RacingKvStore,
-        writes: Vec<(KvKey, Option<Vec<u8>>)>,
-        reserved: Vec<KvKey>,
-    }
-
-    #[async_trait]
-    impl DbTransactionFinalizer for RacingTransaction {
-        type Err = DatabaseError;
-
-        async fn commit(self: Box<Self>) -> Result<(), Self::Err> {
-            let mut data = self.store.data.lock().expect("lock racing kv store");
-            for (key, value) in self.writes {
-                if let Some(value) = value {
-                    data.insert(key, value);
-                } else {
-                    data.remove(&key);
-                }
-            }
-            Ok(())
-        }
-
-        async fn rollback(self: Box<Self>) -> Result<(), Self::Err> {
-            let mut reservations = self.store.reservations.lock().expect("lock reservations");
-            for key in &self.reserved {
-                reservations.remove(key);
-            }
-            Ok(())
-        }
-    }
-
-    #[async_trait]
-    impl KVStoreTransaction<DatabaseError> for RacingTransaction {
-        async fn kv_read(
-            &mut self,
-            primary_namespace: &str,
-            secondary_namespace: &str,
-            key: &str,
-        ) -> Result<Option<Vec<u8>>, DatabaseError> {
-            let map_key = (
-                primary_namespace.to_string(),
-                secondary_namespace.to_string(),
-                key.to_string(),
-            );
-            let value = self
-                .writes
-                .iter()
-                .rev()
-                .find(|(candidate, _)| candidate == &map_key)
-                .map(|(_, value)| value.clone())
-                .unwrap_or_else(|| {
-                    self.store
-                        .data
-                        .lock()
-                        .expect("lock racing kv store")
-                        .get(&map_key)
-                        .cloned()
-                });
-
-            if secondary_namespace == SEND_INTENT_QUOTE_ID_NAMESPACE {
-                self.store.index_read_barrier.wait().await;
-            }
-
-            Ok(value)
-        }
-
-        async fn kv_write(
-            &mut self,
-            primary_namespace: &str,
-            secondary_namespace: &str,
-            key: &str,
-            value: &[u8],
-        ) -> Result<(), DatabaseError> {
-            self.writes.push((
-                (
-                    primary_namespace.to_string(),
-                    secondary_namespace.to_string(),
-                    key.to_string(),
-                ),
-                Some(value.to_vec()),
-            ));
-            Ok(())
-        }
-
-        async fn kv_write_if_absent(
-            &mut self,
-            primary_namespace: &str,
-            secondary_namespace: &str,
-            key: &str,
-            value: &[u8],
-        ) -> Result<bool, DatabaseError> {
-            let map_key = (
-                primary_namespace.to_string(),
-                secondary_namespace.to_string(),
-                key.to_string(),
-            );
-
-            let exists = match self
-                .writes
-                .iter()
-                .rev()
-                .find(|(candidate, _)| candidate == &map_key)
-            {
-                Some((_, pending)) => pending.is_some(),
-                None => {
-                    let data = self.store.data.lock().expect("lock racing kv store");
-                    let reservations = self.store.reservations.lock().expect("lock reservations");
-                    data.contains_key(&map_key) || reservations.contains(&map_key)
-                }
-            };
-
-            if exists {
-                return Ok(false);
-            }
-
-            self.store
-                .reservations
-                .lock()
-                .expect("lock reservations")
-                .insert(map_key.clone());
-            self.reserved.push(map_key.clone());
-            self.writes.push((map_key, Some(value.to_vec())));
-
-            Ok(true)
-        }
-
-        async fn kv_remove(
-            &mut self,
-            primary_namespace: &str,
-            secondary_namespace: &str,
-            key: &str,
-        ) -> Result<(), DatabaseError> {
-            self.writes.push((
-                (
-                    primary_namespace.to_string(),
-                    secondary_namespace.to_string(),
-                    key.to_string(),
-                ),
-                None,
-            ));
-            Ok(())
-        }
-
-        async fn kv_write_if_equals(
-            &mut self,
-            primary_namespace: &str,
-            secondary_namespace: &str,
-            key: &str,
-            expected: &[u8],
-            replacement: &[u8],
-        ) -> Result<bool, DatabaseError> {
-            let map_key = (
-                primary_namespace.to_string(),
-                secondary_namespace.to_string(),
-                key.to_string(),
-            );
-
-            let current = self
-                .writes
-                .iter()
-                .rev()
-                .find(|(candidate, _)| candidate == &map_key)
-                .map(|(_, value)| value.clone())
-                .unwrap_or_else(|| {
-                    self.store
-                        .data
-                        .lock()
-                        .expect("lock racing kv store")
-                        .get(&map_key)
-                        .cloned()
-                });
-
-            match current {
-                Some(current) if current == expected => {
-                    self.writes.push((map_key, Some(replacement.to_vec())));
-                    Ok(true)
-                }
-                _ => Ok(false),
-            }
-        }
-
-        async fn kv_list(
-            &mut self,
-            primary_namespace: &str,
-            secondary_namespace: &str,
-        ) -> Result<Vec<String>, DatabaseError> {
-            self.store
-                .kv_list(primary_namespace, secondary_namespace)
-                .await
-        }
-    }
-
-    #[async_trait]
-    impl KVStoreDatabase for RacingKvStore {
-        type Err = DatabaseError;
-
-        async fn kv_read(
-            &self,
-            primary_namespace: &str,
-            secondary_namespace: &str,
-            key: &str,
-        ) -> Result<Option<Vec<u8>>, Self::Err> {
-            Ok(self
-                .data
-                .lock()
-                .expect("lock racing kv store")
-                .get(&(
-                    primary_namespace.to_string(),
-                    secondary_namespace.to_string(),
-                    key.to_string(),
-                ))
-                .cloned())
-        }
-
-        async fn kv_list(
-            &self,
-            primary_namespace: &str,
-            secondary_namespace: &str,
-        ) -> Result<Vec<String>, Self::Err> {
-            Ok(self
-                .data
-                .lock()
-                .expect("lock racing kv store")
-                .keys()
-                .filter(|(primary, secondary, _)| {
-                    primary == primary_namespace && secondary == secondary_namespace
-                })
-                .map(|(_, _, key)| key.clone())
-                .collect())
-        }
-    }
-
-    #[async_trait]
-    impl KVStore for RacingKvStore {
-        async fn begin_transaction(
-            &self,
-        ) -> Result<Box<dyn KVStoreTransaction<Self::Err> + Send + Sync>, DatabaseError> {
-            Ok(Box::new(RacingTransaction {
-                store: self.clone(),
-                writes: Vec::new(),
-                reserved: Vec::new(),
-            }))
-        }
-    }
+    use crate::send::batch_transaction::record::{
+        BatchOutputAssignment, SendBatchRecord, SendBatchState,
+    };
+    use crate::storage::{BdkStorage, BDK_NAMESPACE, SEND_INTENT_QUOTE_ID_NAMESPACE};
+    use crate::testutil::{store_test_signed_batch, GatedKvStore, PausePoint, ReadPath};
 
     /// Helper: create an in-memory KVStore-backed BdkStorage for tests
     async fn test_storage() -> BdkStorage {
@@ -624,10 +424,20 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_duplicate_quote_creates_only_one_intent() {
-        let storage = BdkStorage::new(Arc::new(RacingKvStore::new(2)));
-        let create = || {
+        let kv = GatedKvStore::default();
+        let storage = BdkStorage::new(Arc::new(kv.clone()));
+        let gate = kv.gate_read(
+            ReadPath::Transaction,
+            PausePoint::AfterRead,
+            BDK_NAMESPACE,
+            SEND_INTENT_QUOTE_ID_NAMESPACE,
+            1,
+        );
+
+        let first_storage = storage.clone();
+        let first = tokio::spawn(async move {
             SendIntent::new(
-                &storage,
+                &first_storage,
                 "quote-race".to_string(),
                 "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
                 10_000,
@@ -635,9 +445,29 @@ mod tests {
                 PaymentTier::Immediate,
                 PaymentMetadata::default(),
             )
-        };
+            .await
+        });
 
-        let (first, second) = tokio::join!(create(), create());
+        tokio::time::timeout(Duration::from_secs(5), gate.wait_entered())
+            .await
+            .expect("first create reached the gated quote-id read");
+
+        let second = SendIntent::new(
+            &storage,
+            "quote-race".to_string(),
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            10_000,
+            500,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await;
+
+        gate.release();
+        let first = tokio::time::timeout(Duration::from_secs(5), first)
+            .await
+            .expect("first create timed out")
+            .expect("join first create");
 
         let success_count = usize::from(first.is_ok()) + usize::from(second.is_ok());
         assert_eq!(success_count, 1, "only one intent per quote id");
@@ -683,6 +513,7 @@ mod tests {
 
         // 2. Transition to Batched
         let batch_id = Uuid::new_v4();
+        store_test_signed_batch(&storage, batch_id, &[pending.intent_id]).await;
         let batched = pending
             .assign_to_batch(&storage, batch_id)
             .await
@@ -763,6 +594,7 @@ mod tests {
         .await
         .expect("new");
         let intent_id = pending.intent_id;
+        let attempt_id = pending.attempt_id;
 
         pending
             .fail(&storage, "fee too high".to_string())
@@ -782,6 +614,7 @@ mod tests {
         .expect("retry failed intent");
 
         assert_eq!(retried.intent_id, intent_id);
+        assert_ne!(retried.attempt_id, attempt_id);
         assert_eq!(retried.max_fee_amount, 750);
 
         let persisted = storage
@@ -801,6 +634,146 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stale_pending_handle_cannot_advance_retried_attempt_with_same_timestamp() {
+        let storage = test_storage().await;
+        let quote_id = "quote-retry-aba".to_string();
+
+        let pending = SendIntent::new(
+            &storage,
+            quote_id.clone(),
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            10_000,
+            500,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("new");
+        let stale = pending.clone();
+        pending
+            .fail(&storage, "first attempt failed".to_string())
+            .await
+            .expect("fail first attempt");
+
+        let replacement_attempt_id = Uuid::new_v4();
+        let replacement = storage
+            .create_or_retry_failed_send_intent(&SendIntentRecord {
+                intent_id: Uuid::new_v4(),
+                attempt_id: replacement_attempt_id,
+                quote_id,
+                address: "bcrt1q6rhpng9evdsfnn833a4f4vej0asu6dk5srld6x".to_string(),
+                amount_sat: 20_000,
+                max_fee_amount_sat: 750,
+                tier: PaymentTier::Standard,
+                metadata: PaymentMetadata::default(),
+                state: SendIntentState::Pending {
+                    created_at: stale.created_at,
+                },
+            })
+            .await
+            .expect("retry with the same state timestamp");
+        assert_eq!(replacement.attempt_id, replacement_attempt_id);
+
+        let stale_batch_id = Uuid::new_v4();
+        store_test_signed_batch(&storage, stale_batch_id, &[replacement.intent_id]).await;
+        let error = stale
+            .assign_to_batch(&storage, stale_batch_id)
+            .await
+            .expect_err("stale handle must not advance the replacement attempt");
+        assert!(matches!(
+            error,
+            Error::SendBatchStateConflict {
+                expected: "Signed with one assignment for exact intent attempt",
+                ..
+            }
+        ));
+
+        let persisted = storage
+            .get_send_intent(&replacement.intent_id)
+            .await
+            .expect("get replacement intent")
+            .expect("replacement intent remains active");
+        assert_eq!(persisted.attempt_id, replacement_attempt_id);
+        assert_eq!(persisted.address, replacement.address);
+        assert!(matches!(persisted.state, SendIntentState::Pending { .. }));
+    }
+
+    #[tokio::test]
+    async fn replacement_attempt_cannot_claim_original_attempts_signed_batch() {
+        let storage = test_storage().await;
+        let quote_id = "quote-signed-attempt-binding".to_string();
+        let original = SendIntent::new(
+            &storage,
+            quote_id.clone(),
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            10_000,
+            500,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("new original attempt");
+        let intent_id = original.intent_id;
+        let original_attempt_id = original.attempt_id;
+        original
+            .fail(&storage, "retry original attempt".to_string())
+            .await
+            .expect("fail original attempt");
+        let replacement = SendIntent::new(
+            &storage,
+            quote_id,
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            10_000,
+            750,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("new replacement attempt");
+        assert_eq!(replacement.intent_id, intent_id);
+        assert_ne!(replacement.attempt_id, original_attempt_id);
+
+        let batch_id = Uuid::new_v4();
+        storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Signed {
+                    tx_bytes: vec![0x01],
+                    assignments: vec![BatchOutputAssignment {
+                        intent_id,
+                        attempt_id: original_attempt_id,
+                        vout: 0,
+                        fee_contribution_sat: 0,
+                    }],
+                    fee_sat: 0,
+                },
+            })
+            .await
+            .expect("store original attempt's signed batch");
+
+        let replacement_attempt_id = replacement.attempt_id;
+        let error = replacement
+            .assign_to_batch(&storage, batch_id)
+            .await
+            .expect_err("replacement must not claim original attempt's signed batch");
+        assert!(matches!(
+            error,
+            Error::SendBatchStateConflict {
+                expected: "Signed with one assignment for exact intent attempt",
+                ..
+            }
+        ));
+
+        let persisted = storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get replacement")
+            .expect("replacement remains");
+        assert_eq!(persisted.attempt_id, replacement_attempt_id);
+        assert!(matches!(persisted.state, SendIntentState::Pending { .. }));
+    }
+
+    #[tokio::test]
     async fn test_finalize_send_intent_creates_tombstone_and_preserves_total_spent() {
         let storage = test_storage().await;
 
@@ -816,8 +789,10 @@ mod tests {
         .await
         .expect("new");
 
+        let batch_id = Uuid::new_v4();
+        store_test_signed_batch(&storage, batch_id, &[pending.intent_id]).await;
         let batched = pending
-            .assign_to_batch(&storage, Uuid::new_v4())
+            .assign_to_batch(&storage, batch_id)
             .await
             .expect("assign");
 
@@ -835,7 +810,10 @@ mod tests {
         let quote_id = awaiting.quote_id.clone();
         let outpoint = awaiting.state.outpoint.clone();
 
-        awaiting.finalize(&storage).await.expect("finalize");
+        assert!(
+            awaiting.finalize(&storage).await.expect("finalize"),
+            "active intent should be finalized"
+        );
 
         let active = storage
             .get_send_intent(&intent_id)
@@ -885,8 +863,10 @@ mod tests {
         .await
         .expect("new");
 
+        let batch_id = Uuid::new_v4();
+        store_test_signed_batch(&storage, batch_id, &[pending.intent_id]).await;
         let awaiting = pending
-            .assign_to_batch(&storage, Uuid::new_v4())
+            .assign_to_batch(&storage, batch_id)
             .await
             .expect("assign")
             .mark_broadcast(
@@ -912,5 +892,242 @@ mod tests {
         .await;
 
         assert!(matches!(result, Err(Error::DuplicateQuoteId(id)) if id == quote_id));
+    }
+
+    #[tokio::test]
+    async fn stale_pending_handle_cannot_fail_a_batched_intent() {
+        let storage = test_storage().await;
+        let quote_id = "quote-stale-fail".to_string();
+
+        let pending = SendIntent::new(
+            &storage,
+            quote_id.clone(),
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            10_000,
+            500,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("new");
+        let stale = pending.clone();
+        let intent_id = pending.intent_id;
+
+        let batch_id = Uuid::new_v4();
+        store_test_signed_batch(&storage, batch_id, &[intent_id]).await;
+        pending
+            .assign_to_batch(&storage, batch_id)
+            .await
+            .expect("assign");
+
+        let err = stale
+            .fail(&storage, "stale failure".to_string())
+            .await
+            .expect_err("stale handle must not fail a batched intent");
+        assert!(matches!(
+            err,
+            Error::SendIntentStateConflict {
+                intent_id: id,
+                expected: "Pending",
+            } if id == intent_id
+        ));
+
+        let persisted = storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get intent")
+            .expect("intent present");
+        assert!(
+            matches!(persisted.state, SendIntentState::Batched { batch_id: b, .. } if b == batch_id),
+            "durable state must remain Batched, got {:?}",
+            persisted.state
+        );
+
+        let attempts = storage
+            .get_failed_send_attempts_by_quote_id(&quote_id)
+            .await
+            .expect("failed attempts");
+        assert!(attempts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stale_pending_handle_cannot_batch_a_failed_intent() {
+        let storage = test_storage().await;
+        let quote_id = "quote-stale-batch".to_string();
+
+        let pending = SendIntent::new(
+            &storage,
+            quote_id,
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            10_000,
+            500,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("new");
+        let stale = pending.clone();
+        let intent_id = pending.intent_id;
+
+        pending
+            .fail(&storage, "fee too high".to_string())
+            .await
+            .expect("fail");
+
+        let batch_id = Uuid::new_v4();
+        store_test_signed_batch(&storage, batch_id, &[intent_id]).await;
+        let err = stale
+            .assign_to_batch(&storage, batch_id)
+            .await
+            .expect_err("stale handle must not batch a failed intent");
+        assert!(matches!(
+            err,
+            Error::SendIntentStateConflict {
+                intent_id: id,
+                expected: "Pending",
+            } if id == intent_id
+        ));
+
+        let persisted = storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get intent")
+            .expect("intent present");
+        assert!(
+            matches!(persisted.state, SendIntentState::Failed { .. }),
+            "durable state must remain Failed, got {:?}",
+            persisted.state
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_batched_handle_cannot_broadcast_a_reverted_intent() {
+        let storage = test_storage().await;
+
+        let pending = SendIntent::new(
+            &storage,
+            "quote-stale-broadcast".to_string(),
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            10_000,
+            500,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("new");
+        let batch_id = Uuid::new_v4();
+        store_test_signed_batch(&storage, batch_id, &[pending.intent_id]).await;
+        let batched = pending
+            .assign_to_batch(&storage, batch_id)
+            .await
+            .expect("assign");
+        let stale = batched.clone();
+        let intent_id = batched.intent_id;
+
+        batched
+            .revert_to_pending(&storage)
+            .await
+            .expect("revert to pending");
+
+        let err = stale
+            .mark_broadcast(
+                &storage,
+                "txid-stale".to_string(),
+                "txid-stale:0".to_string(),
+                250,
+            )
+            .await
+            .expect_err("stale handle must not broadcast a reverted intent");
+        assert!(matches!(
+            err,
+            Error::SendIntentStateConflict {
+                intent_id: id,
+                expected: "Batched",
+            } if id == intent_id
+        ));
+
+        let persisted = storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get intent")
+            .expect("intent present");
+        assert!(
+            matches!(persisted.state, SendIntentState::Pending { .. }),
+            "durable state must remain Pending, got {:?}",
+            persisted.state
+        );
+        assert!(
+            storage
+                .get_quote_id_by_send_outpoint("txid-stale:0")
+                .await
+                .expect("outpoint lookup")
+                .is_none(),
+            "no outpoint index entry may be written for a rejected transition"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_batched_handle_cannot_revert_a_broadcast_intent() {
+        let storage = test_storage().await;
+
+        let pending = SendIntent::new(
+            &storage,
+            "quote-stale-revert".to_string(),
+            "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
+            10_000,
+            500,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("new");
+        let batch_id = Uuid::new_v4();
+        store_test_signed_batch(&storage, batch_id, &[pending.intent_id]).await;
+        let batched = pending
+            .assign_to_batch(&storage, batch_id)
+            .await
+            .expect("assign");
+        let stale = batched.clone();
+        let intent_id = batched.intent_id;
+
+        batched
+            .mark_broadcast(
+                &storage,
+                "txid-live".to_string(),
+                "txid-live:0".to_string(),
+                250,
+            )
+            .await
+            .expect("mark broadcast");
+
+        let err = stale
+            .revert_to_pending(&storage)
+            .await
+            .expect_err("stale handle must not revert a broadcast intent");
+        assert!(matches!(
+            err,
+            Error::SendIntentStateConflict {
+                intent_id: id,
+                expected: "Batched",
+            } if id == intent_id
+        ));
+
+        let persisted = storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get intent")
+            .expect("intent present");
+        assert!(
+            matches!(
+                persisted.state,
+                SendIntentState::AwaitingConfirmation {
+                    batch_id: b,
+                    ref txid,
+                    ..
+                } if b == batch_id && txid == "txid-live"
+            ),
+            "durable state must remain AwaitingConfirmation, got {:?}",
+            persisted.state
+        );
     }
 }

--- a/crates/cdk-bdk/src/send/payment_intent/record.rs
+++ b/crates/cdk-bdk/src/send/payment_intent/record.rs
@@ -46,7 +46,7 @@ pub enum SendIntentState {
 }
 
 /// Full durable record for a send intent
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SendIntentRecord {
     /// Unique intent identifier
     pub intent_id: Uuid,

--- a/crates/cdk-bdk/src/send/payment_intent/record.rs
+++ b/crates/cdk-bdk/src/send/payment_intent/record.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use crate::types::{PaymentMetadata, PaymentTier};
 
 /// Durable send intent state
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SendIntentState {
     /// Intent is waiting for batch assignment
     Pending {
@@ -50,6 +50,13 @@ pub enum SendIntentState {
 pub struct SendIntentRecord {
     /// Unique intent identifier
     pub intent_id: Uuid,
+    /// Unique generation for this quote's current payment attempt.
+    ///
+    /// Older records deserialize to the nil UUID. A retry always replaces it
+    /// with a fresh value so handles from an earlier attempt cannot pass a
+    /// `Pending -> Failed -> Pending` ABA cycle.
+    #[serde(default)]
+    pub attempt_id: Uuid,
     /// Quote ID linking this intent to a melt quote
     pub quote_id: String,
     /// Destination Bitcoin address

--- a/crates/cdk-bdk/src/send/service.rs
+++ b/crates/cdk-bdk/src/send/service.rs
@@ -18,6 +18,16 @@ use crate::send::payment_intent::{self, state as intent_state, SendIntent, SendI
 use crate::types::PaymentTier;
 use crate::CdkBdk;
 
+/// Consecutive deterministic backend rejections after which a batch stops
+/// being automatically rebroadcast and waits for operator intervention.
+///
+/// Transient or ambiguous failures never count toward this limit, and
+/// escalation touches nothing but the retry decision: the batch record, its
+/// durable evidence, and its wallet input reservations are all retained,
+/// because a rejection from this backend never proves the transaction is not
+/// in someone else's mempool.
+pub(crate) const MAX_CONSECUTIVE_BROADCAST_REJECTIONS: u32 = 10;
+
 impl CdkBdk {
     async fn fail_send_intents(&self, intents: &[SendIntent<intent_state::Pending>], reason: &str) {
         for intent in intents {
@@ -182,7 +192,7 @@ impl CdkBdk {
         self.chain_source.broadcast(tx).await
     }
 
-    pub(crate) fn log_broadcast_failure(
+    pub(crate) async fn log_broadcast_failure(
         &self,
         context: &str,
         batch_id: Uuid,
@@ -191,12 +201,42 @@ impl CdkBdk {
     ) {
         match failure.kind {
             BroadcastErrorKind::Rejected => {
-                tracing::error!(
-                    %batch_id,
-                    %txid,
-                    error = %failure.message,
-                    "{context}: backend rejected signed transaction; keeping batch for operator review/retry"
-                );
+                let count = match self
+                    .storage
+                    .record_broadcast_rejection(&batch_id, txid, &failure.message)
+                    .await
+                {
+                    Ok(count) => Some(count),
+                    Err(err) => {
+                        tracing::error!(
+                            %batch_id,
+                            %txid,
+                            error = %err,
+                            "Could not record broadcast rejection"
+                        );
+                        None
+                    }
+                };
+                match count {
+                    Some(count) if count >= MAX_CONSECUTIVE_BROADCAST_REJECTIONS => {
+                        tracing::error!(
+                            %batch_id,
+                            %txid,
+                            consecutive_rejections = count,
+                            error = %failure.message,
+                            "{context}: backend keeps rejecting signed transaction; \
+                             suspending automatic rebroadcast until operator review"
+                        );
+                    }
+                    _ => {
+                        tracing::error!(
+                            %batch_id,
+                            %txid,
+                            error = %failure.message,
+                            "{context}: backend rejected signed transaction; keeping batch for operator review/retry"
+                        );
+                    }
+                }
             }
             BroadcastErrorKind::Transient => {
                 tracing::warn!(
@@ -214,6 +254,18 @@ impl CdkBdk {
                     "{context}: ambiguous broadcast failure; will retry conservatively"
                 );
             }
+        }
+    }
+
+    /// Clear any recorded broadcast rejections after the backend accepted (or
+    /// already knew) the transaction.
+    pub(crate) async fn note_broadcast_success(&self, batch_id: Uuid) {
+        if let Err(err) = self.storage.clear_broadcast_rejection(&batch_id).await {
+            tracing::warn!(
+                %batch_id,
+                error = %err,
+                "Could not clear broadcast rejection record"
+            );
         }
     }
 
@@ -255,6 +307,35 @@ impl CdkBdk {
                 normalized,
                 "Assigned attempt IDs to legacy pending send intents"
             );
+        }
+
+        // Bind pre-attempt-generation Broadcast batches to their member
+        // intents' current attempts. Without this write-once binding the
+        // eligibility gate fences legacy durable evidence from rebroadcast
+        // permanently, wedging any payment that was in flight during the
+        // upgrade.
+        for batch in self.storage.get_all_send_batches().await? {
+            if !matches!(
+                &batch.state,
+                SendBatchState::Broadcast { assignments, .. }
+                    if assignments.iter().any(|a| a.attempt_id.is_nil())
+            ) {
+                continue;
+            }
+            let Some((_, txid, _)) = decode_broadcast_reservation(&batch.batch_id, &batch.state)
+            else {
+                continue;
+            };
+            if self
+                .storage
+                .normalize_legacy_broadcast_attempt_ids(&batch.batch_id, &txid.to_string())
+                .await?
+            {
+                tracing::info!(
+                    batch_id = %batch.batch_id,
+                    "Bound legacy Broadcast batch to current send attempts"
+                );
+            }
         }
 
         // Cancellation is durable precisely so transient wallet/storage
@@ -731,8 +812,11 @@ impl CdkBdk {
 
         // 7. Broadcast
         match self.broadcast_transaction_internal(tx.clone()).await {
-            Ok(BroadcastOutcome::Accepted) => {}
+            Ok(BroadcastOutcome::Accepted) => {
+                self.note_broadcast_success(batch_id).await;
+            }
             Ok(BroadcastOutcome::AlreadyKnown) => {
+                self.note_broadcast_success(batch_id).await;
                 tracing::info!(
                     "Batch {} txid {} was already known to backend",
                     batch_id,
@@ -745,7 +829,8 @@ impl CdkBdk {
                     batch_id,
                     &txid_string,
                     &failure,
-                );
+                )
+                .await;
                 // Post-Broadcast-persist failure: the batch record and intents are
                 // already marked for reconciliation. Recovery will attempt rebroadcast.
                 return Err(Error::Wallet(format!(
@@ -854,6 +939,17 @@ impl CdkBdk {
                 self.storage
                     .delete_send_batch_if_state(&batch.batch_id, &batch.state)
                     .await?;
+                if let Err(err) = self
+                    .storage
+                    .clear_broadcast_rejection(&batch.batch_id)
+                    .await
+                {
+                    tracing::warn!(
+                        batch_id = %batch.batch_id,
+                        error = %err,
+                        "Could not clear broadcast rejection record during batch cleanup"
+                    );
+                }
             } else {
                 tracing::warn!(
                     batch_id = %batch.batch_id,
@@ -888,6 +984,22 @@ impl CdkBdk {
             if let Some(reservation) = decode_broadcast_reservation(&record.batch_id, &record.state)
             {
                 reservations.push(reservation);
+            }
+            // An escalated batch keeps its input reservation but is not
+            // retried against the backend until an operator intervenes.
+            if self
+                .storage
+                .get_broadcast_rejection(&record.batch_id)
+                .await?
+                .is_some_and(|rejection| {
+                    rejection.consecutive_rejections >= MAX_CONSECUTIVE_BROADCAST_REJECTIONS
+                })
+            {
+                tracing::debug!(
+                    batch_id = %record.batch_id,
+                    "Skipping escalated batch; awaiting operator review"
+                );
+                continue;
             }
             if let Some((txid, tx)) = self
                 .prepare_broadcast_batch(record.batch_id, &record.state)
@@ -958,16 +1070,20 @@ impl CdkBdk {
         for (batch_id, txid, tx) in candidates {
             tracing::info!(%batch_id, %txid, "Rebroadcasting stuck batch");
             match self.broadcast_transaction_internal(tx.clone()).await {
-                Ok(outcome) => match outcome {
-                    BroadcastOutcome::Accepted => {
-                        tracing::info!(%batch_id, %txid, "Rebroadcast accepted");
+                Ok(outcome) => {
+                    self.note_broadcast_success(batch_id).await;
+                    match outcome {
+                        BroadcastOutcome::Accepted => {
+                            tracing::info!(%batch_id, %txid, "Rebroadcast accepted");
+                        }
+                        BroadcastOutcome::AlreadyKnown => {
+                            tracing::info!(%batch_id, %txid, "Rebroadcast tx already known");
+                        }
                     }
-                    BroadcastOutcome::AlreadyKnown => {
-                        tracing::info!(%batch_id, %txid, "Rebroadcast tx already known");
-                    }
-                },
+                }
                 Err(failure) => {
-                    self.log_broadcast_failure("Rebroadcast failed", batch_id, &txid, &failure);
+                    self.log_broadcast_failure("Rebroadcast failed", batch_id, &txid, &failure)
+                        .await;
                     // Swallow: next reconciliation tick will retry.
                 }
             }
@@ -2354,6 +2470,172 @@ mod tests {
                 panic!("reserved transaction must remain canonical and unconfirmed");
             };
             assert!(last_seen > sync_started_at);
+        }
+
+        /// Pre-attempt-generation durable Broadcast evidence is fenced from
+        /// rebroadcast until a processor cycle binds its assignments to the
+        /// member intents' current attempts.
+        #[tokio::test]
+        async fn legacy_broadcast_batch_is_normalized_and_unfenced() {
+            let backend = build_test_instance().await;
+            let batch_id = Uuid::new_v4();
+            let tx = wallet_relevant_tx(&backend).await;
+            let txid = tx.compute_txid();
+            let intent_id = Uuid::new_v4();
+            let address = Address::from_script(&tx.output[0].script_pubkey, backend.network)
+                .expect("test output script has an address");
+
+            // Legacy shape: nil attempt IDs on both the member intent and
+            // the batch assignment, as written before attempt generations
+            // existed.
+            backend
+                .storage
+                .create_send_intent_if_absent(&SendIntentRecord {
+                    intent_id,
+                    attempt_id: Uuid::nil(),
+                    quote_id: format!("quote-{intent_id}"),
+                    address: address.to_string(),
+                    amount_sat: 10_000,
+                    max_fee_amount_sat: 500,
+                    tier: PaymentTier::Immediate,
+                    metadata: PaymentMetadata::default(),
+                    state: SendIntentState::AwaitingConfirmation {
+                        batch_id,
+                        txid: txid.to_string(),
+                        outpoint: OutPoint::new(txid, 0).to_string(),
+                        fee_contribution_sat: 500,
+                        created_at: 1_700_000_000,
+                    },
+                })
+                .await
+                .expect("store legacy intent");
+            backend
+                .storage
+                .store_send_batch(&SendBatchRecord {
+                    batch_id,
+                    state: SendBatchState::Broadcast {
+                        txid: txid.to_string(),
+                        tx_bytes: consensus::serialize(&tx),
+                        assignments: vec![BatchOutputAssignment {
+                            intent_id,
+                            attempt_id: Uuid::nil(),
+                            vout: 0,
+                            fee_contribution_sat: 500,
+                        }],
+                        fee_sat: 500,
+                    },
+                })
+                .await
+                .expect("store legacy broadcast batch");
+
+            let stored = backend
+                .storage
+                .get_send_batch(&batch_id)
+                .await
+                .expect("read batch")
+                .expect("batch exists");
+            assert!(
+                backend
+                    .prepare_broadcast_batch(batch_id, &stored.state)
+                    .await
+                    .expect("prepare legacy batch")
+                    .is_none(),
+                "legacy broadcast must be fenced before normalization"
+            );
+
+            backend
+                .process_ready_intents()
+                .await
+                .expect("processor cycle");
+
+            let stored = backend
+                .storage
+                .get_send_batch(&batch_id)
+                .await
+                .expect("read batch")
+                .expect("batch exists");
+            assert!(
+                backend
+                    .prepare_broadcast_batch(batch_id, &stored.state)
+                    .await
+                    .expect("prepare normalized batch")
+                    .is_some(),
+                "normalized broadcast must be eligible for rebroadcast"
+            );
+        }
+
+        /// A batch the backend keeps deterministically rejecting stops being
+        /// retried after the escalation threshold, but keeps its wallet
+        /// reservation: rejection by this backend never proves the
+        /// transaction is not in someone else's mempool.
+        #[tokio::test]
+        async fn rebroadcast_escalates_after_repeated_deterministic_rejection() {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+
+            let mut backend = build_test_instance().await;
+            let batch_id = Uuid::new_v4();
+            let tx = wallet_relevant_tx(&backend).await;
+            let txid = tx.compute_txid();
+            store_eligible_broadcast(&backend, batch_id, &tx).await;
+
+            let requests = Arc::new(AtomicUsize::new(0));
+            let counted = requests.clone();
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind test Esplora server");
+            let address = listener.local_addr().expect("test server address");
+            let server = tokio::spawn(async move {
+                loop {
+                    let (mut stream, _) = listener.accept().await.expect("accept");
+                    counted.fetch_add(1, Ordering::SeqCst);
+                    let mut request = [0u8; 4096];
+                    let _ = stream.read(&mut request).await.expect("read request");
+                    let body = "bad-txns-inputs-missingorspent";
+                    let response = format!(
+                        "HTTP/1.1 400 Bad Request\r\nContent-Length: {}\r\nConnection: close\r\nContent-Type: text/plain\r\n\r\n{body}",
+                        body.len()
+                    );
+                    stream
+                        .write_all(response.as_bytes())
+                        .await
+                        .expect("write rejection");
+                }
+            });
+            backend.chain_source = ChainSource::Esplora(EsploraConfig {
+                url: format!("http://{address}"),
+                parallel_requests: 1,
+            });
+
+            let threshold = super::super::MAX_CONSECUTIVE_BROADCAST_REJECTIONS;
+            for _ in 0..threshold {
+                backend
+                    .rebroadcast_stuck_batches()
+                    .await
+                    .expect("rebroadcast");
+            }
+            assert_eq!(requests.load(Ordering::SeqCst), threshold as usize);
+            let record = backend
+                .storage
+                .get_broadcast_rejection(&batch_id)
+                .await
+                .expect("read rejection record")
+                .expect("rejection record exists");
+            assert_eq!(record.consecutive_rejections, threshold);
+
+            // Escalated: no further network I/O, reservation retained.
+            backend
+                .rebroadcast_stuck_batches()
+                .await
+                .expect("escalated rebroadcast run");
+            assert_eq!(requests.load(Ordering::SeqCst), threshold as usize);
+            {
+                let wallet_with_db = backend.wallet_with_db.lock().await;
+                assert!(
+                    wallet_with_db.wallet.get_tx(txid).is_some(),
+                    "escalated batch must keep its input reservation"
+                );
+            }
+            server.abort();
         }
 
         /// An already-known response proves the backend has the transaction,

--- a/crates/cdk-bdk/src/send/service.rs
+++ b/crates/cdk-bdk/src/send/service.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use bdk_wallet::bitcoin::{Address, OutPoint, Transaction};
+use bdk_wallet::bitcoin::{Address, OutPoint, Transaction, Txid};
 use cdk_common::payment::{Event, MakePaymentResponse, PaymentIdentifier};
 use cdk_common::{Amount, CurrencyUnit, MeltQuoteState, QuoteId};
 use tokio::time::interval;
@@ -13,6 +13,7 @@ use crate::send::batch_transaction::record::{
     BatchOutputAssignment, SendBatchRecord, SendBatchState,
 };
 use crate::send::batch_transaction::{allocate_batch_fee, state as batch_state, SendBatch};
+use crate::send::payment_intent::record::SendIntentState;
 use crate::send::payment_intent::{self, state as intent_state, SendIntent, SendIntentAny};
 use crate::types::PaymentTier;
 use crate::CdkBdk;
@@ -26,6 +27,7 @@ impl CdkBdk {
                     intent.intent_id,
                     err
                 );
+                continue;
             }
 
             if let Ok(quote_id) = QuoteId::from_str(&intent.quote_id) {
@@ -53,12 +55,15 @@ impl CdkBdk {
         let fee = intent.state.fee_contribution_sat;
         let outpoint = intent.state.outpoint.clone();
 
-        intent.finalize(&self.storage).await.map_err(|e| {
+        let finalized = intent.finalize(&self.storage).await.map_err(|e| {
             tracing::error!("Failed to finalize send intent {}: {}", intent_id, e);
             e
         })?;
 
-        if let Ok(quote_id) = QuoteId::from_str(&quote_id) {
+        if finalized {
+            let Ok(quote_id) = QuoteId::from_str(&quote_id) else {
+                return Ok(());
+            };
             let details = MakePaymentResponse {
                 payment_lookup_id: PaymentIdentifier::QuoteId(quote_id.clone()),
                 payment_proof: Some(outpoint),
@@ -162,6 +167,7 @@ impl CdkBdk {
             .iter()
             .map(|intent| IntentOutput {
                 intent_id: intent.intent_id,
+                attempt_id: intent.attempt_id,
                 address: intent.address.as_str(),
                 amount: intent.amount,
             })
@@ -243,7 +249,69 @@ impl CdkBdk {
     }
 
     pub(crate) async fn process_ready_intents(&self) -> Result<(), Error> {
-        let pending = self.storage.get_pending_send_intents().await?;
+        let normalized = self.storage.normalize_legacy_pending_attempt_ids().await?;
+        if normalized > 0 {
+            tracing::info!(
+                normalized,
+                "Assigned attempt IDs to legacy pending send intents"
+            );
+        }
+
+        // Cancellation is durable precisely so transient wallet/storage
+        // failures can be retried. Drain those markers on every processor
+        // cycle rather than requiring a process restart.
+        self.resume_cancelled_send_batches().await?;
+
+        // A transient Signed -> Broadcast storage failure leaves a fully signed
+        // transaction durable but unavailable to the normal pending selector.
+        // Reuse the idempotent recovery path on a later processor cycle instead
+        // of requiring a process restart.
+        if self
+            .storage
+            .get_all_send_batches()
+            .await?
+            .iter()
+            .any(|batch| {
+                matches!(
+                    &batch.state,
+                    SendBatchState::Signed { tx_bytes, .. }
+                        if bdk_wallet::bitcoin::consensus::deserialize::<Transaction>(tx_bytes)
+                            .is_ok()
+                )
+            })
+        {
+            self.recover_send_saga().await?;
+        }
+
+        let broadcast_owned_intents: std::collections::HashSet<_> = self
+            .storage
+            .get_all_send_batches()
+            .await?
+            .into_iter()
+            .filter_map(|batch| match batch.state {
+                SendBatchState::Broadcast { assignments, .. } => Some(assignments),
+                _ => None,
+            })
+            .flatten()
+            .map(|assignment| assignment.intent_id)
+            .collect();
+        let pending: Vec<_> = self
+            .storage
+            .get_pending_send_intents()
+            .await?
+            .into_iter()
+            .filter(|intent| {
+                let eligible = !broadcast_owned_intents.contains(&intent.intent_id);
+                if !eligible {
+                    tracing::warn!(
+                        intent_id = %intent.intent_id,
+                        attempt_id = %intent.attempt_id,
+                        "Keeping Pending replacement fenced by durable Broadcast evidence"
+                    );
+                }
+                eligible
+            })
+            .collect();
         if pending.is_empty() {
             return Ok(());
         }
@@ -279,23 +347,38 @@ impl CdkBdk {
                         age_secs,
                         max_age.as_secs()
                     );
-                    if let Err(e) = self
+                    let failed_state =
+                        crate::send::payment_intent::record::SendIntentState::Failed {
+                            reason: reason.clone(),
+                            created_at,
+                            failed_at: now,
+                        };
+                    match self
                         .storage
-                        .update_send_intent(
+                        .transition_send_intent(
                             &intent.intent_id,
-                            &crate::send::payment_intent::record::SendIntentState::Failed {
-                                reason: reason.clone(),
-                                created_at,
-                                failed_at: now,
-                            },
+                            &intent.attempt_id,
+                            &intent.state,
+                            &failed_state,
                         )
                         .await
                     {
-                        tracing::error!(
-                            "Failed to mark expired intent {} failed: {}",
-                            intent.intent_id,
-                            e
-                        );
+                        Ok(true) => {}
+                        Ok(false) => {
+                            tracing::info!(
+                                "Skipping expiry of intent {}: durable state changed concurrently",
+                                intent.intent_id
+                            );
+                            continue;
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to mark expired intent {} failed: {}",
+                                intent.intent_id,
+                                e
+                            );
+                            continue;
+                        }
                     }
                     if let Ok(quote_id) = QuoteId::from_str(&intent.quote_id) {
                         if let Err(err) = self
@@ -411,8 +494,18 @@ impl CdkBdk {
             }
         };
 
+        // Load durable reservations before taking the wallet mutex. The actual
+        // reservations and coin selection remain in one critical section, while
+        // storage I/O cannot stall every other wallet user.
+        let durable_broadcasts = self.load_broadcast_reservations().await?;
+
         // 1. Build the PSBT
         let mut wallet_with_db = self.wallet_with_db.lock().await;
+        Self::reserve_broadcast_transactions_locked(
+            &mut wallet_with_db.wallet,
+            &durable_broadcasts,
+            0,
+        )?;
         let mut tx_builder = wallet_with_db.wallet.build_tx();
         for (address, amount) in recipients {
             tx_builder.add_recipient(address, bdk_wallet::bitcoin::Amount::from_sat(amount));
@@ -500,31 +593,12 @@ impl CdkBdk {
         let tx_bytes = bdk_wallet::bitcoin::consensus::serialize(&tx);
         let txid = tx.compute_txid();
 
-        // Apply the freshly built tx to BDK's tx graph so the next batch
-        // cycle's coin selection treats its inputs as spent. Without this,
-        // concurrent melts each call `finish()` against the same UTXO view
-        // and pick the same input, causing double-spends rejected by bitcoind.
-        let apply_time = crate::util::unix_now();
-        wallet_with_db
-            .wallet
-            .apply_unconfirmed_txs([(tx.clone(), apply_time)]);
-        if let Err(e) = wallet_with_db.persist() {
-            tracing::warn!(
-                batch_id = %batch_id,
-                "Could not persist BDK wallet after applying unconfirmed tx: {}",
-                e
-            );
-        }
-
-        // Drop wallet lock before broadcasting
-        drop(wallet_with_db);
-
         // 3. Record per-intent vout + fee mapping once, at the only place we have
         // ground truth: the freshly built transaction plus the fee allocation
-        // in memory. Persist this Signed batch before moving any intent out
-        // of Pending; this makes every post-sign crash/failure recoverable
-        // from the signed transaction bytes instead of reverting into a new
-        // batch.
+        // in memory. Persist Signed before applying the transaction to BDK, so
+        // every durable wallet-graph mutation has a recovery record. Keep the
+        // wallet lock through both operations so another local batch cannot
+        // select the same inputs in between.
         let assignments = self.derive_pending_vout_assignments(&tx, &intents, &fee_allocations)?;
         let intent_count = assignments.len();
 
@@ -540,30 +614,67 @@ impl CdkBdk {
             })
             .await
         {
-            // Persisting Signed failed after the wallet's tx graph was
-            // advanced. Revert the apply so the UTXOs aren't stranded in
-            // an orphaned unconfirmed tx. Downstream failures all leave a
-            // durable Signed/Broadcast record that recovery can replay.
-            let evict_time = apply_time.saturating_add(1);
-            let mut wallet_with_db = self.wallet_with_db.lock().await;
-            wallet_with_db
-                .wallet
-                .apply_evicted_txs([(txid, evict_time)]);
-            if let Err(persist_err) = wallet_with_db.persist() {
-                tracing::warn!(
-                    batch_id = %batch_id,
-                    "Could not persist BDK wallet after evicting unconfirmed tx on store_send_batch failure: {}",
-                    persist_err
-                );
-            }
             drop(wallet_with_db);
             return Err(e);
         }
 
+        // Apply the freshly built tx to BDK's tx graph so the next batch
+        // cycle's coin selection treats its inputs as spent. Without this,
+        // concurrent melts each call `finish()` against the same UTXO view
+        // and pick the same input, causing double-spends rejected by bitcoind.
+        let apply_time = reserve_unconfirmed_tx(&mut wallet_with_db.wallet, &tx)?;
+        if let Err(e) = wallet_with_db.persist() {
+            tracing::warn!(
+                batch_id = %batch_id,
+                "Could not persist BDK wallet after applying unconfirmed tx: {}",
+                e
+            );
+        }
+
+        // Drop wallet lock before broadcasting or compensating.
+        drop(wallet_with_db);
+
         // 4. Transition intents to Batched after the signed transaction is durable.
-        let mut batched_intents = Vec::new();
+        let mut batched_intents: Vec<SendIntent<intent_state::Batched>> = Vec::new();
         for intent in intents {
-            let batched = intent.assign_to_batch(&self.storage, batch_id).await?;
+            let batched = match intent.assign_to_batch(&self.storage, batch_id).await {
+                Ok(batched) => batched,
+                Err(e) => {
+                    tracing::warn!(
+                        batch_id = %batch_id,
+                        error = %e,
+                        "Batch member could not be claimed; compensating signed batch"
+                    );
+                    let cancelled = match self
+                        .cancel_signed_send_batch(
+                            batch_id,
+                            &tx_bytes,
+                            &assignments,
+                            actual_fee,
+                            apply_time.saturating_add(1),
+                        )
+                        .await
+                    {
+                        Ok(cancelled) => cancelled,
+                        Err(cancel_err) => {
+                            tracing::error!(
+                                batch_id = %batch_id,
+                                error = %cancel_err,
+                                "Failed to durably compensate signed batch"
+                            );
+                            return Err(cancel_err);
+                        }
+                    };
+                    if !cancelled {
+                        tracing::info!(
+                            batch_id = %batch_id,
+                            "Skipping compensation because the signed batch changed concurrently"
+                        );
+                        return Err(e);
+                    }
+                    return Err(e);
+                }
+            };
             batched_intents.push(batched);
         }
         let signed_batch =
@@ -695,30 +806,65 @@ impl CdkBdk {
         let all_active_intents = self.storage.get_all_send_intents().await?;
 
         for batch in batches {
-            let assignments = match &batch.state {
+            let (stored_txid, tx_bytes, assignments) = match &batch.state {
                 crate::send::batch_transaction::record::SendBatchState::Broadcast {
+                    txid,
+                    tx_bytes,
                     assignments,
                     ..
-                } => assignments,
+                } => (txid, tx_bytes, assignments),
                 _ => continue, // Only clean up broadcast batches
             };
 
             let has_active = assignments.iter().any(|a| {
                 all_active_intents
                     .iter()
-                    .any(|i| i.intent_id == a.intent_id)
+                    .any(|i| i.intent_id == a.intent_id && i.attempt_id == a.attempt_id)
             });
 
-            if !has_active {
+            if has_active {
+                continue;
+            }
+
+            // Missing active state can also mean corruption or replacement.
+            // Retain the Broadcast evidence unless every assigned output has
+            // an exact finalized tombstone.
+            let Some((txid, _)) = decode_broadcast_tx(&batch.batch_id, stored_txid, tx_bytes)
+            else {
+                continue;
+            };
+            let mut all_finalized = !assignments.is_empty();
+            for assignment in assignments {
+                let expected_outpoint = OutPoint::new(txid, assignment.vout).to_string();
+                let finalized = self
+                    .storage
+                    .get_finalized_intent(&assignment.intent_id)
+                    .await?;
+                if finalized
+                    .as_ref()
+                    .is_none_or(|record| record.outpoint != expected_outpoint)
+                {
+                    all_finalized = false;
+                    break;
+                }
+            }
+
+            if all_finalized {
                 tracing::info!("Cleaning up completed batch {}", batch.batch_id);
-                self.storage.delete_send_batch(&batch.batch_id).await?;
+                self.storage
+                    .delete_send_batch_if_state(&batch.batch_id, &batch.state)
+                    .await?;
+            } else {
+                tracing::warn!(
+                    batch_id = %batch.batch_id,
+                    "Retaining Broadcast batch because exact completion is not proven"
+                );
             }
         }
         Ok(())
     }
 
-    /// Re-broadcast any `Broadcast`-state batch whose transaction the BDK
-    /// wallet does not currently know about.
+    /// Re-broadcast any unconfirmed `Broadcast`-state batch.
     ///
     /// `Broadcast` state is persisted before the network send (see the
     /// hot path in `build_sign_broadcast_batch`), so a transient Esplora
@@ -728,88 +874,98 @@ impl CdkBdk {
     /// this helper closes the steady-state gap by retrying on every
     /// sync-reconciliation tick.
     ///
-    /// Staleness signal: `wallet.get_tx(txid).is_none()`. If the wallet
-    /// sees the tx (confirmed or unconfirmed in mempool), we leave it
-    /// alone. Per-batch failures are logged and swallowed; the next
-    /// reconciliation tick retries naturally.
+    /// The stored txid and persisted transaction bytes must identify the same
+    /// transaction. A locally tracked unconfirmed transaction is still retried
+    /// because BDK wallet presence does not prove backend acceptance. Confirmed
+    /// transactions are skipped. Per-batch failures are logged and swallowed;
+    /// the next reconciliation tick retries naturally.
     #[tracing::instrument(skip_all)]
     pub(crate) async fn rebroadcast_stuck_batches(&self) -> Result<(), Error> {
         let batches = self.storage.get_all_send_batches().await?;
+        let mut reservations = Vec::new();
+        let mut eligible = Vec::new();
+        for record in batches {
+            if let Some(reservation) = decode_broadcast_reservation(&record.batch_id, &record.state)
+            {
+                reservations.push(reservation);
+            }
+            if let Some((txid, tx)) = self
+                .prepare_broadcast_batch(record.batch_id, &record.state)
+                .await?
+            {
+                eligible.push((record.batch_id, txid, tx));
+            }
+        }
 
-        // Collect candidates while holding the wallet lock (needed for
-        // `get_tx`), then drop the lock before any network I/O so the
-        // sync loop is never blocked on Esplora latency.
+        // Reserve every candidate in BDK before releasing the wallet lock.
+        // A durable Broadcast record means its inputs must not be selected by
+        // another batch even when the backend has not accepted the transaction
+        // yet. The reservation timestamp must strictly beat any eviction marker
+        // or BDK will continue to treat the transaction as non-canonical.
         let candidates: Vec<(Uuid, String, Transaction)> = {
-            let wallet_with_db = self.wallet_with_db.lock().await;
-            batches
-                .into_iter()
-                .filter_map(|rec| {
-                    let crate::send::batch_transaction::record::SendBatchState::Broadcast {
-                        txid,
-                        tx_bytes,
-                        ..
-                    } = rec.state
-                    else {
-                        return None;
-                    };
+            let mut wallet_with_db = self.wallet_with_db.lock().await;
+            let mut candidates = Vec::new();
 
-                    let parsed_txid = match bdk_wallet::bitcoin::Txid::from_str(&txid) {
-                        Ok(t) => t,
-                        Err(e) => {
-                            tracing::warn!(
-                                batch_id = %rec.batch_id,
-                                txid = %txid,
-                                "Skipping rebroadcast: failed to parse persisted txid: {e}"
-                            );
-                            return None;
-                        }
-                    };
+            for (batch_id, txid, tx) in &reservations {
+                if wallet_with_db
+                    .wallet
+                    .get_tx(*txid)
+                    .is_some_and(|wallet_tx| {
+                        matches!(
+                            wallet_tx.chain_position,
+                            bdk_wallet::chain::ChainPosition::Confirmed { .. }
+                        )
+                    })
+                {
+                    // Confirmed transactions no longer need rebroadcasting.
+                    continue;
+                }
 
-                    if wallet_with_db.wallet.get_tx(parsed_txid).is_some() {
-                        // Wallet knows the tx (confirmed or in mempool);
-                        // no rebroadcast needed.
-                        return None;
-                    }
+                if let Err(err) = reserve_unconfirmed_tx(&mut wallet_with_db.wallet, tx) {
+                    tracing::error!(
+                        %batch_id,
+                        %txid,
+                        error = %err,
+                        "Cannot reserve rebroadcast transaction"
+                    );
+                }
+            }
 
-                    match bdk_wallet::bitcoin::consensus::deserialize::<Transaction>(&tx_bytes) {
-                        Ok(tx) => Some((rec.batch_id, txid, tx)),
-                        Err(e) => {
-                            tracing::warn!(
-                                batch_id = %rec.batch_id,
-                                txid = %txid,
-                                "Skipping rebroadcast: failed to deserialize persisted tx: {e}"
-                            );
-                            None
-                        }
-                    }
-                })
-                .collect()
+            for (batch_id, txid, tx) in eligible {
+                if wallet_with_db.wallet.get_tx(txid).is_some_and(|wallet_tx| {
+                    matches!(
+                        wallet_tx.chain_position,
+                        bdk_wallet::chain::ChainPosition::Confirmed { .. }
+                    )
+                }) {
+                    continue;
+                }
+                candidates.push((batch_id, txid.to_string(), tx));
+            }
+
+            if !reservations.is_empty() {
+                if let Err(err) = wallet_with_db.persist() {
+                    tracing::warn!(
+                        "Could not persist BDK wallet after reserving rebroadcast transactions: {}",
+                        err
+                    );
+                }
+            }
+
+            candidates
         };
 
         for (batch_id, txid, tx) in candidates {
             tracing::info!(%batch_id, %txid, "Rebroadcasting stuck batch");
             match self.broadcast_transaction_internal(tx.clone()).await {
-                Ok(BroadcastOutcome::Accepted) => {
-                    tracing::info!(%batch_id, %txid, "Rebroadcast accepted");
-                    // Apply the now-broadcast tx to BDK's tx graph so the
-                    // next batch cycle doesn't reselect its inputs.
-                    let apply_time = crate::util::unix_now();
-                    let mut wallet_with_db = self.wallet_with_db.lock().await;
-                    wallet_with_db
-                        .wallet
-                        .apply_unconfirmed_txs([(tx, apply_time)]);
-                    if let Err(e) = wallet_with_db.persist() {
-                        tracing::warn!(
-                            %batch_id,
-                            "Could not persist BDK wallet after applying rebroadcast tx: {}",
-                            e
-                        );
+                Ok(outcome) => match outcome {
+                    BroadcastOutcome::Accepted => {
+                        tracing::info!(%batch_id, %txid, "Rebroadcast accepted");
                     }
-                    drop(wallet_with_db);
-                }
-                Ok(BroadcastOutcome::AlreadyKnown) => {
-                    tracing::info!(%batch_id, %txid, "Rebroadcast tx already known");
-                }
+                    BroadcastOutcome::AlreadyKnown => {
+                        tracing::info!(%batch_id, %txid, "Rebroadcast tx already known");
+                    }
+                },
                 Err(failure) => {
                     self.log_broadcast_failure("Rebroadcast failed", batch_id, &txid, &failure);
                     // Swallow: next reconciliation tick will retry.
@@ -818,6 +974,312 @@ impl CdkBdk {
         }
 
         Ok(())
+    }
+
+    /// Load every decodable durable Broadcast transaction for reservation.
+    ///
+    /// Strict intent eligibility deliberately is not checked here: even corrupt
+    /// or superseded durable evidence must fence its transaction inputs. Strict
+    /// checks are only authority for network rebroadcast.
+    pub(crate) async fn load_broadcast_reservations(
+        &self,
+    ) -> Result<Vec<(Uuid, Txid, Transaction)>, Error> {
+        let batches = self.storage.get_all_send_batches().await?;
+        Ok(batches
+            .into_iter()
+            .filter_map(|record| decode_broadcast_reservation(&record.batch_id, &record.state))
+            .collect())
+    }
+
+    /// Refresh preloaded Broadcast reservations while the caller holds the
+    /// wallet mutex.
+    ///
+    /// Sync request construction uses a `minimum_last_seen` strictly newer
+    /// than the request's eviction timestamp. Reservation and sync snapshot
+    /// creation must remain in the same wallet critical section.
+    pub(crate) fn reserve_broadcast_transactions_locked(
+        wallet: &mut bdk_wallet::Wallet,
+        reservations: &[(Uuid, Txid, Transaction)],
+        minimum_last_seen: u64,
+    ) -> Result<(), Error> {
+        for (_, txid, tx) in reservations {
+            if wallet.get_tx(*txid).is_some_and(|wallet_tx| {
+                matches!(
+                    wallet_tx.chain_position,
+                    bdk_wallet::chain::ChainPosition::Confirmed { .. }
+                )
+            }) {
+                continue;
+            }
+            reserve_unconfirmed_tx_at_least(wallet, tx, minimum_last_seen)?;
+        }
+        Ok(())
+    }
+
+    /// Validate and repair a durable Broadcast batch before it can reserve
+    /// wallet inputs or reach a chain backend.
+    ///
+    /// Eligibility is all-or-nothing. Exact Batched members are advanced using
+    /// their compare-and-set transition, then the batch and all members are
+    /// re-read. Any corruption, replacement, failure, or mismatch leaves the
+    /// durable evidence untouched and fences the transaction from the network.
+    pub(crate) async fn prepare_broadcast_batch(
+        &self,
+        batch_id: Uuid,
+        state: &SendBatchState,
+    ) -> Result<Option<(Txid, Transaction)>, Error> {
+        let SendBatchState::Broadcast {
+            txid: stored_txid,
+            tx_bytes,
+            assignments,
+            fee_sat,
+        } = state
+        else {
+            return Ok(None);
+        };
+        let Some((txid, tx)) = decode_broadcast_tx(&batch_id, stored_txid, tx_bytes) else {
+            return Ok(None);
+        };
+
+        let unique_intent_ids: std::collections::HashSet<_> =
+            assignments.iter().map(|item| item.intent_id).collect();
+        let unique_vouts: std::collections::HashSet<_> =
+            assignments.iter().map(|item| item.vout).collect();
+        let allocated_fee = assignments.iter().try_fold(0_u64, |total, assignment| {
+            total.checked_add(assignment.fee_contribution_sat)
+        });
+        if assignments.is_empty()
+            || unique_intent_ids.len() != assignments.len()
+            || unique_vouts.len() != assignments.len()
+            || allocated_fee != Some(*fee_sat)
+            || assignments.iter().any(|item| {
+                item.attempt_id.is_nil()
+                    || usize::try_from(item.vout).map_or(true, |vout| vout >= tx.output.len())
+            })
+        {
+            tracing::error!(
+                %batch_id,
+                "Fencing Broadcast batch with empty, duplicate, legacy, or out-of-range assignments"
+            );
+            return Ok(None);
+        }
+
+        let expected_txid = txid.to_string();
+        let mut repairs = Vec::new();
+        for assignment in assignments {
+            let Some(record) = self.storage.get_send_intent(&assignment.intent_id).await? else {
+                tracing::error!(
+                    %batch_id,
+                    intent_id = %assignment.intent_id,
+                    "Fencing Broadcast batch with a missing member"
+                );
+                return Ok(None);
+            };
+            if record.attempt_id != assignment.attempt_id {
+                tracing::error!(
+                    %batch_id,
+                    intent_id = %assignment.intent_id,
+                    assignment_attempt_id = %assignment.attempt_id,
+                    current_attempt_id = %record.attempt_id,
+                    "Fencing Broadcast batch owned by a replacement send attempt"
+                );
+                return Ok(None);
+            }
+            let Some(output) = usize::try_from(assignment.vout)
+                .ok()
+                .and_then(|vout| tx.output.get(vout))
+            else {
+                return Ok(None);
+            };
+            let address = Address::from_str(&record.address)
+                .ok()
+                .and_then(|address| address.require_network(self.network).ok());
+            if assignment.fee_contribution_sat > record.max_fee_amount_sat
+                || output.value.to_sat() != record.amount_sat
+                || address
+                    .as_ref()
+                    .is_none_or(|address| output.script_pubkey != address.script_pubkey())
+            {
+                tracing::error!(
+                    %batch_id,
+                    intent_id = %assignment.intent_id,
+                    "Fencing Broadcast batch whose output or fee does not match its intent"
+                );
+                return Ok(None);
+            }
+            match payment_intent::from_record(&record) {
+                SendIntentAny::Batched(intent) if intent.state.batch_id == batch_id => {
+                    repairs.push((intent, assignment));
+                }
+                SendIntentAny::AwaitingConfirmation(intent)
+                    if intent.state.batch_id == batch_id
+                        && intent.state.txid == expected_txid
+                        && intent.state.outpoint
+                            == OutPoint::new(txid, assignment.vout).to_string()
+                        && intent.state.fee_contribution_sat == assignment.fee_contribution_sat => {
+                }
+                _ => {
+                    tracing::error!(
+                        %batch_id,
+                        intent_id = %assignment.intent_id,
+                        "Fencing Broadcast batch with a mismatched member"
+                    );
+                    return Ok(None);
+                }
+            }
+        }
+
+        // Validate the entire batch before mutating any member.
+        for (intent, assignment) in repairs {
+            let intent_id = intent.intent_id;
+            let result = intent
+                .mark_broadcast(
+                    &self.storage,
+                    expected_txid.clone(),
+                    OutPoint::new(txid, assignment.vout).to_string(),
+                    assignment.fee_contribution_sat,
+                )
+                .await;
+            if let Err(err) = result {
+                // A concurrent worker may have completed the exact same repair.
+                // The fresh validation below decides eligibility.
+                tracing::info!(
+                    %batch_id,
+                    %intent_id,
+                    error = %err,
+                    "Broadcast member repair compare-and-set did not win; revalidating"
+                );
+            }
+        }
+
+        // Verify the batch itself did not change while members were repaired.
+        let Some(current_batch) = self.storage.get_send_batch(&batch_id).await? else {
+            return Ok(None);
+        };
+        if current_batch.state != *state {
+            return Ok(None);
+        }
+
+        for assignment in assignments {
+            let Some(record) = self.storage.get_send_intent(&assignment.intent_id).await? else {
+                return Ok(None);
+            };
+            if record.attempt_id != assignment.attempt_id {
+                return Ok(None);
+            }
+            let SendIntentState::AwaitingConfirmation {
+                batch_id: intent_batch_id,
+                txid: intent_txid,
+                outpoint,
+                fee_contribution_sat,
+                ..
+            } = record.state
+            else {
+                return Ok(None);
+            };
+            if intent_batch_id != batch_id
+                || intent_txid != expected_txid
+                || outpoint != OutPoint::new(txid, assignment.vout).to_string()
+                || fee_contribution_sat != assignment.fee_contribution_sat
+            {
+                return Ok(None);
+            }
+        }
+
+        Ok(Some((txid, tx)))
+    }
+}
+
+/// Reserve an unconfirmed transaction in BDK's canonical graph.
+///
+/// The last-seen timestamp must strictly exceed an existing eviction marker;
+/// otherwise BDK keeps the transaction non-canonical and coin selection may
+/// reuse its inputs.
+pub(crate) fn reserve_unconfirmed_tx(
+    wallet: &mut bdk_wallet::Wallet,
+    tx: &Transaction,
+) -> Result<u64, Error> {
+    reserve_unconfirmed_tx_at_least(wallet, tx, 0)
+}
+
+/// Reserve an unconfirmed transaction with a caller-provided lower bound for
+/// its last-seen timestamp.
+pub(crate) fn reserve_unconfirmed_tx_at_least(
+    wallet: &mut bdk_wallet::Wallet,
+    tx: &Transaction,
+    minimum_last_seen: u64,
+) -> Result<u64, Error> {
+    let txid = tx.compute_txid();
+    let now = crate::util::unix_now();
+    let last_seen = match wallet.tx_graph().get_last_evicted(txid) {
+        Some(last_evicted) => {
+            minimum_last_seen
+                .max(now)
+                .max(last_evicted.checked_add(1).ok_or_else(|| {
+                    Error::Wallet(format!(
+                        "Cannot reserve transaction {txid} after maximum eviction timestamp"
+                    ))
+                })?)
+        }
+        None => minimum_last_seen.max(now),
+    };
+    wallet.apply_unconfirmed_txs([(tx.clone(), last_seen)]);
+    Ok(last_seen)
+}
+
+/// Decode a persisted `Broadcast` transaction and derive its identity from
+/// the transaction bytes.
+///
+/// Both durable representations must agree. A mismatch is retained for
+/// diagnosis and fenced from the network.
+fn decode_broadcast_tx(
+    batch_id: &Uuid,
+    stored_txid: &str,
+    tx_bytes: &[u8],
+) -> Option<(Txid, Transaction)> {
+    let tx = match bdk_wallet::bitcoin::consensus::deserialize::<Transaction>(tx_bytes) {
+        Ok(tx) => tx,
+        Err(e) => {
+            tracing::warn!(
+                batch_id = %batch_id,
+                txid = %stored_txid,
+                "Skipping rebroadcast: failed to deserialize persisted tx: {e}"
+            );
+            return None;
+        }
+    };
+    let computed_txid = tx.compute_txid();
+    if stored_txid != computed_txid.to_string() {
+        tracing::error!(
+            batch_id = %batch_id,
+            stored_txid = %stored_txid,
+            computed_txid = %computed_txid,
+            "Skipping rebroadcast: persisted txid does not match transaction bytes"
+        );
+        return None;
+    }
+    Some((computed_txid, tx))
+}
+
+/// Decode a Broadcast transaction for input reservation without granting it
+/// authority for network I/O.
+pub(crate) fn decode_broadcast_reservation(
+    batch_id: &Uuid,
+    state: &SendBatchState,
+) -> Option<(Uuid, Txid, Transaction)> {
+    let SendBatchState::Broadcast { tx_bytes, .. } = state else {
+        return None;
+    };
+    match bdk_wallet::bitcoin::consensus::deserialize::<Transaction>(tx_bytes) {
+        Ok(tx) => Some((*batch_id, tx.compute_txid(), tx)),
+        Err(error) => {
+            tracing::warn!(
+                %batch_id,
+                %error,
+                "Cannot reserve undecodable durable Broadcast transaction"
+            );
+            None
+        }
     }
 }
 
@@ -847,6 +1309,7 @@ fn select_batch_intents<T>(
 /// `CdkBdk` instance.
 struct IntentOutput<'a> {
     intent_id: Uuid,
+    attempt_id: Uuid,
     address: &'a str,
     amount: u64,
 }
@@ -892,6 +1355,7 @@ fn derive_vout_assignments_inner(
 
         assignments.push(BatchOutputAssignment {
             intent_id: intent.intent_id,
+            attempt_id: intent.attempt_id,
             vout: vout as u32,
             fee_contribution_sat: fee_allocations[idx],
         });
@@ -902,18 +1366,84 @@ fn derive_vout_assignments_inner(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
     use bdk_wallet::bitcoin::absolute::LockTime;
     use bdk_wallet::bitcoin::transaction::Version;
-    use bdk_wallet::bitcoin::{Amount as BtcAmount, Network, ScriptBuf, TxOut};
+    use bdk_wallet::bitcoin::{
+        consensus, Amount as BtcAmount, Network, ScriptBuf, Transaction, TxOut,
+    };
     use uuid::Uuid;
 
     use super::*;
+    use crate::send::payment_intent::record::{SendIntentRecord, SendIntentState};
     use crate::send::payment_intent::state::Batched as IntentBatched;
     use crate::send::payment_intent::SendIntent;
-    use crate::types::{PaymentMetadata, PaymentTier};
+    use crate::testutil::{store_test_signed_batch, GatedKvStore, PausePoint, ReadPath};
+    use crate::types::{BatchConfig, PaymentMetadata, PaymentTier};
 
     const ADDR_A: &str = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080";
     const ADDR_B: &str = "bcrt1q6rhpng9evdsfnn833a4f4vej0asu6dk5srld6x";
+
+    #[tokio::test]
+    async fn concurrent_finalization_emits_one_success_event() {
+        let backend =
+            crate::testutil::build_test_backend(Arc::new(GatedKvStore::default()), None).await;
+        let quote_id = QuoteId::new();
+        let pending = SendIntent::new(
+            &backend.storage,
+            quote_id.to_string(),
+            ADDR_A.to_string(),
+            10_000,
+            500,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("create intent");
+        let batch_id = Uuid::new_v4();
+        store_test_signed_batch(&backend.storage, batch_id, &[pending.intent_id]).await;
+        let awaiting = pending
+            .assign_to_batch(&backend.storage, batch_id)
+            .await
+            .expect("assign intent")
+            .mark_broadcast(
+                &backend.storage,
+                "txid-concurrent-finalize".to_string(),
+                "txid-concurrent-finalize:0".to_string(),
+                250,
+            )
+            .await
+            .expect("mark intent broadcast");
+        let mut events = backend.payment_sender.subscribe();
+
+        let (first, second) = tokio::join!(
+            backend.finalize_send_intent_and_emit(awaiting.clone()),
+            backend.finalize_send_intent_and_emit(awaiting),
+        );
+        first.expect("first finalizer");
+        second.expect("second finalizer");
+
+        let event = events.try_recv().expect("one payment event");
+        assert!(
+            matches!(
+                event,
+                Event::PaymentSuccessful {
+                    quote_id: event_quote_id,
+                    ..
+                } if event_quote_id == quote_id
+            ),
+            "expected payment successful event"
+        );
+        assert!(
+            matches!(
+                events.try_recv(),
+                Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+            ),
+            "only the winning finalizer may emit an event"
+        );
+    }
 
     fn make_batched_intent(
         intent_id: Uuid,
@@ -922,6 +1452,7 @@ mod tests {
     ) -> SendIntent<IntentBatched> {
         SendIntent {
             intent_id,
+            attempt_id: Uuid::new_v4(),
             quote_id: format!("q-{}", intent_id),
             address: address.to_string(),
             amount,
@@ -938,6 +1469,7 @@ mod tests {
     fn intent_output(intent: &SendIntent<IntentBatched>) -> IntentOutput<'_> {
         IntentOutput {
             intent_id: intent.intent_id,
+            attempt_id: intent.attempt_id,
             address: intent.address.as_str(),
             amount: intent.amount,
         }
@@ -1050,6 +1582,191 @@ mod tests {
         assert!(selected.is_empty());
     }
 
+    /// An intent whose expiry is detected from a stale `Pending` snapshot
+    /// must not be failed when another worker has already batched and
+    /// broadcast it: failing it would compensate (refund) a melt whose
+    /// payment still goes out.
+    #[tokio::test]
+    async fn expiry_cannot_fail_broadcast_intent() {
+        let kv = GatedKvStore::default();
+        let backend = crate::testutil::build_test_backend(
+            Arc::new(kv.clone()),
+            Some(BatchConfig {
+                max_intent_age: Some(Duration::ZERO),
+                ..Default::default()
+            }),
+        )
+        .await;
+
+        let quote_id = QuoteId::new().to_string();
+        let intent_id = Uuid::new_v4();
+        backend
+            .storage
+            .create_send_intent_if_absent(&SendIntentRecord {
+                intent_id,
+                attempt_id: Uuid::new_v4(),
+                quote_id: quote_id.clone(),
+                address: ADDR_A.to_string(),
+                amount_sat: 10_000,
+                max_fee_amount_sat: 500,
+                tier: PaymentTier::Immediate,
+                metadata: PaymentMetadata::default(),
+                state: SendIntentState::Pending {
+                    created_at: 1_700_000_000,
+                },
+            })
+            .await
+            .expect("store expired pending intent");
+
+        let mut events = backend.payment_sender.subscribe();
+
+        let gate = kv.gate_read(
+            ReadPath::Direct,
+            PausePoint::AfterRead,
+            crate::storage::BDK_NAMESPACE,
+            crate::storage::SEND_INTENT_NAMESPACE,
+            1,
+        );
+
+        let processor_backend = backend.clone();
+        let processor =
+            tokio::spawn(async move { processor_backend.process_ready_intents().await });
+
+        tokio::time::timeout(Duration::from_secs(5), gate.wait_entered())
+            .await
+            .expect("batch processor reached the gated read");
+
+        let record = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get intent")
+            .expect("intent present");
+        let pending = match payment_intent::from_record(&record) {
+            SendIntentAny::Pending(intent) => intent,
+            _ => panic!("intent should be pending"),
+        };
+        let batch_id = Uuid::new_v4();
+        store_test_signed_batch(&backend.storage, batch_id, &[intent_id]).await;
+        pending
+            .assign_to_batch(&backend.storage, batch_id)
+            .await
+            .expect("assign")
+            .mark_broadcast(
+                &backend.storage,
+                "txid-broadcast".to_string(),
+                "txid-broadcast:0".to_string(),
+                250,
+            )
+            .await
+            .expect("broadcast");
+
+        gate.release();
+        tokio::time::timeout(Duration::from_secs(5), processor)
+            .await
+            .expect("batch processor timed out")
+            .expect("join batch processor")
+            .expect("process_ready_intents should not error");
+
+        let persisted = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get intent")
+            .expect("intent present");
+        assert!(
+            matches!(
+                persisted.state,
+                SendIntentState::AwaitingConfirmation {
+                    batch_id: b,
+                    ..
+                } if b == batch_id
+            ),
+            "durable state must remain AwaitingConfirmation, got {:?}",
+            persisted.state
+        );
+
+        assert!(matches!(
+            events.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn batch_processor_resumes_durable_cancellation() {
+        let kv = cdk_sqlite::mint::memory::empty()
+            .await
+            .expect("in-memory kv store");
+        let backend =
+            crate::testutil::build_test_backend(Arc::new(kv), Some(BatchConfig::default())).await;
+        let batch_id = Uuid::new_v4();
+        let pending = SendIntent::new(
+            &backend.storage,
+            "quote-resume-cancelled".to_string(),
+            ADDR_A.to_string(),
+            10_000,
+            500,
+            PaymentTier::Standard,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("store pending intent");
+        let intent_id = pending.intent_id;
+        let attempt_id = pending.attempt_id;
+        store_test_signed_batch(&backend.storage, batch_id, &[intent_id]).await;
+        pending
+            .assign_to_batch(&backend.storage, batch_id)
+            .await
+            .expect("assign intent to cancelled batch");
+
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: vec![TxOut {
+                value: BtcAmount::from_sat(10_000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+        backend
+            .storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Cancelled {
+                    tx_bytes: consensus::serialize(&tx),
+                    assignments: vec![BatchOutputAssignment {
+                        intent_id,
+                        attempt_id,
+                        vout: 0,
+                        fee_contribution_sat: 500,
+                    }],
+                    fee_sat: 500,
+                    evict_at: crate::util::unix_now().saturating_add(1),
+                },
+            })
+            .await
+            .expect("store durable cancellation");
+
+        backend
+            .process_ready_intents()
+            .await
+            .expect("processor should resume cancellation");
+
+        let intent = backend
+            .storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("read intent")
+            .expect("intent remains active");
+        assert!(matches!(intent.state, SendIntentState::Pending { .. }));
+        assert!(backend
+            .storage
+            .get_send_batch(&batch_id)
+            .await
+            .expect("read batch")
+            .is_none());
+    }
+
     /// Two intents pay the same address for the same amount within one batch.
     /// The derivation must produce distinct vouts — one for each output —
     /// rather than aliasing both intents onto the same vout.
@@ -1080,9 +1797,11 @@ mod tests {
 
         assert_eq!(assignments.len(), 2);
         assert_eq!(assignments[0].intent_id, intent_a.intent_id);
+        assert_eq!(assignments[0].attempt_id, intent_a.attempt_id);
         assert_eq!(assignments[0].vout, 0);
         assert_eq!(assignments[0].fee_contribution_sat, 50);
         assert_eq!(assignments[1].intent_id, intent_b.intent_id);
+        assert_eq!(assignments[1].attempt_id, intent_b.attempt_id);
         assert_eq!(assignments[1].vout, 1);
         assert_eq!(assignments[1].fee_contribution_sat, 50);
 
@@ -1165,16 +1884,23 @@ mod tests {
         use std::sync::Arc;
         use std::time::Duration;
 
-        use bdk_wallet::bitcoin::consensus;
+        use bdk_wallet::bitcoin::{consensus, Address, OutPoint};
         use bdk_wallet::keys::bip39::Mnemonic;
+        use bdk_wallet::KeychainKind;
         use cdk_common::common::FeeReserve;
         use cdk_common::{Amount, CurrencyUnit};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+        use tokio::sync::oneshot;
         use uuid::Uuid;
 
+        use super::super::decode_broadcast_tx;
         use super::{BtcAmount, LockTime, Network, ScriptBuf, TxOut, Version};
         use crate::send::batch_transaction::record::{
             BatchOutputAssignment, SendBatchRecord, SendBatchState,
         };
+        use crate::send::payment_intent::record::{SendIntentRecord, SendIntentState};
+        use crate::types::{PaymentMetadata, PaymentTier};
         use crate::{CdkBdk, ChainSource, EsploraConfig};
 
         const TEST_TXID: &str = "0000000000000000000000000000000000000000000000000000000000000001";
@@ -1226,10 +1952,10 @@ mod tests {
             .expect("build CdkBdk test instance")
         }
 
-        /// Serialize a minimal valid transaction so `consensus::deserialize`
-        /// can round-trip it during rebroadcast.
-        fn valid_tx_bytes() -> Vec<u8> {
-            let tx = super::Transaction {
+        /// A minimal valid transaction so `consensus::deserialize` can
+        /// round-trip it during rebroadcast.
+        fn valid_tx() -> super::Transaction {
+            super::Transaction {
                 version: Version::TWO,
                 lock_time: LockTime::ZERO,
                 input: Vec::new(),
@@ -1237,8 +1963,151 @@ mod tests {
                     value: BtcAmount::from_sat(10_000),
                     script_pubkey: ScriptBuf::new(),
                 }],
+            }
+        }
+
+        /// Serialize [`valid_tx`] for storage in a `Broadcast` record.
+        fn valid_tx_bytes() -> Vec<u8> {
+            consensus::serialize(&valid_tx())
+        }
+
+        async fn wallet_relevant_tx(backend: &CdkBdk) -> super::Transaction {
+            let script_pubkey = {
+                let mut wallet_with_db = backend.wallet_with_db.lock().await;
+                wallet_with_db
+                    .wallet
+                    .reveal_next_address(KeychainKind::External)
+                    .address
+                    .script_pubkey()
             };
-            consensus::serialize(&tx)
+
+            super::Transaction {
+                version: Version::TWO,
+                lock_time: LockTime::ZERO,
+                input: Vec::new(),
+                output: vec![TxOut {
+                    value: BtcAmount::from_sat(10_000),
+                    script_pubkey,
+                }],
+            }
+        }
+
+        async fn store_eligible_broadcast(
+            backend: &CdkBdk,
+            batch_id: Uuid,
+            tx: &super::Transaction,
+        ) {
+            let intent_id = Uuid::new_v4();
+            let txid = tx.compute_txid();
+            let address = Address::from_script(&tx.output[0].script_pubkey, backend.network)
+                .expect("test output script has an address");
+            backend
+                .storage
+                .create_send_intent_if_absent(&SendIntentRecord {
+                    intent_id,
+                    attempt_id: intent_id,
+                    quote_id: format!("quote-{intent_id}"),
+                    address: address.to_string(),
+                    amount_sat: 10_000,
+                    max_fee_amount_sat: 500,
+                    tier: PaymentTier::Immediate,
+                    metadata: PaymentMetadata::default(),
+                    state: SendIntentState::AwaitingConfirmation {
+                        batch_id,
+                        txid: txid.to_string(),
+                        outpoint: OutPoint::new(txid, 0).to_string(),
+                        fee_contribution_sat: 500,
+                        created_at: 1_700_000_000,
+                    },
+                })
+                .await
+                .expect("store eligible intent");
+            backend
+                .storage
+                .store_send_batch(&SendBatchRecord {
+                    batch_id,
+                    state: SendBatchState::Broadcast {
+                        txid: txid.to_string(),
+                        tx_bytes: consensus::serialize(tx),
+                        assignments: vec![BatchOutputAssignment {
+                            intent_id,
+                            attempt_id: intent_id,
+                            vout: 0,
+                            fee_contribution_sat: 500,
+                        }],
+                        fee_sat: 500,
+                    },
+                })
+                .await
+                .expect("store eligible Broadcast batch");
+        }
+
+        async fn serve_esplora_response(
+            status: &'static str,
+            body: &'static str,
+        ) -> (String, tokio::task::JoinHandle<()>) {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind test Esplora server");
+            let address = listener.local_addr().expect("test server address");
+            let server = tokio::spawn(async move {
+                let (mut stream, _) = listener.accept().await.expect("accept broadcast request");
+                let mut request = [0u8; 4096];
+                let _bytes_read = stream
+                    .read(&mut request)
+                    .await
+                    .expect("read broadcast request");
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\nContent-Type: text/plain\r\n\r\n{body}",
+                    body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("write broadcast response");
+            });
+
+            (format!("http://{address}"), server)
+        }
+
+        async fn serve_blocked_esplora_response() -> (
+            String,
+            oneshot::Receiver<()>,
+            oneshot::Sender<()>,
+            tokio::task::JoinHandle<()>,
+        ) {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind test Esplora server");
+            let address = listener.local_addr().expect("test server address");
+            let (request_seen_tx, request_seen_rx) = oneshot::channel();
+            let (release_tx, release_rx) = oneshot::channel();
+            let server = tokio::spawn(async move {
+                let (mut stream, _) = listener.accept().await.expect("accept broadcast request");
+                let mut request = [0u8; 4096];
+                let _bytes_read = stream
+                    .read(&mut request)
+                    .await
+                    .expect("read broadcast request");
+                let _ = request_seen_tx.send(());
+                release_rx.await.expect("release blocked response");
+                let body = "temporarily unavailable";
+                let response = format!(
+                    "HTTP/1.1 503 Service Unavailable\r\nContent-Length: {}\r\nConnection: close\r\nContent-Type: text/plain\r\n\r\n{body}",
+                    body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("write broadcast response");
+            });
+
+            (
+                format!("http://{address}"),
+                request_seen_rx,
+                release_tx,
+                server,
+            )
         }
 
         /// No persisted batches → nothing to do; must return Ok.
@@ -1264,10 +2133,11 @@ mod tests {
             let batch = SendBatchRecord {
                 batch_id,
                 state: SendBatchState::Broadcast {
-                    txid: TEST_TXID.to_string(),
+                    txid: valid_tx().compute_txid().to_string(),
                     tx_bytes: valid_tx_bytes(),
                     assignments: vec![BatchOutputAssignment {
                         intent_id,
+                        attempt_id: Uuid::nil(),
                         vout: 0,
                         fee_contribution_sat: 500,
                     }],
@@ -1296,6 +2166,232 @@ mod tests {
                 matches!(after.state, SendBatchState::Broadcast { .. }),
                 "batch must remain in Broadcast state after failed rebroadcast; got {:?}",
                 after.state
+            );
+        }
+
+        /// Applying a signed transaction locally before its first network
+        /// broadcast must not suppress retries after a transient failure.
+        #[tokio::test]
+        async fn rebroadcast_retries_locally_tracked_unconfirmed_tx() {
+            let mut backend = build_test_instance().await;
+            let batch_id = Uuid::new_v4();
+            let tx = wallet_relevant_tx(&backend).await;
+            let txid = tx.compute_txid();
+
+            {
+                let mut wallet_with_db = backend.wallet_with_db.lock().await;
+                wallet_with_db
+                    .wallet
+                    .apply_unconfirmed_txs([(tx.clone(), crate::util::unix_now())]);
+                wallet_with_db.persist().expect("persist local transaction");
+                assert!(wallet_with_db.wallet.get_tx(txid).is_some());
+            }
+
+            store_eligible_broadcast(&backend, batch_id, &tx).await;
+
+            let (url, server) =
+                serve_esplora_response("503 Service Unavailable", "temporarily unavailable").await;
+            backend.chain_source = ChainSource::Esplora(EsploraConfig {
+                url,
+                parallel_requests: 1,
+            });
+
+            tokio::time::timeout(Duration::from_secs(5), backend.rebroadcast_stuck_batches())
+                .await
+                .expect("rebroadcast timed out")
+                .expect("rebroadcast should swallow transport errors");
+            tokio::time::timeout(Duration::from_secs(5), server)
+                .await
+                .expect("locally tracked transaction was not sent to Esplora")
+                .expect("join test Esplora server");
+        }
+
+        /// A durable Broadcast transaction must be present in BDK before the
+        /// network request begins, so another batch cannot select its inputs
+        /// while rebroadcast is waiting on the backend.
+        #[tokio::test]
+        async fn rebroadcast_reserves_transaction_before_network_io() {
+            let mut backend = build_test_instance().await;
+            let batch_id = Uuid::new_v4();
+            let tx = wallet_relevant_tx(&backend).await;
+            let txid = tx.compute_txid();
+            store_eligible_broadcast(&backend, batch_id, &tx).await;
+
+            let (url, request_seen, release, server) = serve_blocked_esplora_response().await;
+            backend.chain_source = ChainSource::Esplora(EsploraConfig {
+                url,
+                parallel_requests: 1,
+            });
+            let rebroadcast_backend = backend.clone();
+            let rebroadcast =
+                tokio::spawn(async move { rebroadcast_backend.rebroadcast_stuck_batches().await });
+
+            tokio::time::timeout(Duration::from_secs(5), request_seen)
+                .await
+                .expect("rebroadcast request was not sent")
+                .expect("request signal dropped");
+            {
+                let wallet_with_db =
+                    tokio::time::timeout(Duration::from_secs(1), backend.wallet_with_db.lock())
+                        .await
+                        .expect("network request must not hold the wallet lock");
+                assert!(
+                    wallet_with_db.wallet.get_tx(txid).is_some(),
+                    "transaction must be reserved before network I/O"
+                );
+            }
+
+            release.send(()).expect("release blocked response");
+            tokio::time::timeout(Duration::from_secs(5), rebroadcast)
+                .await
+                .expect("rebroadcast timed out")
+                .expect("join rebroadcast task")
+                .expect("rebroadcast should swallow transport errors");
+            tokio::time::timeout(Duration::from_secs(5), server)
+                .await
+                .expect("server timed out")
+                .expect("join test Esplora server");
+        }
+
+        /// Reapplication must use a last-seen timestamp strictly newer than an
+        /// existing eviction marker or BDK will keep the transaction excluded
+        /// from its canonical graph.
+        #[tokio::test]
+        async fn rebroadcast_reservation_beats_last_evicted_timestamp() {
+            let mut backend = build_test_instance().await;
+            let batch_id = Uuid::new_v4();
+            let tx = wallet_relevant_tx(&backend).await;
+            let txid = tx.compute_txid();
+            let evicted_at = crate::util::unix_now().saturating_add(60);
+            {
+                let mut wallet_with_db = backend.wallet_with_db.lock().await;
+                wallet_with_db
+                    .wallet
+                    .apply_unconfirmed_txs([(tx.clone(), evicted_at.saturating_sub(1))]);
+                wallet_with_db
+                    .wallet
+                    .apply_evicted_txs([(txid, evicted_at)]);
+                wallet_with_db
+                    .persist()
+                    .expect("persist evicted transaction");
+                assert!(wallet_with_db.wallet.get_tx(txid).is_none());
+                assert_eq!(
+                    wallet_with_db.wallet.tx_graph().get_last_evicted(txid),
+                    Some(evicted_at)
+                );
+            }
+            store_eligible_broadcast(&backend, batch_id, &tx).await;
+
+            let (url, server) =
+                serve_esplora_response("503 Service Unavailable", "temporarily unavailable").await;
+            backend.chain_source = ChainSource::Esplora(EsploraConfig {
+                url,
+                parallel_requests: 1,
+            });
+            tokio::time::timeout(Duration::from_secs(5), backend.rebroadcast_stuck_batches())
+                .await
+                .expect("rebroadcast timed out")
+                .expect("rebroadcast should swallow transport errors");
+            tokio::time::timeout(Duration::from_secs(5), server)
+                .await
+                .expect("server timed out")
+                .expect("join test Esplora server");
+
+            let wallet_with_db = backend.wallet_with_db.lock().await;
+            let wallet_tx = wallet_with_db
+                .wallet
+                .get_tx(txid)
+                .expect("reservation must restore canonical transaction");
+            let bdk_wallet::chain::ChainPosition::Unconfirmed {
+                last_seen: Some(last_seen),
+                ..
+            } = wallet_tx.chain_position
+            else {
+                panic!("reserved transaction must be unconfirmed with a last-seen timestamp");
+            };
+            assert!(last_seen > evicted_at);
+        }
+
+        /// A reservation made atomically with sync request construction must
+        /// be newer than the eviction timestamp that the in-flight request can
+        /// later apply.
+        #[tokio::test]
+        async fn sync_reservation_survives_its_request_eviction_timestamp() {
+            let backend = build_test_instance().await;
+            let batch_id = Uuid::new_v4();
+            let tx = wallet_relevant_tx(&backend).await;
+            let txid = tx.compute_txid();
+            store_eligible_broadcast(&backend, batch_id, &tx).await;
+
+            let sync_started_at = crate::util::unix_now().saturating_add(60);
+            let reservation_time = sync_started_at
+                .checked_add(1)
+                .expect("test timestamp has room");
+            let reservations = backend
+                .load_broadcast_reservations()
+                .await
+                .expect("load Broadcast reservations");
+            let mut wallet_with_db = backend.wallet_with_db.lock().await;
+            CdkBdk::reserve_broadcast_transactions_locked(
+                &mut wallet_with_db.wallet,
+                &reservations,
+                reservation_time,
+            )
+            .expect("reserve eligible Broadcast batch");
+            wallet_with_db
+                .wallet
+                .apply_evicted_txs([(txid, sync_started_at)]);
+
+            let wallet_tx = wallet_with_db
+                .wallet
+                .get_tx(txid)
+                .expect("sync eviction must not defeat its atomic reservation");
+            let bdk_wallet::chain::ChainPosition::Unconfirmed {
+                last_seen: Some(last_seen),
+                ..
+            } = wallet_tx.chain_position
+            else {
+                panic!("reserved transaction must remain canonical and unconfirmed");
+            };
+            assert!(last_seen > sync_started_at);
+        }
+
+        /// An already-known response proves the backend has the transaction,
+        /// so a wallet that was missing it must record and persist it locally.
+        #[tokio::test]
+        async fn rebroadcast_applies_already_known_tx_to_wallet() {
+            let mut backend = build_test_instance().await;
+            let batch_id = Uuid::new_v4();
+            let tx = wallet_relevant_tx(&backend).await;
+            let txid = tx.compute_txid();
+
+            {
+                let wallet_with_db = backend.wallet_with_db.lock().await;
+                assert!(wallet_with_db.wallet.get_tx(txid).is_none());
+            }
+
+            store_eligible_broadcast(&backend, batch_id, &tx).await;
+
+            let (url, server) =
+                serve_esplora_response("400 Bad Request", "transaction already known").await;
+            backend.chain_source = ChainSource::Esplora(EsploraConfig {
+                url,
+                parallel_requests: 1,
+            });
+
+            tokio::time::timeout(Duration::from_secs(5), backend.rebroadcast_stuck_batches())
+                .await
+                .expect("rebroadcast timed out")
+                .expect("already-known rebroadcast should succeed");
+            tokio::time::timeout(Duration::from_secs(5), server)
+                .await
+                .expect("transaction was not sent to Esplora")
+                .expect("join test Esplora server");
+
+            let wallet_with_db = backend.wallet_with_db.lock().await;
+            assert!(
+                wallet_with_db.wallet.get_tx(txid).is_some(),
+                "already-known transaction must be tracked by the local wallet"
             );
         }
 
@@ -1349,6 +2445,7 @@ mod tests {
                     tx_bytes: vec![0xff],
                     assignments: vec![BatchOutputAssignment {
                         intent_id: Uuid::new_v4(),
+                        attempt_id: Uuid::nil(),
                         vout: 0,
                         fee_contribution_sat: 500,
                     }],
@@ -1375,11 +2472,38 @@ mod tests {
             assert!(matches!(after.state, SendBatchState::Signed { .. }));
         }
 
-        /// A persisted txid that fails to parse must not abort the loop
-        /// or propagate an error. Other batches on the same tick would
-        /// still be processed; here we just verify no error is returned.
+        /// Conflicting durable transaction identities are fenced.
+        #[test]
+        fn decode_broadcast_tx_rejects_txid_mismatch() {
+            let tx_bytes = valid_tx_bytes();
+            assert!(decode_broadcast_tx(&Uuid::new_v4(), TEST_TXID, &tx_bytes).is_none());
+        }
+
+        #[test]
+        fn decode_broadcast_tx_accepts_matching_identity() {
+            let tx = valid_tx();
+            let txid = tx.compute_txid();
+            let (decoded_txid, decoded) = decode_broadcast_tx(
+                &Uuid::new_v4(),
+                &txid.to_string(),
+                &consensus::serialize(&tx),
+            )
+            .expect("matching transaction");
+            assert_eq!(decoded_txid, txid);
+            assert_eq!(decoded, tx);
+        }
+
+        /// Undecodable bytes are the only reason a `Broadcast` record is
+        /// skipped: without valid bytes there is nothing safe to broadcast.
+        #[test]
+        fn decode_broadcast_tx_rejects_undecodable_bytes() {
+            assert!(decode_broadcast_tx(&Uuid::new_v4(), TEST_TXID, &[0xff]).is_none());
+        }
+
+        /// A malformed stored identity is retained but never reaches the
+        /// reservation or network path.
         #[tokio::test]
-        async fn rebroadcast_skips_unparsable_txid() {
+        async fn rebroadcast_malformed_stored_txid_is_fenced() {
             let backend = build_test_instance().await;
             let batch_id = Uuid::new_v4();
 
@@ -1390,6 +2514,7 @@ mod tests {
                     tx_bytes: valid_tx_bytes(),
                     assignments: vec![BatchOutputAssignment {
                         intent_id: Uuid::new_v4(),
+                        attempt_id: Uuid::nil(),
                         vout: 0,
                         fee_contribution_sat: 500,
                     }],
@@ -1405,7 +2530,16 @@ mod tests {
             tokio::time::timeout(Duration::from_secs(5), backend.rebroadcast_stuck_batches())
                 .await
                 .expect("rebroadcast timed out")
-                .expect("rebroadcast should skip malformed txid gracefully");
+                .expect("rebroadcast should swallow transport errors");
+
+            // Batch must still be in Broadcast state for the next retry.
+            let after = backend
+                .storage
+                .get_send_batch(&batch_id)
+                .await
+                .expect("fetch batch")
+                .expect("batch still present");
+            assert!(matches!(after.state, SendBatchState::Broadcast { .. }));
         }
     }
 }

--- a/crates/cdk-bdk/src/storage/mod.rs
+++ b/crates/cdk-bdk/src/storage/mod.rs
@@ -15,7 +15,10 @@ pub mod receive;
 pub mod send;
 mod types;
 
-pub use types::{FailedSendAttemptRecord, FinalizedReceiveIntentRecord, FinalizedSendIntentRecord};
+pub use types::{
+    BroadcastRejectionRecord, FailedSendAttemptRecord, FinalizedReceiveIntentRecord,
+    FinalizedSendIntentRecord,
+};
 
 /// Primary namespace for BDK KV store operations
 pub const BDK_NAMESPACE: &str = "bdk";
@@ -40,6 +43,10 @@ pub const SEND_BATCH_NAMESPACE: &str = "send_batch";
 
 /// Secondary namespace for failed pre-sign send attempt tombstones.
 pub const FAILED_SEND_ATTEMPT_NAMESPACE: &str = "failed_send_attempt";
+
+/// Secondary namespace for consecutive deterministic broadcast rejection
+/// counters (keyed by batch_id).
+pub const BROADCAST_REJECTION_NAMESPACE: &str = "broadcast_rejection";
 
 /// Secondary namespace for finalized (confirmed) intents.
 /// Stores tombstone records so `check_outgoing_payment` can return
@@ -234,6 +241,14 @@ impl KvRecord for FailedSendAttemptRecord {
 
     fn key(&self) -> String {
         self.attempt_id.to_string()
+    }
+}
+
+impl KvRecord for BroadcastRejectionRecord {
+    const NAMESPACE: &'static str = BROADCAST_REJECTION_NAMESPACE;
+
+    fn key(&self) -> String {
+        self.batch_id.to_string()
     }
 }
 

--- a/crates/cdk-bdk/src/storage/mod.rs
+++ b/crates/cdk-bdk/src/storage/mod.rs
@@ -165,12 +165,15 @@ impl BdkStorage {
                 .await
                 .map_err(Error::from)?
             {
-                match serde_json::from_slice::<T>(&data) {
-                    Ok(record) => records.push(record),
-                    Err(e) => {
-                        tracing::warn!("Failed to deserialize {} {}: {}", T::NAMESPACE, key, e);
-                    }
-                }
+                let record = serde_json::from_slice::<T>(&data).map_err(|error| {
+                    Error::Wallet(format!(
+                        "Failed to deserialize record in namespace {} for key {}: {}",
+                        T::NAMESPACE,
+                        key,
+                        error
+                    ))
+                })?;
+                records.push(record);
             }
         }
 
@@ -303,6 +306,7 @@ mod tests {
     fn make_pending_intent(intent_id: Uuid) -> SendIntentRecord {
         SendIntentRecord {
             intent_id,
+            attempt_id: Uuid::new_v4(),
             quote_id: "test-quote-1".to_string(),
             address: "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
             amount_sat: 50_000,
@@ -356,6 +360,7 @@ mod tests {
         // Also test full SendIntentRecord round-trip
         let intent = SendIntentRecord {
             intent_id: Uuid::new_v4(),
+            attempt_id: Uuid::new_v4(),
             quote_id: "quote-123".to_string(),
             address: "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
             amount_sat: 100_000,
@@ -370,10 +375,22 @@ mod tests {
         let deserialized: SendIntentRecord =
             serde_json::from_str(&json).expect("deserialize intent");
         assert_eq!(intent.intent_id, deserialized.intent_id);
+        assert_eq!(intent.attempt_id, deserialized.attempt_id);
         assert_eq!(intent.quote_id, deserialized.quote_id);
         assert_eq!(intent.address, deserialized.address);
         assert_eq!(intent.amount_sat, deserialized.amount_sat);
         assert_eq!(intent.max_fee_amount_sat, deserialized.max_fee_amount_sat);
+
+        // Records persisted before attempt generations were introduced remain
+        // readable. The first retry replaces this sentinel with a fresh UUID.
+        let mut legacy_json = serde_json::to_value(&intent).expect("serialize legacy intent");
+        legacy_json
+            .as_object_mut()
+            .expect("intent serializes as an object")
+            .remove("attempt_id");
+        let legacy: SendIntentRecord =
+            serde_json::from_value(legacy_json).expect("deserialize legacy intent");
+        assert_eq!(legacy.attempt_id, Uuid::nil());
     }
 
     #[test]
@@ -384,6 +401,7 @@ mod tests {
             .enumerate()
             .map(|(idx, id)| BatchOutputAssignment {
                 intent_id: *id,
+                attempt_id: Uuid::nil(),
                 vout: idx as u32,
                 fee_contribution_sat: 125,
             })
@@ -398,6 +416,12 @@ mod tests {
                 tx_bytes: vec![0x05, 0x06, 0x07, 0x08],
                 assignments: assignments.clone(),
                 fee_sat: 250,
+            },
+            SendBatchState::Cancelled {
+                tx_bytes: vec![0x05, 0x06, 0x07, 0x08],
+                assignments: assignments.clone(),
+                fee_sat: 250,
+                evict_at: 1_700_000_001,
             },
             SendBatchState::Broadcast {
                 txid: "deadbeef1234".to_string(),
@@ -534,6 +558,146 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_send_intents_fails_closed_on_malformed_record() {
+        let storage = test_storage().await;
+        let intent = make_pending_intent(Uuid::new_v4());
+        storage
+            .create_send_intent_if_absent(&intent)
+            .await
+            .expect("store valid intent");
+
+        let malformed_key = Uuid::new_v4().to_string();
+        let mut tx = storage
+            .kv_store
+            .begin_transaction()
+            .await
+            .expect("begin transaction");
+        tx.kv_write(
+            BDK_NAMESPACE,
+            SEND_INTENT_NAMESPACE,
+            &malformed_key,
+            b"{not-json",
+        )
+        .await
+        .expect("write malformed record");
+        tx.commit().await.expect("commit malformed record");
+
+        let error = storage
+            .get_all_send_intents()
+            .await
+            .expect_err("malformed record must fail the complete listing");
+        let message = error.to_string();
+        assert!(message.contains(SEND_INTENT_NAMESPACE));
+        assert!(message.contains(&malformed_key));
+    }
+
+    #[tokio::test]
+    async fn normalize_legacy_pending_attempt_ids_is_idempotent_and_state_scoped() {
+        let storage = test_storage().await;
+        let mut first = make_pending_intent(Uuid::new_v4());
+        first.quote_id = "legacy-pending-one".to_string();
+        first.attempt_id = Uuid::nil();
+        let mut second = make_pending_intent(Uuid::new_v4());
+        second.quote_id = "legacy-pending-two".to_string();
+        second.attempt_id = Uuid::nil();
+        let mut failed = make_pending_intent(Uuid::new_v4());
+        failed.quote_id = "legacy-failed".to_string();
+        failed.attempt_id = Uuid::nil();
+        failed.state = SendIntentState::Failed {
+            reason: "legacy failure".to_string(),
+            created_at: 1_700_000_000,
+            failed_at: 1_700_000_001,
+        };
+        let current = make_pending_intent(Uuid::new_v4());
+        let current_attempt_id = current.attempt_id;
+
+        for intent in [&first, &second, &failed, &current] {
+            storage
+                .create_send_intent_if_absent(intent)
+                .await
+                .expect("store intent");
+        }
+
+        assert_eq!(
+            storage
+                .normalize_legacy_pending_attempt_ids()
+                .await
+                .expect("normalize"),
+            2
+        );
+        let normalized_first = storage
+            .get_send_intent(&first.intent_id)
+            .await
+            .expect("read first")
+            .expect("first exists");
+        let normalized_second = storage
+            .get_send_intent(&second.intent_id)
+            .await
+            .expect("read second")
+            .expect("second exists");
+        assert!(!normalized_first.attempt_id.is_nil());
+        assert!(!normalized_second.attempt_id.is_nil());
+        assert_ne!(normalized_first.attempt_id, normalized_second.attempt_id);
+        assert_eq!(
+            storage
+                .get_send_intent(&failed.intent_id)
+                .await
+                .expect("read failed")
+                .expect("failed exists")
+                .attempt_id,
+            Uuid::nil()
+        );
+        assert_eq!(
+            storage
+                .get_send_intent(&current.intent_id)
+                .await
+                .expect("read current")
+                .expect("current exists")
+                .attempt_id,
+            current_attempt_id
+        );
+        assert_eq!(
+            storage
+                .normalize_legacy_pending_attempt_ids()
+                .await
+                .expect("normalize again"),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_transition_atomically_records_the_actual_attempt_id() {
+        let storage = test_storage().await;
+        let intent = make_pending_intent(Uuid::new_v4());
+        let expected_state = intent.state.clone();
+        storage
+            .create_send_intent_if_absent(&intent)
+            .await
+            .expect("store intent");
+
+        assert!(storage
+            .transition_send_intent(
+                &intent.intent_id,
+                &intent.attempt_id,
+                &expected_state,
+                &SendIntentState::Failed {
+                    reason: "pre-sign failure".to_string(),
+                    created_at: 1_700_000_000,
+                    failed_at: 1_700_000_001,
+                },
+            )
+            .await
+            .expect("transition"));
+
+        let attempts = storage
+            .get_failed_send_attempts_by_quote_id(&intent.quote_id)
+            .await
+            .expect("list failed attempts");
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(attempts[0].attempt_id, intent.attempt_id);
+    }
+
+    #[tokio::test]
     async fn test_create_send_intent_if_absent_rejects_duplicate_quote_id() {
         let storage = test_storage().await;
         let first = make_pending_intent(Uuid::new_v4());
@@ -622,7 +786,7 @@ mod tests {
             finalized_at: 1_700_000_001,
         };
         storage
-            .finalize_send_intent(&intent_id, &tombstone)
+            .finalize_send_intent(&intent, &tombstone)
             .await
             .expect("finalize intent");
 
@@ -665,7 +829,7 @@ mod tests {
             finalized_at: 1_700_000_001,
         };
         storage
-            .finalize_send_intent(&intent_id, &tombstone)
+            .finalize_send_intent(&intent, &tombstone)
             .await
             .expect("finalize intent");
 
@@ -746,6 +910,7 @@ mod tests {
             .enumerate()
             .map(|(idx, intent_id)| BatchOutputAssignment {
                 intent_id: *intent_id,
+                attempt_id: Uuid::nil(),
                 vout: idx as u32,
                 fee_contribution_sat: 125,
             })
@@ -876,6 +1041,7 @@ mod tests {
         let confirming_id = Uuid::new_v4();
         let confirming = SendIntentRecord {
             intent_id: confirming_id,
+            attempt_id: Uuid::new_v4(),
             quote_id: "quote-confirm".to_string(),
             address: "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
             amount_sat: 75_000,
@@ -989,6 +1155,7 @@ mod tests {
         let storage = test_storage().await;
         let active_intent = SendIntentRecord {
             intent_id: Uuid::new_v4(),
+            attempt_id: Uuid::new_v4(),
             quote_id: "active-legacy-quote".to_string(),
             address: "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080".to_string(),
             amount_sat: 75_000,
@@ -1062,11 +1229,13 @@ mod tests {
                 assignments: vec![
                     BatchOutputAssignment {
                         intent_id: intent_id_1,
+                        attempt_id: Uuid::nil(),
                         vout: 0,
                         fee_contribution_sat: 250,
                     },
                     BatchOutputAssignment {
                         intent_id: intent_id_2,
+                        attempt_id: Uuid::nil(),
                         vout: 1,
                         fee_contribution_sat: 250,
                     },
@@ -1080,6 +1249,7 @@ mod tests {
         for (id, quote) in [(intent_id_1, "q1"), (intent_id_2, "q2")] {
             let intent = SendIntentRecord {
                 intent_id: id,
+                attempt_id: Uuid::new_v4(),
                 quote_id: quote.to_string(),
                 address: "bcrt1qaddr".to_string(),
                 amount_sat: 10_000,
@@ -1158,6 +1328,7 @@ mod tests {
                 tx_bytes: vec![0xAA, 0xBB],
                 assignments: vec![BatchOutputAssignment {
                     intent_id: signed_intent_id,
+                    attempt_id: Uuid::nil(),
                     vout: 0,
                     fee_contribution_sat: 100,
                 }],
@@ -1170,7 +1341,9 @@ mod tests {
                 SendBatchState::Signed { assignments, .. } => {
                     assignments.iter().map(|a| a.intent_id).collect()
                 }
-                SendBatchState::Broadcast { .. } => unreachable!(),
+                SendBatchState::Cancelled { .. } | SendBatchState::Broadcast { .. } => {
+                    unreachable!()
+                }
             };
 
             let batch = SendBatchRecord { batch_id, state };
@@ -1179,6 +1352,7 @@ mod tests {
             for intent_id in &intent_ids {
                 let intent = SendIntentRecord {
                     intent_id: *intent_id,
+                    attempt_id: Uuid::new_v4(),
                     quote_id: format!("q-{}", intent_id),
                     address: "bcrt1qaddr".to_string(),
                     amount_sat: 25_000,
@@ -1246,6 +1420,7 @@ mod tests {
                 tx_bytes: vec![0x01, 0x02, 0x03],
                 assignments: vec![BatchOutputAssignment {
                     intent_id: broadcast_intent_id,
+                    attempt_id: Uuid::nil(),
                     vout: 0,
                     fee_contribution_sat: 200,
                 }],
@@ -1256,6 +1431,7 @@ mod tests {
 
         let awaiting_intent = SendIntentRecord {
             intent_id: broadcast_intent_id,
+            attempt_id: Uuid::new_v4(),
             quote_id: "q-broadcast".to_string(),
             address: "bcrt1qaddr".to_string(),
             amount_sat: 40_000,
@@ -1277,6 +1453,7 @@ mod tests {
 
         let orphan_intent = SendIntentRecord {
             intent_id: orphan_intent_id,
+            attempt_id: Uuid::new_v4(),
             quote_id: "q-orphan".to_string(),
             address: "bcrt1qaddr".to_string(),
             amount_sat: 20_000,
@@ -1343,6 +1520,7 @@ mod tests {
 
         let intent = SendIntentRecord {
             intent_id: present_intent_id,
+            attempt_id: Uuid::new_v4(),
             quote_id: "q-present".to_string(),
             address: "bcrt1qaddr".to_string(),
             amount_sat: 25_000,
@@ -1381,6 +1559,7 @@ mod tests {
 
         let intent = SendIntentRecord {
             intent_id,
+            attempt_id: Uuid::new_v4(),
             quote_id: "q-missing-batch".to_string(),
             address: "bcrt1qaddr".to_string(),
             amount_sat: 15_000,
@@ -1442,6 +1621,7 @@ mod tests {
 
         let intent = SendIntentRecord {
             intent_id,
+            attempt_id: Uuid::new_v4(),
             quote_id: "q-membership".to_string(),
             address: "bcrt1qaddr".to_string(),
             amount_sat: 30_000,
@@ -1504,11 +1684,13 @@ mod tests {
                 assignments: vec![
                     BatchOutputAssignment {
                         intent_id: batched_intent_id,
+                        attempt_id: Uuid::nil(),
                         vout: 0,
                         fee_contribution_sat: 200,
                     },
                     BatchOutputAssignment {
                         intent_id: awaiting_intent_id,
+                        attempt_id: Uuid::nil(),
                         vout: 1,
                         fee_contribution_sat: 200,
                     },
@@ -1539,6 +1721,7 @@ mod tests {
         ] {
             let intent = SendIntentRecord {
                 intent_id,
+                attempt_id: Uuid::new_v4(),
                 quote_id: format!("q-{}", intent_id),
                 address: "bcrt1qaddr".to_string(),
                 amount_sat: 10_000,

--- a/crates/cdk-bdk/src/storage/send.rs
+++ b/crates/cdk-bdk/src/storage/send.rs
@@ -4,7 +4,8 @@ use uuid::Uuid;
 
 use super::{
     outpoint_to_key, BdkStorage, FailedSendAttemptRecord, FinalizedSendIntentRecord, BDK_NAMESPACE,
-    FINALIZED_INTENT_NAMESPACE, FINALIZED_SEND_INTENT_QUOTE_ID_NAMESPACE, SEND_INTENT_NAMESPACE,
+    FAILED_SEND_ATTEMPT_NAMESPACE, FINALIZED_INTENT_NAMESPACE,
+    FINALIZED_SEND_INTENT_QUOTE_ID_NAMESPACE, SEND_BATCH_NAMESPACE, SEND_INTENT_NAMESPACE,
     SEND_INTENT_QUOTE_ID_NAMESPACE, SEND_OUTPOINT_QUOTE_ID_BACKFILL_KEY,
     SEND_OUTPOINT_QUOTE_ID_NAMESPACE, STORAGE_MIGRATION_NAMESPACE,
 };
@@ -93,6 +94,16 @@ impl BdkStorage {
 
     /// Store a new send intent, or re-queue an existing failed intent with
     /// the same quote id.
+    ///
+    /// Both paths are atomic against concurrent lifecycle changes:
+    ///
+    /// - The retry path rewrites the existing record with a
+    ///   compare-and-set on the exact bytes read, so a stale retry cannot
+    ///   rewind an intent another worker already advanced or finalized.
+    /// - The create path reserves the quote id with `kv_write_if_absent`
+    ///   and only then re-checks the finalized tombstone index, so a retry
+    ///   racing [`Self::finalize_send_intent`] can never leave both a
+    ///   tombstone and a live intent for the same quote.
     pub async fn create_or_retry_failed_send_intent(
         &self,
         intent: &SendIntentRecord,
@@ -102,20 +113,6 @@ impl BdkStorage {
             .begin_transaction()
             .await
             .map_err(Error::from)?;
-
-        let finalized = tx
-            .kv_read(
-                BDK_NAMESPACE,
-                FINALIZED_SEND_INTENT_QUOTE_ID_NAMESPACE,
-                &intent.quote_id,
-            )
-            .await
-            .map_err(Error::from)?;
-
-        if finalized.is_some() {
-            tx.rollback().await.map_err(Error::from)?;
-            return Err(Error::DuplicateQuoteId(intent.quote_id.clone()));
-        }
 
         let active = tx
             .kv_read(
@@ -131,8 +128,9 @@ impl BdkStorage {
                 .map_err(|e| Error::Wallet(format!("Invalid quote-id index entry: {}", e)))?;
             let intent_id = Uuid::from_str(intent_id_str)
                 .map_err(|e| Error::Wallet(format!("Invalid indexed intent id: {}", e)))?;
+            let key = intent_id.to_string();
             let intent_bytes = tx
-                .kv_read(BDK_NAMESPACE, SEND_INTENT_NAMESPACE, &intent_id.to_string())
+                .kv_read(BDK_NAMESPACE, SEND_INTENT_NAMESPACE, &key)
                 .await
                 .map_err(Error::from)?
                 .ok_or(Error::SendIntentNotFound(intent_id))?;
@@ -143,8 +141,43 @@ impl BdkStorage {
                 return Err(Error::DuplicateQuoteId(intent.quote_id.clone()));
             }
 
-            SendIntentRecord {
+            let batch_keys = tx
+                .kv_list(BDK_NAMESPACE, SEND_BATCH_NAMESPACE)
+                .await
+                .map_err(Error::from)?;
+            for batch_key in batch_keys {
+                let Some(batch_bytes) = tx
+                    .kv_read(BDK_NAMESPACE, SEND_BATCH_NAMESPACE, &batch_key)
+                    .await
+                    .map_err(Error::from)?
+                else {
+                    continue;
+                };
+                let batch: SendBatchRecord =
+                    serde_json::from_slice(&batch_bytes).map_err(|error| {
+                        Error::Wallet(format!(
+                            "Failed to deserialize record in namespace {} for key {}: {}",
+                            SEND_BATCH_NAMESPACE, batch_key, error
+                        ))
+                    })?;
+                if matches!(
+                    batch.state,
+                    SendBatchState::Broadcast { ref assignments, .. }
+                        if assignments
+                            .iter()
+                            .any(|assignment| assignment.intent_id == intent_id)
+                ) {
+                    tx.rollback().await.map_err(Error::from)?;
+                    return Err(Error::SendIntentStateConflict {
+                        intent_id,
+                        expected: "Failed without durable Broadcast evidence",
+                    });
+                }
+            }
+
+            let record = SendIntentRecord {
                 intent_id,
+                attempt_id: intent.attempt_id,
                 quote_id: intent.quote_id.clone(),
                 address: intent.address.clone(),
                 amount_sat: intent.amount_sat,
@@ -152,7 +185,23 @@ impl BdkStorage {
                 tier: intent.tier,
                 metadata: intent.metadata.clone(),
                 state: intent.state.clone(),
+            };
+            let serialized = serde_json::to_vec(&record)?;
+            let rewritten = tx
+                .kv_write_if_equals(
+                    BDK_NAMESPACE,
+                    SEND_INTENT_NAMESPACE,
+                    &key,
+                    &intent_bytes,
+                    &serialized,
+                )
+                .await
+                .map_err(Error::from)?;
+            if !rewritten {
+                tx.rollback().await.map_err(Error::from)?;
+                return Err(Error::DuplicateQuoteId(intent.quote_id.clone()));
             }
+            record
         } else {
             // Reserve the quote id atomically with the record write.
             let reserved = tx
@@ -168,18 +217,30 @@ impl BdkStorage {
                 tx.rollback().await.map_err(Error::from)?;
                 return Err(Error::DuplicateQuoteId(intent.quote_id.clone()));
             }
+            let finalized = tx
+                .kv_read(
+                    BDK_NAMESPACE,
+                    FINALIZED_SEND_INTENT_QUOTE_ID_NAMESPACE,
+                    &intent.quote_id,
+                )
+                .await
+                .map_err(Error::from)?;
+            if finalized.is_some() {
+                tx.rollback().await.map_err(Error::from)?;
+                return Err(Error::DuplicateQuoteId(intent.quote_id.clone()));
+            }
+            let serialized = serde_json::to_vec(intent)?;
+            tx.kv_write(
+                BDK_NAMESPACE,
+                SEND_INTENT_NAMESPACE,
+                &intent.intent_id.to_string(),
+                &serialized,
+            )
+            .await
+            .map_err(Error::from)?;
             intent.clone()
         };
 
-        let serialized = serde_json::to_vec(&record)?;
-        tx.kv_write(
-            BDK_NAMESPACE,
-            SEND_INTENT_NAMESPACE,
-            &record.intent_id.to_string(),
-            &serialized,
-        )
-        .await
-        .map_err(Error::from)?;
         if let SendIntentState::AwaitingConfirmation { outpoint, .. } = &record.state {
             tx.kv_write(
                 BDK_NAMESPACE,
@@ -260,6 +321,232 @@ impl BdkStorage {
         tx.commit().await.map_err(Error::from)
     }
 
+    /// Atomically transition a send intent from `expected_state` to
+    /// `next_state` using a compare-and-set against the durable record.
+    ///
+    /// Returns `Ok(true)` when the transition was applied. Returns
+    /// `Ok(false)` — without writing anything — when the durable record no
+    /// longer matches `expected_attempt_id` and `expected_state`, meaning
+    /// another worker advanced, rewound, or retried it concurrently.
+    ///
+    /// The outpoint quote-id index is maintained in the same transaction,
+    /// mirroring [`Self::update_send_intent`].
+    pub async fn transition_send_intent(
+        &self,
+        intent_id: &Uuid,
+        expected_attempt_id: &Uuid,
+        expected_state: &SendIntentState,
+        next_state: &SendIntentState,
+    ) -> Result<bool, Error> {
+        let key = intent_id.to_string();
+        let mut tx = self
+            .kv_store
+            .begin_transaction()
+            .await
+            .map_err(Error::from)?;
+
+        let Some(expected_bytes) = tx
+            .kv_read(BDK_NAMESPACE, SEND_INTENT_NAMESPACE, &key)
+            .await
+            .map_err(Error::from)?
+        else {
+            tx.rollback().await.map_err(Error::from)?;
+            return Err(Error::SendIntentNotFound(*intent_id));
+        };
+
+        let mut intent: SendIntentRecord = serde_json::from_slice(&expected_bytes)?;
+        if &intent.attempt_id != expected_attempt_id || &intent.state != expected_state {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        }
+
+        let previous_outpoint = match &intent.state {
+            SendIntentState::AwaitingConfirmation { outpoint, .. } => Some(outpoint.clone()),
+            _ => None,
+        };
+        let new_outpoint = match next_state {
+            SendIntentState::AwaitingConfirmation { outpoint, .. } => Some(outpoint.clone()),
+            _ => None,
+        };
+        intent.state = next_state.clone();
+
+        let replacement = serde_json::to_vec(&intent)?;
+        let written = tx
+            .kv_write_if_equals(
+                BDK_NAMESPACE,
+                SEND_INTENT_NAMESPACE,
+                &key,
+                &expected_bytes,
+                &replacement,
+            )
+            .await
+            .map_err(Error::from)?;
+        if !written {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        }
+        if let SendIntentState::Failed {
+            reason, failed_at, ..
+        } = next_state
+        {
+            let failed_attempt = FailedSendAttemptRecord {
+                attempt_id: *expected_attempt_id,
+                intent_id: *intent_id,
+                quote_id: intent.quote_id.clone(),
+                reason: reason.clone(),
+                failed_at: *failed_at,
+            };
+            let serialized = serde_json::to_vec(&failed_attempt)?;
+            tx.kv_write(
+                BDK_NAMESPACE,
+                FAILED_SEND_ATTEMPT_NAMESPACE,
+                &expected_attempt_id.to_string(),
+                &serialized,
+            )
+            .await
+            .map_err(Error::from)?;
+        }
+        if let Some(outpoint) =
+            previous_outpoint.filter(|outpoint| Some(outpoint) != new_outpoint.as_ref())
+        {
+            tx.kv_remove(
+                BDK_NAMESPACE,
+                SEND_OUTPOINT_QUOTE_ID_NAMESPACE,
+                &outpoint_to_key(&outpoint),
+            )
+            .await
+            .map_err(Error::from)?;
+        }
+        if let Some(outpoint) = new_outpoint {
+            tx.kv_write(
+                BDK_NAMESPACE,
+                SEND_OUTPOINT_QUOTE_ID_NAMESPACE,
+                &outpoint_to_key(&outpoint),
+                intent.quote_id.as_bytes(),
+            )
+            .await
+            .map_err(Error::from)?;
+        }
+        tx.commit().await.map_err(Error::from)?;
+        Ok(true)
+    }
+
+    /// Atomically claim a pending intent for a batch that is still `Signed`.
+    ///
+    /// The no-op batch compare-and-set locks the exact signed record before
+    /// the intent is advanced. Cancellation therefore either happens first
+    /// and rejects the claim, or waits for the claim and compensates it.
+    pub(crate) async fn claim_send_intent_for_signed_batch(
+        &self,
+        intent_id: &Uuid,
+        expected_attempt_id: &Uuid,
+        created_at: u64,
+        batch_id: &Uuid,
+    ) -> Result<(), Error> {
+        let batch_key = batch_id.to_string();
+        let intent_key = intent_id.to_string();
+        let mut tx = self
+            .kv_store
+            .begin_transaction()
+            .await
+            .map_err(Error::from)?;
+
+        let Some(batch_bytes) = tx
+            .kv_read(BDK_NAMESPACE, SEND_BATCH_NAMESPACE, &batch_key)
+            .await
+            .map_err(Error::from)?
+        else {
+            tx.rollback().await.map_err(Error::from)?;
+            return Err(Error::SendBatchStateConflict {
+                batch_id: *batch_id,
+                expected: "Signed",
+            });
+        };
+        let batch: SendBatchRecord = serde_json::from_slice(&batch_bytes)?;
+        let lists_exact_attempt_once = match &batch.state {
+            SendBatchState::Signed { assignments, .. } if !expected_attempt_id.is_nil() => {
+                let mut matching_intent = assignments
+                    .iter()
+                    .filter(|assignment| assignment.intent_id == *intent_id);
+                matches!(
+                    (matching_intent.next(), matching_intent.next()),
+                    (Some(assignment), None)
+                        if assignment.attempt_id == *expected_attempt_id
+                )
+            }
+            _ => false,
+        };
+        if !lists_exact_attempt_once {
+            tx.rollback().await.map_err(Error::from)?;
+            return Err(Error::SendBatchStateConflict {
+                batch_id: *batch_id,
+                expected: "Signed with one assignment for exact intent attempt",
+            });
+        }
+
+        let batch_locked = tx
+            .kv_write_if_equals(
+                BDK_NAMESPACE,
+                SEND_BATCH_NAMESPACE,
+                &batch_key,
+                &batch_bytes,
+                &batch_bytes,
+            )
+            .await
+            .map_err(Error::from)?;
+        if !batch_locked {
+            tx.rollback().await.map_err(Error::from)?;
+            return Err(Error::SendBatchStateConflict {
+                batch_id: *batch_id,
+                expected: "Signed",
+            });
+        }
+
+        let Some(intent_bytes) = tx
+            .kv_read(BDK_NAMESPACE, SEND_INTENT_NAMESPACE, &intent_key)
+            .await
+            .map_err(Error::from)?
+        else {
+            tx.rollback().await.map_err(Error::from)?;
+            return Err(Error::SendIntentNotFound(*intent_id));
+        };
+        let mut intent: SendIntentRecord = serde_json::from_slice(&intent_bytes)?;
+        let expected_state = SendIntentState::Pending { created_at };
+        if &intent.attempt_id != expected_attempt_id || intent.state != expected_state {
+            tx.rollback().await.map_err(Error::from)?;
+            return Err(Error::SendIntentStateConflict {
+                intent_id: *intent_id,
+                expected: "Pending",
+            });
+        }
+
+        intent.state = SendIntentState::Batched {
+            batch_id: *batch_id,
+            created_at,
+        };
+        let replacement = serde_json::to_vec(&intent)?;
+        let intent_claimed = tx
+            .kv_write_if_equals(
+                BDK_NAMESPACE,
+                SEND_INTENT_NAMESPACE,
+                &intent_key,
+                &intent_bytes,
+                &replacement,
+            )
+            .await
+            .map_err(Error::from)?;
+        if !intent_claimed {
+            tx.rollback().await.map_err(Error::from)?;
+            return Err(Error::SendIntentStateConflict {
+                intent_id: *intent_id,
+                expected: "Pending",
+            });
+        }
+
+        tx.commit().await.map_err(Error::from)?;
+        Ok(())
+    }
+
     /// Delete a send intent
     pub async fn delete_send_intent(&self, intent_id: &Uuid) -> Result<(), Error> {
         let Some(intent) = self.get_send_intent(intent_id).await? else {
@@ -308,12 +595,110 @@ impl BdkStorage {
             .collect())
     }
 
+    /// Atomically assign fresh attempt IDs to legacy pending send intents.
+    ///
+    /// Records written before attempt generations were introduced deserialize
+    /// with a nil attempt ID. All such pending records are rewritten in one
+    /// transaction. A concurrent change causes the whole normalization to roll
+    /// back rather than overwriting the newer record.
+    pub async fn normalize_legacy_pending_attempt_ids(&self) -> Result<usize, Error> {
+        let mut tx = self
+            .kv_store
+            .begin_transaction()
+            .await
+            .map_err(Error::from)?;
+        let keys = tx
+            .kv_list(BDK_NAMESPACE, SEND_INTENT_NAMESPACE)
+            .await
+            .map_err(Error::from)?;
+        let mut normalized = 0;
+
+        for key in keys {
+            let Some(bytes) = tx
+                .kv_read(BDK_NAMESPACE, SEND_INTENT_NAMESPACE, &key)
+                .await
+                .map_err(Error::from)?
+            else {
+                tx.rollback().await.map_err(Error::from)?;
+                return Err(Error::Wallet(format!(
+                    "Send intent disappeared while normalizing legacy attempts for key {}",
+                    key
+                )));
+            };
+            let mut intent: SendIntentRecord = serde_json::from_slice(&bytes).map_err(|error| {
+                Error::Wallet(format!(
+                    "Failed to deserialize record in namespace {} for key {}: {}",
+                    SEND_INTENT_NAMESPACE, key, error
+                ))
+            })?;
+            if !intent.attempt_id.is_nil()
+                || !matches!(intent.state, SendIntentState::Pending { .. })
+            {
+                continue;
+            }
+
+            intent.attempt_id = Uuid::new_v4();
+            let replacement = serde_json::to_vec(&intent)?;
+            let rewritten = tx
+                .kv_write_if_equals(
+                    BDK_NAMESPACE,
+                    SEND_INTENT_NAMESPACE,
+                    &key,
+                    &bytes,
+                    &replacement,
+                )
+                .await
+                .map_err(Error::from)?;
+            if !rewritten {
+                tx.rollback().await.map_err(Error::from)?;
+                return Err(Error::Wallet(format!(
+                    "Send intent changed while normalizing legacy attempt for key {}",
+                    key
+                )));
+            }
+            normalized += 1;
+        }
+
+        tx.commit().await.map_err(Error::from)?;
+        Ok(normalized)
+    }
+
     /// Store a failed pre-sign send attempt tombstone.
     pub async fn add_failed_send_attempt(
         &self,
         record: &FailedSendAttemptRecord,
     ) -> Result<(), Error> {
-        self.put_record(record).await
+        // A tombstone belongs permanently to the attempt supplied by the
+        // caller. In particular, never retarget a delayed write to whichever
+        // retry currently occupies the active intent record.
+        let key = record.attempt_id.to_string();
+        let bytes = serde_json::to_vec(record)?;
+        let mut tx = self
+            .kv_store
+            .begin_transaction()
+            .await
+            .map_err(Error::from)?;
+        let inserted = tx
+            .kv_write_if_absent(BDK_NAMESPACE, FAILED_SEND_ATTEMPT_NAMESPACE, &key, &bytes)
+            .await
+            .map_err(Error::from)?;
+        if inserted {
+            tx.commit().await.map_err(Error::from)?;
+            return Ok(());
+        }
+
+        let existing = tx
+            .kv_read(BDK_NAMESPACE, FAILED_SEND_ATTEMPT_NAMESPACE, &key)
+            .await
+            .map_err(Error::from)?;
+        tx.rollback().await.map_err(Error::from)?;
+        if existing.as_deref() == Some(bytes.as_slice()) {
+            Ok(())
+        } else {
+            Err(Error::Wallet(format!(
+                "Failed send attempt {key} already exists with different contents"
+            )))
+        }
     }
 
     /// List failed pre-sign send attempts for a quote id.
@@ -354,6 +739,114 @@ impl BdkStorage {
 
         self.update_record_state::<SendBatchRecord, SendBatchState>(&key, new_state)
             .await
+    }
+
+    /// Atomically transition a send batch from `expected_state` to
+    /// `next_state` using a compare-and-set against the durable record.
+    ///
+    /// Returns `Ok(true)` when the transition was applied and `Ok(false)`
+    /// when another worker changed or removed the batch first.
+    pub async fn transition_send_batch(
+        &self,
+        batch_id: &Uuid,
+        expected_state: &SendBatchState,
+        next_state: &SendBatchState,
+    ) -> Result<bool, Error> {
+        let key = batch_id.to_string();
+        let mut tx = self
+            .kv_store
+            .begin_transaction()
+            .await
+            .map_err(Error::from)?;
+
+        let Some(expected_bytes) = tx
+            .kv_read(BDK_NAMESPACE, SEND_BATCH_NAMESPACE, &key)
+            .await
+            .map_err(Error::from)?
+        else {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        };
+
+        let mut batch: SendBatchRecord = serde_json::from_slice(&expected_bytes)?;
+        if &batch.state != expected_state {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        }
+        batch.state = next_state.clone();
+
+        let replacement = serde_json::to_vec(&batch)?;
+        let written = tx
+            .kv_write_if_equals(
+                BDK_NAMESPACE,
+                SEND_BATCH_NAMESPACE,
+                &key,
+                &expected_bytes,
+                &replacement,
+            )
+            .await
+            .map_err(Error::from)?;
+        if !written {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        }
+
+        tx.commit().await.map_err(Error::from)?;
+        Ok(true)
+    }
+
+    /// Delete a send batch only while it still matches `expected_state`.
+    ///
+    /// The no-op conditional update locks the matching record for the rest of
+    /// the transaction before deletion, so a concurrent promotion to
+    /// `Broadcast` and compensation cannot both succeed.
+    pub async fn delete_send_batch_if_state(
+        &self,
+        batch_id: &Uuid,
+        expected_state: &SendBatchState,
+    ) -> Result<bool, Error> {
+        let key = batch_id.to_string();
+        let mut tx = self
+            .kv_store
+            .begin_transaction()
+            .await
+            .map_err(Error::from)?;
+
+        let Some(expected_bytes) = tx
+            .kv_read(BDK_NAMESPACE, SEND_BATCH_NAMESPACE, &key)
+            .await
+            .map_err(Error::from)?
+        else {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        };
+
+        let batch: SendBatchRecord = serde_json::from_slice(&expected_bytes)?;
+        if &batch.state != expected_state {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        }
+
+        let locked = tx
+            .kv_write_if_equals(
+                BDK_NAMESPACE,
+                SEND_BATCH_NAMESPACE,
+                &key,
+                &expected_bytes,
+                &expected_bytes,
+            )
+            .await
+            .map_err(Error::from)?;
+        if !locked {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        }
+
+        tx.kv_remove(BDK_NAMESPACE, SEND_BATCH_NAMESPACE, &key)
+            .await
+            .map_err(Error::from)?;
+        tx.commit().await.map_err(Error::from)?;
+        Ok(true)
     }
 
     /// Delete a send batch
@@ -521,19 +1014,56 @@ impl BdkStorage {
     /// Atomically finalize an active send intent and create a tombstone.
     pub async fn finalize_send_intent(
         &self,
-        intent_id: &Uuid,
+        expected: &SendIntentRecord,
         record: &FinalizedSendIntentRecord,
-    ) -> Result<(), Error> {
-        let Some(intent) = self.get_send_intent(intent_id).await? else {
-            return Err(Error::SendIntentNotFound(*intent_id));
-        };
+    ) -> Result<bool, Error> {
+        if record.intent_id != expected.intent_id || record.quote_id != expected.quote_id {
+            return Err(Error::SendIntentStateConflict {
+                intent_id: expected.intent_id,
+                expected: "matching finalized intent identity",
+            });
+        }
 
+        let key = expected.intent_id.to_string();
+        let expected_bytes = serde_json::to_vec(expected)?;
         let serialized = serde_json::to_vec(record)?;
         let mut tx = self
             .kv_store
             .begin_transaction()
             .await
             .map_err(Error::from)?;
+        let Some(active_bytes) = tx
+            .kv_read(BDK_NAMESPACE, SEND_INTENT_NAMESPACE, &key)
+            .await
+            .map_err(Error::from)?
+        else {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        };
+        let intent: SendIntentRecord = serde_json::from_slice(&active_bytes)?;
+        if active_bytes != expected_bytes {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        }
+
+        // Take ownership of this exact active record before creating the
+        // tombstone. Writing the same bytes is intentional: the conditional
+        // update locks the row in SQL stores and gives all backends one atomic
+        // winner, while preserving the record until the transaction removes it.
+        let won = tx
+            .kv_write_if_equals(
+                BDK_NAMESPACE,
+                SEND_INTENT_NAMESPACE,
+                &key,
+                &expected_bytes,
+                &active_bytes,
+            )
+            .await
+            .map_err(Error::from)?;
+        if !won {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        }
         tx.kv_write(
             BDK_NAMESPACE,
             FINALIZED_INTENT_NAMESPACE,
@@ -558,7 +1088,7 @@ impl BdkStorage {
         )
         .await
         .map_err(Error::from)?;
-        tx.kv_remove(BDK_NAMESPACE, SEND_INTENT_NAMESPACE, &intent_id.to_string())
+        tx.kv_remove(BDK_NAMESPACE, SEND_INTENT_NAMESPACE, &key)
             .await
             .map_err(Error::from)?;
         tx.kv_remove(
@@ -569,6 +1099,359 @@ impl BdkStorage {
         .await
         .map_err(Error::from)?;
         tx.commit().await.map_err(Error::from)?;
-        Ok(())
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::send::payment_intent::SendIntent;
+    use crate::testutil::{store_test_signed_batch, GatedKvStore, PausePoint, ReadPath};
+    use crate::types::{PaymentMetadata, PaymentTier};
+
+    const ADDR: &str = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080";
+
+    #[tokio::test]
+    async fn failed_attempt_insert_never_retargets_or_overwrites() {
+        let storage = BdkStorage::new(Arc::new(GatedKvStore::default()));
+        let intent_id = Uuid::new_v4();
+        let first = FailedSendAttemptRecord {
+            attempt_id: Uuid::new_v4(),
+            intent_id,
+            quote_id: "failed-attempt-history".to_string(),
+            reason: "first failure".to_string(),
+            failed_at: 1,
+        };
+        let second = FailedSendAttemptRecord {
+            attempt_id: Uuid::new_v4(),
+            intent_id,
+            quote_id: first.quote_id.clone(),
+            reason: "second failure".to_string(),
+            failed_at: 2,
+        };
+        storage
+            .add_failed_send_attempt(&first)
+            .await
+            .expect("store first attempt");
+        storage
+            .add_failed_send_attempt(&second)
+            .await
+            .expect("store second attempt");
+        storage
+            .add_failed_send_attempt(&first)
+            .await
+            .expect("identical delayed write is idempotent");
+
+        let conflicting = FailedSendAttemptRecord {
+            reason: "retargeted contents".to_string(),
+            ..second.clone()
+        };
+        assert!(storage.add_failed_send_attempt(&conflicting).await.is_err());
+
+        let records = storage
+            .get_failed_send_attempts_by_quote_id(&first.quote_id)
+            .await
+            .expect("read attempt history");
+        assert_eq!(records.len(), 2);
+        assert!(records.iter().any(|record| {
+            record.attempt_id == first.attempt_id && record.reason == first.reason
+        }));
+        assert!(records.iter().any(|record| {
+            record.attempt_id == second.attempt_id && record.reason == second.reason
+        }));
+    }
+
+    /// A retry that is paused before reading the active quote-id index
+    /// while `finalize_send_intent` commits must be rejected: the quote
+    /// ends with exactly one finalized tombstone and no live intent.
+    #[tokio::test]
+    async fn concurrent_retry_cannot_reactivate_finalized_quote() {
+        let kv = GatedKvStore::default();
+        let storage = BdkStorage::new(Arc::new(kv.clone()));
+        let quote_id = "quote-finalize-race".to_string();
+
+        let pending = SendIntent::new(
+            &storage,
+            quote_id.clone(),
+            ADDR.to_string(),
+            20_000,
+            1_000,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("new");
+        let batch_id = Uuid::new_v4();
+        store_test_signed_batch(&storage, batch_id, &[pending.intent_id]).await;
+        let awaiting = pending
+            .assign_to_batch(&storage, batch_id)
+            .await
+            .expect("assign")
+            .mark_broadcast(
+                &storage,
+                "txid-race".to_string(),
+                "txid-race:0".to_string(),
+                250,
+            )
+            .await
+            .expect("mark broadcast");
+        let intent_id = awaiting.intent_id;
+        let tombstone = FinalizedSendIntentRecord {
+            intent_id,
+            quote_id: quote_id.clone(),
+            total_spent_sat: 20_250,
+            outpoint: "txid-race:0".to_string(),
+            finalized_at: 1_700_000_000,
+        };
+
+        let gate = kv.gate_read(
+            ReadPath::Transaction,
+            PausePoint::BeforeRead,
+            BDK_NAMESPACE,
+            SEND_INTENT_QUOTE_ID_NAMESPACE,
+            1,
+        );
+
+        let retry_storage = storage.clone();
+        let retry_quote = quote_id.clone();
+        let retry = tokio::spawn(async move {
+            SendIntent::new(
+                &retry_storage,
+                retry_quote,
+                ADDR.to_string(),
+                20_000,
+                1_000,
+                PaymentTier::Immediate,
+                PaymentMetadata::default(),
+            )
+            .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), gate.wait_entered())
+            .await
+            .expect("retry reached the gated read");
+        storage
+            .finalize_send_intent(
+                &storage
+                    .get_send_intent(&intent_id)
+                    .await
+                    .expect("read intent")
+                    .expect("intent exists"),
+                &tombstone,
+            )
+            .await
+            .expect("finalize");
+        gate.release();
+
+        let result = retry.await.expect("join retry task");
+        assert!(
+            matches!(result, Err(Error::DuplicateQuoteId(ref id)) if *id == quote_id),
+            "retry must be rejected with DuplicateQuoteId, got {:?}",
+            result
+        );
+
+        assert!(storage
+            .get_finalized_intent(&intent_id)
+            .await
+            .expect("get tombstone")
+            .is_some());
+        assert!(storage
+            .get_all_send_intents()
+            .await
+            .expect("list send intents")
+            .is_empty());
+        assert!(storage
+            .get_send_intent_by_quote_id(&quote_id)
+            .await
+            .expect("lookup by quote id")
+            .is_none());
+    }
+
+    /// A retry that snapshots a `Failed` record and then loses the race
+    /// against another worker requeuing and batching the intent must not
+    /// rewind the record back to `Pending`.
+    #[tokio::test]
+    async fn stale_failed_retry_cannot_rewind_batched_intent() {
+        let kv = GatedKvStore::default();
+        let storage = BdkStorage::new(Arc::new(kv.clone()));
+        let quote_id = "quote-stale-retry".to_string();
+
+        let pending = SendIntent::new(
+            &storage,
+            quote_id.clone(),
+            ADDR.to_string(),
+            20_000,
+            1_000,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("new");
+        let intent_id = pending.intent_id;
+        pending
+            .fail(&storage, "fee too high".to_string())
+            .await
+            .expect("fail");
+
+        let gate = kv.gate_read(
+            ReadPath::Transaction,
+            PausePoint::AfterRead,
+            BDK_NAMESPACE,
+            SEND_INTENT_NAMESPACE,
+            1,
+        );
+        let retry_a_storage = storage.clone();
+        let retry_a_quote = quote_id.clone();
+        let retry_a = tokio::spawn(async move {
+            SendIntent::new(
+                &retry_a_storage,
+                retry_a_quote,
+                ADDR.to_string(),
+                20_000,
+                1_500,
+                PaymentTier::Immediate,
+                PaymentMetadata::default(),
+            )
+            .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), gate.wait_entered())
+            .await
+            .expect("retry A reached the gated read");
+
+        let retried_b = SendIntent::new(
+            &storage,
+            quote_id.clone(),
+            ADDR.to_string(),
+            20_000,
+            1_500,
+            PaymentTier::Immediate,
+            PaymentMetadata::default(),
+        )
+        .await
+        .expect("retry B requeues the failed intent");
+        assert_eq!(retried_b.intent_id, intent_id);
+        let batch_id = Uuid::new_v4();
+        store_test_signed_batch(&storage, batch_id, &[intent_id]).await;
+        retried_b
+            .assign_to_batch(&storage, batch_id)
+            .await
+            .expect("batch intent for retry B");
+
+        gate.release();
+        let result_a = retry_a.await.expect("join retry A");
+        assert!(
+            matches!(result_a, Err(Error::DuplicateQuoteId(ref id)) if *id == quote_id),
+            "stale retry must be rejected with DuplicateQuoteId, got {:?}",
+            result_a
+        );
+
+        let persisted = storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("get intent")
+            .expect("intent present");
+        assert!(
+            matches!(persisted.state, SendIntentState::Batched { batch_id: b, .. } if b == batch_id),
+            "stale retry must not rewind the batched intent, got {:?}",
+            persisted.state
+        );
+    }
+
+    /// Compensation that snapshots a `Signed` batch must not delete it after
+    /// another worker promotes the durable record to `Broadcast`.
+    #[tokio::test]
+    async fn stale_signed_batch_delete_cannot_remove_broadcast_batch() {
+        let kv = GatedKvStore::default();
+        let storage = BdkStorage::new(Arc::new(kv.clone()));
+        let batch_id = Uuid::new_v4();
+        let signed_state = SendBatchState::Signed {
+            tx_bytes: vec![1, 2, 3],
+            assignments: Vec::new(),
+            fee_sat: 500,
+        };
+        let broadcast_state = SendBatchState::Broadcast {
+            txid: "broadcast-won".to_string(),
+            tx_bytes: vec![1, 2, 3],
+            assignments: Vec::new(),
+            fee_sat: 500,
+        };
+        storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: signed_state.clone(),
+            })
+            .await
+            .expect("store signed batch");
+
+        let gate = kv.gate_read(
+            ReadPath::Transaction,
+            PausePoint::AfterRead,
+            BDK_NAMESPACE,
+            SEND_BATCH_NAMESPACE,
+            1,
+        );
+        let stale_storage = storage.clone();
+        let stale_signed_state = signed_state.clone();
+        let stale_delete = tokio::spawn(async move {
+            stale_storage
+                .delete_send_batch_if_state(&batch_id, &stale_signed_state)
+                .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), gate.wait_entered())
+            .await
+            .expect("conditional delete reached the gated read");
+        assert!(storage
+            .transition_send_batch(&batch_id, &signed_state, &broadcast_state)
+            .await
+            .expect("promote batch"));
+        gate.release();
+
+        assert!(!stale_delete
+            .await
+            .expect("join stale delete")
+            .expect("stale delete should not error"));
+        let persisted = storage
+            .get_send_batch(&batch_id)
+            .await
+            .expect("get batch")
+            .expect("broadcast batch remains");
+        assert_eq!(persisted.state, broadcast_state);
+    }
+
+    #[tokio::test]
+    async fn conditional_signed_batch_delete_succeeds_on_sqlite() {
+        let db = cdk_sqlite::mint::memory::empty()
+            .await
+            .expect("in-memory database");
+        let storage = BdkStorage::new(Arc::new(db));
+        let batch_id = Uuid::new_v4();
+        let signed_state = SendBatchState::Signed {
+            tx_bytes: vec![1, 2, 3],
+            assignments: Vec::new(),
+            fee_sat: 500,
+        };
+        storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: signed_state.clone(),
+            })
+            .await
+            .expect("store signed batch");
+
+        assert!(storage
+            .delete_send_batch_if_state(&batch_id, &signed_state)
+            .await
+            .expect("delete signed batch"));
+        assert!(storage
+            .get_send_batch(&batch_id)
+            .await
+            .expect("get deleted batch")
+            .is_none());
     }
 }

--- a/crates/cdk-bdk/src/storage/send.rs
+++ b/crates/cdk-bdk/src/storage/send.rs
@@ -3,7 +3,8 @@ use std::str::FromStr;
 use uuid::Uuid;
 
 use super::{
-    outpoint_to_key, BdkStorage, FailedSendAttemptRecord, FinalizedSendIntentRecord, BDK_NAMESPACE,
+    outpoint_to_key, BdkStorage, BroadcastRejectionRecord, FailedSendAttemptRecord,
+    FinalizedSendIntentRecord, BDK_NAMESPACE, BROADCAST_REJECTION_NAMESPACE,
     FAILED_SEND_ATTEMPT_NAMESPACE, FINALIZED_INTENT_NAMESPACE,
     FINALIZED_SEND_INTENT_QUOTE_ID_NAMESPACE, SEND_BATCH_NAMESPACE, SEND_INTENT_NAMESPACE,
     SEND_INTENT_QUOTE_ID_NAMESPACE, SEND_OUTPOINT_QUOTE_ID_BACKFILL_KEY,
@@ -663,6 +664,268 @@ impl BdkStorage {
         Ok(normalized)
     }
 
+    /// Write-once binding of pre-attempt-generation Broadcast batches to
+    /// their member intents.
+    ///
+    /// Broadcast records written before attempt generations were introduced
+    /// deserialize with nil assignment attempt IDs, and the rebroadcast
+    /// eligibility gate fences such batches permanently. When every member
+    /// intent is still bound to this exact batch (state, batch ID, computed
+    /// txid, outpoint, and fee all match), each nil assignment is bound to
+    /// the member's current attempt, assigning a fresh attempt ID to legacy
+    /// members first. Batches with missing, replaced, or mismatched members
+    /// are left untouched and stay fenced for operator review.
+    ///
+    /// `txid` must be the transaction ID computed from the batch's persisted
+    /// transaction bytes, not the record's informational `txid` field.
+    ///
+    /// All rewrites for one batch commit atomically. A concurrent
+    /// modification rolls the transaction back and returns `Ok(false)`; the
+    /// next processor cycle retries.
+    pub async fn normalize_legacy_broadcast_attempt_ids(
+        &self,
+        batch_id: &Uuid,
+        txid: &str,
+    ) -> Result<bool, Error> {
+        let batch_key = batch_id.to_string();
+        let mut tx = self
+            .kv_store
+            .begin_transaction()
+            .await
+            .map_err(Error::from)?;
+
+        let Some(batch_bytes) = tx
+            .kv_read(BDK_NAMESPACE, SEND_BATCH_NAMESPACE, &batch_key)
+            .await
+            .map_err(Error::from)?
+        else {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        };
+        let mut batch: SendBatchRecord = serde_json::from_slice(&batch_bytes).map_err(|error| {
+            Error::Wallet(format!(
+                "Failed to deserialize record in namespace {} for key {}: {}",
+                SEND_BATCH_NAMESPACE, batch_key, error
+            ))
+        })?;
+        let SendBatchState::Broadcast {
+            txid: stored_txid,
+            tx_bytes,
+            assignments,
+            fee_sat,
+        } = batch.state
+        else {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        };
+        if !assignments.iter().any(|a| a.attempt_id.is_nil()) {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        }
+
+        // Validate every member's binding to this exact batch and plan the
+        // rewrites before writing anything: a batch is bound only as a
+        // whole.
+        let mut member_rewrites: Vec<(String, Vec<u8>, Vec<u8>)> = Vec::new();
+        let mut bound_assignments = assignments.clone();
+        for (index, assignment) in assignments.iter().enumerate() {
+            let intent_key = assignment.intent_id.to_string();
+            let Some(intent_bytes) = tx
+                .kv_read(BDK_NAMESPACE, SEND_INTENT_NAMESPACE, &intent_key)
+                .await
+                .map_err(Error::from)?
+            else {
+                // Missing member: leave the batch fenced.
+                tx.rollback().await.map_err(Error::from)?;
+                return Ok(false);
+            };
+            let mut intent: SendIntentRecord =
+                serde_json::from_slice(&intent_bytes).map_err(|error| {
+                    Error::Wallet(format!(
+                        "Failed to deserialize record in namespace {} for key {}: {}",
+                        SEND_INTENT_NAMESPACE, intent_key, error
+                    ))
+                })?;
+            let bound_to_batch = match &intent.state {
+                SendIntentState::AwaitingConfirmation {
+                    batch_id: member_batch_id,
+                    txid: member_txid,
+                    outpoint,
+                    fee_contribution_sat,
+                    ..
+                } => {
+                    *member_batch_id == *batch_id
+                        && member_txid == txid
+                        && *outpoint == format!("{txid}:{}", assignment.vout)
+                        && *fee_contribution_sat == assignment.fee_contribution_sat
+                }
+                // A Batched member has not been advanced to its final
+                // broadcast fields yet; the eligibility gate repairs it.
+                SendIntentState::Batched {
+                    batch_id: member_batch_id,
+                    ..
+                } => *member_batch_id == *batch_id,
+                _ => false,
+            };
+            if !bound_to_batch {
+                tx.rollback().await.map_err(Error::from)?;
+                return Ok(false);
+            }
+
+            let target_attempt = if intent.attempt_id.is_nil() {
+                let fresh = Uuid::new_v4();
+                intent.attempt_id = fresh;
+                let replacement = serde_json::to_vec(&intent)?;
+                member_rewrites.push((intent_key, intent_bytes, replacement));
+                fresh
+            } else {
+                intent.attempt_id
+            };
+            bound_assignments[index].attempt_id = target_attempt;
+        }
+
+        for (intent_key, intent_bytes, replacement) in member_rewrites {
+            let rewritten = tx
+                .kv_write_if_equals(
+                    BDK_NAMESPACE,
+                    SEND_INTENT_NAMESPACE,
+                    &intent_key,
+                    &intent_bytes,
+                    &replacement,
+                )
+                .await
+                .map_err(Error::from)?;
+            if !rewritten {
+                tx.rollback().await.map_err(Error::from)?;
+                return Ok(false);
+            }
+        }
+
+        batch.state = SendBatchState::Broadcast {
+            txid: stored_txid,
+            tx_bytes,
+            assignments: bound_assignments,
+            fee_sat,
+        };
+        let batch_replacement = serde_json::to_vec(&batch)?;
+        let rewritten = tx
+            .kv_write_if_equals(
+                BDK_NAMESPACE,
+                SEND_BATCH_NAMESPACE,
+                &batch_key,
+                &batch_bytes,
+                &batch_replacement,
+            )
+            .await
+            .map_err(Error::from)?;
+        if !rewritten {
+            tx.rollback().await.map_err(Error::from)?;
+            return Ok(false);
+        }
+
+        tx.commit().await.map_err(Error::from)?;
+        Ok(true)
+    }
+
+    /// Record a deterministic broadcast rejection for a batch, returning the
+    /// consecutive rejection count.
+    ///
+    /// Only rejections the backend will never reconsider may be recorded
+    /// here; transient or ambiguous outcomes must not increment the counter.
+    /// A concurrent modification rolls the transaction back and returns an
+    /// error; the caller logs it and the next cycle retries.
+    pub async fn record_broadcast_rejection(
+        &self,
+        batch_id: &Uuid,
+        txid: &str,
+        error: &str,
+    ) -> Result<u32, Error> {
+        let key = batch_id.to_string();
+        let mut tx = self
+            .kv_store
+            .begin_transaction()
+            .await
+            .map_err(Error::from)?;
+        let existing = tx
+            .kv_read(BDK_NAMESPACE, BROADCAST_REJECTION_NAMESPACE, &key)
+            .await
+            .map_err(Error::from)?;
+
+        let mut record = match &existing {
+            Some(bytes) => serde_json::from_slice::<BroadcastRejectionRecord>(bytes)?,
+            None => BroadcastRejectionRecord {
+                batch_id: *batch_id,
+                txid: txid.to_string(),
+                consecutive_rejections: 0,
+                last_error: String::new(),
+                last_rejected_at: 0,
+            },
+        };
+        record.consecutive_rejections = record.consecutive_rejections.saturating_add(1);
+        record.txid = txid.to_string();
+        record.last_error = error.to_string();
+        record.last_rejected_at = crate::util::unix_now();
+        let replacement = serde_json::to_vec(&record)?;
+
+        let written = match &existing {
+            Some(bytes) => tx
+                .kv_write_if_equals(
+                    BDK_NAMESPACE,
+                    BROADCAST_REJECTION_NAMESPACE,
+                    &key,
+                    bytes,
+                    &replacement,
+                )
+                .await
+                .map_err(Error::from)?,
+            None => tx
+                .kv_write_if_absent(
+                    BDK_NAMESPACE,
+                    BROADCAST_REJECTION_NAMESPACE,
+                    &key,
+                    &replacement,
+                )
+                .await
+                .map_err(Error::from)?,
+        };
+        if !written {
+            tx.rollback().await.map_err(Error::from)?;
+            return Err(Error::Wallet(format!(
+                "Broadcast rejection record changed while updating batch {key}"
+            )));
+        }
+
+        tx.commit().await.map_err(Error::from)?;
+        Ok(record.consecutive_rejections)
+    }
+
+    /// Clear a batch's rejection record after an accepted or already-known
+    /// broadcast outcome, or when the batch record is deleted. Idempotent.
+    pub async fn clear_broadcast_rejection(&self, batch_id: &Uuid) -> Result<(), Error> {
+        let mut tx = self
+            .kv_store
+            .begin_transaction()
+            .await
+            .map_err(Error::from)?;
+        tx.kv_remove(
+            BDK_NAMESPACE,
+            BROADCAST_REJECTION_NAMESPACE,
+            &batch_id.to_string(),
+        )
+        .await
+        .map_err(Error::from)?;
+        tx.commit().await.map_err(Error::from)?;
+        Ok(())
+    }
+
+    /// Read a batch's broadcast rejection record, if any.
+    pub async fn get_broadcast_rejection(
+        &self,
+        batch_id: &Uuid,
+    ) -> Result<Option<BroadcastRejectionRecord>, Error> {
+        self.get_record(&batch_id.to_string()).await
+    }
+
     /// Store a failed pre-sign send attempt tombstone.
     pub async fn add_failed_send_attempt(
         &self,
@@ -1115,6 +1378,7 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+    use crate::send::batch_transaction::record::BatchOutputAssignment;
     use crate::send::payment_intent::SendIntent;
     use crate::testutil::{store_test_signed_batch, GatedKvStore, PausePoint, ReadPath};
     use crate::types::{PaymentMetadata, PaymentTier};
@@ -1496,6 +1760,245 @@ mod tests {
                 .expect("get tombstone")
                 .is_some());
         }
+    }
+
+    /// Pre-attempt-generation Broadcast batches are bound to their member
+    /// intents' current attempts in one atomic write, so the rebroadcast
+    /// eligibility gate can evaluate them. Covers both an advanced
+    /// AwaitingConfirmation member and a crash-leftover Batched member.
+    #[tokio::test]
+    async fn normalize_legacy_broadcast_attempt_ids_binds_matching_members() {
+        let db = cdk_sqlite::mint::memory::empty()
+            .await
+            .expect("in-memory database");
+        let storage = BdkStorage::new(Arc::new(db));
+        let batch_id = Uuid::new_v4();
+        let txid = "aa".repeat(32);
+        let awaiting_id = Uuid::new_v4();
+        let batched_id = Uuid::new_v4();
+
+        let awaiting = SendIntentRecord {
+            intent_id: awaiting_id,
+            attempt_id: Uuid::nil(),
+            quote_id: format!("quote-{awaiting_id}"),
+            address: ADDR.to_string(),
+            amount_sat: 20_000,
+            max_fee_amount_sat: 1_000,
+            tier: PaymentTier::Immediate,
+            metadata: PaymentMetadata::default(),
+            state: SendIntentState::AwaitingConfirmation {
+                batch_id,
+                txid: txid.clone(),
+                outpoint: format!("{txid}:0"),
+                fee_contribution_sat: 250,
+                created_at: 1_700_000_000,
+            },
+        };
+        let batched = SendIntentRecord {
+            intent_id: batched_id,
+            attempt_id: Uuid::nil(),
+            quote_id: format!("quote-{batched_id}"),
+            address: ADDR.to_string(),
+            amount_sat: 10_000,
+            max_fee_amount_sat: 500,
+            tier: PaymentTier::Immediate,
+            metadata: PaymentMetadata::default(),
+            state: SendIntentState::Batched {
+                batch_id,
+                created_at: 1_700_000_000,
+            },
+        };
+        for intent in [&awaiting, &batched] {
+            storage
+                .create_send_intent_if_absent(intent)
+                .await
+                .expect("store member");
+        }
+        storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Broadcast {
+                    txid: txid.clone(),
+                    tx_bytes: vec![0x01],
+                    assignments: vec![
+                        BatchOutputAssignment {
+                            intent_id: awaiting_id,
+                            attempt_id: Uuid::nil(),
+                            vout: 0,
+                            fee_contribution_sat: 250,
+                        },
+                        BatchOutputAssignment {
+                            intent_id: batched_id,
+                            attempt_id: Uuid::nil(),
+                            vout: 1,
+                            fee_contribution_sat: 250,
+                        },
+                    ],
+                    fee_sat: 500,
+                },
+            })
+            .await
+            .expect("store legacy broadcast batch");
+
+        assert!(storage
+            .normalize_legacy_broadcast_attempt_ids(&batch_id, &txid)
+            .await
+            .expect("normalize"));
+
+        let awaiting_after = storage
+            .get_send_intent(&awaiting_id)
+            .await
+            .expect("read awaiting member")
+            .expect("awaiting member exists");
+        let batched_after = storage
+            .get_send_intent(&batched_id)
+            .await
+            .expect("read batched member")
+            .expect("batched member exists");
+        assert!(!awaiting_after.attempt_id.is_nil());
+        assert!(!batched_after.attempt_id.is_nil());
+        let batch_after = storage
+            .get_send_batch(&batch_id)
+            .await
+            .expect("read batch")
+            .expect("batch exists");
+        match batch_after.state {
+            SendBatchState::Broadcast { assignments, .. } => {
+                assert_eq!(assignments[0].attempt_id, awaiting_after.attempt_id);
+                assert_eq!(assignments[1].attempt_id, batched_after.attempt_id);
+            }
+            other => panic!("expected Broadcast, got {:?}", other),
+        }
+
+        // Idempotent: nothing left to normalize.
+        assert!(!storage
+            .normalize_legacy_broadcast_attempt_ids(&batch_id, &txid)
+            .await
+            .expect("normalize again"));
+    }
+
+    /// A batch whose member no longer matches its assignment must stay
+    /// untouched and fenced for operator review.
+    #[tokio::test]
+    async fn normalize_legacy_broadcast_attempt_ids_leaves_mismatched_batch_fenced() {
+        let db = cdk_sqlite::mint::memory::empty()
+            .await
+            .expect("in-memory database");
+        let storage = BdkStorage::new(Arc::new(db));
+        let batch_id = Uuid::new_v4();
+        let txid = "bb".repeat(32);
+        let intent_id = Uuid::new_v4();
+
+        // The member's outpoint does not match the assignment's vout: the
+        // batch cannot be proven to belong to this intent.
+        let member = SendIntentRecord {
+            intent_id,
+            attempt_id: Uuid::nil(),
+            quote_id: format!("quote-{intent_id}"),
+            address: ADDR.to_string(),
+            amount_sat: 20_000,
+            max_fee_amount_sat: 1_000,
+            tier: PaymentTier::Immediate,
+            metadata: PaymentMetadata::default(),
+            state: SendIntentState::AwaitingConfirmation {
+                batch_id,
+                txid: txid.clone(),
+                outpoint: format!("{txid}:1"),
+                fee_contribution_sat: 250,
+                created_at: 1_700_000_000,
+            },
+        };
+        storage
+            .create_send_intent_if_absent(&member)
+            .await
+            .expect("store member");
+        storage
+            .store_send_batch(&SendBatchRecord {
+                batch_id,
+                state: SendBatchState::Broadcast {
+                    txid: txid.clone(),
+                    tx_bytes: vec![0x01],
+                    assignments: vec![BatchOutputAssignment {
+                        intent_id,
+                        attempt_id: Uuid::nil(),
+                        vout: 0,
+                        fee_contribution_sat: 250,
+                    }],
+                    fee_sat: 250,
+                },
+            })
+            .await
+            .expect("store legacy broadcast batch");
+
+        assert!(!storage
+            .normalize_legacy_broadcast_attempt_ids(&batch_id, &txid)
+            .await
+            .expect("normalize must not error"));
+
+        // Neither record was rewritten.
+        let member_after = storage
+            .get_send_intent(&intent_id)
+            .await
+            .expect("read member")
+            .expect("member exists");
+        assert_eq!(member_after.attempt_id, Uuid::nil());
+        let batch_after = storage
+            .get_send_batch(&batch_id)
+            .await
+            .expect("read batch")
+            .expect("batch exists");
+        match batch_after.state {
+            SendBatchState::Broadcast { assignments, .. } => {
+                assert_eq!(assignments[0].attempt_id, Uuid::nil());
+            }
+            other => panic!("expected Broadcast, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn broadcast_rejection_record_counts_and_clears() {
+        let db = cdk_sqlite::mint::memory::empty()
+            .await
+            .expect("in-memory database");
+        let storage = BdkStorage::new(Arc::new(db));
+        let batch_id = Uuid::new_v4();
+
+        assert!(storage
+            .get_broadcast_rejection(&batch_id)
+            .await
+            .expect("read")
+            .is_none());
+
+        for expected in 1..=3_u32 {
+            let count = storage
+                .record_broadcast_rejection(&batch_id, "txid", "bad-txns-inputs-missingorspent")
+                .await
+                .expect("record rejection");
+            assert_eq!(count, expected);
+        }
+        let record = storage
+            .get_broadcast_rejection(&batch_id)
+            .await
+            .expect("read")
+            .expect("record exists");
+        assert_eq!(record.consecutive_rejections, 3);
+        assert_eq!(record.last_error, "bad-txns-inputs-missingorspent");
+
+        storage
+            .clear_broadcast_rejection(&batch_id)
+            .await
+            .expect("clear");
+        assert!(storage
+            .get_broadcast_rejection(&batch_id)
+            .await
+            .expect("read")
+            .is_none());
+
+        // Clearing is idempotent.
+        storage
+            .clear_broadcast_rejection(&batch_id)
+            .await
+            .expect("clear again");
     }
 
     #[tokio::test]

--- a/crates/cdk-bdk/src/storage/send.rs
+++ b/crates/cdk-bdk/src/storage/send.rs
@@ -1025,7 +1025,6 @@ impl BdkStorage {
         }
 
         let key = expected.intent_id.to_string();
-        let expected_bytes = serde_json::to_vec(expected)?;
         let serialized = serde_json::to_vec(record)?;
         let mut tx = self
             .kv_store
@@ -1041,21 +1040,28 @@ impl BdkStorage {
             return Ok(false);
         };
         let intent: SendIntentRecord = serde_json::from_slice(&active_bytes)?;
-        if active_bytes != expected_bytes {
+        // Compare records semantically, not by raw bytes: the caller's
+        // expected record round-tripped through storage and a fresh
+        // serialization, so identity must not depend on the exact byte
+        // representation.
+        if intent != *expected {
             tx.rollback().await.map_err(Error::from)?;
             return Ok(false);
         }
 
         // Take ownership of this exact active record before creating the
-        // tombstone. Writing the same bytes is intentional: the conditional
-        // update locks the row in SQL stores and gives all backends one atomic
-        // winner, while preserving the record until the transaction removes it.
+        // tombstone. Writing back the bytes just read is intentional: the
+        // conditional update locks the row in SQL stores and gives all
+        // backends one atomic winner, while preserving the record until the
+        // transaction removes it. The condition is the stored bytes, not a
+        // re-serialization, so the lock does not depend on how a fresh
+        // serialization would represent the record.
         let won = tx
             .kv_write_if_equals(
                 BDK_NAMESPACE,
                 SEND_INTENT_NAMESPACE,
                 &key,
-                &expected_bytes,
+                &active_bytes,
                 &active_bytes,
             )
             .await
@@ -1422,6 +1428,74 @@ mod tests {
             .expect("get batch")
             .expect("broadcast batch remains");
         assert_eq!(persisted.state, broadcast_state);
+    }
+
+    /// Regression test: finalizing an intent whose expected record
+    /// round-tripped through storage must not be mistaken for a concurrent
+    /// modification. The identity comparison must be semantic, never based
+    /// on the serialized byte representation of the record.
+    #[tokio::test]
+    async fn finalize_send_intent_with_multi_entry_metadata() {
+        let db = cdk_sqlite::mint::memory::empty()
+            .await
+            .expect("in-memory database");
+        let storage = BdkStorage::new(Arc::new(db));
+
+        for _ in 0..25 {
+            let intent_id = Uuid::new_v4();
+            let txid = format!("txid-{intent_id}");
+            let intent = SendIntentRecord {
+                intent_id,
+                attempt_id: Uuid::new_v4(),
+                quote_id: format!("quote-{intent_id}"),
+                address: ADDR.to_string(),
+                amount_sat: 20_000,
+                max_fee_amount_sat: 1_000,
+                tier: PaymentTier::Immediate,
+                metadata: PaymentMetadata::from_optional_json(Some(
+                    r#"{"key1": "value1", "key2": "value2", "key3": "value3"}"#,
+                )),
+                state: SendIntentState::AwaitingConfirmation {
+                    batch_id: Uuid::new_v4(),
+                    txid: txid.clone(),
+                    outpoint: format!("{txid}:0"),
+                    fee_contribution_sat: 250,
+                    created_at: 1_700_000_000,
+                },
+            };
+            storage
+                .create_send_intent_if_absent(&intent)
+                .await
+                .expect("store intent");
+
+            // Mirror the confirmation flow: the record handed to
+            // `finalize_send_intent` is deserialized from storage, not the
+            // originally inserted value.
+            let active = storage
+                .get_send_intent(&intent_id)
+                .await
+                .expect("read intent")
+                .expect("intent exists");
+            let tombstone = FinalizedSendIntentRecord {
+                intent_id,
+                quote_id: active.quote_id.clone(),
+                total_spent_sat: 20_250,
+                outpoint: format!("{txid}:0"),
+                finalized_at: 1_700_000_001,
+            };
+            assert!(
+                storage
+                    .finalize_send_intent(&active, &tombstone)
+                    .await
+                    .expect("finalize"),
+                "finalization must not be rejected for multi-entry metadata"
+            );
+            assert!(storage
+                .get_finalized_intent(&intent_id)
+                .await
+                .expect("get tombstone")
+                .is_some());
+        }
     }
 
     #[tokio::test]

--- a/crates/cdk-bdk/src/storage/types.rs
+++ b/crates/cdk-bdk/src/storage/types.rs
@@ -55,3 +55,24 @@ pub struct FinalizedReceiveIntentRecord {
     /// When finalization occurred (unix timestamp seconds)
     pub finalized_at: u64,
 }
+
+/// Durable record of consecutive deterministic broadcast rejections.
+///
+/// Tracks how many times in a row a chain backend has definitively rejected
+/// a `Broadcast` batch's transaction, so the rebroadcast loop can stop
+/// hammering the backend and surface the batch for operator review instead
+/// of retrying forever. Cleared on any accepted or already-known broadcast
+/// outcome and when the batch record is deleted.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BroadcastRejectionRecord {
+    /// Batch whose transaction is being rejected
+    pub batch_id: Uuid,
+    /// Computed transaction ID that was rejected
+    pub txid: String,
+    /// Consecutive deterministic rejections since the last success
+    pub consecutive_rejections: u32,
+    /// Last rejection message from the backend
+    pub last_error: String,
+    /// When the last rejection was recorded (unix timestamp seconds)
+    pub last_rejected_at: u64,
+}

--- a/crates/cdk-bdk/src/testutil.rs
+++ b/crates/cdk-bdk/src/testutil.rs
@@ -1,0 +1,501 @@
+//! Deterministic KV interleaving harness for concurrency tests.
+//!
+//! [`GatedKvStore`] is an in-memory read-committed KV store that lets a
+//! test pause one actor at a specific read — inside or outside a
+//! transaction, before or after the value is sampled — while another
+//! actor commits, then release the pause and observe the outcome.
+
+use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
+use std::sync::{Arc, Mutex as StdMutex};
+
+use async_trait::async_trait;
+use bdk_wallet::bitcoin::Network;
+use bdk_wallet::keys::bip39::Mnemonic;
+use cdk_common::common::FeeReserve;
+use cdk_common::database::{
+    DbTransactionFinalizer, Error as DatabaseError, KVStore, KVStoreDatabase, KVStoreTransaction,
+};
+use cdk_common::{Amount, CurrencyUnit};
+use tokio::sync::Notify;
+use uuid::Uuid;
+
+use crate::send::batch_transaction::record::{
+    BatchOutputAssignment, SendBatchRecord, SendBatchState,
+};
+use crate::storage::BdkStorage;
+use crate::types::BatchConfig;
+use crate::{CdkBdk, ChainSource, EsploraConfig};
+
+/// Build a `CdkBdk` test instance backed by the given KV store, pointed
+/// at a bogus Esplora URL. The sync loop is never started, so the
+/// unreachable URL is harmless.
+pub(crate) async fn build_test_backend(
+    kv: Arc<dyn KVStore<Err = DatabaseError> + Send + Sync>,
+    batch_config: Option<BatchConfig>,
+) -> CdkBdk {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.keep();
+    let mnemonic = Mnemonic::from_str(
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+    )
+    .expect("mnemonic");
+
+    let chain_source = ChainSource::Esplora(EsploraConfig {
+        url: "http://127.0.0.1:1".to_string(),
+        parallel_requests: 1,
+    });
+
+    let fee_reserve = FeeReserve {
+        min_fee_reserve: Amount::new(1, CurrencyUnit::Sat).into(),
+        percent_fee_reserve: 0.02,
+    };
+
+    CdkBdk::new(
+        mnemonic,
+        Network::Regtest,
+        chain_source,
+        path.to_string_lossy().into_owned(),
+        fee_reserve,
+        kv,
+        batch_config,
+        1,
+        0,
+        546,
+        60,
+        Some(5),
+        None,
+    )
+    .expect("build CdkBdk test instance")
+}
+
+/// Persist a minimal signed batch listing each supplied intent once.
+pub(crate) async fn store_test_signed_batch(
+    storage: &BdkStorage,
+    batch_id: Uuid,
+    intent_ids: &[Uuid],
+) {
+    let mut assignments = Vec::with_capacity(intent_ids.len());
+    for (vout, intent_id) in intent_ids.iter().enumerate() {
+        let intent = storage
+            .get_send_intent(intent_id)
+            .await
+            .expect("load test batch intent")
+            .expect("test batch intent exists");
+        assignments.push(BatchOutputAssignment {
+            intent_id: *intent_id,
+            attempt_id: intent.attempt_id,
+            vout: u32::try_from(vout).expect("test batch output count fits in u32"),
+            fee_contribution_sat: 0,
+        });
+    }
+    storage
+        .store_send_batch(&SendBatchRecord {
+            batch_id,
+            state: SendBatchState::Signed {
+                tx_bytes: vec![0x01],
+                assignments,
+                fee_sat: 0,
+            },
+        })
+        .await
+        .expect("store test signed batch");
+}
+
+type KvKey = (String, String, String);
+
+/// Buffered write inside a transaction: the key and the value to write
+/// (`None` removes the key).
+type TxWrite = (KvKey, Option<Vec<u8>>);
+
+/// Where a read gate pauses relative to sampling the value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PausePoint {
+    /// Block before the value is sampled, so the read observes commits
+    /// that land while it is paused.
+    BeforeRead,
+    /// Block after the value is sampled, so the reader holds a stale
+    /// snapshot while another actor commits.
+    AfterRead,
+}
+
+/// Which read path a gate applies to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReadPath {
+    /// Reads outside a transaction (`KVStoreDatabase::kv_read`).
+    Direct,
+    /// Reads inside a transaction (`KVStoreTransaction::kv_read`).
+    Transaction,
+}
+
+struct ReadGate {
+    primary: String,
+    secondary: String,
+    path: ReadPath,
+    pause: PausePoint,
+    remaining: usize,
+    entered: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+/// Handle for an armed read gate: await entry, then release the reader.
+pub(crate) struct GateHandle {
+    entered: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+impl GateHandle {
+    /// Wait until the gated read has been reached.
+    pub(crate) async fn wait_entered(&self) {
+        self.entered.notified().await;
+    }
+
+    /// Allow the gated read to continue.
+    pub(crate) fn release(&self) {
+        self.release.notify_one();
+    }
+}
+
+/// In-memory KV store with read gates.
+///
+/// `kv_write_if_absent` reserves its key across transactions (mirroring
+/// the atomic conditional insert of the SQL backend), and
+/// `kv_write_if_equals` compares against the latest committed value at
+/// write time (mirroring the atomic conditional update of the SQL
+/// backend), so compare-and-set behavior under test matches production.
+#[derive(Clone, Default)]
+pub(crate) struct GatedKvStore {
+    data: Arc<StdMutex<HashMap<KvKey, Vec<u8>>>>,
+    reservations: Arc<StdMutex<HashSet<KvKey>>>,
+    gates: Arc<StdMutex<Vec<ReadGate>>>,
+}
+
+impl GatedKvStore {
+    /// Pause the `occurrence`-th matching read (1-based, counted from
+    /// registration) until [`GateHandle::release`] is called.
+    pub(crate) fn gate_read(
+        &self,
+        path: ReadPath,
+        pause: PausePoint,
+        primary: &str,
+        secondary: &str,
+        occurrence: usize,
+    ) -> GateHandle {
+        assert!(occurrence >= 1, "gate occurrences are 1-based");
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        self.gates.lock().expect("lock gates").push(ReadGate {
+            primary: primary.to_string(),
+            secondary: secondary.to_string(),
+            path,
+            pause,
+            remaining: occurrence,
+            entered: entered.clone(),
+            release: release.clone(),
+        });
+        GateHandle { entered, release }
+    }
+
+    /// Consume the gate matching this read, if any.
+    fn take_gate(
+        &self,
+        path: ReadPath,
+        primary: &str,
+        secondary: &str,
+    ) -> Option<(PausePoint, Arc<Notify>, Arc<Notify>)> {
+        let mut gates = self.gates.lock().expect("lock gates");
+        let index = gates.iter().position(|gate| {
+            gate.path == path && gate.primary == primary && gate.secondary == secondary
+        })?;
+        let gate = &mut gates[index];
+        gate.remaining -= 1;
+        if gate.remaining > 0 {
+            return None;
+        }
+        let gate = gates.remove(index);
+        Some((gate.pause, gate.entered, gate.release))
+    }
+
+    /// Read `key` from the committed data, honoring a registered gate.
+    async fn gated_read(
+        &self,
+        path: ReadPath,
+        primary: &str,
+        secondary: &str,
+        key: &str,
+        tx_writes: Option<&[TxWrite]>,
+    ) -> Option<Vec<u8>> {
+        let gate = self.take_gate(path, primary, secondary);
+        let mut pause_after = None;
+        if let Some((pause, entered, release)) = gate {
+            match pause {
+                PausePoint::BeforeRead => {
+                    entered.notify_one();
+                    release.notified().await;
+                }
+                PausePoint::AfterRead => {
+                    pause_after = Some((entered, release));
+                }
+            }
+        }
+
+        let map_key = (primary.to_string(), secondary.to_string(), key.to_string());
+        let value = tx_writes
+            .and_then(|writes| {
+                writes
+                    .iter()
+                    .rev()
+                    .find(|(candidate, _)| candidate == &map_key)
+                    .map(|(_, value)| value.clone())
+            })
+            .unwrap_or_else(|| {
+                self.data
+                    .lock()
+                    .expect("lock gated kv store")
+                    .get(&map_key)
+                    .cloned()
+            });
+
+        if let Some((entered, release)) = pause_after {
+            entered.notify_one();
+            release.notified().await;
+        }
+
+        value
+    }
+}
+
+struct GatedTransaction {
+    store: GatedKvStore,
+    writes: Vec<TxWrite>,
+    reserved: Vec<KvKey>,
+}
+
+#[async_trait]
+impl DbTransactionFinalizer for GatedTransaction {
+    type Err = DatabaseError;
+
+    async fn commit(self: Box<Self>) -> Result<(), Self::Err> {
+        {
+            let mut data = self.store.data.lock().expect("lock gated kv store");
+            for (key, value) in self.writes {
+                if let Some(value) = value {
+                    data.insert(key, value);
+                } else {
+                    data.remove(&key);
+                }
+            }
+        }
+        let mut reservations = self.store.reservations.lock().expect("lock reservations");
+        for key in &self.reserved {
+            reservations.remove(key);
+        }
+        Ok(())
+    }
+
+    async fn rollback(self: Box<Self>) -> Result<(), Self::Err> {
+        let mut reservations = self.store.reservations.lock().expect("lock reservations");
+        for key in &self.reserved {
+            reservations.remove(key);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl KVStoreTransaction<DatabaseError> for GatedTransaction {
+    async fn kv_read(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+    ) -> Result<Option<Vec<u8>>, DatabaseError> {
+        Ok(self
+            .store
+            .gated_read(
+                ReadPath::Transaction,
+                primary_namespace,
+                secondary_namespace,
+                key,
+                Some(&self.writes),
+            )
+            .await)
+    }
+
+    async fn kv_write(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        value: &[u8],
+    ) -> Result<(), DatabaseError> {
+        self.writes.push((
+            (
+                primary_namespace.to_string(),
+                secondary_namespace.to_string(),
+                key.to_string(),
+            ),
+            Some(value.to_vec()),
+        ));
+        Ok(())
+    }
+
+    async fn kv_write_if_absent(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        value: &[u8],
+    ) -> Result<bool, DatabaseError> {
+        let map_key = (
+            primary_namespace.to_string(),
+            secondary_namespace.to_string(),
+            key.to_string(),
+        );
+
+        let exists = match self
+            .writes
+            .iter()
+            .rev()
+            .find(|(candidate, _)| candidate == &map_key)
+        {
+            Some((_, pending)) => pending.is_some(),
+            None => {
+                let data = self.store.data.lock().expect("lock gated kv store");
+                let reservations = self.store.reservations.lock().expect("lock reservations");
+                data.contains_key(&map_key) || reservations.contains(&map_key)
+            }
+        };
+
+        if exists {
+            return Ok(false);
+        }
+
+        self.store
+            .reservations
+            .lock()
+            .expect("lock reservations")
+            .insert(map_key.clone());
+        self.reserved.push(map_key.clone());
+        self.writes.push((map_key, Some(value.to_vec())));
+
+        Ok(true)
+    }
+
+    async fn kv_remove(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+    ) -> Result<(), DatabaseError> {
+        self.writes.push((
+            (
+                primary_namespace.to_string(),
+                secondary_namespace.to_string(),
+                key.to_string(),
+            ),
+            None,
+        ));
+        Ok(())
+    }
+
+    async fn kv_write_if_equals(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        expected: &[u8],
+        replacement: &[u8],
+    ) -> Result<bool, DatabaseError> {
+        let map_key = (
+            primary_namespace.to_string(),
+            secondary_namespace.to_string(),
+            key.to_string(),
+        );
+
+        let current = self
+            .writes
+            .iter()
+            .rev()
+            .find(|(candidate, _)| candidate == &map_key)
+            .map(|(_, value)| value.clone())
+            .unwrap_or_else(|| {
+                self.store
+                    .data
+                    .lock()
+                    .expect("lock gated kv store")
+                    .get(&map_key)
+                    .cloned()
+            });
+
+        match current {
+            Some(current) if current == expected => {
+                self.writes.push((map_key, Some(replacement.to_vec())));
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    async fn kv_list(
+        &mut self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+    ) -> Result<Vec<String>, DatabaseError> {
+        self.store
+            .kv_list(primary_namespace, secondary_namespace)
+            .await
+    }
+}
+
+#[async_trait]
+impl KVStoreDatabase for GatedKvStore {
+    type Err = DatabaseError;
+
+    async fn kv_read(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+    ) -> Result<Option<Vec<u8>>, Self::Err> {
+        Ok(self
+            .gated_read(
+                ReadPath::Direct,
+                primary_namespace,
+                secondary_namespace,
+                key,
+                None,
+            )
+            .await)
+    }
+
+    async fn kv_list(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+    ) -> Result<Vec<String>, Self::Err> {
+        Ok(self
+            .data
+            .lock()
+            .expect("lock gated kv store")
+            .keys()
+            .filter(|(primary, secondary, _)| {
+                primary == primary_namespace && secondary == secondary_namespace
+            })
+            .map(|(_, _, key)| key.clone())
+            .collect())
+    }
+}
+
+#[async_trait]
+impl KVStore for GatedKvStore {
+    async fn begin_transaction(
+        &self,
+    ) -> Result<Box<dyn KVStoreTransaction<Self::Err> + Send + Sync>, DatabaseError> {
+        Ok(Box::new(GatedTransaction {
+            store: self.clone(),
+            writes: Vec::new(),
+            reserved: Vec::new(),
+        }))
+    }
+}

--- a/crates/cdk-bdk/src/types.rs
+++ b/crates/cdk-bdk/src/types.rs
@@ -237,10 +237,14 @@ pub fn validate_fee_options(fee_options: &[PaymentTier]) -> Result<(), String> {
 ///
 /// Stored for future extensions. In v1 no behavior is driven by metadata
 /// values. Future features like payjoin may consume this metadata.
+///
+/// Entries use a `BTreeMap` so serialization is canonical: the same metadata
+/// always produces the same stored bytes regardless of how the map was
+/// constructed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct PaymentMetadata {
     /// Key-value pairs
-    pub entries: std::collections::HashMap<String, String>,
+    pub entries: std::collections::BTreeMap<String, String>,
 }
 
 impl PaymentMetadata {
@@ -257,7 +261,7 @@ impl PaymentMetadata {
             return meta;
         }
         // Fall back to interpreting the JSON as a bare key-value map
-        if let Ok(entries) = serde_json::from_str::<std::collections::HashMap<String, String>>(s) {
+        if let Ok(entries) = serde_json::from_str::<std::collections::BTreeMap<String, String>>(s) {
             return Self { entries };
         }
         Self::default()

--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -845,6 +845,19 @@ impl MintPayment for Cln {
     }
 
     #[instrument(skip(self))]
+    /// Check the status of an outgoing payment.
+    ///
+    /// CLN never reports `Unpaid`/`Failed` for a dispatched payment: an
+    /// `xpay` command may survive a client disconnect and keep retrying, so a
+    /// not-paid observation is not an authoritative terminal outcome and is
+    /// reported as `Unknown` to keep the mint fail-closed (see
+    /// [`MintPayment::check_outgoing_payment`]). A failed payment's BOLT12
+    /// quote binding is retained for the same reason — releasing it would
+    /// turn a later poll's missing-binding answer into an authoritative
+    /// `Unpaid`. The one exception is a BOLT12 quote with no recorded
+    /// payment-hash binding: the binding is written before any payment is
+    /// dispatched, so its absence proves the payment was never attempted and
+    /// `Unpaid` is truthful.
     async fn check_outgoing_payment(
         &self,
         payment_identifier: &PaymentIdentifier,
@@ -859,7 +872,7 @@ impl MintPayment for Cln {
                 .map_err(payment::Error::from)?
             {
                 Bolt12QuotePaymentHashLookup::Found(payment_hash) => {
-                    (payment_hash, MeltQuoteState::Unpaid)
+                    (payment_hash, MeltQuoteState::Unknown)
                 }
                 Bolt12QuotePaymentHashLookup::Missing => {
                     return Ok(outgoing_payment_response_with_status(
@@ -896,14 +909,19 @@ impl MintPayment for Cln {
 
         match select_cln_payment(&listpays_response.pays) {
             Some(pays_response) => {
-                let status = cln_pays_status_to_mint_state(pays_response.status);
-
-                if status == MeltQuoteState::Failed {
-                    if let PaymentIdentifier::QuoteId(quote_id) = payment_identifier {
-                        self.cleanup_bolt12_quote_payment_hash(quote_id, &payment_hash)
-                            .await;
-                    }
-                }
+                // A negative CLN status is not an authoritative terminal
+                // outcome for the mint; report it as Unknown so recovery
+                // cannot refund proofs while the payment may still settle.
+                // The BOLT12 quote binding is deliberately retained as well:
+                // releasing it would let a later poll observe the missing
+                // binding as authoritative `Unpaid` and compensate a payment
+                // that may still settle. Only the synchronous make_payment
+                // error path may release a binding, once it holds a
+                // definitive terminal failure.
+                let status = match cln_pays_status_to_mint_state(pays_response.status) {
+                    MeltQuoteState::Unpaid | MeltQuoteState::Failed => MeltQuoteState::Unknown,
+                    status => status,
+                };
 
                 Ok(MakePaymentResponse {
                     payment_lookup_id: payment_identifier.clone(),

--- a/crates/cdk-common/src/mint.rs
+++ b/crates/cdk-common/src/mint.rs
@@ -166,8 +166,11 @@ pub enum MeltSagaState {
     /// A terminal negative status cannot prove that the payment was not sent.
     PaymentAttempted,
     /// The backend acknowledged the payment attempt.
-    /// Later authoritative status checks may finalize or compensate it.
+    /// Later status checks may finalize it, but must never compensate it.
     PaymentPending,
+    /// The backend authoritatively reported that the payment operation ended
+    /// without paying. Recovery may safely compensate this melt.
+    PaymentFailed,
     /// TX1 committed (proofs Spent, quote Paid) - change signing + cleanup pending
     Finalizing,
 }
@@ -178,6 +181,7 @@ impl fmt::Display for MeltSagaState {
             MeltSagaState::SetupComplete => write!(f, "setup_complete"),
             MeltSagaState::PaymentAttempted => write!(f, "payment_attempted"),
             MeltSagaState::PaymentPending => write!(f, "payment_pending"),
+            MeltSagaState::PaymentFailed => write!(f, "payment_failed"),
             MeltSagaState::Finalizing => write!(f, "finalizing"),
         }
     }
@@ -191,6 +195,7 @@ impl FromStr for MeltSagaState {
             "setup_complete" => Ok(MeltSagaState::SetupComplete),
             "payment_attempted" => Ok(MeltSagaState::PaymentAttempted),
             "payment_pending" => Ok(MeltSagaState::PaymentPending),
+            "payment_failed" => Ok(MeltSagaState::PaymentFailed),
             "finalizing" => Ok(MeltSagaState::Finalizing),
             _ => Err(Error::Custom(format!("Invalid melt saga state: {}", value))),
         }
@@ -232,6 +237,7 @@ impl SagaStateEnum {
                 MeltSagaState::SetupComplete => "setup_complete",
                 MeltSagaState::PaymentAttempted => "payment_attempted",
                 MeltSagaState::PaymentPending => "payment_pending",
+                MeltSagaState::PaymentFailed => "payment_failed",
                 MeltSagaState::Finalizing => "finalizing",
             },
         }

--- a/crates/cdk-common/src/mint.rs
+++ b/crates/cdk-common/src/mint.rs
@@ -162,11 +162,11 @@ impl FromStr for SwapSagaState {
 pub enum MeltSagaState {
     /// Setup complete (proofs reserved, quote verified)
     SetupComplete,
-    /// Payment attempted through the configured backend (may or may not have succeeded)
+    /// Write-ahead marker recorded before dispatch to the configured backend.
+    /// A terminal negative status cannot prove that the payment was not sent.
     PaymentAttempted,
-    /// The backend acknowledged that the payment is pending or indeterminate.
-    /// Contradictory public `Unpaid` or `Failed` polls must not return the
-    /// reserved proofs; recovery requires a trusted failure event.
+    /// The backend acknowledged the payment attempt.
+    /// Later authoritative status checks may finalize or compensate it.
     PaymentPending,
     /// TX1 committed (proofs Spent, quote Paid) - change signing + cleanup pending
     Finalizing,

--- a/crates/cdk-common/src/payment.rs
+++ b/crates/cdk-common/src/payment.rs
@@ -497,6 +497,13 @@ pub trait MintPayment {
     ) -> Result<Vec<WaitPaymentResponse>, Self::Err>;
 
     /// Check the status of an outgoing payment
+    ///
+    /// The reported status must be conservative about finality. The mint
+    /// treats `Unpaid` and `Failed` as authoritative terminal outcomes and
+    /// may compensate the melt, returning the reserved proofs to the user.
+    /// A backend that cannot guarantee a not-paid payment will never
+    /// settle — for example because an orchestrator may be between attempts
+    /// of the same payment — MUST report `Pending` or `Unknown` instead.
     async fn check_outgoing_payment(
         &self,
         payment_identifier: &PaymentIdentifier,

--- a/crates/cdk/src/mint/melt/melt_saga/mod.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/mod.rs
@@ -766,18 +766,14 @@ impl MeltSaga<SetupComplete> {
         // dispatch, payment events, and reconciliation for this quote. Do not
         // hold a database connection across payment-backend network I/O: a few
         // slow payments would otherwise exhaust PostgreSQL dispatch capacity.
-        let response = self
+        let (response, acknowledged) = self
             .execute_payment_and_verify(Arc::clone(payment_backend))
             .await?;
-        match response.status {
-            MeltQuoteState::Paid => {
-                self.persist_paid_payment(&response).await?;
-            }
-            MeltQuoteState::Pending | MeltQuoteState::Unknown => {
-                self.persist_pending_payment(&response.payment_lookup_id)
-                    .await?;
-            }
-            MeltQuoteState::Unpaid | MeltQuoteState::Failed => {}
+        if response.status == MeltQuoteState::Paid {
+            self.persist_paid_payment(&response).await?;
+        } else {
+            self.persist_external_payment_state(&response, acknowledged)
+                .await?;
         }
 
         Ok(response)
@@ -788,7 +784,7 @@ impl MeltSaga<SetupComplete> {
         payment_backend: Arc<
             dyn cdk_common::payment::MintPayment<Err = cdk_common::payment::Error> + Send + Sync,
         >,
-    ) -> Result<MakePaymentResponse, Error> {
+    ) -> Result<(MakePaymentResponse, bool), Error> {
         // Make payment with idempotent verification
         let quote = &self.state_data.quote;
         let payment_options = OutgoingPaymentOptions::from_melt_quote_with_fee(quote.clone())?;
@@ -797,9 +793,17 @@ impl MeltSaga<SetupComplete> {
             .make_payment(&quote.unit, payment_options)
             .await
         {
-            Ok(pay) if pay.status == MeltQuoteState::Paid => Ok(pay),
-            Ok(pay) => self.verify_ambiguous_payment(payment_backend, pay).await,
-            Err(err) => self.handle_payment_error(payment_backend, err).await,
+            Ok(pay) if pay.status == MeltQuoteState::Paid => Ok((pay, true)),
+            Ok(pay) => {
+                let acknowledged = pay.status != MeltQuoteState::Unknown;
+                let response = self.verify_ambiguous_payment(payment_backend, pay).await?;
+                Ok((response, acknowledged))
+            }
+            Err(err) => {
+                let response = self.handle_payment_error(payment_backend, err).await?;
+                let acknowledged = response.status == MeltQuoteState::Pending;
+                Ok((response, acknowledged))
+            }
         }
     }
 
@@ -924,7 +928,8 @@ impl MeltSaga<SetupComplete> {
         Ok(check_response)
     }
 
-    /// Persists the backend's payment lookup id and durable pending marker.
+    /// Persists the backend's payment lookup id and, when the backend
+    /// acknowledged the attempt, a durable pending marker.
     ///
     /// For bolt12 melts the quote is created with `request_lookup_id: None`
     /// (no invoice exists until `make_payment`), so the id returned by the
@@ -934,11 +939,13 @@ impl MeltSaga<SetupComplete> {
     /// a payment that settles after the in-process recheck can never be
     /// resolved, and startup recovery would treat the quote as never sent and
     /// compensate while the payment may still settle.
-    async fn persist_pending_payment(
+    async fn persist_external_payment_state(
         &self,
-        payment_lookup_id: &cdk_common::payment::PaymentIdentifier,
+        payment_response: &MakePaymentResponse,
+        acknowledged: bool,
     ) -> Result<(), Error> {
         let quote_id = &self.state_data.quote.id;
+        let payment_lookup_id = &payment_response.payment_lookup_id;
 
         let mut tx = self.db.begin_transaction().await?;
         let mut quote = tx
@@ -961,11 +968,18 @@ impl MeltSaga<SetupComplete> {
             .get_saga_for_update(&self.operation_id)
             .await?
             .ok_or(Error::Internal)?;
-        tx.update_acquired_saga(
-            &mut saga,
-            SagaStateEnum::Melt(MeltSagaState::PaymentPending),
-        )
-        .await?;
+        if saga.state != SagaStateEnum::Melt(MeltSagaState::PaymentAttempted) {
+            tx.rollback().await?;
+            return Err(Error::UnknownPaymentState);
+        }
+
+        if acknowledged {
+            tx.update_acquired_saga(
+                &mut saga,
+                SagaStateEnum::Melt(MeltSagaState::PaymentPending),
+            )
+            .await?;
+        }
 
         tx.commit().await?;
         Ok(())

--- a/crates/cdk/src/mint/melt/melt_saga/mod.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/mod.rs
@@ -81,10 +81,15 @@ mod tests;
 /// - User can retry with same proofs
 ///
 /// **After payment attempt (PaymentAttempted state):**
-/// - Compensation is NOT executed (would cause fund loss)
+/// - Compensation is NOT executed directly (would cause fund loss)
 /// - Startup check will verify payment status with the payment backend
 /// - If payment succeeded: finalize is retried
-/// - If payment failed or is unpaid: compensation runs
+/// - An authoritative `Unpaid`/`Failed` status records `PaymentFailed`;
+///   `Pending`/`Unknown` leave the payment pending
+///
+/// **After authoritative failure (PaymentFailed state):**
+/// - The backend completed the payment operation without paying
+/// - Compensation may run without another backend status check
 ///
 /// This two-phase approach prevents fund loss where the mint pays the invoice
 /// but returns the proofs to the user.
@@ -93,7 +98,9 @@ mod tests;
 ///
 /// Unlike swap, melt must handle uncertain payment states:
 /// - **Paid**: Proceed to finalize
-/// - **Failed/Unpaid**: Compensate and return error
+/// - **Failed/Unpaid**: Authoritative terminal outcome by backend contract
+///   (see [`MintPayment::check_outgoing_payment`]) — record the terminal
+///   failure, then compensate
 /// - **Pending/Unknown**: Proofs remain pending, saga cannot complete
 ///   (leave proofs pending for startup check to resolve)
 ///
@@ -101,7 +108,9 @@ mod tests;
 ///
 /// The saga persists its state for crash recovery:
 /// - **SetupComplete**: Payment was never attempted → safe to compensate
-/// - **PaymentAttempted**: Check the backend and trust its current status
+/// - **PaymentAttempted/PaymentPending**: Polling finalizes a paid result and
+///   compensates an authoritative negative one; `Pending`/`Unknown` stay pending
+/// - **PaymentFailed**: An authoritative terminal result was recorded → compensate
 ///
 /// On startup, the recovery process checks the persisted saga state and takes
 /// appropriate action to either finalize (if payment succeeded) or compensate
@@ -609,7 +618,7 @@ impl MeltSaga<SetupComplete> {
     /// Makes payment via the payment backend or internal settlement.
     ///
     /// This is an external operation that happens after `setup_melt` and before `finalize`.
-    /// No database changes occur in this step (except for internal settlement case).
+    /// Durable dispatch and terminal-result markers make it crash recoverable.
     ///
     /// # What This Does
     ///
@@ -628,7 +637,8 @@ impl MeltSaga<SetupComplete> {
     /// crashes after payment but before finalize, the startup recovery will:
     /// - See `PaymentAttempted` state
     /// - Check with the payment backend to determine if payment succeeded
-    /// - Finalize if paid, compensate if failed
+    /// - Finalize if paid, compensate an authoritative negative result, and
+    ///   leave `Pending`/`Unknown` polling results pending
     ///
     /// # Idempotent Payment Verification
     ///
@@ -644,8 +654,8 @@ impl MeltSaga<SetupComplete> {
     ///
     /// # Failure Handling
     ///
-    /// If payment is confirmed as failed/unpaid, all registered compensations are
-    /// executed to roll back the setup transaction.
+    /// If `make_payment` authoritatively returns failed/unpaid, `PaymentFailed`
+    /// is persisted before all registered compensations roll back the setup.
     ///
     /// # Errors
     ///
@@ -795,13 +805,13 @@ impl MeltSaga<SetupComplete> {
         {
             Ok(pay) if pay.status == MeltQuoteState::Paid => Ok((pay, true)),
             Ok(pay) => {
-                let acknowledged = pay.status != MeltQuoteState::Unknown;
                 let response = self.verify_ambiguous_payment(payment_backend, pay).await?;
+                let acknowledged = response.status != MeltQuoteState::Unknown;
                 Ok((response, acknowledged))
             }
             Err(err) => {
                 let response = self.handle_payment_error(payment_backend, err).await?;
-                let acknowledged = response.status == MeltQuoteState::Pending;
+                let acknowledged = response.status != MeltQuoteState::Unknown;
                 Ok((response, acknowledged))
             }
         }
@@ -835,37 +845,22 @@ impl MeltSaga<SetupComplete> {
             return Ok(check_response);
         }
 
-        // Pending and Unknown are monotonic for an immediate verification. A
-        // contradictory Unpaid/Failed/Unknown read may come from a lagging
-        // backend replica; refunding here would return proofs while the payment
-        // can still settle.
-        if matches!(
-            pay.status,
-            MeltQuoteState::Pending | MeltQuoteState::Unknown
-        ) {
-            tracing::warn!(
-                "Payment was initially {} but verification returned {}. Keeping the initial status for safety.",
-                pay.status,
-                check_response.status
-            );
-            return Ok(pay);
-        }
-
-        // An Ok response with a terminal negative status is the backend's
-        // authoritative outcome, unlike an Err whose dispatch phase is
-        // unknown. A positive or in-flight follow-up overrides it, but a
-        // missing/Unknown observation does not erase that terminal result.
-        if matches!(pay.status, MeltQuoteState::Unpaid | MeltQuoteState::Failed)
-            && check_response.status == MeltQuoteState::Unknown
+        // An indeterminate recheck cannot erase a definite initial result: an
+        // `Ok` terminal status from make_payment is the backend's authoritative
+        // outcome, and an initial Pending proves an in-flight attempt. Keep the
+        // initial response when the follow-up cannot identify the payment.
+        if check_response.status == MeltQuoteState::Unknown && pay.status != MeltQuoteState::Unknown
         {
             tracing::warn!(
-                "Payment backend returned authoritative {} for quote {}, but verification returned Unknown. Keeping the terminal response.",
+                "Payment was initially {} but verification returned Unknown. Keeping the initial status for safety.",
                 pay.status,
-                self.state_data.quote.id
             );
             return Ok(pay);
         }
 
+        // Every other follow-up is taken at face value: by backend contract
+        // `Unpaid`/`Failed` are authoritative terminal outcomes and `Pending`
+        // proves an in-flight attempt (see MintPayment::check_outgoing_payment).
         Ok(check_response)
     }
 
@@ -900,7 +895,7 @@ impl MeltSaga<SetupComplete> {
                 Error::Internal
             })?;
 
-        let mut check_response = self.check_payment_state(payment_backend, lookup_id).await?;
+        let check_response = self.check_payment_state(payment_backend, lookup_id).await?;
 
         tracing::info!(
             "Initial payment attempt for {} errored. Follow up check status: {}",
@@ -908,28 +903,16 @@ impl MeltSaga<SetupComplete> {
             check_response.status
         );
 
-        // make_payment returned no authoritative terminal result. A positive
-        // Paid check can safely finalize and Pending remains pending, but a
-        // Failed or Unpaid follow-up may be a stale backend read after an
-        // ambiguous dispatch error. Keep every non-positive terminal read
-        // indeterminate so the melt cannot compensate while payment may settle.
-        if matches!(
-            check_response.status,
-            MeltQuoteState::Unpaid | MeltQuoteState::Failed
-        ) {
-            tracing::warn!(
-                "Payment attempt for {} errored and follow up check returned {}. Keeping payment status Unknown for safety.",
-                self.state_data.quote.id,
-                check_response.status
-            );
-            check_response.status = MeltQuoteState::Unknown;
-        }
-
+        // make_payment returned no result of its own. The follow-up status
+        // check is taken at face value: by backend contract `Unpaid`/`Failed`
+        // are authoritative terminal outcomes, `Pending` proves the backend
+        // can identify an in-flight attempt, and `Unknown` leaves dispatch
+        // ambiguous (see MintPayment::check_outgoing_payment).
         Ok(check_response)
     }
 
-    /// Persists the backend's payment lookup id and, when the backend
-    /// acknowledged the attempt, a durable pending marker.
+    /// Persists the backend's payment lookup id and, when the backend returned
+    /// an authoritative result, a durable pending or failed marker.
     ///
     /// For bolt12 melts the quote is created with `request_lookup_id: None`
     /// (no invoice exists until `make_payment`), so the id returned by the
@@ -973,12 +956,17 @@ impl MeltSaga<SetupComplete> {
             return Err(Error::UnknownPaymentState);
         }
 
-        if acknowledged {
-            tx.update_acquired_saga(
-                &mut saga,
-                SagaStateEnum::Melt(MeltSagaState::PaymentPending),
-            )
-            .await?;
+        let next_state = match (acknowledged, payment_response.status) {
+            (true, MeltQuoteState::Unpaid | MeltQuoteState::Failed) => {
+                Some(MeltSagaState::PaymentFailed)
+            }
+            (true, MeltQuoteState::Pending) => Some(MeltSagaState::PaymentPending),
+            _ => None,
+        };
+
+        if let Some(next_state) = next_state {
+            tx.update_acquired_saga(&mut saga, SagaStateEnum::Melt(next_state))
+                .await?;
         }
 
         tx.commit().await?;
@@ -1163,8 +1151,9 @@ pub enum PaymentOutcome {
     /// Payment was confirmed by the backend; the saga is ready to be finalized.
     Confirmed(Box<MeltSaga<PaymentConfirmed>>),
     /// Payment is still pending at the backend. Inputs and outputs remain
-    /// reserved and the quote is left in `Pending`; finalization or rollback
-    /// will happen later via a payment event or a status-check reconciliation.
+    /// reserved and the quote is left in `Pending`; polling may finalize a
+    /// successful payment, while rollback requires an authoritative permanent
+    /// failure event.
     Pending {
         /// Metrics guard carried into the pending waiter so the operation is
         /// recorded when the waiter reaches a terminal result.

--- a/crates/cdk/src/mint/melt/melt_saga/tests.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/tests.rs
@@ -2084,8 +2084,8 @@ async fn assert_payment_error_with_terminal_follow_up_does_not_compensate(
     let pending_saga = assert_saga_exists(&mint, &operation_id).await;
     assert_eq!(
         pending_saga.state,
-        SagaStateEnum::Melt(MeltSagaState::PaymentPending),
-        "an untrusted terminal follow-up must leave the payment recoverable"
+        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted),
+        "an untrusted terminal follow-up must leave dispatch ambiguous"
     );
     let stored_quote = mint
         .localstore
@@ -2152,7 +2152,7 @@ async fn test_unknown_dispatch_with_unpaid_check_does_not_compensate() {
     let pending_saga = assert_saga_exists(&mint, &operation_id).await;
     assert_eq!(
         pending_saga.state,
-        SagaStateEnum::Melt(MeltSagaState::PaymentPending)
+        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted)
     );
     let stored_quote = mint
         .localstore
@@ -3443,7 +3443,7 @@ async fn test_unknown_follow_up_after_payment_error_keeps_proofs_pending() {
     let pending_saga = assert_saga_exists(&mint, &operation_id).await;
     assert_eq!(
         pending_saga.state,
-        SagaStateEnum::Melt(MeltSagaState::PaymentPending),
+        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted),
         "a backend Unknown response must leave dispatch marked ambiguous"
     );
 

--- a/crates/cdk/src/mint/melt/melt_saga/tests.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/tests.rs
@@ -1967,6 +1967,183 @@ async fn test_saga_deleted_after_payment_failure() {
     // SUCCESS: Saga properly deleted after direct payment failure!
 }
 
+#[tokio::test]
+async fn test_authoritative_failure_is_durable_before_compensation() {
+    let mint = create_test_mint().await.unwrap();
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+    let quote = create_test_melt_quote_with_description(
+        &mint,
+        Amount::from(9_000),
+        FakeInvoiceDescription {
+            pay_invoice_state: MeltQuoteState::Failed,
+            check_payment_state: MeltQuoteState::Unknown,
+            pay_err: false,
+            check_err: false,
+        },
+    )
+    .await;
+    let melt_request = create_test_melt_request(&proofs, &quote);
+    let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+    let saga = MeltSaga::new(
+        std::sync::Arc::new(mint.clone()),
+        mint.localstore(),
+        mint.pubsub_manager(),
+    );
+    let setup_saga = saga
+        .setup_melt(
+            &melt_request,
+            verification,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+        )
+        .await
+        .unwrap();
+    let operation_id = setup_saga.operation_id;
+    let (payment_saga, _decision) = setup_saga
+        .attempt_internal_settlement(&melt_request)
+        .await
+        .unwrap();
+
+    let response = payment_saga.attempt_external_payment().await.unwrap();
+
+    assert_eq!(response.status, MeltQuoteState::Failed);
+    let persisted_saga = assert_saga_exists(&mint, &operation_id).await;
+    assert_eq!(
+        persisted_saga.state,
+        SagaStateEnum::Melt(MeltSagaState::PaymentFailed)
+    );
+    assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+    assert_eq!(
+        mint.localstore
+            .get_melt_quote(&quote.id)
+            .await
+            .unwrap()
+            .expect("quote should exist")
+            .state,
+        MeltQuoteState::Pending
+    );
+}
+
+/// An Unknown dispatch result followed by a Failed backend check is
+/// authoritative by backend contract: the terminal failure is persisted
+/// durably as `PaymentFailed` before compensation.
+#[tokio::test]
+async fn test_failed_recheck_after_unknown_dispatch_is_durable_before_compensation() {
+    let mint = create_test_mint().await.unwrap();
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+    let quote = create_test_melt_quote_with_description(
+        &mint,
+        Amount::from(9_000),
+        FakeInvoiceDescription {
+            pay_invoice_state: MeltQuoteState::Unknown,
+            check_payment_state: MeltQuoteState::Failed,
+            pay_err: false,
+            check_err: false,
+        },
+    )
+    .await;
+    let melt_request = create_test_melt_request(&proofs, &quote);
+    let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+    let saga = MeltSaga::new(
+        std::sync::Arc::new(mint.clone()),
+        mint.localstore(),
+        mint.pubsub_manager(),
+    );
+    let setup_saga = saga
+        .setup_melt(
+            &melt_request,
+            verification,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+        )
+        .await
+        .unwrap();
+    let operation_id = setup_saga.operation_id;
+    let (payment_saga, _decision) = setup_saga
+        .attempt_internal_settlement(&melt_request)
+        .await
+        .unwrap();
+
+    let response = payment_saga.attempt_external_payment().await.unwrap();
+
+    assert_eq!(response.status, MeltQuoteState::Failed);
+    let persisted_saga = assert_saga_exists(&mint, &operation_id).await;
+    assert_eq!(
+        persisted_saga.state,
+        SagaStateEnum::Melt(MeltSagaState::PaymentFailed)
+    );
+    assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+    assert_eq!(
+        mint.localstore
+            .get_melt_quote(&quote.id)
+            .await
+            .unwrap()
+            .expect("quote should exist")
+            .state,
+        MeltQuoteState::Pending
+    );
+}
+
+/// A payment error followed by a Failed backend check is authoritative by
+/// backend contract: the terminal failure is persisted durably as
+/// `PaymentFailed` before compensation.
+#[tokio::test]
+async fn test_failed_recheck_after_error_is_durable_before_compensation() {
+    let mint = create_test_mint().await.unwrap();
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+    let quote = create_test_melt_quote_with_description(
+        &mint,
+        Amount::from(9_000),
+        FakeInvoiceDescription {
+            pay_invoice_state: MeltQuoteState::Unknown,
+            check_payment_state: MeltQuoteState::Failed,
+            pay_err: true,
+            check_err: false,
+        },
+    )
+    .await;
+    let melt_request = create_test_melt_request(&proofs, &quote);
+    let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+    let saga = MeltSaga::new(
+        std::sync::Arc::new(mint.clone()),
+        mint.localstore(),
+        mint.pubsub_manager(),
+    );
+    let setup_saga = saga
+        .setup_melt(
+            &melt_request,
+            verification,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+        )
+        .await
+        .unwrap();
+    let operation_id = setup_saga.operation_id;
+    let (payment_saga, _decision) = setup_saga
+        .attempt_internal_settlement(&melt_request)
+        .await
+        .unwrap();
+
+    let response = payment_saga.attempt_external_payment().await.unwrap();
+
+    assert_eq!(response.status, MeltQuoteState::Failed);
+    let persisted_saga = assert_saga_exists(&mint, &operation_id).await;
+    assert_eq!(
+        persisted_saga.state,
+        SagaStateEnum::Melt(MeltSagaState::PaymentFailed)
+    );
+    assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+    assert_eq!(
+        mint.localstore
+            .get_melt_quote(&quote.id)
+            .await
+            .unwrap()
+            .expect("quote should exist")
+            .state,
+        MeltQuoteState::Pending
+    );
+}
+
 /// A payment error followed by a Pending backend check must keep proofs reserved.
 ///
 /// Dispatch-ambiguous backends use Pending to prevent the live error path from
@@ -2034,9 +2211,7 @@ async fn test_payment_error_with_pending_check_does_not_compensate() {
     assert_eq!(stored_quote.state, MeltQuoteState::Pending);
 }
 
-async fn assert_payment_error_with_terminal_follow_up_does_not_compensate(
-    follow_up_state: MeltQuoteState,
-) {
+async fn assert_payment_error_with_terminal_follow_up_compensates(follow_up_state: MeltQuoteState) {
     assert!(matches!(
         follow_up_state,
         MeltQuoteState::Failed | MeltQuoteState::Unpaid
@@ -2077,39 +2252,40 @@ async fn assert_payment_error_with_terminal_follow_up_does_not_compensate(
         .await
         .unwrap();
 
-    let outcome = payment_saga.make_payment(decision).await.unwrap();
+    // A terminal follow-up is authoritative by backend contract: the payment
+    // can never settle, so the melt fails and the setup is compensated.
+    let err = match payment_saga.make_payment(decision).await {
+        Ok(_) => panic!("terminal follow-up should fail the melt"),
+        Err(err) => err,
+    };
+    assert!(matches!(err, crate::Error::PaymentFailed));
 
-    assert!(matches!(outcome, PaymentOutcome::Pending { .. }));
-    assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
-    let pending_saga = assert_saga_exists(&mint, &operation_id).await;
-    assert_eq!(
-        pending_saga.state,
-        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted),
-        "an untrusted terminal follow-up must leave dispatch ambiguous"
-    );
+    assert_saga_not_exists(&mint, &operation_id).await;
+    assert_proofs_state(&mint, &input_ys, None).await;
     let stored_quote = mint
         .localstore
         .get_melt_quote(&quote.id)
         .await
         .unwrap()
         .expect("quote should remain persisted");
-    assert_eq!(stored_quote.state, MeltQuoteState::Pending);
+    assert_eq!(stored_quote.state, MeltQuoteState::Unpaid);
 }
 
 #[tokio::test]
-async fn test_payment_error_with_failed_check_does_not_compensate() {
-    assert_payment_error_with_terminal_follow_up_does_not_compensate(MeltQuoteState::Failed).await;
+async fn test_payment_error_with_failed_check_compensates() {
+    assert_payment_error_with_terminal_follow_up_compensates(MeltQuoteState::Failed).await;
 }
 
 #[tokio::test]
-async fn test_payment_error_with_unpaid_check_does_not_compensate() {
-    assert_payment_error_with_terminal_follow_up_does_not_compensate(MeltQuoteState::Unpaid).await;
+async fn test_payment_error_with_unpaid_check_compensates() {
+    assert_payment_error_with_terminal_follow_up_compensates(MeltQuoteState::Unpaid).await;
 }
 
-/// An Unknown dispatch result cannot be overridden by an immediate stale
-/// Unpaid read: the payment may still settle after the proofs are returned.
+/// An Unknown dispatch result is overridden by an authoritative Unpaid
+/// follow-up: by backend contract the payment can never settle, so the melt
+/// fails and the setup is compensated.
 #[tokio::test]
-async fn test_unknown_dispatch_with_unpaid_check_does_not_compensate() {
+async fn test_unknown_dispatch_with_unpaid_check_compensates() {
     let mint = create_test_mint().await.unwrap();
     let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
     let input_ys = proofs.ys().unwrap();
@@ -2145,22 +2321,21 @@ async fn test_unknown_dispatch_with_unpaid_check_does_not_compensate() {
         .await
         .unwrap();
 
-    let outcome = payment_saga.make_payment(decision).await.unwrap();
+    let err = match payment_saga.make_payment(decision).await {
+        Ok(_) => panic!("authoritative Unpaid follow-up should fail the melt"),
+        Err(err) => err,
+    };
+    assert!(matches!(err, crate::Error::PaymentFailed));
 
-    assert!(matches!(outcome, PaymentOutcome::Pending { .. }));
-    assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
-    let pending_saga = assert_saga_exists(&mint, &operation_id).await;
-    assert_eq!(
-        pending_saga.state,
-        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted)
-    );
+    assert_saga_not_exists(&mint, &operation_id).await;
+    assert_proofs_state(&mint, &input_ys, None).await;
     let stored_quote = mint
         .localstore
         .get_melt_quote(&quote.id)
         .await
         .unwrap()
         .expect("quote should remain persisted");
-    assert_eq!(stored_quote.state, MeltQuoteState::Pending);
+    assert_eq!(stored_quote.state, MeltQuoteState::Unpaid);
 }
 
 // ============================================================================

--- a/crates/cdk/src/mint/melt/shared.rs
+++ b/crates/cdk/src/mint/melt/shared.rs
@@ -201,6 +201,33 @@ pub(crate) async fn rollback_setup_melt_quote(
     .await
 }
 
+/// Roll back a melt only after an authoritative payment failure was recorded.
+pub(crate) async fn rollback_failed_melt_quote(
+    db: &DynMintDatabase,
+    pubsub: &PubSubManager,
+    quote_id: &QuoteId,
+    input_ys: &[PublicKey],
+    blinded_secrets: &[PublicKey],
+    operation_id: &uuid::Uuid,
+) -> Result<(), Error> {
+    if input_ys.is_empty() && blinded_secrets.is_empty() {
+        return Ok(());
+    }
+
+    let mut tx = db.begin_transaction().await?;
+    tx.lock_quotes(std::slice::from_ref(quote_id)).await?;
+    rollback_melt_quote_inner(
+        tx,
+        pubsub,
+        quote_id,
+        input_ys,
+        blinded_secrets,
+        operation_id,
+        Some(mint_types::MeltSagaState::PaymentFailed),
+    )
+    .await
+}
+
 async fn rollback_melt_quote_inner(
     mut tx: DynMintTransaction,
     pubsub: &PubSubManager,

--- a/crates/cdk/src/mint/melt/tests/pending_async_melt_tests.rs
+++ b/crates/cdk/src/mint/melt/tests/pending_async_melt_tests.rs
@@ -255,7 +255,7 @@ fn create_test_melt_request(
 }
 
 #[tokio::test]
-async fn pending_dispatch_is_sticky_across_stale_unpaid_verification() {
+async fn acknowledged_pending_dispatch_rolls_back_after_terminal_recheck() {
     let backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync> =
         Arc::new(NoEventPendingBackend::new(1, Some(MeltQuoteState::Unpaid)));
     let mint = create_pending_test_mint(backend).await.unwrap();
@@ -265,10 +265,9 @@ async fn pending_dispatch_is_sticky_across_stale_unpaid_verification() {
     let melt_request = create_test_melt_request(&proofs, &quote);
 
     let pending = mint.melt(&melt_request).await.unwrap();
-    assert!(matches!(
-        pending.await,
-        Err(Error::PendingMeltTimeout { .. })
-    ));
+    let checked = mint.check_melt_quote(&quote.id).await.unwrap();
+    assert_eq!(checked.state(), MeltQuoteState::Unpaid);
+    drop(pending);
 
     let stored_quote = mint
         .localstore()
@@ -276,25 +275,19 @@ async fn pending_dispatch_is_sticky_across_stale_unpaid_verification() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(stored_quote.state, MeltQuoteState::Pending);
+    assert_eq!(stored_quote.state, MeltQuoteState::Unpaid);
     let proof_states = mint
         .localstore()
         .get_proofs_states(&input_ys)
         .await
         .unwrap();
-    assert!(proof_states
-        .iter()
-        .all(|state| *state == Some(cdk_common::State::Pending)));
+    assert!(proof_states.iter().all(Option::is_none));
     let saga = mint
         .localstore()
         .get_melt_saga_by_quote_id(&quote.id)
         .await
-        .unwrap()
-        .expect("pending saga should remain");
-    assert_eq!(
-        saga.state,
-        cdk_common::mint::SagaStateEnum::Melt(cdk_common::mint::MeltSagaState::PaymentPending)
-    );
+        .unwrap();
+    assert!(saga.is_none());
 }
 
 #[tokio::test]
@@ -324,7 +317,7 @@ async fn pending_melt_completes_via_explicit_status_check_without_notification()
 }
 
 #[tokio::test]
-async fn pending_melt_ignores_failed_status_check_without_notification() {
+async fn pending_melt_rolls_back_via_status_check_without_notification() {
     let backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync> =
         Arc::new(NoEventPendingBackend::new(2, Some(MeltQuoteState::Failed)));
     let mint = create_pending_test_mint(backend).await.unwrap();
@@ -335,7 +328,7 @@ async fn pending_melt_ignores_failed_status_check_without_notification() {
 
     let pending = mint.melt(&melt_request).await.unwrap();
     let checked = mint.check_melt_quote(&quote.id).await.unwrap();
-    assert_eq!(checked.state(), MeltQuoteState::Pending);
+    assert_eq!(checked.state(), MeltQuoteState::Unpaid);
     drop(pending);
 
     let stored_quote = mint
@@ -344,31 +337,25 @@ async fn pending_melt_ignores_failed_status_check_without_notification() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(stored_quote.state, MeltQuoteState::Pending);
+    assert_eq!(stored_quote.state, MeltQuoteState::Unpaid);
 
     let proof_states = mint
         .localstore()
         .get_proofs_states(&input_ys)
         .await
         .unwrap();
-    assert!(proof_states
-        .iter()
-        .all(|state| *state == Some(cdk_common::State::Pending)));
+    assert!(proof_states.iter().all(Option::is_none));
 
     let saga = mint
         .localstore()
         .get_melt_saga_by_quote_id(&quote.id)
         .await
-        .unwrap()
-        .expect("ambiguous dispatch saga should remain");
-    assert_eq!(
-        saga.state,
-        cdk_common::mint::SagaStateEnum::Melt(cdk_common::mint::MeltSagaState::PaymentPending)
-    );
+        .unwrap();
+    assert!(saga.is_none());
 }
 
 #[tokio::test]
-async fn payment_error_that_looks_local_still_stays_pending() {
+async fn payment_error_that_looks_local_records_pending_acknowledgement() {
     let backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync> = Arc::new(
         NoEventPendingBackend::new(usize::MAX, None).with_amount_mismatch_dispatch_error(),
     );
@@ -379,8 +366,8 @@ async fn payment_error_that_looks_local_still_stays_pending() {
     let melt_request = create_test_melt_request(&proofs, &quote);
 
     // Even an error that resembles local validation can be returned after a
-    // backend crossed its dispatch boundary. A subsequent Unpaid read does
-    // not prove that no payment is in flight.
+    // backend crossed its dispatch boundary. A follow-up Pending read proves
+    // that the backend can identify the in-flight attempt.
     let pending = mint.melt(&melt_request).await.unwrap();
     assert_eq!(pending.pending_response().state(), MeltQuoteState::Pending);
     let pending_saga = tokio::time::timeout(Duration::from_secs(5), async {

--- a/crates/cdk/src/mint/melt/tests/pending_async_melt_tests.rs
+++ b/crates/cdk/src/mint/melt/tests/pending_async_melt_tests.rs
@@ -254,8 +254,11 @@ fn create_test_melt_request(
     cdk_common::nuts::MeltRequest::new(quote.id.clone(), proofs.clone(), None)
 }
 
+/// A terminal status poll is an authoritative outcome by backend contract:
+/// the acknowledged pending melt is rolled back and the user can reclaim
+/// their proofs.
 #[tokio::test]
-async fn acknowledged_pending_dispatch_rolls_back_after_terminal_recheck() {
+async fn acknowledged_pending_dispatch_rolls_back_after_terminal_poll() {
     let backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync> =
         Arc::new(NoEventPendingBackend::new(1, Some(MeltQuoteState::Unpaid)));
     let mint = create_pending_test_mint(backend).await.unwrap();
@@ -316,10 +319,13 @@ async fn pending_melt_completes_via_explicit_status_check_without_notification()
     assert_eq!(stored_quote.state, MeltQuoteState::Paid);
 }
 
+/// An `Unknown` status poll is not an authoritative outcome (e.g. CLN
+/// reports it whenever a payment may still settle), so the acknowledged
+/// pending melt must stay reserved for a later authoritative signal.
 #[tokio::test]
-async fn pending_melt_rolls_back_via_status_check_without_notification() {
+async fn unknown_status_poll_keeps_pending_melt_reserved() {
     let backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync> =
-        Arc::new(NoEventPendingBackend::new(2, Some(MeltQuoteState::Failed)));
+        Arc::new(NoEventPendingBackend::new(2, Some(MeltQuoteState::Unknown)));
     let mint = create_pending_test_mint(backend).await.unwrap();
     let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
     let input_ys = proofs.ys().unwrap();
@@ -328,7 +334,7 @@ async fn pending_melt_rolls_back_via_status_check_without_notification() {
 
     let pending = mint.melt(&melt_request).await.unwrap();
     let checked = mint.check_melt_quote(&quote.id).await.unwrap();
-    assert_eq!(checked.state(), MeltQuoteState::Unpaid);
+    assert_eq!(checked.state(), MeltQuoteState::Pending);
     drop(pending);
 
     let stored_quote = mint
@@ -337,21 +343,27 @@ async fn pending_melt_rolls_back_via_status_check_without_notification() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(stored_quote.state, MeltQuoteState::Unpaid);
+    assert_eq!(stored_quote.state, MeltQuoteState::Pending);
 
     let proof_states = mint
         .localstore()
         .get_proofs_states(&input_ys)
         .await
         .unwrap();
-    assert!(proof_states.iter().all(Option::is_none));
+    assert!(proof_states
+        .iter()
+        .all(|state| *state == Some(cdk_common::State::Pending)));
 
     let saga = mint
         .localstore()
         .get_melt_saga_by_quote_id(&quote.id)
         .await
         .unwrap();
-    assert!(saga.is_none());
+    assert_eq!(
+        saga.expect("an indeterminate poll must preserve the recovery saga")
+            .state,
+        cdk_common::mint::SagaStateEnum::Melt(cdk_common::mint::MeltSagaState::PaymentPending)
+    );
 }
 
 #[tokio::test]
@@ -740,10 +752,14 @@ async fn internal_settlement_without_lookup_id_finalizes_on_demand() {
     );
 }
 
-/// Startup recovery must keep a write-ahead attempt pending because it cannot
-/// prove whether the backend call happened before the crash.
+/// Startup recovery compensates a write-ahead attempt when the backend
+/// authoritatively reports the payment as never dispatched. By contract an
+/// `Unpaid` answer is only returned when the payment can never settle — for
+/// a quote without a persisted lookup id the backend derives the answer from
+/// the quote-scoped identifier (e.g. CLN's bolt12 binding is written before
+/// any dispatch, so its absence proves the payment never happened).
 #[tokio::test]
-async fn payment_attempt_without_lookup_id_stays_pending_at_startup() {
+async fn payment_attempt_without_lookup_id_compensates_at_startup() {
     let backend: Arc<dyn MintPayment<Err = payment::Error> + Send + Sync> = Arc::new(
         NoEventPendingBackend::new(1, Some(MeltQuoteState::Unpaid)).with_stripped_quote_lookup_id(),
     );
@@ -817,30 +833,25 @@ async fn payment_attempt_without_lookup_id_stays_pending_at_startup() {
         .await
         .expect("recovery should succeed");
 
-    // A public backend poll cannot resolve the ambiguous dispatch.
+    // The authoritative Unpaid resolves the ambiguous dispatch: the melt is
+    // compensated and the inputs are released back to the user.
     let states = mint
         .localstore()
         .get_proofs_states(&input_ys)
         .await
         .unwrap();
-    assert!(states
-        .iter()
-        .all(|state| *state == Some(cdk_common::State::Pending)));
+    assert!(states.iter().all(Option::is_none));
     let stored_quote = mint
         .localstore()
         .get_melt_quote(&quote.id)
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(stored_quote.state, MeltQuoteState::Pending);
+    assert_eq!(stored_quote.state, MeltQuoteState::Unpaid);
     let saga = mint
         .localstore()
         .get_melt_saga_by_quote_id(&quote.id)
         .await
-        .unwrap()
-        .expect("ambiguous dispatch saga should remain");
-    assert_eq!(
-        saga.state,
-        cdk_common::mint::SagaStateEnum::Melt(cdk_common::mint::MeltSagaState::PaymentAttempted)
-    );
+        .unwrap();
+    assert!(saga.is_none());
 }

--- a/crates/cdk/src/mint/saga_recovery.rs
+++ b/crates/cdk/src/mint/saga_recovery.rs
@@ -68,9 +68,10 @@ async fn check_melt_payment_status_bounded(
 ///    keeps the credit),
 /// 2. a fresh backend status check confirms the payment did not succeed (the
 ///    caller's observation may be stale),
-/// 3. a payment with an ambiguous dispatch state is only compensated after a
-///    trusted failure event (public `Unpaid` and `Failed` polls remain
-///    fail-closed), and
+/// 3. the durable saga state proves either that dispatch never began
+///    (`SetupComplete`) or that the backend acknowledged the attempt
+///    (`PaymentPending`); an ambiguous write-ahead marker (`PaymentAttempted`)
+///    remains fail-closed, and
 /// 4. the saga has not advanced to `Finalizing`.
 ///
 /// Any check that cannot be answered fails closed: the quote is left pending
@@ -95,12 +96,11 @@ pub(crate) async fn process_melt_saga_outcome(
     pubsub: &PubSubManager,
     mint: &Mint,
 ) -> Result<(), Error> {
-    process_melt_saga_outcome_inner(saga, quote, payment_response, db, pubsub, mint, false).await
+    process_melt_saga_outcome_inner(saga, quote, payment_response, db, pubsub, mint).await
 }
 
-/// Process a failure delivered by the trusted payment-backend event stream.
-/// Unlike public polling, a definitive failure event may resolve a previously
-/// acknowledged pending payment after a fresh terminal backend check.
+/// Process a failure delivered by the payment-backend event stream.
+/// Event and polling paths use the same state validation and backend recheck.
 pub(crate) async fn process_melt_saga_failure_event(
     saga: &Saga,
     quote: &mut MeltQuote,
@@ -109,7 +109,7 @@ pub(crate) async fn process_melt_saga_failure_event(
     pubsub: &PubSubManager,
     mint: &Mint,
 ) -> Result<(), Error> {
-    process_melt_saga_outcome_inner(saga, quote, payment_response, db, pubsub, mint, true).await
+    process_melt_saga_outcome_inner(saga, quote, payment_response, db, pubsub, mint).await
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -120,14 +120,13 @@ async fn process_melt_saga_outcome_inner(
     db: &cdk_common::database::DynMintDatabase,
     pubsub: &PubSubManager,
     mint: &Mint,
-    definitive_failure_event: bool,
 ) -> Result<(), Error> {
     match payment_response.status {
         MeltQuoteState::Paid => {
             finalize_paid_melt_outcome(saga, quote, payment_response, db, pubsub, mint).await
         }
         MeltQuoteState::Unpaid | MeltQuoteState::Failed => {
-            reconcile_terminal_melt(saga, quote, db, pubsub, mint, definitive_failure_event).await
+            reconcile_terminal_melt(saga, quote, db, pubsub, mint).await
         }
         MeltQuoteState::Pending => {
             persist_pending_after_dispatch(saga, quote, payment_response, db).await?;
@@ -166,11 +165,8 @@ async fn reconcile_terminal_melt(
     db: &cdk_common::database::DynMintDatabase,
     pubsub: &PubSubManager,
     mint: &Mint,
-    definitive_failure_event: bool,
 ) -> Result<(), Error> {
-    let result =
-        reconcile_terminal_melt_inner(saga, quote, db, pubsub, mint, definitive_failure_event)
-            .await;
+    let result = reconcile_terminal_melt_inner(saga, quote, db, pubsub, mint).await;
 
     match result? {
         Some((saga, payment_response)) => {
@@ -187,7 +183,6 @@ async fn reconcile_terminal_melt_inner(
     db: &cdk_common::database::DynMintDatabase,
     pubsub: &PubSubManager,
     mint: &Mint,
-    definitive_failure_event: bool,
 ) -> Result<Option<(Saga, MakePaymentResponse)>, Error> {
     let current_saga = db.get_melt_saga_by_quote_id(&quote.id).await?;
     let Some(saga) = current_saga else {
@@ -254,18 +249,27 @@ async fn reconcile_terminal_melt_inner(
         MeltQuoteState::Unpaid | MeltQuoteState::Failed => {}
     }
 
-    if matches!(
-        &saga.state,
-        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted | MeltSagaState::PaymentPending)
-    ) && !definitive_failure_event
-    {
-        tracing::warn!(
-            "Ignoring contradictory {} status for melt quote {} because saga {} has an ambiguous dispatch state",
-            fresh_response.status,
-            quote.id,
-            saga.operation_id
-        );
-        return Ok(None);
+    match &saga.state {
+        SagaStateEnum::Melt(MeltSagaState::SetupComplete | MeltSagaState::PaymentPending) => {}
+        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted) => {
+            tracing::warn!(
+                "Ignoring terminal {} status for melt quote {} because saga {} has an ambiguous dispatch state",
+                fresh_response.status,
+                quote.id,
+                saga.operation_id
+            );
+            return Ok(None);
+        }
+        SagaStateEnum::Melt(MeltSagaState::Finalizing) => {
+            tracing::info!(
+                "Ignoring terminal {} status for melt quote {} because saga {} is already finalizing",
+                fresh_response.status,
+                quote.id,
+                saga.operation_id
+            );
+            return Ok(None);
+        }
+        SagaStateEnum::Swap(_) => return Ok(None),
     }
 
     let input_ys = db.get_proof_ys_by_operation_id(&saga.operation_id).await?;
@@ -322,7 +326,7 @@ async fn persist_payment_lookup_id_in_transaction(
     quote: &mut MeltQuote,
     payment_response: &MakePaymentResponse,
 ) -> Result<(), Error> {
-    let mut current_saga = tx
+    let current_saga = tx
         .get_saga_for_update(&saga.operation_id)
         .await?
         .ok_or(Error::Internal)?;
@@ -349,12 +353,6 @@ async fn persist_payment_lookup_id_in_transaction(
         )
         .await?;
     }
-
-    tx.update_acquired_saga(
-        &mut current_saga,
-        SagaStateEnum::Melt(MeltSagaState::PaymentPending),
-    )
-    .await?;
 
     quote.request_lookup_id = Some(payment_response.payment_lookup_id.clone());
     Ok(())
@@ -599,8 +597,8 @@ mod tests {
         let operation_id = assert_single_melt_saga_operation_id(&mint).await;
         drop(setup_saga);
 
-        // Park the saga as an ambiguous dispatch so reconciliation takes the
-        // status-check path.
+        // Park the saga as a backend-acknowledged payment so reconciliation
+        // takes the status-check path.
         let mut tx = mint.localstore.begin_transaction().await.unwrap();
         let mut acquired = tx
             .get_saga_for_update(&operation_id)
@@ -835,7 +833,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_ambiguous_dispatch_recovers_only_from_definitive_failure() {
+    async fn test_terminal_recovery_respects_dispatch_marker() {
         for saga_state in [
             MeltSagaState::PaymentAttempted,
             MeltSagaState::PaymentPending,
@@ -936,27 +934,42 @@ mod tests {
                 .await
                 .unwrap();
 
-                let _ = assert_saga_exists(&mint, &operation_id).await;
-                assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
-                assert_eq!(quote.state, MeltQuoteState::Pending);
+                match saga_state {
+                    MeltSagaState::PaymentAttempted => {
+                        let stored_saga = assert_saga_exists(&mint, &operation_id).await;
+                        assert_eq!(
+                            stored_saga.state,
+                            SagaStateEnum::Melt(MeltSagaState::PaymentAttempted)
+                        );
+                        assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+                        assert_eq!(quote.state, MeltQuoteState::Pending);
 
-                let stored_saga = assert_saga_exists(&mint, &operation_id).await;
-                assert_eq!(stored_saga.state, SagaStateEnum::Melt(saga_state.clone()));
+                        process_melt_saga_failure_event(
+                            &stored_saga,
+                            &mut quote,
+                            &payment_response,
+                            &mint.localstore,
+                            &mint.pubsub_manager,
+                            &mint,
+                        )
+                        .await
+                        .unwrap();
 
-                process_melt_saga_failure_event(
-                    &stored_saga,
-                    &mut quote,
-                    &payment_response,
-                    &mint.localstore,
-                    &mint.pubsub_manager,
-                    &mint,
-                )
-                .await
-                .unwrap();
-
-                assert_saga_not_exists(&mint, &operation_id).await;
-                assert_proofs_state(&mint, &input_ys, None).await;
-                assert_eq!(quote.state, MeltQuoteState::Unpaid);
+                        let stored_saga = assert_saga_exists(&mint, &operation_id).await;
+                        assert_eq!(
+                            stored_saga.state,
+                            SagaStateEnum::Melt(MeltSagaState::PaymentAttempted)
+                        );
+                        assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+                        assert_eq!(quote.state, MeltQuoteState::Pending);
+                    }
+                    MeltSagaState::PaymentPending => {
+                        assert_saga_not_exists(&mint, &operation_id).await;
+                        assert_proofs_state(&mint, &input_ys, None).await;
+                        assert_eq!(quote.state, MeltQuoteState::Unpaid);
+                    }
+                    state => panic!("unexpected test saga state: {state}"),
+                }
             }
         }
     }

--- a/crates/cdk/src/mint/saga_recovery.rs
+++ b/crates/cdk/src/mint/saga_recovery.rs
@@ -12,46 +12,6 @@ use crate::mint::subscription::PubSubManager;
 use crate::mint::Mint;
 use crate::Error;
 
-/// Maximum time to wait for a payment-backend status check during melt
-/// reconciliation.
-///
-/// Bounding the call prevents a slow or unreachable Lightning node from
-/// indefinitely tying up a reconciliation task. On timeout the reconciler
-/// fails closed and leaves the melt pending for a later pass.
-#[cfg(not(test))]
-const MELT_PAYMENT_STATUS_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
-/// Shorter timeout in tests so the fail-closed path is exercised without
-/// slowing the suite.
-#[cfg(test)]
-const MELT_PAYMENT_STATUS_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
-
-/// Check the payment status with the backend using a bounded wait.
-///
-/// Returns `Ok(None)` on timeout (treated as indeterminate, fail closed);
-/// backend errors propagate so the caller can apply its own handling.
-async fn check_melt_payment_status_bounded(
-    mint: &Mint,
-    quote: &MeltQuote,
-) -> Result<Option<MakePaymentResponse>, Error> {
-    match tokio::time::timeout(
-        MELT_PAYMENT_STATUS_CHECK_TIMEOUT,
-        mint.check_melt_payment_status(quote),
-    )
-    .await
-    {
-        Ok(Ok(response)) => Ok(Some(response)),
-        Ok(Err(err)) => Err(err),
-        Err(_elapsed) => {
-            tracing::warn!(
-                "Payment status check for melt quote {} timed out after {:?}. Leaving pending.",
-                quote.id,
-                MELT_PAYMENT_STATUS_CHECK_TIMEOUT
-            );
-            Ok(None)
-        }
-    }
-}
-
 /// Process the outcome of a melt saga based on payment status.
 ///
 /// This function handles the shared logic for deciding whether to finalize, compensate, or skip
@@ -61,21 +21,13 @@ async fn check_melt_payment_status_bounded(
 /// is the single finalization path — it handles operation recording, saga deletion, and all
 /// cleanup atomically.
 ///
-/// For the `Unpaid`/`Failed` case, compensation is only allowed after these
-/// checks:
-/// 1. the melt did not settle internally (a credited mint quote can never be
-///    compensated — that would return the payer's proofs while the recipient
-///    keeps the credit),
-/// 2. a fresh backend status check confirms the payment did not succeed (the
-///    caller's observation may be stale),
-/// 3. the durable saga state proves either that dispatch never began
-///    (`SetupComplete`) or that the backend acknowledged the attempt
-///    (`PaymentPending`); an ambiguous write-ahead marker (`PaymentAttempted`)
-///    remains fail-closed, and
-/// 4. the saga has not advanced to `Finalizing`.
-///
-/// Any check that cannot be answered fails closed: the quote is left pending
-/// rather than compensated.
+/// Polling is finalization-only for non-terminal states: `Pending` and
+/// `Unknown` observations leave the melt pending because a payment
+/// orchestrator may be between attempts. `Unpaid` and `Failed` are
+/// authoritative terminal outcomes by backend contract (see
+/// [`cdk_common::payment::MintPayment::check_outgoing_payment`]); the failure
+/// is persisted as `PaymentFailed` before compensation so a crash cannot turn
+/// it back into an ambiguous payment attempt.
 ///
 /// # Arguments
 /// * `saga` - The melt saga being processed
@@ -96,37 +48,38 @@ pub(crate) async fn process_melt_saga_outcome(
     pubsub: &PubSubManager,
     mint: &Mint,
 ) -> Result<(), Error> {
-    process_melt_saga_outcome_inner(saga, quote, payment_response, db, pubsub, mint).await
-}
-
-/// Process a failure delivered by the payment-backend event stream.
-/// Event and polling paths use the same state validation and backend recheck.
-pub(crate) async fn process_melt_saga_failure_event(
-    saga: &Saga,
-    quote: &mut MeltQuote,
-    payment_response: &MakePaymentResponse,
-    db: &cdk_common::database::DynMintDatabase,
-    pubsub: &PubSubManager,
-    mint: &Mint,
-) -> Result<(), Error> {
-    process_melt_saga_outcome_inner(saga, quote, payment_response, db, pubsub, mint).await
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn process_melt_saga_outcome_inner(
-    saga: &Saga,
-    quote: &mut MeltQuote,
-    payment_response: &MakePaymentResponse,
-    db: &cdk_common::database::DynMintDatabase,
-    pubsub: &PubSubManager,
-    mint: &Mint,
-) -> Result<(), Error> {
     match payment_response.status {
         MeltQuoteState::Paid => {
             finalize_paid_melt_outcome(saga, quote, payment_response, db, pubsub, mint).await
         }
         MeltQuoteState::Unpaid | MeltQuoteState::Failed => {
-            reconcile_terminal_melt(saga, quote, db, pubsub, mint).await
+            match mint.internal_melt_settlement_response(quote).await {
+                Ok(Some(internal_response)) => {
+                    return finalize_paid_melt_outcome(
+                        saga,
+                        quote,
+                        &internal_response,
+                        db,
+                        pubsub,
+                        mint,
+                    )
+                    .await;
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    tracing::error!(
+                        "Could not determine internal settlement state for melt quote {} (saga {}): {}. Leaving pending.",
+                        quote.id,
+                        saga.operation_id,
+                        err
+                    );
+                    return Ok(());
+                }
+            }
+
+            persist_permanent_payment_failure(saga, quote, db, payment_response).await?;
+
+            recover_recorded_payment_failure(saga, quote, db, pubsub).await
         }
         MeltQuoteState::Pending => {
             persist_pending_after_dispatch(saga, quote, payment_response, db).await?;
@@ -149,6 +102,22 @@ async fn process_melt_saga_outcome_inner(
     }
 }
 
+/// Process a permanent failure delivered by the payment-backend event stream.
+///
+/// [`cdk_common::payment::Event::PaymentFailed`] is an orchestration-level
+/// terminal signal, so event and polling outcomes share the same processing
+/// path.
+pub(crate) async fn process_melt_saga_failure_event(
+    saga: &Saga,
+    quote: &mut MeltQuote,
+    payment_response: &MakePaymentResponse,
+    db: &cdk_common::database::DynMintDatabase,
+    pubsub: &PubSubManager,
+    mint: &Mint,
+) -> Result<(), Error> {
+    process_melt_saga_outcome(saga, quote, payment_response, db, pubsub, mint).await
+}
+
 async fn persist_pending_after_dispatch(
     stale_saga: &Saga,
     quote: &mut MeltQuote,
@@ -158,125 +127,92 @@ async fn persist_pending_after_dispatch(
     persist_payment_lookup_id(stale_saga, quote, payment_response, db).await
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn reconcile_terminal_melt(
-    saga: &Saga,
+async fn persist_permanent_payment_failure(
+    stale_saga: &Saga,
     quote: &mut MeltQuote,
     db: &cdk_common::database::DynMintDatabase,
-    pubsub: &PubSubManager,
-    mint: &Mint,
+    payment_response: &MakePaymentResponse,
 ) -> Result<(), Error> {
-    let result = reconcile_terminal_melt_inner(saga, quote, db, pubsub, mint).await;
+    let mut tx = db.begin_transaction().await?;
+    let Some(mut current_saga) = tx.get_saga_for_update(&stale_saga.operation_id).await? else {
+        tx.rollback().await?;
+        return Ok(());
+    };
 
-    match result? {
-        Some((saga, payment_response)) => {
-            finalize_paid_melt_outcome(&saga, quote, &payment_response, db, pubsub, mint).await
+    match &current_saga.state {
+        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted | MeltSagaState::PaymentPending) => {}
+        SagaStateEnum::Melt(MeltSagaState::PaymentFailed) => {
+            tx.rollback().await?;
+            return Ok(());
         }
-        None => Ok(()),
+        SagaStateEnum::Melt(MeltSagaState::SetupComplete | MeltSagaState::Finalizing)
+        | SagaStateEnum::Swap(_) => {
+            tracing::warn!(
+                "Ignoring permanent payment failure for melt quote {} because saga {} is {}",
+                quote.id,
+                stale_saga.operation_id,
+                current_saga.state.state()
+            );
+            tx.rollback().await?;
+            return Ok(());
+        }
     }
+
+    let mut current_quote = tx
+        .get_melt_quote(&quote.id)
+        .await?
+        .ok_or(Error::UnknownQuote)?;
+    if current_quote.request_lookup_id.as_ref() != Some(&payment_response.payment_lookup_id) {
+        tx.update_melt_quote_request_lookup_id(
+            &mut current_quote,
+            &payment_response.payment_lookup_id,
+        )
+        .await?;
+    }
+
+    tx.update_acquired_saga(
+        &mut current_saga,
+        SagaStateEnum::Melt(MeltSagaState::PaymentFailed),
+    )
+    .await?;
+    tx.commit().await?;
+    quote.request_lookup_id = Some(payment_response.payment_lookup_id.clone());
+    Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn reconcile_terminal_melt_inner(
+/// Compensate a melt only when a durable authoritative failure was recorded.
+pub(crate) async fn recover_recorded_payment_failure(
     stale_saga: &Saga,
     quote: &mut MeltQuote,
     db: &cdk_common::database::DynMintDatabase,
     pubsub: &PubSubManager,
-    mint: &Mint,
-) -> Result<Option<(Saga, MakePaymentResponse)>, Error> {
+) -> Result<(), Error> {
     let current_saga = db.get_melt_saga_by_quote_id(&quote.id).await?;
     let Some(saga) = current_saga else {
         *quote = db
             .get_melt_quote(&quote.id)
             .await?
             .ok_or(Error::UnknownQuote)?;
-        if quote.state != MeltQuoteState::Paid {
-            tracing::warn!(
-                "Melt saga {} disappeared while quote {} is {}; leaving it unchanged",
-                stale_saga.operation_id,
-                quote.id,
-                quote.state
-            );
-        }
-        return Ok(None);
+        return Ok(());
     };
 
-    *quote = db
-        .get_melt_quote(&quote.id)
-        .await?
-        .ok_or(Error::UnknownQuote)?;
-
-    match mint.internal_melt_settlement_response(quote).await {
-        Ok(Some(internal_response)) => {
-            return Ok(Some((saga, internal_response)));
-        }
-        Ok(None) => {}
-        Err(err) => {
-            tracing::error!(
-                "Could not determine internal settlement state for melt quote {} (saga {}): {}. Leaving pending.",
-                quote.id,
-                saga.operation_id,
-                err
-            );
-            return Ok(None);
-        }
-    }
-
-    let fresh_response = match check_melt_payment_status_bounded(mint, quote).await {
-        Ok(Some(response)) => response,
-        Ok(None) => {
-            // Timed out: fail closed, leave pending.
-            return Ok(None);
-        }
-        Err(err) => {
-            tracing::error!(
-                "Cannot verify payment status for melt quote {} (saga {}): {}. Leaving pending.",
-                quote.id,
-                saga.operation_id,
-                err
-            );
-            return Ok(None);
-        }
-    };
-
-    match fresh_response.status {
-        MeltQuoteState::Paid => return Ok(Some((saga, fresh_response))),
-        MeltQuoteState::Pending => {
-            persist_payment_lookup_id(&saga, quote, &fresh_response, db).await?;
-            return Ok(None);
-        }
-        MeltQuoteState::Unknown => return Ok(None),
-        MeltQuoteState::Unpaid | MeltQuoteState::Failed => {}
-    }
-
-    match &saga.state {
-        SagaStateEnum::Melt(MeltSagaState::SetupComplete | MeltSagaState::PaymentPending) => {}
-        SagaStateEnum::Melt(MeltSagaState::PaymentAttempted) => {
-            tracing::warn!(
-                "Ignoring terminal {} status for melt quote {} because saga {} has an ambiguous dispatch state",
-                fresh_response.status,
-                quote.id,
-                saga.operation_id
-            );
-            return Ok(None);
-        }
-        SagaStateEnum::Melt(MeltSagaState::Finalizing) => {
-            tracing::info!(
-                "Ignoring terminal {} status for melt quote {} because saga {} is already finalizing",
-                fresh_response.status,
-                quote.id,
-                saga.operation_id
-            );
-            return Ok(None);
-        }
-        SagaStateEnum::Swap(_) => return Ok(None),
+    if saga.operation_id != stale_saga.operation_id
+        || saga.state != SagaStateEnum::Melt(MeltSagaState::PaymentFailed)
+    {
+        tracing::warn!(
+            "Ignoring negative payment observation for melt quote {} because saga {} is {}",
+            quote.id,
+            saga.operation_id,
+            saga.state.state()
+        );
+        return Ok(());
     }
 
     let input_ys = db.get_proof_ys_by_operation_id(&saga.operation_id).await?;
     let blinded_secrets = db
         .get_blinded_secrets_by_operation_id(&saga.operation_id)
         .await?;
-    let rollback = super::melt::shared::rollback_melt_quote(
+    let rollback = super::melt::shared::rollback_failed_melt_quote(
         db,
         pubsub,
         &quote.id,
@@ -303,7 +239,7 @@ async fn reconcile_terminal_melt_inner(
         Err(err) => return Err(err),
     }
 
-    Ok(None)
+    Ok(())
 }
 
 /// Persists a backend-provided lookup id so later checks can recover a pending
@@ -465,11 +401,11 @@ mod tests {
     use crate::mint::melt::melt_saga::MeltSaga;
     use crate::test_helpers::mint::{create_test_mint, mint_test_proofs};
 
-    /// A slow backend must not pin the reconciliation locks for the full
-    /// duration of its response: the bounded status check times out and the
-    /// reconciler fails closed, leaving the melt pending.
+    /// A negative observation must not trigger a second backend check: the
+    /// status is an authoritative terminal outcome by contract, so the melt
+    /// is compensated without re-querying the (here hanging) backend.
     #[tokio::test]
-    async fn slow_backend_status_check_fails_closed_without_holding_locks() {
+    async fn negative_outcome_compensates_without_a_second_backend_check() {
         use std::sync::Arc;
         use std::time::Duration;
 
@@ -478,7 +414,8 @@ mod tests {
         use crate::mint::{MintBuilder, MintMeltLimits};
         use crate::types::{FeeReserve, QuoteTTL};
 
-        // Backend whose status check never answers within the bounded window.
+        // Backend whose status check never answers. The outcome processor must
+        // not call it for a negative observation.
         struct HangingStatusBackend {
             inner: cdk_fake_wallet::FakeWallet,
         }
@@ -522,7 +459,6 @@ mod tests {
                 &self,
                 _payment_identifier: &PaymentIdentifier,
             ) -> Result<MakePaymentResponse, Self::Err> {
-                // Longer than MELT_PAYMENT_STATUS_CHECK_TIMEOUT.
                 std::future::pending::<()>().await;
                 unreachable!("pending never resolves")
             }
@@ -597,8 +533,7 @@ mod tests {
         let operation_id = assert_single_melt_saga_operation_id(&mint).await;
         drop(setup_saga);
 
-        // Park the saga as a backend-acknowledged payment so reconciliation
-        // takes the status-check path.
+        // Park the saga as a backend-acknowledged payment.
         let mut tx = mint.localstore.begin_transaction().await.unwrap();
         let mut acquired = tx
             .get_saga_for_update(&operation_id)
@@ -630,8 +565,6 @@ mod tests {
             total_spent: quote.amount(),
         };
 
-        // The reconciler would normally block for the full backend response;
-        // the bounded check must return within the timeout instead.
         let started = std::time::Instant::now();
         process_melt_saga_outcome(
             &saga,
@@ -646,14 +579,15 @@ mod tests {
         let elapsed = started.elapsed();
 
         assert!(
-            elapsed < Duration::from_secs(60),
-            "reconciliation returned after the bounded status check, not the hanging backend (elapsed {:?})",
+            elapsed < Duration::from_secs(1),
+            "negative polling unexpectedly called the hanging backend (elapsed {:?})",
             elapsed
         );
-        // Failed-closed: the melt stays pending and the saga survives.
-        assert_eq!(quote.state, MeltQuoteState::Pending);
-        assert_saga_exists(&mint, &operation_id).await;
-        assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+        // The terminal status is authoritative: the melt is compensated, the
+        // saga is gone, and the proofs are released back to the user.
+        assert_eq!(quote.state, MeltQuoteState::Unpaid);
+        assert_saga_not_exists(&mint, &operation_id).await;
+        assert_proofs_state(&mint, &input_ys, None).await;
     }
 
     #[tokio::test]
@@ -733,10 +667,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_failed_outcome_rolls_back_and_deletes_saga() {
-        // Compensation requires the fresh backend re-check to confirm the
-        // failure, so seed the fake backend with a terminal Failed state for
-        // this invoice's payment hash.
+    async fn test_recorded_payment_failure_rolls_back_and_deletes_saga() {
         let fake_description = FakeInvoiceDescription {
             pay_invoice_state: MeltQuoteState::Failed,
             check_payment_state: MeltQuoteState::Failed,
@@ -794,32 +725,22 @@ mod tests {
         let operation_id = assert_single_melt_saga_operation_id(&mint).await;
         drop(setup_saga);
 
-        let mut quote = mint
-            .localstore
-            .get_melt_quote(&quote.id)
+        let mut tx = mint.localstore.begin_transaction().await.unwrap();
+        let mut acquired_saga = tx
+            .get_saga_for_update(&operation_id)
             .await
             .unwrap()
-            .unwrap();
-        let saga = assert_saga_exists(&mint, &operation_id).await;
-        let payment_response = MakePaymentResponse {
-            payment_lookup_id: PaymentIdentifier::CustomId("failed_outcome_lookup".to_string()),
-            payment_proof: None,
-            status: MeltQuoteState::Failed,
-            total_spent: quote.amount(),
-        };
-
-        process_melt_saga_outcome(
-            &saga,
-            &mut quote,
-            &payment_response,
-            &mint.localstore,
-            &mint.pubsub_manager,
-            &mint,
+            .expect("saga should exist");
+        tx.update_acquired_saga(
+            &mut acquired_saga,
+            SagaStateEnum::Melt(MeltSagaState::PaymentFailed),
         )
         .await
         .unwrap();
+        tx.commit().await.unwrap();
 
-        assert_eq!(quote.state, MeltQuoteState::Unpaid);
+        mint.recover_from_incomplete_melt_sagas().await.unwrap();
+
         assert_saga_not_exists(&mint, &operation_id).await;
         assert_proofs_state(&mint, &input_ys, None).await;
 
@@ -832,8 +753,143 @@ mod tests {
         assert_eq!(recovered_quote.state, MeltQuoteState::Unpaid);
     }
 
+    /// An `Unknown` poll is not an authoritative outcome (e.g. CLN reports it
+    /// whenever a payment may still settle), so it must keep the melt
+    /// reserved from either dispatch marker; only a later authoritative
+    /// failure may compensate it.
     #[tokio::test]
-    async fn test_terminal_recovery_respects_dispatch_marker() {
+    async fn test_unknown_poll_waits_for_permanent_failure_event() {
+        for saga_state in [
+            MeltSagaState::PaymentAttempted,
+            MeltSagaState::PaymentPending,
+        ] {
+            let fake_description = FakeInvoiceDescription {
+                pay_invoice_state: MeltQuoteState::Unknown,
+                check_payment_state: MeltQuoteState::Unknown,
+                pay_err: false,
+                check_err: false,
+            };
+            let amount_msats: u64 = Amount::from(9_000).into();
+            let invoice = create_fake_invoice(
+                amount_msats,
+                serde_json::to_string(&fake_description).unwrap(),
+            );
+            let payment_states = std::collections::HashMap::from([(
+                invoice.payment_hash().to_string(),
+                (
+                    MeltQuoteState::Unknown,
+                    Amount::from(9_000).with_unit(CurrencyUnit::Sat),
+                ),
+            )]);
+            let mint = create_test_mint_with_payment_states(payment_states)
+                .await
+                .unwrap();
+            let request = cdk_common::melt::MeltQuoteRequest::Bolt11(MeltQuoteBolt11Request {
+                request: invoice,
+                unit: CurrencyUnit::Sat,
+                options: None,
+            });
+            let quote_response = mint.get_melt_quote(request).await.unwrap();
+            let quote = mint
+                .localstore
+                .get_melt_quote(quote_response.quote().unwrap())
+                .await
+                .unwrap()
+                .expect("quote should exist");
+            let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+            let input_ys = proofs.ys().unwrap();
+            let melt_request = create_test_melt_request(&proofs, &quote);
+            let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+            let saga = MeltSaga::new(
+                std::sync::Arc::new(mint.clone()),
+                mint.localstore(),
+                mint.pubsub_manager(),
+            );
+            let setup_saga = saga
+                .setup_melt(
+                    &melt_request,
+                    verification,
+                    PaymentMethod::Known(KnownMethod::Bolt11),
+                )
+                .await
+                .unwrap();
+            let operation_id = assert_single_melt_saga_operation_id(&mint).await;
+            drop(setup_saga);
+
+            let mut tx = mint.localstore.begin_transaction().await.unwrap();
+            let mut acquired_saga = tx
+                .get_saga_for_update(&operation_id)
+                .await
+                .unwrap()
+                .expect("saga should exist");
+            tx.update_acquired_saga(&mut acquired_saga, SagaStateEnum::Melt(saga_state.clone()))
+                .await
+                .unwrap();
+            tx.commit().await.unwrap();
+
+            let saga = assert_saga_exists(&mint, &operation_id).await;
+            let mut quote = mint
+                .localstore
+                .get_melt_quote(&quote.id)
+                .await
+                .unwrap()
+                .expect("quote should exist");
+            let lookup_id = quote
+                .request_lookup_id
+                .clone()
+                .expect("bolt11 quote should have a lookup id");
+            let unknown_response = MakePaymentResponse {
+                payment_lookup_id: lookup_id.clone(),
+                payment_proof: None,
+                status: MeltQuoteState::Unknown,
+                total_spent: quote.amount(),
+            };
+
+            process_melt_saga_outcome(
+                &saga,
+                &mut quote,
+                &unknown_response,
+                &mint.localstore,
+                &mint.pubsub_manager,
+                &mint,
+            )
+            .await
+            .unwrap();
+
+            let stored_saga = assert_saga_exists(&mint, &operation_id).await;
+            assert_eq!(stored_saga.state, SagaStateEnum::Melt(saga_state.clone()));
+            assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
+            assert_eq!(quote.state, MeltQuoteState::Pending);
+
+            let failed_response = MakePaymentResponse {
+                payment_lookup_id: lookup_id,
+                payment_proof: None,
+                status: MeltQuoteState::Failed,
+                total_spent: quote.amount(),
+            };
+            process_melt_saga_failure_event(
+                &stored_saga,
+                &mut quote,
+                &failed_response,
+                &mint.localstore,
+                &mint.pubsub_manager,
+                &mint,
+            )
+            .await
+            .unwrap();
+
+            assert_saga_not_exists(&mint, &operation_id).await;
+            assert_proofs_state(&mint, &input_ys, None).await;
+            assert_eq!(quote.state, MeltQuoteState::Unpaid);
+        }
+    }
+
+    /// A terminal `Unpaid`/`Failed` poll is an authoritative outcome by
+    /// backend contract: the negative observation is persisted as
+    /// `PaymentFailed` and the melt is compensated from either dispatch
+    /// marker, without waiting for a permanent-failure event.
+    #[tokio::test]
+    async fn test_terminal_poll_compensates_dispatched_payment() {
         for saga_state in [
             MeltSagaState::PaymentAttempted,
             MeltSagaState::PaymentPending,
@@ -934,42 +990,17 @@ mod tests {
                 .await
                 .unwrap();
 
-                match saga_state {
-                    MeltSagaState::PaymentAttempted => {
-                        let stored_saga = assert_saga_exists(&mint, &operation_id).await;
-                        assert_eq!(
-                            stored_saga.state,
-                            SagaStateEnum::Melt(MeltSagaState::PaymentAttempted)
-                        );
-                        assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
-                        assert_eq!(quote.state, MeltQuoteState::Pending);
+                assert_saga_not_exists(&mint, &operation_id).await;
+                assert_proofs_state(&mint, &input_ys, None).await;
+                assert_eq!(quote.state, MeltQuoteState::Unpaid);
 
-                        process_melt_saga_failure_event(
-                            &stored_saga,
-                            &mut quote,
-                            &payment_response,
-                            &mint.localstore,
-                            &mint.pubsub_manager,
-                            &mint,
-                        )
-                        .await
-                        .unwrap();
-
-                        let stored_saga = assert_saga_exists(&mint, &operation_id).await;
-                        assert_eq!(
-                            stored_saga.state,
-                            SagaStateEnum::Melt(MeltSagaState::PaymentAttempted)
-                        );
-                        assert_proofs_state(&mint, &input_ys, Some(State::Pending)).await;
-                        assert_eq!(quote.state, MeltQuoteState::Pending);
-                    }
-                    MeltSagaState::PaymentPending => {
-                        assert_saga_not_exists(&mint, &operation_id).await;
-                        assert_proofs_state(&mint, &input_ys, None).await;
-                        assert_eq!(quote.state, MeltQuoteState::Unpaid);
-                    }
-                    state => panic!("unexpected test saga state: {state}"),
-                }
+                let persisted_quote = mint
+                    .localstore
+                    .get_melt_quote(&quote.id)
+                    .await
+                    .unwrap()
+                    .expect("quote should still exist after rollback");
+                assert_eq!(persisted_quote.state, MeltQuoteState::Unpaid);
             }
         }
     }
@@ -1341,8 +1372,9 @@ mod tests {
             amount_msats,
             serde_json::to_string(&fake_description).unwrap(),
         );
-        // The fresh backend re-check confirms the failure, so compensation
-        // proceeds all the way to the rollback guard.
+        // The negative observation is authoritative, but persisting the
+        // failure must reach the Finalizing guard without changing the
+        // already-finalizing saga.
         let payment_states = std::collections::HashMap::from([(
             invoice.payment_hash().to_string(),
             (

--- a/crates/cdk/src/mint/start_up_check.rs
+++ b/crates/cdk/src/mint/start_up_check.rs
@@ -390,9 +390,10 @@ impl Mint {
     /// - **Finalize**: If payment was confirmed as PAID on the payment backend, the
     ///   saga already reached `Finalizing`, or the melt settled internally
     /// - **Compensate**: If the saga is `SetupComplete` (payment never
-    ///   attempted), or the backend confirms `Unpaid`/`Failed`
-    /// - **Skip**: If payment is `Pending`/`Unknown`, or its status cannot be
-    ///   verified
+    ///   attempted), or `PaymentFailed` (authoritative failure was recorded),
+    ///   or the backend reports an authoritative `Unpaid`/`Failed` status
+    /// - **Skip**: For `Pending`/`Unknown` polling results, which are not
+    ///   authoritative because an orchestrator may be between attempts
     ///
     /// This recovery handles SetupComplete state which means:
     /// - Proofs were reserved (marked as PENDING)
@@ -409,7 +410,9 @@ impl Mint {
     /// 2. Mint crashed before finalize() committed
     /// 3. Recovery compensated (returned proofs) instead of finalizing
     ///
-    /// Now we check the payment backend payment status before deciding whether to compensate or finalize.
+    /// Recovery checks backend status to finalize a paid result, and to
+    /// compensate an authoritative `Unpaid`/`Failed` result. `Pending` and
+    /// `Unknown` cannot compensate a payment that may still be retried.
     pub async fn recover_from_incomplete_melt_sagas(&self) -> Result<(), Error> {
         let incomplete_sagas = self
             .localstore
@@ -579,6 +582,13 @@ impl Mint {
                             // Setup complete but payment never attempted - always compensate
                             tracing::info!(
                                 "Saga {} in SetupComplete state - payment never attempted, will compensate",
+                                saga.operation_id
+                            );
+                            true
+                        }
+                        cdk_common::mint::MeltSagaState::PaymentFailed => {
+                            tracing::info!(
+                                "Saga {} has an authoritative payment failure - will compensate",
                                 saga.operation_id
                             );
                             true
@@ -757,6 +767,9 @@ impl Mint {
                                 continue; // Saga handled
                             }
                             MeltQuoteState::Unpaid | MeltQuoteState::Failed => {
+                                // A negative status is an authoritative
+                                // terminal result by backend contract (see
+                                // MintPayment::check_outgoing_payment).
                                 if let Err(err) = super::saga_recovery::process_melt_saga_outcome(
                                     &saga,
                                     &mut quote,
@@ -777,7 +790,8 @@ impl Mint {
                                 continue; // Saga handled
                             }
                             MeltQuoteState::Pending | MeltQuoteState::Unknown => {
-                                // Payment still pending - skip for check_pending_melt_quotes
+                                // Not authoritative: an orchestrator may be
+                                // between payment attempts.
                                 tracing::info!(
                                     "Saga {} for quote {} - payment {} on the payment backend, skipping",
                                     saga.operation_id,
@@ -810,16 +824,37 @@ impl Mint {
                     blinded_secrets.len()
                 );
 
-                if let Err(err) = super::melt::shared::rollback_setup_melt_quote(
-                    &self.localstore,
-                    &self.pubsub_manager,
-                    &quote_id_parsed,
-                    &input_ys,
-                    &blinded_secrets,
-                    &saga.operation_id,
-                )
-                .await
-                {
+                let rollback = match &saga.state {
+                    cdk_common::mint::SagaStateEnum::Melt(
+                        cdk_common::mint::MeltSagaState::SetupComplete,
+                    ) => {
+                        super::melt::shared::rollback_setup_melt_quote(
+                            &self.localstore,
+                            &self.pubsub_manager,
+                            &quote_id_parsed,
+                            &input_ys,
+                            &blinded_secrets,
+                            &saga.operation_id,
+                        )
+                        .await
+                    }
+                    cdk_common::mint::SagaStateEnum::Melt(
+                        cdk_common::mint::MeltSagaState::PaymentFailed,
+                    ) => {
+                        super::melt::shared::rollback_failed_melt_quote(
+                            &self.localstore,
+                            &self.pubsub_manager,
+                            &quote_id_parsed,
+                            &input_ys,
+                            &blinded_secrets,
+                            &saga.operation_id,
+                        )
+                        .await
+                    }
+                    _ => continue,
+                };
+
+                if let Err(err) = rollback {
                     tracing::error!(
                         "Failed to rollback melt quote {} for saga {}: {}",
                         quote_id_parsed,
@@ -869,6 +904,18 @@ impl Mint {
                 return Ok(());
             }
         };
+
+        if saga.state
+            == cdk_common::mint::SagaStateEnum::Melt(cdk_common::mint::MeltSagaState::PaymentFailed)
+        {
+            return super::saga_recovery::recover_recorded_payment_failure(
+                &saga,
+                quote,
+                &self.localstore,
+                &self.pubsub_manager,
+            )
+            .await;
+        }
 
         // An internal settlement commits the mint-quote credit and marks this
         // quote Paid in one transaction, so the quote may be Paid here while


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
