### PR TITLE
Source keyset unit and expiry from the info

### DIFF
--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -728,6 +728,62 @@ mod test {
         );
     }
 
+    /// Keyset rows are insert-only today, so the mutated info is handed to
+    /// `publish_snapshot` directly rather than written to storage.
+    #[tokio::test]
+    async fn reload_publishes_info_final_expiry_over_cached_key() {
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let signatory = DbSignatory::new(
+            store,
+            b"test-seed-snapshot-final-expiry",
+            Default::default(),
+            Default::default(),
+        )
+        .await
+        .expect("DbSignatory::new");
+
+        let rotated = signatory
+            .rotate_keyset(RotateKeyArguments {
+                unit: CurrencyUnit::Sat,
+                amounts: vec![1, 2, 4, 8],
+                input_fee_ppk: 0,
+                keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                final_expiry: Some(unix_time() + 1_000),
+            })
+            .await
+            .expect("rotate_keyset");
+
+        let (epoch, active, mut info) = {
+            let current = signatory.keysets.load();
+            let epoch = current.epoch.expect("snapshot is loaded");
+            let (info, _) = current
+                .by_id
+                .get(&rotated.id)
+                .expect("rotated keyset is in the snapshot");
+            (epoch, current.active_by_unit.clone(), info.clone())
+        };
+
+        let new_expiry = Some(unix_time() + 9_000);
+        info.final_expiry = new_expiry;
+        signatory.publish_snapshot(epoch + 1, active, vec![info]);
+
+        let published = signatory
+            .keysets_snapshot()
+            .keysets
+            .into_iter()
+            .find(|k| k.id == rotated.id)
+            .expect("rotated keyset is published");
+
+        assert_eq!(
+            published.final_expiry, new_expiry,
+            "published keyset must carry the info's final_expiry, not the cached key's"
+        );
+    }
+
     #[tokio::test]
     async fn subscribe_keysets_pushes_rotation() {
         let store = Arc::new(

--- a/crates/cdk-signatory/src/signatory.rs
+++ b/crates/cdk-signatory/src/signatory.rs
@@ -116,17 +116,20 @@ impl From<SignatoryKeySet> for MintKeySetInfo {
     }
 }
 
+/// The info is authoritative for every field but the key material: a reload
+/// reuses the already-derived [`MintKeySet`] while re-reading the info, so
+/// sourcing anything else from the key would publish a stale value.
 impl From<&(MintKeySetInfo, MintKeySet)> for SignatoryKeySet {
     fn from((info, key): &(MintKeySetInfo, MintKeySet)) -> Self {
         Self {
             id: info.id,
-            unit: key.unit.clone(),
+            unit: info.unit.clone(),
             active: info.active,
             input_fee_ppk: info.input_fee_ppk,
             amounts: info.amounts.clone(),
             keys: key.keys.clone().into(),
             version: info.derivation_path_index.unwrap_or(1),
-            final_expiry: key.final_expiry,
+            final_expiry: info.final_expiry,
             issuer_version: info.issuer_version.clone(),
         }
     }
@@ -173,6 +176,8 @@ mod tests {
     use std::collections::BTreeMap;
     use std::str::FromStr;
 
+    use bitcoin::bip32::DerivationPath;
+    use bitcoin::secp256k1::Secp256k1;
     use cdk_common::nuts::nut01::Keys;
     use cdk_common::util::unix_time;
     use cdk_common::{CurrencyUnit, Id};
@@ -222,5 +227,46 @@ mod tests {
     fn test_is_expired_zero() {
         let ks = dummy_signatory_keyset(Some(0));
         assert!(ks.is_expired());
+    }
+
+    #[test]
+    fn conversion_prefers_info_over_cached_key() {
+        let path = DerivationPath::from_str("m/0'/0'/0'").unwrap();
+        let key = MintKeySet::generate_from_seed(
+            &Secp256k1::new(),
+            b"test-seed-conversion",
+            &[1, 2, 4, 8],
+            CurrencyUnit::Usd,
+            path.clone(),
+            0,
+            Some(222),
+            KeySetVersion::Version00,
+        );
+
+        let info = MintKeySetInfo {
+            id: key.id,
+            unit: CurrencyUnit::Sat,
+            active: true,
+            valid_from: 0,
+            derivation_path: path,
+            derivation_path_index: Some(1),
+            amounts: vec![1, 2, 4, 8],
+            input_fee_ppk: 0,
+            final_expiry: Some(111),
+            issuer_version: None,
+        };
+
+        let keyset: SignatoryKeySet = (&(info, key)).into();
+
+        assert_eq!(
+            keyset.unit,
+            CurrencyUnit::Sat,
+            "unit must come from the keyset info, not the cached key"
+        );
+        assert_eq!(
+            keyset.final_expiry,
+            Some(111),
+            "final_expiry must come from the keyset info, not the cached key"
+        );
     }
 }


### PR DESCRIPTION


### Description

A reload reuses the already-derived MintKeySet keyed by id while re-reading the keyset info from the database, so any field taken from the cached key can go stale. unit and final_expiry were the only two still key-sourced, so a divergence would have been published to wallets.

No supported flow can trigger it today (rotation is the only writer, rows are insert-only, and blind_sign gates on the info), but make the info authoritative for everything but the key material and pin it with tests.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
