### PR TITLE
fix(wallet): bound untrusted input sizes

### DIFF
--- a/crates/cashu/src/amount.rs
+++ b/crates/cashu/src/amount.rs
@@ -14,6 +14,13 @@ use thiserror::Error;
 use crate::nuts::CurrencyUnit;
 use crate::Id;
 
+/// Maximum number of outputs produced by a local amount split.
+///
+/// This protocol-independent ceiling applies to both wallet and mint code to
+/// bound allocations. Mints may configure a lower request limit, but cannot
+/// configure a higher limit than this local ceiling.
+pub const MAX_SPLIT_OUTPUTS: usize = 4096;
+
 /// Amount Error
 #[derive(Debug, Error)]
 pub enum Error {
@@ -41,6 +48,14 @@ pub enum Error {
     /// Cannot represent amount with available denominations
     #[error("Cannot represent amount {0} with available denominations (got {1})")]
     CannotSplitAmount(u64, u64),
+    /// Splitting the amount would create too many outputs
+    #[error("Amount split would create {actual} outputs, maximum is {max}")]
+    SplitOutputLimitExceeded {
+        /// Number of outputs the split would create
+        actual: u64,
+        /// Maximum number of outputs allowed in one split
+        max: usize,
+    },
 }
 
 /// Amount can be any unit
@@ -209,18 +224,25 @@ impl Amount<()> {
             ));
         }
 
-        let parts: Vec<Self> = fee_and_amounts
-            .amounts
-            .iter()
-            .rev()
-            .fold((Vec::new(), self.value), |(mut acc, total), &amount| {
-                let count = total / amount;
-                for _ in 0..count {
-                    acc.push(Self::from(amount));
-                }
-                (acc, total % amount)
-            })
-            .0;
+        let mut parts = Vec::new();
+        let mut total = self.value;
+
+        for &amount in fee_and_amounts.amounts.iter().rev() {
+            let count = total / amount;
+            let output_count = u64::try_from(parts.len())
+                .ok()
+                .and_then(|len| len.checked_add(count))
+                .ok_or(Error::AmountOverflow)?;
+            if output_count > MAX_SPLIT_OUTPUTS as u64 {
+                return Err(Error::SplitOutputLimitExceeded {
+                    actual: output_count,
+                    max: MAX_SPLIT_OUTPUTS,
+                });
+            }
+
+            parts.extend((0..count).map(|_| Self::from(amount)));
+            total %= amount;
+        }
 
         let sum: u64 = parts.iter().map(|a| a.value).sum();
         if sum != self.value {
@@ -258,14 +280,32 @@ impl Amount<()> {
                 while parts_total.lt(self) {
                     for part in parts_of_value.iter().copied() {
                         if (part.checked_add(parts_total).ok_or(Error::AmountOverflow)?).le(self) {
+                            if parts.len() == MAX_SPLIT_OUTPUTS {
+                                return Err(Error::SplitOutputLimitExceeded {
+                                    actual: MAX_SPLIT_OUTPUTS as u64 + 1,
+                                    max: MAX_SPLIT_OUTPUTS,
+                                });
+                            }
                             parts.push(part);
+                            parts_total =
+                                parts_total.checked_add(part).ok_or(Error::AmountOverflow)?;
                         } else {
                             let amount_left =
                                 self.checked_sub(parts_total).ok_or(Error::AmountOverflow)?;
-                            parts.extend(amount_left.split(fee_and_amounts)?);
+                            let remainder = amount_left.split(fee_and_amounts)?;
+                            let output_count = parts
+                                .len()
+                                .checked_add(remainder.len())
+                                .ok_or(Error::AmountOverflow)?;
+                            if output_count > MAX_SPLIT_OUTPUTS {
+                                return Err(Error::SplitOutputLimitExceeded {
+                                    actual: output_count as u64,
+                                    max: MAX_SPLIT_OUTPUTS,
+                                });
+                            }
+                            parts.extend(remainder);
+                            parts_total = *self;
                         }
-
-                        parts_total = Amount::try_sum(parts.clone().iter().copied())?;
 
                         if parts_total.eq(self) {
                             break;
@@ -276,6 +316,12 @@ impl Amount<()> {
                 parts
             }
             SplitTarget::Values(values) => {
+                if values.len() > MAX_SPLIT_OUTPUTS {
+                    return Err(Error::SplitOutputLimitExceeded {
+                        actual: values.len() as u64,
+                        max: MAX_SPLIT_OUTPUTS,
+                    });
+                }
                 let values_total: Amount = Amount::try_sum(values.clone())?;
 
                 match self.cmp(&values_total) {
@@ -288,6 +334,18 @@ impl Amount<()> {
                             .checked_sub(values_total)
                             .ok_or(Error::AmountOverflow)?;
                         let mut extra_amount = extra.split(fee_and_amounts)?;
+
+                        let output_count = values
+                            .len()
+                            .checked_add(extra_amount.len())
+                            .ok_or(Error::AmountOverflow)?;
+                        if output_count > MAX_SPLIT_OUTPUTS {
+                            return Err(Error::SplitOutputLimitExceeded {
+                                actual: output_count as u64,
+                                max: MAX_SPLIT_OUTPUTS,
+                            });
+                        }
+
                         let mut values = values.clone();
 
                         values.append(&mut extra_amount);
@@ -753,6 +811,77 @@ mod tests {
             .map(|a| Amount::from(*a))
             .collect();
         assert_eq!(Amount::from(255).split(&fee_and_amounts).unwrap(), amounts);
+    }
+
+    #[test]
+    fn test_split_enforces_output_budget() {
+        let fee_and_amounts = (0, vec![1]).into();
+
+        let at_limit = Amount::from(MAX_SPLIT_OUTPUTS as u64)
+            .split(&fee_and_amounts)
+            .unwrap();
+        assert_eq!(at_limit.len(), MAX_SPLIT_OUTPUTS);
+
+        assert!(matches!(
+            Amount::from(MAX_SPLIT_OUTPUTS as u64 + 1).split(&fee_and_amounts),
+            Err(Error::SplitOutputLimitExceeded {
+                actual,
+                max: MAX_SPLIT_OUTPUTS,
+            }) if actual == MAX_SPLIT_OUTPUTS as u64 + 1
+        ));
+    }
+
+    #[test]
+    fn test_split_rejects_large_output_count_before_allocation() {
+        let fee_and_amounts = (0, vec![1]).into();
+
+        assert!(matches!(
+            Amount::from(u64::MAX).split(&fee_and_amounts),
+            Err(Error::SplitOutputLimitExceeded {
+                actual: u64::MAX,
+                max: MAX_SPLIT_OUTPUTS,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_targeted_split_enforces_output_budget() {
+        let fee_and_amounts = (0, vec![1]).into();
+
+        assert!(matches!(
+            Amount::from(MAX_SPLIT_OUTPUTS as u64 + 1)
+                .split_targeted(&SplitTarget::Value(Amount::ONE), &fee_and_amounts),
+            Err(Error::SplitOutputLimitExceeded {
+                max: MAX_SPLIT_OUTPUTS,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_values_split_with_change_enforces_output_budget() {
+        let fee_and_amounts = (0, vec![1]).into();
+
+        // MAX - 1 requested values plus one change output hits the limit.
+        let at_limit = Amount::from(MAX_SPLIT_OUTPUTS as u64)
+            .split_targeted(
+                &SplitTarget::Values(vec![Amount::ONE; MAX_SPLIT_OUTPUTS - 1]),
+                &fee_and_amounts,
+            )
+            .expect("combined outputs at the limit");
+        assert_eq!(at_limit.len(), MAX_SPLIT_OUTPUTS);
+
+        // MAX requested values plus one change output exceeds the limit.
+        assert!(matches!(
+            Amount::from(MAX_SPLIT_OUTPUTS as u64 + 1).split_targeted(
+                &SplitTarget::Values(vec![Amount::ONE; MAX_SPLIT_OUTPUTS]),
+                &fee_and_amounts
+            ),
+            Err(Error::SplitOutputLimitExceeded {
+                max: MAX_SPLIT_OUTPUTS,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/cdk-cli/src/sub_commands/check_requests.rs
+++ b/crates/cdk-cli/src/sub_commands/check_requests.rs
@@ -1,16 +1,54 @@
+use std::collections::HashSet;
 use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::Result;
 use cdk::mint_url::MintUrl;
 use cdk::nuts::Token;
+use cdk::wallet::payment_request::parse_nostr_payment_payload;
 use cdk::wallet::{ReceiveOptions, WalletRepository};
-use cdk_common::PaymentRequestPayload;
-use nostr_sdk::{Filter, Keys, Kind, PublicKey, SecretKey};
+use nostr_sdk::{Filter, Keys, Kind, PublicKey, SecretKey, Timestamp};
 
 use super::create_request::StoredNostrWaitInfo;
 use crate::terminal::escape_control;
 use crate::utils::get_or_create_wallet;
+
+/// Maximum relay events inspected for any one persisted request.
+///
+/// This bounds work for legacy records whose safe time range starts at the
+/// Unix epoch without introducing another time cutoff that could hide a
+/// still-pending payment.
+const NOSTR_MAX_EVENTS_PER_REQUEST: usize = 256;
+
+fn payment_events_filter(pubkey: PublicKey, since: Timestamp, until: Option<Timestamp>) -> Filter {
+    let filter = Filter::new()
+        .pubkey(pubkey)
+        .kind(Kind::GiftWrap)
+        .since(since)
+        .limit(NOSTR_MAX_EVENTS_PER_REQUEST);
+
+    match until {
+        Some(until) => filter.until(until),
+        None => filter,
+    }
+}
+
+fn next_history_until(
+    since: Timestamp,
+    event_timestamps: impl IntoIterator<Item = Timestamp>,
+    page_len: usize,
+) -> u64 {
+    if page_len < NOSTR_MAX_EVENTS_PER_REQUEST {
+        return since.as_secs();
+    }
+
+    event_timestamps
+        .into_iter()
+        .map(|timestamp| timestamp.as_secs())
+        .min()
+        .unwrap_or_else(|| since.as_secs())
+        .max(since.as_secs())
+}
 
 fn unaccepted_mint_warning(request_id: &str, mint_url: &MintUrl) -> String {
     format!(
@@ -42,7 +80,7 @@ pub async fn check_requests(wallet_repository: &WalletRepository) -> Result<()> 
                 .kv_read("cdk_cli", "pending_nostr_requests", &key)
                 .await?
             {
-                let info: StoredNostrWaitInfo = serde_json::from_slice(&val)?;
+                let mut info: StoredNostrWaitInfo = serde_json::from_slice(&val)?;
 
                 let secret_key = SecretKey::from_str(&info.secret_key_hex)?;
                 let keys = Keys::new(secret_key);
@@ -54,14 +92,58 @@ pub async fn check_requests(wallet_repository: &WalletRepository) -> Result<()> 
                 }
                 client.connect().await;
 
-                let filter = Filter::new().pubkey(pubkey).kind(Kind::GiftWrap);
-                let events = client.fetch_events(filter, Duration::from_secs(10)).await?;
+                let since = info.nostr_query_since(Timestamp::now().as_secs());
+                let fresh_filter = payment_events_filter(pubkey, since, None);
+                let fresh_events = client
+                    .fetch_events(fresh_filter, Duration::from_secs(10))
+                    .await?
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                let mut events = fresh_events.clone();
 
+                let mut history_page =
+                    match info.history_until.filter(|until| *until > since.as_secs()) {
+                        Some(until) => {
+                            let filter =
+                                payment_events_filter(pubkey, since, Some(Timestamp::from(until)));
+                            Some(
+                                client
+                                    .fetch_events(filter, Duration::from_secs(10))
+                                    .await?
+                                    .iter()
+                                    .cloned()
+                                    .collect::<Vec<_>>(),
+                            )
+                        }
+                        None => None,
+                    };
+                let cursor_page = history_page.as_ref().unwrap_or(&fresh_events);
+                let next_history_cursor = next_history_until(
+                    since,
+                    cursor_page.iter().map(|event| event.created_at),
+                    cursor_page.len(),
+                );
+                let next_boundary_event_ids = cursor_page
+                    .iter()
+                    .filter(|event| event.created_at.as_secs() == next_history_cursor)
+                    .map(|event| event.id.to_hex())
+                    .collect();
+                if let Some(history_page) = history_page.as_mut() {
+                    history_page.retain(|event| {
+                        !info.history_boundary_event_ids.contains(&event.id.to_hex())
+                    });
+                }
+                if let Some(history_page) = history_page {
+                    events.extend(history_page);
+                }
+                let mut seen_event_ids = HashSet::new();
+                events.retain(|event| seen_event_ids.insert(event.id));
+
+                let mut receive_failed = false;
                 for event in events {
                     if let Ok(unwrapped) = client.unwrap_gift_wrap(&event).await {
-                        if let Ok(payload) =
-                            serde_json::from_str::<PaymentRequestPayload>(&unwrapped.rumor.content)
-                        {
+                        if let Ok(payload) = parse_nostr_payment_payload(&unwrapped.rumor.content) {
                             if !info.accepts_mint(&payload.mint) {
                                 tracing::warn!("{}", unaccepted_mint_warning(&key, &payload.mint));
                                 continue;
@@ -79,16 +161,21 @@ pub async fn check_requests(wallet_repository: &WalletRepository) -> Result<()> 
                             let unit = token.unit().unwrap_or_default();
 
                             // Get or create wallet for the token's mint
-                            let wallet =
+                            let receive_wallet =
                                 get_or_create_wallet(wallet_repository, &mint_url, &unit).await?;
 
-                            match wallet.receive(&token_str, ReceiveOptions::default()).await {
+                            match receive_wallet
+                                .receive(&token_str, ReceiveOptions::default())
+                                .await
+                            {
                                 Ok(amount) => {
                                     if amount > cdk::Amount::ZERO {
                                         println!("Received {} from request {}", amount, key);
                                     }
                                 }
                                 Err(e) => {
+                                    receive_failed |= !e.is_definitive_failure()
+                                        && !matches!(&e, cdk::Error::TokenAlreadySpent);
                                     // Silently ignore already claimed proofs if that's what the error is
                                     // or print if it's something else.
                                     // For now, let's just log it.
@@ -102,6 +189,16 @@ pub async fn check_requests(wallet_repository: &WalletRepository) -> Result<()> 
                         }
                     }
                 }
+
+                if !receive_failed {
+                    info.history_until = Some(next_history_cursor);
+                    info.history_boundary_event_ids = next_boundary_event_ids;
+                }
+                let val = serde_json::to_vec(&info)?;
+                wallet
+                    .localstore
+                    .kv_write("cdk_cli", "pending_nostr_requests", &key, &val)
+                    .await?;
             }
         }
     }
@@ -128,5 +225,47 @@ mod tests {
         assert!(!output
             .chars()
             .any(|ch| { ch.is_control() || cdk_common::terminal::is_bidi_control_character(ch) }));
+    }
+
+    #[test]
+    fn payment_event_filter_bounds_events_without_an_end_time() {
+        let pubkey = Keys::generate().public_key();
+        let filter = payment_events_filter(pubkey, Timestamp::from(0), None);
+        let value = serde_json::to_value(filter).expect("filter should serialize");
+
+        assert_eq!(
+            value.get("limit").and_then(serde_json::Value::as_u64),
+            Some(NOSTR_MAX_EVENTS_PER_REQUEST as u64)
+        );
+        assert!(value.get("until").is_none());
+        assert_eq!(
+            value.get("since").and_then(serde_json::Value::as_u64),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn history_cursor_moves_backward_one_bounded_page_at_a_time() {
+        let since = Timestamp::from(100);
+        let timestamps = [Timestamp::from(500), Timestamp::from(300)];
+
+        assert_eq!(
+            next_history_until(since, timestamps, NOSTR_MAX_EVENTS_PER_REQUEST),
+            300
+        );
+        assert_eq!(next_history_until(since, timestamps, 2), 100);
+    }
+
+    #[test]
+    fn historical_filter_has_inclusive_upper_cursor() {
+        let pubkey = Keys::generate().public_key();
+        let filter =
+            payment_events_filter(pubkey, Timestamp::from(100), Some(Timestamp::from(299)));
+        let value = serde_json::to_value(filter).expect("filter should serialize");
+
+        assert_eq!(
+            value.get("until").and_then(serde_json::Value::as_u64),
+            Some(299)
+        );
     }
 }

--- a/crates/cdk-cli/src/sub_commands/create_request.rs
+++ b/crates/cdk-cli/src/sub_commands/create_request.rs
@@ -14,11 +14,36 @@ pub(super) struct StoredNostrWaitInfo {
     pub(super) mints: Vec<MintUrl>,
     #[serde(default)]
     pub(super) mint_preferred: Option<bool>,
+    /// Time at which this request started accepting payments.
+    ///
+    /// Old records omit this field and are queried from the Unix epoch so a
+    /// still-pending payment is not silently missed.
+    #[serde(default)]
+    pub(super) created_at: Option<u64>,
+    /// Inclusive upper timestamp for the next backward history page.
+    #[serde(default)]
+    pub(super) history_until: Option<u64>,
+    /// Event IDs already processed at the inclusive history boundary.
+    #[serde(default)]
+    pub(super) history_boundary_event_ids: Vec<String>,
 }
 
 impl StoredNostrWaitInfo {
     pub(super) fn accepts_mint(&self, mint_url: &MintUrl) -> bool {
         self.mints.is_empty() || self.mint_preferred == Some(true) || self.mints.contains(mint_url)
+    }
+
+    pub(super) fn nostr_query_since(&self, now: u64) -> nostr_sdk::Timestamp {
+        // NIP-59 gift wraps deliberately backdate their timestamps by up to
+        // two days. Include that overlap so an immediate payment is visible.
+        const GIFT_WRAP_BACKDATE_SECS: u64 = 2 * 24 * 60 * 60;
+
+        nostr_sdk::Timestamp::from(
+            self.created_at
+                .unwrap_or_default()
+                .min(now)
+                .saturating_sub(GIFT_WRAP_BACKDATE_SECS),
+        )
     }
 }
 
@@ -30,6 +55,9 @@ impl From<NostrWaitInfo> for StoredNostrWaitInfo {
             pubkey_hex: info.pubkey.to_hex(),
             mints: info.mints,
             mint_preferred: info.mint_preferred,
+            created_at: Some(nostr_sdk::Timestamp::now().as_secs()),
+            history_until: None,
+            history_boundary_event_ids: Vec::new(),
         }
     }
 }
@@ -196,6 +224,9 @@ mod tests {
 
         assert!(info.mints.is_empty());
         assert!(info.mint_preferred.is_none());
+        assert!(info.created_at.is_none());
+        assert!(info.history_until.is_none());
+        assert_eq!(info.nostr_query_since(123), nostr_sdk::Timestamp::from(0));
     }
 
     #[test]
@@ -218,6 +249,24 @@ mod tests {
             pubkey_hex: "pubkey".to_string(),
             mints,
             mint_preferred,
+            created_at: Some(100),
+            history_until: None,
+            history_boundary_event_ids: Vec::new(),
         }
+    }
+
+    #[test]
+    fn stored_request_queries_from_creation_without_seven_day_cutoff() {
+        let mut info = stored_info(vec![], None);
+        info.created_at = Some(1_000_000);
+
+        assert_eq!(
+            info.nostr_query_since(2_000_000),
+            nostr_sdk::Timestamp::from(827_200)
+        );
+        assert_eq!(
+            info.nostr_query_since(900_000),
+            nostr_sdk::Timestamp::from(727_200)
+        );
     }
 }

--- a/crates/cdk-cli/src/sub_commands/receive.rs
+++ b/crates/cdk-cli/src/sub_commands/receive.rs
@@ -16,6 +16,9 @@ use crate::nostr_storage;
 use crate::terminal::escape_control;
 use crate::utils::get_or_create_wallet;
 
+/// Default query window when no explicit or persisted cursor is available.
+const NOSTR_LOOKBACK_SECS: u64 = 7 * 24 * 60 * 60;
+
 #[derive(Args)]
 pub struct ReceiveSubCommand {
     /// Cashu Token
@@ -94,8 +97,11 @@ pub async fn receive(
             signing_keys.push(nostr_key.clone());
 
             let relays = sub_command_args.relay.clone();
-            let since =
+            let stored_since =
                 nostr_storage::get_nostr_last_checked(work_dir, &nostr_key.public_key()).await?;
+            let since = sub_command_args
+                .since
+                .or_else(|| stored_since.map(u64::from));
 
             let tokens = nostr_receive(relays, nostr_key.clone(), since).await?;
 
@@ -182,7 +188,7 @@ async fn receive_token(
 async fn nostr_receive(
     relays: Vec<String>,
     nostr_signing_key: SecretKey,
-    since: Option<u32>,
+    since: Option<u64>,
 ) -> Result<HashSet<String>> {
     let verifying_key = nostr_signing_key.public_key();
 
@@ -190,17 +196,16 @@ async fn nostr_receive(
 
     let nostr_pubkey = nostr_sdk::PublicKey::from_hex(&x_only_pubkey.to_string())?;
 
-    let since = since.map(|s| Timestamp::from(s as u64));
+    let since = since.unwrap_or_else(|| {
+        Timestamp::now()
+            .as_secs()
+            .saturating_sub(NOSTR_LOOKBACK_SECS)
+    });
 
-    let filter = match since {
-        Some(since) => Filter::new()
-            .pubkey(nostr_pubkey)
-            .kind(Kind::EncryptedDirectMessage)
-            .since(since),
-        None => Filter::new()
-            .pubkey(nostr_pubkey)
-            .kind(Kind::EncryptedDirectMessage),
-    };
+    let filter = Filter::new()
+        .pubkey(nostr_pubkey)
+        .kind(Kind::EncryptedDirectMessage)
+        .since(Timestamp::from(since));
 
     let client = nostr_sdk::Client::default();
 

--- a/crates/cdk-ffi/src/lib.rs
+++ b/crates/cdk-ffi/src/lib.rs
@@ -41,6 +41,19 @@ pub use types::*;
 pub use wallet::*;
 pub use wallet_repository::*;
 
+/// Reject proof-count targets that could cause excessive wallet work.
+fn validate_target_proof_count(target_proof_count: Option<u32>) -> Result<Option<u32>, FfiError> {
+    match target_proof_count {
+        Some(count) if count as usize > cdk::wallet::MAX_TARGET_PROOF_COUNT => {
+            Err(FfiError::internal(format!(
+                "target_proof_count must be at most {}",
+                cdk::wallet::MAX_TARGET_PROOF_COUNT
+            )))
+        }
+        count => Ok(count),
+    }
+}
+
 uniffi::setup_scaffolding!();
 
 #[cfg(test)]
@@ -57,6 +70,13 @@ mod tests {
 
         let zero = Amount::zero();
         assert!(zero.is_zero());
+    }
+
+    #[test]
+    fn target_proof_count_is_bounded() {
+        let max = cdk::wallet::MAX_TARGET_PROOF_COUNT as u32;
+        assert!(validate_target_proof_count(Some(max)).is_ok());
+        assert!(validate_target_proof_count(Some(u32::MAX)).is_err());
     }
 
     #[test]

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -62,6 +62,8 @@ impl Wallet {
         store: crate::database::WalletStore,
         config: WalletConfig,
     ) -> Result<Self, FfiError> {
+        let target_proof_count =
+            crate::validate_target_proof_count(config.target_proof_count)?.unwrap_or(3);
         let db = crate::database::resolve_wallet_store(store)?;
         let localstore = crate::database::create_cdk_database_from_ffi(db);
 
@@ -84,7 +86,7 @@ impl Wallet {
             .unit(unit.into())
             .localstore(localstore)
             .seed(seed)
-            .target_proof_count(config.target_proof_count.unwrap_or(3) as usize);
+            .target_proof_count(target_proof_count as usize);
 
         if let Some(config) = pace_with {
             builder = builder.with_rate_limiting_config(config);

--- a/crates/cdk-ffi/src/wallet_repository.rs
+++ b/crates/cdk-ffi/src/wallet_repository.rs
@@ -217,6 +217,7 @@ impl WalletRepository {
         unit: Option<CurrencyUnit>,
         target_proof_count: Option<u32>,
     ) -> Result<(), FfiError> {
+        let target_proof_count = crate::validate_target_proof_count(target_proof_count)?;
         let cdk_mint_url: cdk::mint_url::MintUrl = mint_url.try_into()?;
 
         let config = target_proof_count.map(|count| {
@@ -243,6 +244,7 @@ impl WalletRepository {
         unit: CurrencyUnit,
         target_proof_count: Option<u32>,
     ) -> Result<Arc<crate::wallet::Wallet>, FfiError> {
+        let target_proof_count = crate::validate_target_proof_count(target_proof_count)?;
         let cdk_mint_url: cdk::mint_url::MintUrl = mint_url.try_into()?;
 
         let config = target_proof_count.map(|count| {

--- a/crates/cdk-http-client/Cargo.toml
+++ b/crates/cdk-http-client/Cargo.toml
@@ -61,7 +61,7 @@ tokio-tungstenite = { workspace = true, features = [
 getrandom = { version = "0.4", features = ["wasm_js"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3", features = ["WebSocket", "MessageEvent", "CloseEvent", "ErrorEvent", "BinaryType", "Request", "RequestInit", "RequestRedirect", "Response", "Headers"] }
+web-sys = { version = "0.3", features = ["AbortController", "AbortSignal", "Window", "WebSocket", "MessageEvent", "CloseEvent", "ErrorEvent", "BinaryType", "Request", "RequestInit", "RequestRedirect", "Response", "Headers", "ReadableStream", "ReadableStreamDefaultReader", "ReadableStreamReadResult"] }
 js-sys = "0.3"
 futures-channel = "0.3"
 uuid = { workspace = true, features = ["js"] }

--- a/crates/cdk-http-client/src/backends/bitreq_backend.rs
+++ b/crates/cdk-http-client/src/backends/bitreq_backend.rs
@@ -103,9 +103,15 @@ impl HttpClient {
         HttpClientBuilder::default()
     }
 
-    /// Apply proxy and redirect settings to a request
+    /// Apply proxy, response-size, timeout, and redirect settings to a request
     fn configure_request(&self, request: bitreq::Request, url: &str) -> Response<bitreq::Request> {
         let request = apply_proxy_if_needed(request, url, &self.proxy_config)?;
+        // Bound the response body (bitreq's default cap is 1 GiB): responses
+        // come from untrusted mints and must not exhaust wallet memory.
+        let request = request.with_max_body_size(crate::MAX_RESPONSE_BYTES);
+        // Bound total request time so a malicious or broken server cannot
+        // stall the wallet forever by dripping bytes.
+        let request = request.with_timeout(crate::DEFAULT_REQUEST_TIMEOUT.as_secs());
         Ok(if self.no_redirects {
             request.with_max_redirects(0)
         } else {
@@ -326,6 +332,9 @@ impl BitreqRequestBuilder {
             return Err(err);
         }
         let request = apply_proxy_if_needed(self.inner, &self.url, &self.proxy_config)?;
+        let request = request
+            .with_max_body_size(crate::MAX_RESPONSE_BYTES)
+            .with_timeout(crate::DEFAULT_REQUEST_TIMEOUT.as_secs());
         let request = if self.no_redirects {
             request.with_max_redirects(0)
         } else {
@@ -347,6 +356,9 @@ impl BitreqRequestBuilder {
             return Err(err);
         }
         let request = apply_proxy_if_needed(self.inner, &self.url, &self.proxy_config)?;
+        let request = request
+            .with_max_body_size(crate::MAX_RESPONSE_BYTES)
+            .with_timeout(crate::DEFAULT_REQUEST_TIMEOUT.as_secs());
         let request = if self.no_redirects {
             request.with_max_redirects(0)
         } else {

--- a/crates/cdk-http-client/src/backends/reqwest_backend.rs
+++ b/crates/cdk-http-client/src/backends/reqwest_backend.rs
@@ -69,7 +69,7 @@ impl HttpClient {
     ) -> Response<R> {
         let response = request.send().await.map_err(map_reqwest_error)?;
         let status = response.status().as_u16();
-        let body = response.bytes().await.map_err(map_reqwest_error)?.to_vec();
+        let body = read_bounded_body(response).await?;
 
         RawResponse::new(status, body).json_or_status_error()
     }
@@ -118,7 +118,7 @@ impl HttpClient {
             .await
             .map_err(map_reqwest_error)?;
         let status = response.status().as_u16();
-        let body = response.bytes().await.map_err(map_reqwest_error)?.to_vec();
+        let body = read_bounded_body(response).await?;
         Ok(RawResponse::new(status, body))
     }
 
@@ -151,6 +151,28 @@ fn map_reqwest_error(err: reqwest::Error) -> HttpError {
     } else {
         HttpError::Other(err.to_string())
     }
+}
+
+/// Read a response body, rejecting it as soon as it grows past
+/// [`crate::MAX_RESPONSE_BYTES`].
+///
+/// Responses come from untrusted mints; reading chunk by chunk with a running
+/// total prevents a malicious server from exhausting wallet memory with an
+/// oversized body.
+async fn read_bounded_body(mut response: reqwest::Response) -> Result<Vec<u8>, HttpError> {
+    let mut bytes = Vec::new();
+
+    while let Some(chunk) = response.chunk().await.map_err(map_reqwest_error)? {
+        if chunk.len() > crate::MAX_RESPONSE_BYTES.saturating_sub(bytes.len()) {
+            return Err(HttpError::Other(format!(
+                "HTTP response body exceeds the {}-byte limit",
+                crate::MAX_RESPONSE_BYTES
+            )));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+
+    Ok(bytes)
 }
 
 /// reqwest-based RequestBuilder wrapper.
@@ -247,7 +269,7 @@ impl ReqwestRequestBuilder {
 
         let response = inner.send().await.map_err(map_reqwest_error)?;
         let status = response.status().as_u16();
-        let body = response.bytes().await.map_err(map_reqwest_error)?.to_vec();
+        let body = read_bounded_body(response).await?;
         Ok(RawResponse::new(status, body))
     }
 
@@ -263,6 +285,7 @@ pub struct HttpClientBuilder {
     proxy: Option<ProxyConfig>,
     accept_invalid_certs: bool,
     no_redirects: bool,
+    timeout: Option<std::time::Duration>,
 }
 
 impl HttpClientBuilder {
@@ -275,6 +298,15 @@ impl HttpClientBuilder {
     /// Disable automatic HTTP redirect following.
     pub fn no_redirects(mut self) -> Self {
         self.no_redirects = true;
+        self
+    }
+
+    /// Set a per-request timeout covering the whole request, including
+    /// reading the response body.
+    ///
+    /// Defaults to [`crate::DEFAULT_REQUEST_TIMEOUT`] when not set.
+    pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.timeout = Some(timeout);
         self
     }
 
@@ -304,8 +336,9 @@ impl HttpClientBuilder {
     /// Build the HTTP client.
     pub fn build(self) -> Response<HttpClient> {
         super::install_rustls_crypto_provider();
-        let mut builder =
-            reqwest::Client::builder().danger_accept_invalid_certs(self.accept_invalid_certs);
+        let mut builder = reqwest::Client::builder()
+            .danger_accept_invalid_certs(self.accept_invalid_certs)
+            .timeout(self.timeout.unwrap_or(crate::DEFAULT_REQUEST_TIMEOUT));
         if self.no_redirects {
             builder = builder.redirect(reqwest::redirect::Policy::none());
         }

--- a/crates/cdk-http-client/src/backends/wasm_backend.rs
+++ b/crates/cdk-http-client/src/backends/wasm_backend.rs
@@ -12,10 +12,120 @@ use super::url_for_debug;
 use crate::error::HttpError;
 use crate::response::{RawResponse, Response};
 
+struct RequestDeadline {
+    controller: web_sys::AbortController,
+    window: web_sys::Window,
+    timer_id: i32,
+    _callback: Closure<dyn FnMut()>,
+}
+
+impl RequestDeadline {
+    fn new() -> Result<Self, HttpError> {
+        let controller = web_sys::AbortController::new()
+            .map_err(|e| HttpError::Build(format!("Failed to create abort controller: {:?}", e)))?;
+        let window = web_sys::window()
+            .ok_or_else(|| HttpError::Build("Window is unavailable".to_string()))?;
+        let timeout_controller = controller.clone();
+        let callback = Closure::new(move || timeout_controller.abort());
+        let timeout_ms =
+            i32::try_from(crate::DEFAULT_REQUEST_TIMEOUT.as_millis()).unwrap_or(i32::MAX);
+        let timer_id = window
+            .set_timeout_with_callback_and_timeout_and_arguments_0(
+                callback.as_ref().unchecked_ref(),
+                timeout_ms,
+            )
+            .map_err(|e| HttpError::Build(format!("Failed to set request timeout: {:?}", e)))?;
+
+        Ok(Self {
+            controller,
+            window,
+            timer_id,
+            _callback: callback,
+        })
+    }
+
+    fn signal(&self) -> web_sys::AbortSignal {
+        self.controller.signal()
+    }
+}
+
+impl Drop for RequestDeadline {
+    fn drop(&mut self) {
+        self.window.clear_timeout_with_handle(self.timer_id);
+    }
+}
+
+fn fetch_error(signal: &web_sys::AbortSignal, error: JsValue) -> HttpError {
+    if signal.aborted() {
+        HttpError::Timeout
+    } else {
+        HttpError::Connection(format!("Fetch failed: {:?}", error))
+    }
+}
+
+fn body_error(signal: &web_sys::AbortSignal, error: HttpError) -> HttpError {
+    if signal.aborted() {
+        HttpError::Timeout
+    } else {
+        error
+    }
+}
+
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_name = "fetch")]
     fn js_fetch(input: &web_sys::Request) -> js_sys::Promise;
+}
+
+/// Read a response body chunk by chunk, rejecting it as soon as it grows
+/// past [`crate::MAX_RESPONSE_BYTES`].
+///
+/// Responses come from untrusted mints; streaming with a running total
+/// prevents a malicious server from exhausting wallet memory, which is
+/// especially constrained under WASM.
+async fn read_bounded_body(resp: &web_sys::Response) -> Result<Vec<u8>, HttpError> {
+    let Some(body) = resp.body() else {
+        return Ok(Vec::new());
+    };
+
+    let reader: web_sys::ReadableStreamDefaultReader =
+        body.get_reader().dyn_into().map_err(|_| {
+            HttpError::Other("Response body reader is not a default reader".to_string())
+        })?;
+
+    let mut bytes = Vec::new();
+    loop {
+        let result = JsFuture::from(reader.read())
+            .await
+            .map_err(|e| HttpError::Other(format!("Failed to read body chunk: {:?}", e)))?;
+        let result: web_sys::ReadableStreamReadResult = result
+            .dyn_into()
+            .map_err(|_| HttpError::Other("Unexpected body chunk result".to_string()))?;
+
+        if result.get_done().unwrap_or(true) {
+            break;
+        }
+
+        let chunk = result
+            .get_value()
+            .dyn_into::<js_sys::Uint8Array>()
+            .map_err(|_| HttpError::Other("Body chunk is not a Uint8Array".to_string()))?;
+        let chunk_len = chunk.length() as usize;
+        if chunk_len > crate::MAX_RESPONSE_BYTES.saturating_sub(bytes.len()) {
+            reader.release_lock();
+            return Err(HttpError::Other(format!(
+                "HTTP response body exceeds the {}-byte limit",
+                crate::MAX_RESPONSE_BYTES
+            )));
+        }
+
+        let start = bytes.len();
+        bytes.resize(start + chunk_len, 0);
+        chunk.copy_to(&mut bytes[start..]);
+    }
+
+    reader.release_lock();
+    Ok(bytes)
 }
 
 /// HTTP client wrapper
@@ -156,6 +266,9 @@ impl WasmRequestBuilder {
         }
         let opts = web_sys::RequestInit::new();
         opts.set_method(&self.method);
+        let deadline = RequestDeadline::new()?;
+        let timeout_signal = deadline.signal();
+        opts.set_signal(Some(&timeout_signal));
         if self.no_redirects {
             opts.set_redirect(web_sys::RequestRedirect::Error);
         }
@@ -184,7 +297,7 @@ impl WasmRequestBuilder {
 
         let resp_value = JsFuture::from(js_fetch(&request))
             .await
-            .map_err(|e| HttpError::Connection(format!("Fetch failed: {:?}", e)))?;
+            .map_err(|e| fetch_error(&timeout_signal, e))?;
 
         let resp: web_sys::Response = resp_value
             .dyn_into()
@@ -192,16 +305,9 @@ impl WasmRequestBuilder {
 
         let status = resp.status();
 
-        let body_promise = resp
-            .array_buffer()
-            .map_err(|e| HttpError::Other(format!("Failed to read body: {:?}", e)))?;
-
-        let body_value = JsFuture::from(body_promise)
+        let body = read_bounded_body(&resp)
             .await
-            .map_err(|e| HttpError::Other(format!("Failed to read body: {:?}", e)))?;
-
-        let body_array = js_sys::Uint8Array::new(&body_value);
-        let body = body_array.to_vec();
+            .map_err(|e| body_error(&timeout_signal, e))?;
 
         Ok(RawResponse::new(status, body))
     }

--- a/crates/cdk-http-client/src/lib.rs
+++ b/crates/cdk-http-client/src/lib.rs
@@ -74,7 +74,7 @@ pub(crate) const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 ///
 /// Bounds the total time a request may take, including reading the response
 /// body, so a malicious or broken server cannot stall the wallet forever by
-/// dripping bytes. The Tor transport uses its own read timeout.
+/// dripping bytes. The Tor transport uses its own overall response timeout.
 pub(crate) const DEFAULT_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 #[cfg(all(

--- a/crates/cdk-http-client/src/lib.rs
+++ b/crates/cdk-http-client/src/lib.rs
@@ -64,6 +64,19 @@ mod response;
 mod transport;
 pub mod ws;
 
+/// Maximum response body size accepted from a mint or related service.
+///
+/// Responses come from untrusted servers; bounding them prevents a malicious
+/// endpoint from exhausting wallet memory with an oversized body.
+pub(crate) const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
+
+/// Default per-request timeout for clearnet HTTP backends.
+///
+/// Bounds the total time a request may take, including reading the response
+/// body, so a malicious or broken server cannot stall the wallet forever by
+/// dripping bytes. The Tor transport uses its own read timeout.
+pub(crate) const DEFAULT_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 #[cfg(all(
     feature = "bitreq",
     not(feature = "reqwest"),

--- a/crates/cdk-http-client/src/transport/tor_transport.rs
+++ b/crates/cdk-http-client/src/transport/tor_transport.rs
@@ -1,7 +1,9 @@
 //! Tor transport implementation (non-wasm32 only)
 
 use std::fmt;
+use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 use arti_client::{TorClient, TorClientConfig};
 use arti_hyper::ArtiHttpConnector;
@@ -12,6 +14,7 @@ use dnssec_prover::query::{ProofBuilder, QueryBuf};
 #[cfg(feature = "bip353")]
 use dnssec_prover::rr::TXT_TYPE;
 use http::header::{self, HeaderName, HeaderValue};
+use hyper::body::HttpBody;
 use hyper::http::{Method, Request, Uri};
 use hyper::{Body, Client};
 use serde::de::DeserializeOwned;
@@ -25,6 +28,33 @@ use crate::{HttpError, RawResponse};
 
 /// Fixed-size pool size.
 pub const DEFAULT_TOR_POOL_SIZE: usize = 5;
+
+const TOR_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+
+async fn with_response_timeout<F, T>(response: F, timeout: Duration) -> Result<T, HttpError>
+where
+    F: Future<Output = Result<T, HttpError>>,
+{
+    tokio::time::timeout(timeout, response)
+        .await
+        .map_err(|_| HttpError::Timeout)?
+}
+
+async fn read_response_body(mut body: Body, max_bytes: usize) -> Result<Vec<u8>, HttpError> {
+    let mut bytes = Vec::new();
+
+    while let Some(chunk) = body.data().await {
+        let chunk = chunk.map_err(|e| HttpError::Other(e.to_string()))?;
+        if chunk.len() > max_bytes.saturating_sub(bytes.len()) {
+            return Err(HttpError::Other(format!(
+                "Tor HTTP response body exceeds the {max_bytes}-byte limit"
+            )));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+
+    Ok(bytes)
+}
 
 /// Tor transport that maintains a pool of isolated TorClient handles.
 #[derive(Clone)]
@@ -209,17 +239,17 @@ impl TorAsync {
             );
         }
 
-        let resp = client
-            .request(req)
-            .await
-            .map_err(|e| HttpError::Connection(e.to_string()))?;
+        let response = async {
+            let resp = client
+                .request(req)
+                .await
+                .map_err(|e| HttpError::Connection(e.to_string()))?;
+            let status = resp.status().as_u16();
+            let bytes = read_response_body(resp.into_body(), crate::MAX_RESPONSE_BYTES).await?;
+            Ok(RawResponse::new(status, bytes))
+        };
 
-        let status = resp.status().as_u16();
-        let bytes = hyper::body::to_bytes(resp.into_body())
-            .await
-            .map_err(|e| HttpError::Other(e.to_string()))?;
-
-        Ok(RawResponse::new(status, bytes.to_vec()))
+        with_response_timeout(response, TOR_RESPONSE_TIMEOUT).await
     }
 
     async fn request<R>(
@@ -361,5 +391,54 @@ impl Transport for TorAsync {
             Some((body.into_bytes(), "application/x-www-form-urlencoded")),
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn response_body_allows_exact_byte_limit() {
+        let bytes = read_response_body(Body::from(vec![0_u8; 16]), 16)
+            .await
+            .expect("body at the limit should be accepted");
+
+        assert_eq!(bytes.len(), 16);
+    }
+
+    #[tokio::test]
+    async fn response_body_rejects_bytes_over_limit() {
+        let error = read_response_body(Body::from(vec![0_u8; 17]), 16)
+            .await
+            .expect_err("body over the limit should be rejected");
+
+        assert!(matches!(
+            error,
+            HttpError::Other(message) if message.contains("16-byte limit")
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn response_body_read_times_out() {
+        let (sender, body) = Body::channel();
+
+        let error = with_response_timeout(read_response_body(body, 16), Duration::from_secs(1))
+            .await
+            .expect_err("body that never completes should time out");
+        drop(sender);
+
+        assert!(matches!(error, HttpError::Timeout));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn response_header_read_times_out() {
+        let response = std::future::pending::<Result<(), HttpError>>();
+
+        let error = with_response_timeout(response, Duration::from_secs(1))
+            .await
+            .expect_err("response headers that never arrive should time out");
+
+        assert!(matches!(error, HttpError::Timeout));
     }
 }

--- a/crates/cdk-nostr/src/inbox.rs
+++ b/crates/cdk-nostr/src/inbox.rs
@@ -20,6 +20,7 @@ use tokio::sync::broadcast::error::RecvError;
 use tokio_util::sync::CancellationToken;
 
 use crate::error::{Error, Result};
+use crate::MAX_DECRYPTED_CONTENT_BYTES;
 
 /// A gift wrap that was addressed to the inbox identity and successfully
 /// unwrapped
@@ -169,12 +170,23 @@ impl NostrInbox {
                             continue;
                         }
                         match client.unwrap_gift_wrap(&event).await {
-                            Ok(unwrapped) => listener.on_event(Nip17Event {
-                                wrap_id: event.id,
-                                wrap_created_at: event.created_at,
-                                sender: unwrapped.sender,
-                                rumor: unwrapped.rumor,
-                            }),
+                            Ok(unwrapped)
+                                if unwrapped.rumor.content.len() <= MAX_DECRYPTED_CONTENT_BYTES =>
+                            {
+                                listener.on_event(Nip17Event {
+                                    wrap_id: event.id,
+                                    wrap_created_at: event.created_at,
+                                    sender: unwrapped.sender,
+                                    rumor: unwrapped.rumor,
+                                });
+                            }
+                            Ok(unwrapped) => {
+                                tracing::warn!(
+                                    "inbox: dropping gift wrap {} with {}-byte decrypted content",
+                                    event.id,
+                                    unwrapped.rumor.content.len()
+                                );
+                            }
                             Err(e) => {
                                 // Not encrypted for us or malformed — log and keep going
                                 tracing::debug!("inbox: unwrap gift wrap {} failed: {e}", event.id);

--- a/crates/cdk-nostr/src/lib.rs
+++ b/crates/cdk-nostr/src/lib.rs
@@ -16,6 +16,13 @@
 
 #![warn(missing_docs)]
 
+/// Maximum decrypted payload accepted from a Nostr relay stream.
+///
+/// Relays are untrusted and may ignore subscription filters or event-size
+/// policies. Keeping this bounded prevents oversized plaintext from flowing
+/// into application parsers and callbacks.
+pub(crate) const MAX_DECRYPTED_CONTENT_BYTES: usize = 64 * 1024;
+
 pub mod error;
 pub mod inbox;
 pub mod keys;

--- a/crates/cdk-nostr/src/nwc/service.rs
+++ b/crates/cdk-nostr/src/nwc/service.rs
@@ -31,6 +31,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::nwc::error::{Error, Result};
 use crate::nwc::handler::NwcRequestHandler;
+use crate::MAX_DECRYPTED_CONTENT_BYTES;
 
 /// Commands advertised in the info event and reported by `get_info`.
 ///
@@ -313,6 +314,12 @@ fn decrypt_request(
             (plaintext, Encryption::Nip04)
         }
     };
+
+    if plaintext.len() > MAX_DECRYPTED_CONTENT_BYTES {
+        return Err(Error::Protocol(format!(
+            "decrypted request exceeds {MAX_DECRYPTED_CONTENT_BYTES} bytes"
+        )));
+    }
 
     let request: Request =
         serde_json::from_str(&plaintext).map_err(|e| Error::Protocol(e.to_string()))?;

--- a/crates/cdk/src/mint/builder.rs
+++ b/crates/cdk/src/mint/builder.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use bitcoin::bip32::DerivationPath;
+use cdk_common::amount::MAX_SPLIT_OUTPUTS;
 use cdk_common::database::{DynMintAuthDatabase, DynMintDatabase, MintKeysDatabase};
 use cdk_common::error::Error;
 use cdk_common::nut00::KnownMethod;
@@ -322,11 +323,26 @@ impl MintBuilder {
         self
     }
 
-    /// Set transaction limits for DoS protection
+    /// Set transaction limits for DoS protection.
+    ///
+    /// The output limit must not exceed [`MAX_SPLIT_OUTPUTS`]. The builder
+    /// validates this when the mint is built because internally generated
+    /// output amounts are subject to that global limit.
     pub fn with_limits(mut self, max_inputs: usize, max_outputs: usize) -> Self {
         self.max_inputs = max_inputs;
         self.max_outputs = max_outputs;
         self
+    }
+
+    fn validate_limits(&self) -> Result<(), Error> {
+        if self.max_outputs > MAX_SPLIT_OUTPUTS {
+            return Err(Error::Custom(format!(
+                "Mint max_outputs ({}) cannot exceed Amount split limit ({MAX_SPLIT_OUTPUTS})",
+                self.max_outputs
+            )));
+        }
+
+        Ok(())
     }
 
     /// Set batch minting settings (NUT-29)
@@ -601,6 +617,8 @@ impl MintBuilder {
         #[allow(unused_mut)] mut self,
         signatory: Arc<dyn Signatory + Send + Sync>,
     ) -> Result<Mint, Error> {
+        self.validate_limits()?;
+
         // Check active keysets and rotate if necessary
         let active_keysets = signatory.keysets().await?;
 
@@ -910,6 +928,35 @@ mod tests {
             .expect("mnemonic")
             .to_seed_normalized("")
             .to_vec()
+    }
+
+    #[tokio::test]
+    async fn test_mint_builder_rejects_output_limit_above_split_limit() {
+        let localstore = Arc::new(memory::empty().await.expect("mint db"));
+        let builder = MintBuilder::new(localstore.clone())
+            .with_limits(1000, MAX_SPLIT_OUTPUTS.saturating_add(1));
+
+        let err = builder
+            .build_with_seed(localstore, &seed())
+            .await
+            .expect_err("output limit above Amount split limit must be rejected");
+
+        assert!(matches!(
+            err,
+            Error::Custom(message)
+                if message.contains(&MAX_SPLIT_OUTPUTS.to_string())
+                    && message.contains("max_outputs")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_mint_builder_accepts_output_limit_at_split_limit() {
+        let localstore = Arc::new(memory::empty().await.expect("mint db"));
+        let builder = MintBuilder::new(localstore).with_limits(1000, MAX_SPLIT_OUTPUTS);
+
+        builder
+            .validate_limits()
+            .expect("output limit at Amount split limit should be accepted");
     }
 
     #[tokio::test]

--- a/crates/cdk/src/wallet/builder.rs
+++ b/crates/cdk/src/wallet/builder.rs
@@ -19,6 +19,12 @@ use crate::wallet::{
     SubscriptionManager, Wallet,
 };
 
+/// Maximum target proof count accepted by [`WalletBuilder`].
+///
+/// The wallet tops up every denomination to this count during swaps, so an
+/// excessive target creates outsized swap requests and database load.
+pub const MAX_TARGET_PROOF_COUNT: usize = 100;
+
 /// Builder for creating a new [`Wallet`]
 ///
 /// Rate limiting: unless a limiter is injected with
@@ -258,6 +264,14 @@ impl WalletBuilder {
 
     /// Build the wallet
     pub fn build(mut self) -> Result<Wallet, Error> {
+        if let Some(count) = self.target_proof_count {
+            if count > MAX_TARGET_PROOF_COUNT {
+                return Err(Error::Custom(format!(
+                    "target_proof_count must be at most {MAX_TARGET_PROOF_COUNT}"
+                )));
+            }
+        }
+
         let mint_url = self
             .mint_url
             .take()

--- a/crates/cdk/src/wallet/issue/saga/mod.rs
+++ b/crates/cdk/src/wallet/issue/saga/mod.rs
@@ -406,14 +406,18 @@ impl<'a> MintSaga<'a, Initial> {
             s => s,
         };
 
-        let premint_secrets = match &spending_conditions {
-            Some(spending_conditions) => PreMintSecrets::with_conditions(
-                active_keyset_id,
-                amount,
-                &split_target,
-                spending_conditions,
-                fee_and_amounts,
-            )?,
+        let (premint_secrets, counter_start, counter_end) = match &spending_conditions {
+            Some(spending_conditions) => (
+                PreMintSecrets::with_conditions(
+                    active_keyset_id,
+                    amount,
+                    &split_target,
+                    spending_conditions,
+                    fee_and_amounts,
+                )?,
+                None,
+                None,
+            ),
             None => {
                 let amount_split = amount.split_targeted(&split_target, fee_and_amounts)?;
                 let num_secrets = amount_split.len() as u32;
@@ -432,16 +436,21 @@ impl<'a> MintSaga<'a, Initial> {
 
                 let count = new_counter - num_secrets;
 
-                PreMintSecrets::from_seed(
-                    active_keyset_id,
-                    count,
-                    &self.wallet.seed,
-                    amount,
-                    &split_target,
-                    fee_and_amounts,
-                )?
+                (
+                    PreMintSecrets::from_seed(
+                        active_keyset_id,
+                        count,
+                        &self.wallet.seed,
+                        amount,
+                        &split_target,
+                        fee_and_amounts,
+                    )?,
+                    Some(count),
+                    Some(new_counter),
+                )
             }
         };
+        crate::wallet::validate_generated_output_count(premint_secrets.len())?;
 
         let mut request = MintRequest {
             quote: quote_id.to_string(),
@@ -469,14 +478,6 @@ impl<'a> MintSaga<'a, Initial> {
 
         let operation_id = self.state_data.operation_id;
 
-        // Get counter range for recovery
-        let counter_end = self
-            .wallet
-            .localstore
-            .increment_keyset_counter(&active_keyset_id, 0)
-            .await?;
-        let counter_start = counter_end.saturating_sub(premint_secrets.secrets.len() as u32);
-
         // Persist saga state for crash recovery
         let saga = WalletSaga::new(
             operation_id,
@@ -487,8 +488,8 @@ impl<'a> MintSaga<'a, Initial> {
             OperationData::Mint(MintOperationData::new_single(
                 quote_id.to_string(),
                 amount,
-                Some(counter_start),
-                Some(counter_end),
+                counter_start,
+                counter_end,
                 Some(request.outputs.clone()),
             )),
         );
@@ -510,6 +511,8 @@ impl<'a> MintSaga<'a, Initial> {
             operation_id: self.state_data.operation_id,
             active_keyset_id,
             premint_secrets,
+            counter_start,
+            counter_end,
             mint_request: PreparedMintRequest::Single {
                 quote_id: quote_id.to_string(),
                 quote_info: quote_info.clone(),
@@ -668,24 +671,6 @@ impl<'a> MintSaga<'a, Initial> {
             return Err(Error::AmountUndefined);
         }
 
-        // Reserve all quotes (with rollback on failure)
-        for quote_id in quote_ids {
-            self.wallet
-                .localstore
-                .reserve_mint_quote(quote_id, &self.state_data.operation_id)
-                .await?;
-        }
-
-        // Register compensation to release all quotes on failure
-        add_compensation(
-            &mut self.compensations,
-            Box::new(ReleaseMintQuote {
-                localstore: self.wallet.localstore.clone(),
-                operation_id: self.state_data.operation_id,
-            }),
-        )
-        .await;
-
         // Get active keyset
         let keyset_policy = self.state_data.keyset_policy;
         let active_keyset_id = self
@@ -698,11 +683,11 @@ impl<'a> MintSaga<'a, Initial> {
             .get_keyset_fees_and_amounts_by_id_with_policy(active_keyset_id, keyset_policy)
             .await?;
 
-        // Generate a consecutive output segment for each quote. NUT-29 sends
-        // one shared output list, so retaining these boundaries is what lets
-        // transaction history and crash recovery attribute proofs correctly.
-        let mut premint_secrets = PreMintSecrets::new(active_keyset_id);
-        let mut output_counts = Vec::with_capacity(quote_amounts.len());
+        // Determine the full NUT-29 output size before reserving any derivation
+        // counters. Each quote split is independently bounded by Amount, but the
+        // shared request and persisted saga must honor the same aggregate bound.
+        let mut split_targets = Vec::with_capacity(quote_amounts.len());
+        let mut aggregate_output_count = 0usize;
         for quote_amount in &quote_amounts {
             let split_target = match &amount_split_target {
                 SplitTarget::None => {
@@ -712,137 +697,175 @@ impl<'a> MintSaga<'a, Initial> {
                 }
                 split_target => split_target.clone(),
             };
-
-            let quote_secrets = match &spending_conditions {
-                Some(sc) => PreMintSecrets::with_conditions(
-                    active_keyset_id,
-                    *quote_amount,
-                    &split_target,
-                    sc,
-                    &fee_and_amounts,
-                )?,
-                None => {
-                    let amount_split =
-                        quote_amount.split_targeted(&split_target, &fee_and_amounts)?;
-                    let num_secrets =
-                        u32::try_from(amount_split.len()).map_err(|_| Error::AmountOverflow)?;
-                    let new_counter = self
-                        .wallet
-                        .localstore
-                        .increment_keyset_counter(&active_keyset_id, num_secrets)
-                        .await?;
-                    let count = new_counter - num_secrets;
-
-                    PreMintSecrets::from_seed(
-                        active_keyset_id,
-                        count,
-                        &self.wallet.seed,
-                        *quote_amount,
-                        &split_target,
-                        &fee_and_amounts,
-                    )?
-                }
-            };
-
-            output_counts.push(quote_secrets.len());
-            premint_secrets.secrets.extend(quote_secrets.secrets);
+            let output_count = quote_amount
+                .split_targeted(&split_target, &fee_and_amounts)?
+                .len();
+            aggregate_output_count = aggregate_output_count
+                .checked_add(output_count)
+                .ok_or(Error::AmountOverflow)?;
+            crate::wallet::validate_generated_output_count(aggregate_output_count)?;
+            split_targets.push(split_target);
         }
 
-        let outputs = premint_secrets.blinded_messages();
-
-        // Create batch mint request
-        let mut batch_request = BatchMintRequest {
-            quotes: quote_ids.iter().map(|s| s.to_string()).collect(),
-            quote_amounts: Some(quote_amounts.clone()),
-            outputs: outputs.clone(),
-            signatures: None,
-        };
-
-        // Build signatures for each quote (NUT-20)
-        let mut signatures: Vec<Option<String>> = Vec::new();
-
-        for quote in &quote_infos {
-            let secret_key = match self.wallet.mint_quote_signing_key(quote).await? {
-                Some(secret_key) => Some(secret_key),
-                None => external_keys.and_then(|keys| keys.get(&quote.id)).cloned(),
-            };
-
-            let requires_signature = secret_key.is_some() || quote.payment_method.is_bolt12();
-
-            if requires_signature {
-                let sk = secret_key.ok_or(Error::SignatureMissingOrInvalid)?;
-                let sig = batch_request
-                    .sign_quote(&quote.id, &sk)
-                    .map_err(|e| Error::Custom(format!("NUT-20 signing failed: {}", e)))?;
-                signatures.push(Some(sig));
-            } else {
-                // Quote is unlocked
-                signatures.push(None);
-            }
-        }
-
-        // Refresh every snapshot after signing-key resolution so later
-        // versioned writes use the latest persisted versions.
-        for quote in &mut quote_infos {
-            *quote = self
-                .wallet
-                .localstore
-                .get_mint_quote(&quote.id)
-                .await?
-                .ok_or(Error::UnknownQuote)?;
-        }
-
-        // Check if any quote requires a signature.
-        let has_locked = signatures.iter().any(Option::is_some);
-        let signatures_to_send = if has_locked { Some(signatures) } else { None };
-        batch_request.signatures = signatures_to_send;
-
-        // Get counter range for recovery
-        let counter_end = self
-            .wallet
-            .localstore
-            .increment_keyset_counter(&active_keyset_id, 0)
-            .await?;
-        let counter_start = counter_end.saturating_sub(premint_secrets.secrets.len() as u32);
-
-        // Persist saga state
-        let saga = WalletSaga::new(
-            self.state_data.operation_id,
-            WalletSagaState::Issue(IssueSagaState::SecretsPrepared),
-            total_amount,
-            self.wallet.mint_url.clone(),
-            self.wallet.unit.clone(),
-            OperationData::Mint(MintOperationData::new_partitioned_batch(
-                quote_ids.iter().map(|s| s.to_string()).collect(),
-                total_amount,
-                Some(counter_start),
-                Some(counter_end),
-                Some(outputs),
-                output_counts.clone(),
-                quote_amounts,
-            )),
-        );
-
-        self.wallet.localstore.add_saga(saga.clone()).await?;
-
-        // Register compensation
+        // Only persist reservations after the complete shared output list has
+        // passed validation.
+        // Register compensation before the first write so a failure partway
+        // through the loop releases every quote already linked to this operation.
         add_compensation(
             &mut self.compensations,
-            Box::new(MintCompensation {
+            Box::new(ReleaseMintQuote {
                 localstore: self.wallet.localstore.clone(),
-                quote_id: quote_ids.first().cloned().unwrap_or_default().to_string(),
-                saga_id: self.state_data.operation_id,
+                operation_id: self.state_data.operation_id,
             }),
         )
         .await;
 
-        Ok(MintSaga {
-            wallet: self.wallet,
-            compensations: self.compensations,
-            state_data: Prepared {
+        for quote_id in quote_ids {
+            if let Err(error) = self
+                .wallet
+                .localstore
+                .reserve_mint_quote(quote_id, &self.state_data.operation_id)
+                .await
+            {
+                self.wallet
+                    .localstore
+                    .release_mint_quote(&self.state_data.operation_id)
+                    .await?;
+                clear_compensations(&mut self.compensations).await;
+                return Err(error.into());
+            }
+        }
+
+        let prepare_result: Result<Prepared, Error> = async {
+            let (mut counter, counter_start, counter_end) = match spending_conditions {
+                None if aggregate_output_count > 0 => {
+                    let counter_count =
+                        u32::try_from(aggregate_output_count).map_err(|_| Error::AmountOverflow)?;
+                    let counter_end = self
+                        .wallet
+                        .localstore
+                        .increment_keyset_counter(&active_keyset_id, counter_count)
+                        .await?;
+                    let counter_start = counter_end - counter_count;
+                    (counter_start, Some(counter_start), Some(counter_end))
+                }
+                _ => (0, None, None),
+            };
+
+            // Generate a consecutive output segment for each quote. NUT-29 sends
+            // one shared output list, so retaining these boundaries is what lets
+            // transaction history and crash recovery attribute proofs correctly.
+            let mut premint_secrets = PreMintSecrets::new(active_keyset_id);
+            let mut output_counts = Vec::with_capacity(quote_amounts.len());
+            for (quote_amount, split_target) in quote_amounts.iter().zip(split_targets) {
+                let quote_secrets = match &spending_conditions {
+                    Some(sc) => PreMintSecrets::with_conditions(
+                        active_keyset_id,
+                        *quote_amount,
+                        &split_target,
+                        sc,
+                        &fee_and_amounts,
+                    )?,
+                    None => {
+                        let quote_secrets = PreMintSecrets::from_seed(
+                            active_keyset_id,
+                            counter,
+                            &self.wallet.seed,
+                            *quote_amount,
+                            &split_target,
+                            &fee_and_amounts,
+                        )?;
+                        counter = counter
+                            .checked_add(
+                                u32::try_from(quote_secrets.len())
+                                    .map_err(|_| Error::AmountOverflow)?,
+                            )
+                            .ok_or(Error::AmountOverflow)?;
+                        quote_secrets
+                    }
+                };
+
+                output_counts.push(quote_secrets.len());
+                premint_secrets.secrets.extend(quote_secrets.secrets);
+            }
+            crate::wallet::validate_generated_output_count(premint_secrets.len())?;
+
+            let outputs = premint_secrets.blinded_messages();
+
+            // Create batch mint request
+            let mut batch_request = BatchMintRequest {
+                quotes: quote_ids.iter().map(|s| s.to_string()).collect(),
+                quote_amounts: Some(quote_amounts.clone()),
+                outputs: outputs.clone(),
+                signatures: None,
+            };
+
+            // Build signatures for each quote (NUT-20)
+            let mut signatures: Vec<Option<String>> = Vec::new();
+
+            for quote in &quote_infos {
+                let secret_key = match self.wallet.mint_quote_signing_key(quote).await? {
+                    Some(secret_key) => Some(secret_key),
+                    None => external_keys.and_then(|keys| keys.get(&quote.id)).cloned(),
+                };
+
+                let requires_signature = secret_key.is_some() || quote.payment_method.is_bolt12();
+
+                if requires_signature {
+                    let sk = secret_key.ok_or(Error::SignatureMissingOrInvalid)?;
+                    let sig = batch_request
+                        .sign_quote(&quote.id, &sk)
+                        .map_err(|e| Error::Custom(format!("NUT-20 signing failed: {}", e)))?;
+                    signatures.push(Some(sig));
+                } else {
+                    // Quote is unlocked
+                    signatures.push(None);
+                }
+            }
+
+            // Refresh every snapshot after signing-key resolution so later
+            // versioned writes use the latest persisted versions.
+            for quote in &mut quote_infos {
+                *quote = self
+                    .wallet
+                    .localstore
+                    .get_mint_quote(&quote.id)
+                    .await?
+                    .ok_or(Error::UnknownQuote)?;
+            }
+
+            // Check if any quote requires a signature.
+            let has_locked = signatures.iter().any(Option::is_some);
+            let signatures_to_send = if has_locked { Some(signatures) } else { None };
+            batch_request.signatures = signatures_to_send;
+
+            // Persist saga state
+            let saga = WalletSaga::new(
+                self.state_data.operation_id,
+                WalletSagaState::Issue(IssueSagaState::SecretsPrepared),
+                total_amount,
+                self.wallet.mint_url.clone(),
+                self.wallet.unit.clone(),
+                OperationData::Mint(MintOperationData::new_partitioned_batch(
+                    quote_ids.iter().map(|s| s.to_string()).collect(),
+                    total_amount,
+                    counter_start,
+                    counter_end,
+                    Some(outputs),
+                    output_counts.clone(),
+                    quote_amounts,
+                )),
+            );
+
+            self.wallet.localstore.add_saga(saga.clone()).await?;
+
+            // Register compensation
+            Ok(Prepared {
                 operation_id: self.state_data.operation_id,
                 active_keyset_id,
                 premint_secrets,
+                counter_start,
+                counter_end,
                 mint_request: PreparedMintRequest::Batch {
                     quote_ids: quote_ids.iter().map(|s| s.to_string()).collect(),
                     quote_infos,
@@ -852,8 +875,37 @@ impl<'a> MintSaga<'a, Initial> {
                 payment_method,
                 keyset_policy,
                 saga,
-            },
-        })
+            })
+        }
+        .await;
+
+        match prepare_result {
+            Ok(state_data) => {
+                add_compensation(
+                    &mut self.compensations,
+                    Box::new(MintCompensation {
+                        localstore: self.wallet.localstore.clone(),
+                        quote_id: quote_ids.first().cloned().unwrap_or_default().to_string(),
+                        saga_id: self.state_data.operation_id,
+                    }),
+                )
+                .await;
+
+                Ok(MintSaga {
+                    wallet: self.wallet,
+                    compensations: self.compensations,
+                    state_data,
+                })
+            }
+            Err(error) => {
+                self.wallet
+                    .localstore
+                    .release_mint_quote(&self.state_data.operation_id)
+                    .await?;
+                clear_compensations(&mut self.compensations).await;
+                Err(error)
+            }
+        }
     }
 }
 
@@ -875,6 +927,8 @@ impl<'a> MintSaga<'a, Prepared> {
             operation_id,
             active_keyset_id,
             premint_secrets,
+            counter_start,
+            counter_end,
             mint_request,
             payment_method,
             keyset_policy,
@@ -912,14 +966,6 @@ impl<'a> MintSaga<'a, Prepared> {
         );
 
         let logic_res = async {
-            // Get counter range for recovery
-            let counter_end = wallet
-                .localstore
-                .increment_keyset_counter(&active_keyset_id, 0)
-                .await?;
-            let counter_start =
-                counter_end.saturating_sub(premint_secrets.secrets.len() as u32);
-
             // Get outputs for saga update and for mint call
             let outputs = premint_secrets.blinded_messages();
 
@@ -929,8 +975,8 @@ impl<'a> MintSaga<'a, Prepared> {
             let mut updated_saga = saga.clone();
             updated_saga.update_state(WalletSagaState::Issue(IssueSagaState::MintRequested));
             if let OperationData::Mint(ref mut data) = updated_saga.data {
-                data.counter_start = Some(counter_start);
-                data.counter_end = Some(counter_end);
+                data.counter_start = counter_start;
+                data.counter_end = counter_end;
                 data.blinded_messages = Some(outputs.clone());
             }
 
@@ -1201,6 +1247,228 @@ mod tests {
         mint_quote.amount_paid = amount;
         mint_quote.secret_key = Some(signing_key);
         mint_quote
+    }
+
+    #[tokio::test]
+    async fn batch_prepare_rejects_aggregate_outputs_before_counter_reservation() {
+        use cdk_common::amount::MAX_SPLIT_OUTPUTS;
+
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+        let amount = Amount::from(MAX_SPLIT_OUTPUTS as u64);
+
+        let mut first = test_mint_quote(mint_url.clone());
+        first.id = "aggregate-limit-first".to_owned();
+        first.state = MintQuoteState::Paid;
+        first.amount = Some(amount);
+        first.amount_paid = amount;
+        let mut second = test_mint_quote(mint_url);
+        second.id = "aggregate-limit-second".to_owned();
+        second.state = MintQuoteState::Paid;
+        second.amount = Some(amount);
+        second.amount_paid = amount;
+        db.add_mint_quote(first.clone()).await.expect("first quote");
+        db.add_mint_quote(second.clone())
+            .await
+            .expect("second quote");
+
+        let keyset_id = wallet.active_keyset().await.expect("active keyset").id;
+        let initial_counter = db
+            .increment_keyset_counter(&keyset_id, 0)
+            .await
+            .expect("read counter");
+        let result = MintSaga::new(&wallet)
+            .prepare_batch(
+                &[first.id.as_str(), second.id.as_str()],
+                SplitTarget::Value(Amount::ONE),
+                None,
+                None,
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(Error::MaxOutputsExceeded {
+                actual,
+                max: MAX_SPLIT_OUTPUTS,
+            }) if actual == MAX_SPLIT_OUTPUTS * 2
+        ));
+        assert_eq!(
+            db.increment_keyset_counter(&keyset_id, 0)
+                .await
+                .expect("read counter"),
+            initial_counter
+        );
+        assert!(db
+            .get_incomplete_sagas()
+            .await
+            .expect("list sagas")
+            .is_empty());
+        assert!(db
+            .get_mint_quote(&first.id)
+            .await
+            .expect("read first quote")
+            .expect("first quote exists")
+            .used_by_operation
+            .is_none());
+        assert!(db
+            .get_mint_quote(&second.id)
+            .await
+            .expect("read second quote")
+            .expect("second quote exists")
+            .used_by_operation
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn batch_prepare_releases_partial_quote_reservations() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let wallet =
+            create_test_wallet_with_mock(db.clone(), Arc::new(MockMintConnector::new())).await;
+
+        let mut first = test_mint_quote(mint_url.clone());
+        first.id = "partial-reservation-first".to_owned();
+        first.state = MintQuoteState::Paid;
+        first.amount = Some(Amount::ONE);
+        first.amount_paid = Amount::ONE;
+        let mut second = test_mint_quote(mint_url);
+        second.id = "partial-reservation-second".to_owned();
+        second.state = MintQuoteState::Paid;
+        second.amount = Some(Amount::ONE);
+        second.amount_paid = Amount::ONE;
+        db.add_mint_quote(first.clone()).await.expect("first quote");
+        db.add_mint_quote(second.clone())
+            .await
+            .expect("second quote");
+
+        let other_operation = uuid::Uuid::new_v4();
+        db.reserve_mint_quote(&second.id, &other_operation)
+            .await
+            .expect("reserve second quote elsewhere");
+
+        let result = MintSaga::new(&wallet)
+            .prepare_batch(
+                &[first.id.as_str(), second.id.as_str()],
+                SplitTarget::Values(vec![Amount::ONE]),
+                None,
+                None,
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(db
+            .get_mint_quote(&first.id)
+            .await
+            .expect("read first")
+            .expect("first exists")
+            .used_by_operation
+            .is_none());
+        assert_eq!(
+            db.get_mint_quote(&second.id)
+                .await
+                .expect("read second")
+                .expect("second exists")
+                .used_by_operation,
+            Some(other_operation.to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_execute_persists_exact_reserved_range_after_concurrent_advance() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client.clone()).await;
+
+        let mut first = test_mint_quote(mint_url.clone());
+        first.id = "counter-race-first".to_owned();
+        first.state = MintQuoteState::Paid;
+        first.amount = Some(Amount::ONE);
+        first.amount_paid = Amount::ONE;
+        let mut second = test_mint_quote(mint_url);
+        second.id = "counter-race-second".to_owned();
+        second.state = MintQuoteState::Paid;
+        second.amount = Some(Amount::ONE);
+        second.amount_paid = Amount::ONE;
+        db.add_mint_quote(first.clone()).await.expect("first quote");
+        db.add_mint_quote(second.clone())
+            .await
+            .expect("second quote");
+
+        let prepared = MintSaga::new(&wallet)
+            .prepare_batch(
+                &[first.id.as_str(), second.id.as_str()],
+                SplitTarget::Values(vec![Amount::ONE]),
+                None,
+                None,
+            )
+            .await
+            .expect("prepare batch");
+        let saga_id = prepared.state_data.operation_id;
+        let counter_start = prepared.state_data.counter_start;
+        let counter_end = prepared.state_data.counter_end;
+        let keyset_id = prepared.state_data.active_keyset_id;
+        assert_eq!(
+            counter_end
+                .expect("deterministic end")
+                .checked_sub(counter_start.expect("deterministic start")),
+            Some(2)
+        );
+
+        db.increment_keyset_counter(&keyset_id, 7)
+            .await
+            .expect("concurrent reservation");
+        mock_client.push_post_batch_mint_response(Err(Error::Custom(
+            "stop after write-ahead update".to_owned(),
+        )));
+        assert!(prepared.execute().await.is_err());
+
+        let saga = db
+            .get_saga(&saga_id)
+            .await
+            .expect("read saga")
+            .expect("ambiguous failure keeps saga");
+        let OperationData::Mint(data) = saga.data else {
+            panic!("expected mint saga data");
+        };
+        assert_eq!(data.counter_start, counter_start);
+        assert_eq!(data.counter_end, counter_end);
+    }
+
+    #[tokio::test]
+    async fn conditioned_batch_persists_no_seed_counter_range() {
+        let db = create_test_db().await;
+        let mint_url = test_mint_url();
+        let wallet =
+            create_test_wallet_with_mock(db.clone(), Arc::new(MockMintConnector::new())).await;
+        let mut quote = test_mint_quote(mint_url);
+        quote.id = "conditioned-no-counter".to_owned();
+        quote.state = MintQuoteState::Paid;
+        quote.amount = Some(Amount::ONE);
+        quote.amount_paid = Amount::ONE;
+        db.add_mint_quote(quote.clone()).await.expect("quote");
+        let conditions = SpendingConditions::new_p2pk(SecretKey::generate().public_key(), None);
+
+        let prepared = MintSaga::new(&wallet)
+            .prepare_batch(
+                &[quote.id.as_str()],
+                SplitTarget::Values(vec![Amount::ONE]),
+                Some(conditions),
+                None,
+            )
+            .await
+            .expect("prepare conditioned batch");
+
+        assert_eq!(prepared.state_data.counter_start, None);
+        assert_eq!(prepared.state_data.counter_end, None);
+        let OperationData::Mint(data) = &prepared.state_data.saga.data else {
+            panic!("expected mint saga data");
+        };
+        assert_eq!(data.counter_start, None);
+        assert_eq!(data.counter_end, None);
     }
 
     #[cfg(feature = "npubcash")]

--- a/crates/cdk/src/wallet/issue/saga/resume.rs
+++ b/crates/cdk/src/wallet/issue/saga/resume.rs
@@ -190,6 +190,12 @@ impl Wallet {
             _ => return Ok(()),
         };
 
+        crate::wallet::recovery::validate_recovery_output_data(
+            blinded_messages,
+            counter_start,
+            counter_end,
+        )?;
+
         let premint_secrets = PreMintSecrets::restore_batch(
             blinded_messages[0].keyset_id,
             &self.seed,
@@ -379,6 +385,21 @@ impl Wallet {
                 return Ok(None);
             }
         };
+        let (counter_start, counter_end) = match (data.counter_start, data.counter_end) {
+            (Some(start), Some(end)) => (start, end),
+            _ => {
+                tracing::debug!(
+                    "Issue saga {} - no counter range stored, cannot replay",
+                    saga_id
+                );
+                return Ok(None);
+            }
+        };
+        crate::wallet::recovery::validate_recovery_output_data(
+            blinded_messages,
+            counter_start,
+            counter_end,
+        )?;
 
         let quote_ids = data.quote_ids();
         let is_batch = data.is_batch();
@@ -493,6 +514,12 @@ impl Wallet {
                     return Ok(None);
                 }
             };
+
+            crate::wallet::recovery::validate_recovery_output_data(
+                blinded_messages,
+                counter_start,
+                counter_end,
+            )?;
 
             let keyset_id = blinded_messages[0].keyset_id;
 
@@ -623,6 +650,12 @@ impl Wallet {
                 return Ok(None);
             }
         };
+
+        crate::wallet::recovery::validate_recovery_output_data(
+            blinded_messages,
+            counter_start,
+            counter_end,
+        )?;
 
         let keyset_id = blinded_messages[0].keyset_id;
 

--- a/crates/cdk/src/wallet/issue/saga/state.rs
+++ b/crates/cdk/src/wallet/issue/saga/state.rs
@@ -111,6 +111,10 @@ pub struct Prepared {
     pub active_keyset_id: Id,
     /// Premint secrets
     pub premint_secrets: PreMintSecrets,
+    /// Exact first derivation counter reserved for these outputs, if seed-derived
+    pub counter_start: Option<u32>,
+    /// Exact exclusive end of the reserved range, or `None` for conditioned outputs
+    pub counter_end: Option<u32>,
     /// Mint request (single or batch)
     pub mint_request: PreparedMintRequest,
     /// Payment method (Bolt11 or Bolt12)
@@ -135,6 +139,8 @@ impl fmt::Debug for Prepared {
                     .map(|secret| secret.amount)
                     .collect::<Vec<_>>(),
             )
+            .field("counter_start", &self.counter_start)
+            .field("counter_end", &self.counter_end)
             .field("mint_request", &self.mint_request)
             .field("payment_method", &self.payment_method)
             .field("keyset_policy", &self.keyset_policy)
@@ -249,6 +255,8 @@ mod tests {
             operation_id,
             active_keyset_id: keyset_id,
             premint_secrets,
+            counter_start: Some(0),
+            counter_end: Some(1),
             mint_request,
             payment_method: PaymentMethod::BOLT11,
             keyset_policy: KeysetLoadPolicy::default(),

--- a/crates/cdk/src/wallet/mint_connector/http_client.rs
+++ b/crates/cdk/src/wallet/mint_connector/http_client.rs
@@ -41,6 +41,9 @@ const HTTP_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(50);
 /// Upper bound for the exponential backoff between replays.
 const HTTP_RETRY_MAX_BACKOFF: Duration = Duration::from_secs(1);
 
+/// Maximum replay window accepted from untrusted NUT-19 mint settings.
+const NUT19_MAX_TTL_SECS: u64 = 300;
+
 fn payment_method_path_segment(method: &PaymentMethod) -> Result<&str, Error> {
     match method {
         PaymentMethod::Known(known) => Ok(known.as_str()),
@@ -939,7 +942,11 @@ where
 
         if let Ok(mut cache_support) = self.cache_support.write() {
             *cache_support = (
-                info.nuts.nut19.ttl.unwrap_or(300),
+                info.nuts
+                    .nut19
+                    .ttl
+                    .unwrap_or(NUT19_MAX_TTL_SECS)
+                    .min(NUT19_MAX_TTL_SECS),
                 info.nuts
                     .nut19
                     .cached_endpoints
@@ -1301,6 +1308,30 @@ mod tests {
 
         assert!(debug.contains("https://mint.example.com"));
         assert!(debug.contains("auth_wallet: \"[REDACTED]\""));
+    }
+
+    #[tokio::test]
+    async fn mint_info_clamps_nut19_ttl() {
+        let mint_info = MintInfo::new()
+            .nuts(crate::nuts::Nuts::new().nut19(Some(NUT19_MAX_TTL_SECS + 1), Vec::new()));
+        let transport = MockTransport {
+            get_response: Arc::new(Mutex::new(Some(
+                serde_json::to_string(&mint_info).expect("serialize mint info"),
+            ))),
+            ..Default::default()
+        };
+        let mint_url = MintUrl::from_str("https://mint.example.com").expect("parse url");
+        let client = HttpClient::with_transport(mint_url, transport, None);
+
+        client
+            .get_mint_info()
+            .await
+            .expect("get mint info should succeed");
+
+        assert_eq!(
+            client.cache_support.read().expect("cache lock").0,
+            NUT19_MAX_TTL_SECS
+        );
     }
 
     /// Regression test: `post_mint_quote` must send only the

--- a/crates/cdk/src/wallet/mint_metadata_cache.rs
+++ b/crates/cdk/src/wallet/mint_metadata_cache.rs
@@ -24,7 +24,7 @@
 //! let fresh = manager.load_from_mint(&storage, &client).await?;
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
@@ -43,6 +43,126 @@ use crate::wallet::util::escape_log_value;
 use crate::wallet::{AuthMintConnector, AuthWallet, MintConnector};
 use crate::{Error, Wallet};
 
+/// Maximum number of unreferenced keyset descriptions retained in persistence.
+///
+/// HTTP response bodies are already bounded by the transport. This separate,
+/// larger bound prevents a mint that rotates otherwise-valid snapshots from
+/// growing an append-only wallet database indefinitely.
+const MAX_PERSISTED_KEYSET_DESCRIPTIONS: usize = 1_000;
+
+/// Maximum number of per-ID keyset requests made during one metadata refresh.
+///
+/// Cached keys do not count towards this limit.
+const MAX_UNCACHED_KEYSET_FETCHES_PER_REFRESH: usize = 32;
+
+fn keyset_ids_in_use(
+    proofs: impl IntoIterator<Item = cdk_common::wallet::ProofInfo>,
+) -> HashSet<Id> {
+    proofs
+        .into_iter()
+        .map(|proof| proof.proof.keyset_id)
+        .collect()
+}
+
+fn prioritize_keysets(keysets: &mut [KeySetInfo]) {
+    // A stable sort preserves the mint's order within each class, while ensuring
+    // inactive history cannot consume the fetch budget before active keysets.
+    keysets.sort_by_key(|keyset| !keyset.active);
+}
+
+fn prioritize_refresh_keysets(keysets: &mut [KeySetInfo], protected: &HashSet<Id>) {
+    // Proof-bearing keysets are as important as active keysets: both must be
+    // fetched before optional history regardless of response ordering.
+    keysets.sort_by_key(|keyset| !(keyset.active || protected.contains(&keyset.id)));
+}
+
+fn required_uncached_keysets(
+    keysets: &[KeySetInfo],
+    keys: &HashMap<Id, Arc<Keys>>,
+    protected: &HashSet<Id>,
+) -> usize {
+    keysets
+        .iter()
+        .filter(|keyset| {
+            (keyset.active || protected.contains(&keyset.id)) && !keys.contains_key(&keyset.id)
+        })
+        .count()
+}
+
+fn retain_refreshed_domain(
+    metadata: &mut MintMetadata,
+    auth: bool,
+    advertised: &HashSet<Id>,
+    protected: &HashSet<Id>,
+) {
+    metadata.keysets.retain(|id, keyset| {
+        let is_auth = keyset.unit == CurrencyUnit::Auth;
+        is_auth != auth || advertised.contains(id) || protected.contains(id)
+    });
+    metadata
+        .keys
+        .retain(|id, _| metadata.keysets.contains_key(id));
+}
+
+fn select_persisted_keysets(
+    mut keysets: Vec<KeySetInfo>,
+    protected: &HashSet<Id>,
+) -> Vec<KeySetInfo> {
+    prioritize_keysets(&mut keysets);
+
+    let mut regular_optional = 0;
+    let mut auth_optional = 0;
+    keysets
+        .into_iter()
+        .filter(|keyset| {
+            if keyset.active || protected.contains(&keyset.id) {
+                true
+            } else {
+                let optional = if keyset.unit == CurrencyUnit::Auth {
+                    &mut auth_optional
+                } else {
+                    &mut regular_optional
+                };
+                if *optional < MAX_PERSISTED_KEYSET_DESCRIPTIONS {
+                    *optional += 1;
+                    true
+                } else {
+                    false
+                }
+            }
+        })
+        .collect()
+}
+
+fn select_keysets_to_persist(
+    mut keysets: Vec<KeySetInfo>,
+    existing: &HashSet<Id>,
+    protected: &HashSet<Id>,
+) -> Vec<KeySetInfo> {
+    // Update existing rows and always save proof-bearing descriptions. Fill any
+    // remaining slots with active descriptions before inactive history.
+    keysets.sort_by_key(|keyset| {
+        (
+            !(existing.contains(&keyset.id) || protected.contains(&keyset.id)),
+            !keyset.active,
+        )
+    });
+
+    let mut persisted_ids = existing.clone();
+    keysets
+        .into_iter()
+        .filter(|keyset| {
+            let should_persist = persisted_ids.contains(&keyset.id)
+                || protected.contains(&keyset.id)
+                || persisted_ids.len() < MAX_PERSISTED_KEYSET_DESCRIPTIONS;
+            if should_persist {
+                persisted_ids.insert(keyset.id);
+            }
+            should_persist
+        })
+        .collect()
+}
+
 /// Metadata freshness and versioning information
 ///
 /// Tracks when data was last fetched and which version is currently cached.
@@ -55,7 +175,7 @@ pub struct FreshnessStatus {
     /// A future time when the cache would be considered as staled.
     pub updated_at: Instant,
 
-    /// Monotonically increasing version number (for database sync tracking)
+    /// Monotonically increasing generation for this freshness domain.
     version: usize,
 }
 
@@ -67,6 +187,29 @@ impl Default for FreshnessStatus {
             version: 0,
         }
     }
+}
+
+fn mark_refreshed(status: &mut FreshnessStatus, complete: bool) {
+    if complete {
+        status.is_populated = true;
+        status.updated_at = Instant::now();
+    }
+}
+
+fn record_successful_refresh(metadata: &mut MintMetadata, regular: bool, auth: bool) {
+    if regular {
+        mark_refreshed(&mut metadata.status, true);
+        metadata.status.version += 1;
+    }
+    if auth {
+        mark_refreshed(&mut metadata.auth_status, true);
+        metadata.auth_status.version += 1;
+    }
+    metadata.persistence_version += 1;
+}
+
+fn should_persist_mint_info(metadata: &MintMetadata) -> bool {
+    metadata.status.is_populated
 }
 
 /// Complete metadata snapshot for a single mint
@@ -95,6 +238,9 @@ pub struct MintMetadata {
 
     /// Freshness tracking for blind auth keysets
     auth_status: FreshnessStatus,
+
+    /// Generation of any mutation that needs database persistence.
+    persistence_version: usize,
 }
 
 /// On-demand mint metadata cache with database persistence
@@ -128,6 +274,10 @@ pub struct MintMetadataCache {
     /// Tracks which database instances have been synced to which cache version.
     /// Key: pointer identity of storage Arc, Value: last synced cache version
     db_sync_versions: Arc<RwLock<HashMap<usize, usize>>>,
+
+    /// Serializes persistence attempts so an older snapshot cannot finish after
+    /// and overwrite a newer successfully persisted snapshot.
+    db_sync_lock: Arc<Mutex<()>>,
 
     /// Mutex to ensure only one fetch operation runs at a time
     /// Other callers wait for the lock, then re-read the updated cache
@@ -198,6 +348,7 @@ impl MintMetadataCache {
             metadata: Arc::new(ArcSwap::default()),
             ttl: Arc::new(RwLock::new(Some(Duration::from_secs(3600)))),
             db_sync_versions: Arc::new(Default::default()),
+            db_sync_lock: Arc::new(Mutex::new(())),
             fetch_lock: Arc::new(Mutex::new(())),
         }
     }
@@ -294,10 +445,27 @@ impl MintMetadataCache {
             let _ = self.load_from_db(storage).await;
         }
 
+        let protected_keysets = match storage
+            .get_proofs(Some(self.mint_url.clone()), None, None, None)
+            .await
+        {
+            Ok(proofs) => keyset_ids_in_use(proofs),
+            Err(err) => {
+                tracing::warn!(
+                    "Failed to inspect proof keysets for {}; preserving all cached keysets: {}",
+                    self.mint_url,
+                    err
+                );
+                self.metadata.load().keysets.keys().copied().collect()
+            }
+        };
+
         // Perform the fetch
         // Note: keys already in cache (e.g. from load_from_db at boot) are
         // skipped by fetch_from_http's Vacant entry check.
-        let metadata = self.fetch_from_http(Some(client), None).await?;
+        let metadata = self
+            .fetch_from_http(Some(client), None, &protected_keysets)
+            .await?;
 
         // Persist to database
         self.database_sync(storage.clone(), metadata.clone()).await;
@@ -342,8 +510,17 @@ impl MintMetadataCache {
 
         // Load keysets and their keys
         if let Some(keysets) = storage.get_mint_keysets(self.mint_url.clone()).await? {
+            let protected_keysets = keyset_ids_in_use(
+                storage
+                    .get_proofs(Some(self.mint_url.clone()), None, None, None)
+                    .await?,
+            );
+            let selected_keysets = select_persisted_keysets(keysets, &protected_keysets);
+            let selected_ids = selected_keysets.iter().map(|keyset| keyset.id).collect();
+            retain_refreshed_domain(&mut new_metadata, false, &selected_ids, &protected_keysets);
+            retain_refreshed_domain(&mut new_metadata, true, &selected_ids, &protected_keysets);
             new_metadata.active_keysets.clear();
-            for keyset_info in keysets {
+            for keyset_info in selected_keysets {
                 let keyset_arc = Arc::new(keyset_info.clone());
                 new_metadata
                     .keysets
@@ -363,8 +540,17 @@ impl MintMetadataCache {
         // Only mark as populated if we actually loaded keysets.
         // Don't update `updated_at` — the TTL should reflect when we last
         // fetched from the mint, not when we read from the local DB.
-        new_metadata.status.is_populated = !new_metadata.keysets.is_empty();
+        new_metadata.status.is_populated = new_metadata
+            .keysets
+            .values()
+            .any(|keyset| keyset.unit != CurrencyUnit::Auth);
+        new_metadata.auth_status.is_populated = new_metadata
+            .keysets
+            .values()
+            .any(|keyset| keyset.unit == CurrencyUnit::Auth);
         new_metadata.status.version += 1;
+        new_metadata.auth_status.version += 1;
+        new_metadata.persistence_version += 1;
 
         tracing::info!(
             "Loaded cache from database for {} with {} keysets (version {})",
@@ -381,7 +567,7 @@ impl MintMetadataCache {
         let storage_id = Self::arc_pointer_id(storage);
         self.db_sync_versions
             .write()
-            .insert(storage_id, metadata_arc.status.version);
+            .insert(storage_id, metadata_arc.persistence_version);
 
         Ok(metadata_arc)
     }
@@ -433,7 +619,7 @@ impl MintMetadataCache {
                 .unwrap_or(true)
         {
             // Cache is ready - check if database needs updating
-            if db_synced_version != cached_metadata.status.version {
+            if db_synced_version != cached_metadata.persistence_version {
                 // Database is stale - sync before returning
                 self.database_sync(storage.clone(), cached_metadata.clone())
                     .await;
@@ -504,7 +690,7 @@ impl MintMetadataCache {
                 .map(|ttl| cached_metadata.auth_status.updated_at + ttl > Instant::now())
                 .unwrap_or(true)
         {
-            if db_synced_version != cached_metadata.status.version {
+            if db_synced_version != cached_metadata.persistence_version {
                 // Database needs updating - sync before returning
                 self.database_sync(storage.clone(), cached_metadata.clone())
                     .await;
@@ -516,7 +702,7 @@ impl MintMetadataCache {
         let _guard = self.fetch_lock.lock().await;
 
         // Re-check if auth data was updated while waiting for lock
-        let current_metadata = self.metadata.load().clone();
+        let mut current_metadata = self.metadata.load().clone();
         if current_metadata.auth_status.is_populated
             && ttl
                 .map(|ttl| current_metadata.auth_status.updated_at + ttl > Instant::now())
@@ -528,8 +714,50 @@ impl MintMetadataCache {
             return Ok(current_metadata);
         }
 
+        // An auth-only refresh must start from the persisted regular snapshot.
+        // Otherwise its default MintInfo could overwrite valid regular metadata.
+        if !current_metadata.status.is_populated {
+            match self.load_from_db(storage).await {
+                Ok(metadata) => {
+                    current_metadata = metadata;
+                    if current_metadata.auth_status.is_populated
+                        && ttl
+                            .map(|ttl| {
+                                current_metadata.auth_status.updated_at + ttl > Instant::now()
+                            })
+                            .unwrap_or(true)
+                    {
+                        return Ok(current_metadata);
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "Failed to load regular metadata before auth refresh for {}: {}",
+                        self.mint_url,
+                        err
+                    );
+                }
+            }
+        }
+
         // Auth data not in cache - fetch from mint
-        let metadata = self.fetch_from_http(None, Some(auth_client)).await?;
+        let protected_keysets = match storage
+            .get_proofs(Some(self.mint_url.clone()), None, None, None)
+            .await
+        {
+            Ok(proofs) => keyset_ids_in_use(proofs),
+            Err(err) => {
+                tracing::warn!(
+                    "Failed to inspect proof keysets for {}; preserving all cached keysets: {}",
+                    self.mint_url,
+                    err
+                );
+                self.metadata.load().keysets.keys().copied().collect()
+            }
+        };
+        let metadata = self
+            .fetch_from_http(None, Some(auth_client), &protected_keysets)
+            .await?;
 
         // Persist to database
         self.database_sync(storage.clone(), metadata.clone()).await;
@@ -548,10 +776,15 @@ impl MintMetadataCache {
         storage: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
         metadata: Arc<MintMetadata>,
     ) {
+        let _guard = self.db_sync_lock.lock().await;
         let mint_url = self.mint_url.clone();
         let db_sync_versions = self.db_sync_versions.clone();
 
-        Self::persist_to_database(mint_url, storage, metadata, db_sync_versions).await
+        if let Err(err) =
+            Self::persist_to_database(mint_url.clone(), storage, metadata, db_sync_versions).await
+        {
+            tracing::warn!("Failed to persist metadata for {}: {}", mint_url, err);
+        }
     }
 
     /// Persist metadata to database
@@ -571,47 +804,66 @@ impl MintMetadataCache {
         storage: Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
         metadata: Arc<MintMetadata>,
         db_sync_versions: Arc<RwLock<HashMap<usize, usize>>>,
-    ) {
+    ) -> Result<(), database::Error> {
         let storage_id = Self::arc_pointer_id(&storage);
 
         // Check if this write is still needed
         {
-            let mut versions = db_sync_versions.write();
-
+            let versions = db_sync_versions.read();
             let current_synced_version = versions.get(&storage_id).cloned().unwrap_or_default();
 
-            if metadata.status.version <= current_synced_version {
+            if metadata.persistence_version <= current_synced_version {
                 // A newer version has already been persisted - skip this write
-                return;
+                return Ok(());
             }
-
-            // Mark this version as being synced
-            versions.insert(storage_id, metadata.status.version);
         }
 
         // Save mint info
-        storage
-            .add_mint(mint_url.clone(), Some(metadata.mint_info.clone()))
-            .await
-            .inspect_err(|e| tracing::warn!("Failed to save mint info for {}: {}", mint_url, e))
-            .ok();
+        if should_persist_mint_info(&metadata) {
+            storage
+                .add_mint(mint_url.clone(), Some(metadata.mint_info.clone()))
+                .await?;
+        }
 
-        // Save all keysets
-        let keysets: Vec<_> = metadata.keysets.values().map(|ks| (**ks).clone()).collect();
+        // The database API can add or update descriptions but cannot remove
+        // them. Refuse new, unreferenced IDs after the cumulative cap while
+        // continuing to update existing rows and preserve proof keysets.
+        let existing_keysets = storage
+            .get_mint_keysets(mint_url.clone())
+            .await?
+            .unwrap_or_default();
+        let protected_keysets = keyset_ids_in_use(
+            storage
+                .get_proofs(Some(mint_url.clone()), None, None, None)
+                .await?,
+        );
+        let existing_ids = existing_keysets
+            .into_iter()
+            .map(|keyset| keyset.id)
+            .collect();
+        let keysets = select_keysets_to_persist(
+            metadata
+                .keysets
+                .values()
+                .map(|keyset| (**keyset).clone())
+                .collect(),
+            &existing_ids,
+            &protected_keysets,
+        );
+        let persisted_keyset_ids: HashSet<_> = keysets.iter().map(|keyset| keyset.id).collect();
 
         if !keysets.is_empty() {
-            storage
-                .add_mint_keysets(mint_url.clone(), keysets)
-                .await
-                .inspect_err(|e| tracing::warn!("Failed to save keysets for {}: {}", mint_url, e))
-                .ok();
+            storage.add_mint_keysets(mint_url.clone(), keysets).await?;
         }
 
         // Save keys for each keyset
         for (keyset_id, keys) in &metadata.keys {
+            if !persisted_keyset_ids.contains(keyset_id) {
+                continue;
+            }
             if let Some(keyset_info) = metadata.keysets.get(keyset_id) {
                 // Check if keys already exist in database to avoid duplicate insertion
-                if storage.get_keys(keyset_id).await.ok().flatten().is_some() {
+                if storage.get_keys(keyset_id).await?.is_some() {
                     tracing::trace!(
                         "Keys for keyset {} already in database, skipping insert",
                         keyset_id
@@ -628,20 +880,20 @@ impl MintMetadataCache {
                     keys: (**keys).clone(),
                 };
 
-                storage
-                    .add_keys(keyset)
-                    .await
-                    .inspect_err(|e| {
-                        tracing::warn!(
-                            "Failed to save keys for keyset {} at {}: {}",
-                            keyset_id,
-                            mint_url,
-                            e
-                        )
-                    })
-                    .ok();
+                storage.add_keys(keyset).await?;
             }
         }
+
+        // Only a fully successful attempt is considered synced. Concurrent
+        // older writes must not lower a newer completed generation.
+        db_sync_versions
+            .write()
+            .entry(storage_id)
+            .and_modify(|version| {
+                *version = (*version).max(metadata.persistence_version);
+            })
+            .or_insert(metadata.persistence_version);
+        Ok(())
     }
 
     /// Fetch fresh metadata from mint HTTP API and update cache
@@ -665,6 +917,7 @@ impl MintMetadataCache {
         &self,
         client: Option<&Arc<dyn MintConnector + Send + Sync>>,
         auth_client: Option<&Arc<dyn AuthMintConnector + Send + Sync>>,
+        protected_keysets: &HashSet<Id>,
     ) -> Result<Arc<MintMetadata>, Error> {
         tracing::debug!(
             "Fetching mint metadata from HTTP for {}",
@@ -673,7 +926,8 @@ impl MintMetadataCache {
 
         // Start with current cache to preserve data from other sources
         let mut new_metadata = (*self.metadata.load().clone()).clone();
-        let mut keysets_to_fetch = Vec::new();
+        let mut regular_keysets = Vec::new();
+        let mut auth_keysets = Vec::new();
 
         // Fetch regular mint data
         if let Some(client) = client.as_ref() {
@@ -687,82 +941,151 @@ impl MintMetadataCache {
             })?;
 
             // Get list of keysets
-            keysets_to_fetch.extend(
-                client
-                    .get_mint_keysets()
-                    .await
-                    .inspect_err(|err| {
-                        tracing::error!(
-                            "Failed to fetch keysets for {}: {}",
-                            escape_log_value(&self.mint_url),
-                            escape_log_value(err)
-                        );
-                    })?
-                    .keysets,
-            );
+            regular_keysets = client
+                .get_mint_keysets()
+                .await
+                .inspect_err(|err| {
+                    tracing::error!(
+                        "Failed to fetch keysets for {}: {}",
+                        escape_log_value(&self.mint_url),
+                        escape_log_value(err)
+                    );
+                })?
+                .keysets;
         }
 
         // Fetch auth keysets if auth client provided
         if let Some(auth_client) = auth_client.as_ref() {
-            keysets_to_fetch.extend(auth_client.get_mint_blind_auth_keysets().await?.keysets);
+            auth_keysets = auth_client.get_mint_blind_auth_keysets().await?.keysets;
         }
+
+        if regular_keysets
+            .iter()
+            .any(|keyset| keyset.unit == CurrencyUnit::Auth)
+            || auth_keysets
+                .iter()
+                .any(|keyset| keyset.unit != CurrencyUnit::Auth)
+        {
+            return Err(Error::Custom(
+                "Mint returned a keyset in the wrong metadata endpoint".to_string(),
+            ));
+        }
+
+        prioritize_refresh_keysets(&mut regular_keysets, protected_keysets);
+        prioritize_refresh_keysets(&mut auth_keysets, protected_keysets);
 
         tracing::debug!(
             "Fetched {} keysets for {}",
-            keysets_to_fetch.len(),
+            regular_keysets.len() + auth_keysets.len(),
             escape_log_value(&self.mint_url)
         );
 
+        if client.is_some() {
+            let advertised = regular_keysets.iter().map(|keyset| keyset.id).collect();
+            retain_refreshed_domain(&mut new_metadata, false, &advertised, protected_keysets);
+        }
+        if auth_client.is_some() {
+            let advertised = auth_keysets.iter().map(|keyset| keyset.id).collect();
+            retain_refreshed_domain(&mut new_metadata, true, &advertised, protected_keysets);
+        }
+
+        let required_regular =
+            required_uncached_keysets(&regular_keysets, &new_metadata.keys, protected_keysets);
+        let required_auth =
+            required_uncached_keysets(&auth_keysets, &new_metadata.keys, protected_keysets);
+        if required_regular > MAX_UNCACHED_KEYSET_FETCHES_PER_REFRESH
+            || required_auth > MAX_UNCACHED_KEYSET_FETCHES_PER_REFRESH
+        {
+            tracing::warn!(
+                mint_url = %self.mint_url,
+                required_regular,
+                required_auth,
+                limit = MAX_UNCACHED_KEYSET_FETCHES_PER_REFRESH,
+                "Required key material exceeds per-domain refresh limit; preserving previous cache"
+            );
+            return Err(Error::Custom(
+                "Mint metadata requires too many uncached active or proof keysets".to_string(),
+            ));
+        }
+
         // Fetch keys for each keyset
-        new_metadata.active_keysets.clear();
-        for keyset_info in keysets_to_fetch {
+        let mut regular_uncached_fetches = 0;
+        let mut auth_uncached_fetches = 0;
+        let mut skipped_regular_keys = 0;
+        let mut skipped_auth_keys = 0;
+        for keyset_info in regular_keysets.into_iter().chain(auth_keysets) {
+            let is_auth = keyset_info.unit == CurrencyUnit::Auth;
             let keyset_arc = Arc::new(keyset_info.clone());
             new_metadata
                 .keysets
                 .insert(keyset_info.id, keyset_arc.clone());
 
-            // Track active keysets separately for quick access
-            if keyset_info.active {
-                new_metadata.active_keysets.push(keyset_arc);
-            }
-
             // Only fetch keys if we don't already have them cached
-            if let std::collections::hash_map::Entry::Vacant(e) =
-                new_metadata.keys.entry(keyset_info.id)
-            {
-                let keyset = if keyset_info.unit == CurrencyUnit::Auth {
-                    auth_client
-                        .as_ref()
-                        .ok_or(Error::Internal)?
-                        .get_mint_blind_auth_keyset(keyset_info.id)
-                        .await?
-                } else {
-                    client
-                        .as_ref()
-                        .ok_or(Error::Internal)?
-                        .get_mint_keyset(keyset_info.id)
-                        .await?
-                };
+            let _has_keys = match new_metadata.keys.entry(keyset_info.id) {
+                std::collections::hash_map::Entry::Occupied(_) => true,
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    let fetches = if is_auth {
+                        &mut auth_uncached_fetches
+                    } else {
+                        &mut regular_uncached_fetches
+                    };
+                    if *fetches >= MAX_UNCACHED_KEYSET_FETCHES_PER_REFRESH {
+                        if is_auth {
+                            skipped_auth_keys += 1;
+                        } else {
+                            skipped_regular_keys += 1;
+                        }
+                        false
+                    } else {
+                        *fetches += 1;
 
-                // Verify the keyset ID matches the keys
-                keyset.verify_id()?;
+                        let keyset = if keyset_info.unit == CurrencyUnit::Auth {
+                            auth_client
+                                .as_ref()
+                                .ok_or(Error::Internal)?
+                                .get_mint_blind_auth_keyset(keyset_info.id)
+                                .await?
+                        } else {
+                            client
+                                .as_ref()
+                                .ok_or(Error::Internal)?
+                                .get_mint_keyset(keyset_info.id)
+                                .await?
+                        };
 
-                e.insert(Arc::new(keyset.keys));
-            }
+                        // Verify the keyset ID matches the keys
+                        keyset.verify_id()?;
+
+                        e.insert(Arc::new(keyset.keys));
+                        true
+                    }
+                }
+            };
+
+            // Descriptions are useful independently of cached key material
+            // (notably when resolving token proofs), so skipped optional keys do
+            // not remove their successfully fetched descriptions.
         }
+
+        if skipped_regular_keys > 0 || skipped_auth_keys > 0 {
+            tracing::warn!(
+                mint_url = %self.mint_url,
+                skipped_regular = skipped_regular_keys,
+                skipped_auth = skipped_auth_keys,
+                limit = MAX_UNCACHED_KEYSET_FETCHES_PER_REFRESH,
+                "Skipped optional inactive key material after reaching the fetch limit"
+            );
+        }
+
+        new_metadata.active_keysets = new_metadata
+            .keysets
+            .values()
+            .filter(|keyset| keyset.active && new_metadata.keys.contains_key(&keyset.id))
+            .cloned()
+            .collect();
 
         // Update freshness status based on what was fetched
-        if client.is_some() {
-            new_metadata.status.is_populated = true;
-            new_metadata.status.updated_at = Instant::now();
-            new_metadata.status.version += 1;
-        }
-
-        if auth_client.is_some() {
-            new_metadata.auth_status.is_populated = true;
-            new_metadata.auth_status.updated_at = Instant::now();
-            new_metadata.auth_status.version += 1;
-        }
+        record_successful_refresh(&mut new_metadata, client.is_some(), auth_client.is_some());
 
         tracing::info!(
             "Updated cache for {} with {} keysets (version {})",
@@ -780,5 +1103,189 @@ impl MintMetadataCache {
     /// Get the mint URL this cache manages
     pub fn mint_url(&self) -> &MintUrl {
         &self.mint_url
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(index: u64) -> Id {
+        Id::from_bytes(&index.to_be_bytes()).expect("eight-byte keyset id")
+    }
+
+    fn keyset(index: u64, unit: CurrencyUnit, active: bool) -> KeySetInfo {
+        KeySetInfo {
+            id: id(index),
+            unit,
+            active,
+            input_fee_ppk: 0,
+            final_expiry: None,
+        }
+    }
+
+    fn insert_keyset(metadata: &mut MintMetadata, keyset: KeySetInfo) {
+        metadata.keysets.insert(keyset.id, Arc::new(keyset));
+    }
+
+    #[test]
+    fn active_keysets_are_prioritized_beyond_inactive_fetch_limit() {
+        let mut keysets: Vec<_> = (0..MAX_UNCACHED_KEYSET_FETCHES_PER_REFRESH as u64 + 10)
+            .map(|index| keyset(index, CurrencyUnit::Sat, false))
+            .collect();
+        let active_id = id(1_000);
+        keysets.push(keyset(1_000, CurrencyUnit::Sat, true));
+
+        prioritize_refresh_keysets(&mut keysets, &HashSet::new());
+
+        assert_eq!(keysets.first().map(|keyset| keyset.id), Some(active_id));
+    }
+
+    #[test]
+    fn refreshing_auth_does_not_evict_or_compete_with_regular_keysets() {
+        let mut metadata = MintMetadata::default();
+        let regular_id = id(1);
+        let old_auth_id = id(2);
+        let current_auth_id = id(3);
+        insert_keyset(&mut metadata, keyset(1, CurrencyUnit::Sat, true));
+        insert_keyset(&mut metadata, keyset(2, CurrencyUnit::Auth, false));
+        insert_keyset(&mut metadata, keyset(3, CurrencyUnit::Auth, true));
+
+        retain_refreshed_domain(
+            &mut metadata,
+            true,
+            &HashSet::from([current_auth_id]),
+            &HashSet::new(),
+        );
+
+        assert!(metadata.keysets.contains_key(&regular_id));
+        assert!(metadata.keysets.contains_key(&current_auth_id));
+        assert!(!metadata.keysets.contains_key(&old_auth_id));
+    }
+
+    #[test]
+    fn rotating_snapshots_do_not_grow_cache_and_proof_keysets_are_retained() {
+        let mut metadata = MintMetadata::default();
+        let proof_keyset_id = id(10_000);
+        insert_keyset(&mut metadata, keyset(10_000, CurrencyUnit::Sat, false));
+        let protected = HashSet::from([proof_keyset_id]);
+        // This deliberately exceeds the former 100-description rejection limit.
+        const SNAPSHOT_SIZE: u64 = 150;
+
+        for generation in 0..20 {
+            let first = generation * SNAPSHOT_SIZE;
+            let advertised: HashSet<_> = (first..first + SNAPSHOT_SIZE).map(id).collect();
+            retain_refreshed_domain(&mut metadata, false, &advertised, &protected);
+            for index in first..first + SNAPSHOT_SIZE {
+                insert_keyset(&mut metadata, keyset(index, CurrencyUnit::Sat, false));
+            }
+
+            assert!(metadata.keysets.contains_key(&proof_keyset_id));
+            assert_eq!(metadata.keysets.len(), SNAPSHOT_SIZE as usize + 1);
+        }
+    }
+
+    #[test]
+    fn persisted_selection_keeps_active_and_proof_keysets_past_limit() {
+        let proof_keyset_id = id(20_000);
+        let active_keyset_id = id(20_001);
+        let mut keysets: Vec<_> = (0..MAX_PERSISTED_KEYSET_DESCRIPTIONS as u64 + 20)
+            .map(|index| keyset(index, CurrencyUnit::Sat, false))
+            .collect();
+        keysets.push(keyset(20_000, CurrencyUnit::Sat, false));
+        keysets.push(keyset(20_001, CurrencyUnit::Sat, true));
+
+        let selected = select_persisted_keysets(keysets, &HashSet::from([proof_keyset_id]));
+
+        assert!(selected.iter().any(|keyset| keyset.id == proof_keyset_id));
+        assert!(selected.iter().any(|keyset| keyset.id == active_keyset_id));
+        assert_eq!(selected.len(), MAX_PERSISTED_KEYSET_DESCRIPTIONS + 2);
+    }
+
+    #[test]
+    fn successful_description_refresh_is_fresh_without_optional_keys() {
+        let mut status = FreshnessStatus::default();
+
+        mark_refreshed(&mut status, true);
+
+        assert!(status.is_populated);
+    }
+
+    #[test]
+    fn skipped_optional_key_material_keeps_its_description() {
+        let mut metadata = MintMetadata::default();
+        let description = keyset(30_000, CurrencyUnit::Sat, false);
+        insert_keyset(&mut metadata, description.clone());
+
+        assert_eq!(
+            required_uncached_keysets(
+                std::slice::from_ref(&description),
+                &metadata.keys,
+                &HashSet::new(),
+            ),
+            0
+        );
+        assert!(metadata.keysets.contains_key(&description.id));
+        assert!(!metadata.keys.contains_key(&description.id));
+    }
+
+    #[test]
+    fn too_many_required_uncached_keys_exceeds_hard_fetch_cap() {
+        let keysets: Vec<_> = (0..=MAX_UNCACHED_KEYSET_FETCHES_PER_REFRESH as u64)
+            .map(|index| keyset(index, CurrencyUnit::Sat, true))
+            .collect();
+
+        assert!(
+            required_uncached_keysets(&keysets, &HashMap::new(), &HashSet::new(),)
+                > MAX_UNCACHED_KEYSET_FETCHES_PER_REFRESH
+        );
+    }
+
+    #[test]
+    fn auth_refresh_does_not_advance_regular_waiter_generation() {
+        let mut metadata = MintMetadata::default();
+        let regular_version = metadata.status.version;
+
+        record_successful_refresh(&mut metadata, false, true);
+
+        assert_eq!(metadata.status.version, regular_version);
+        assert_eq!(metadata.auth_status.version, 1);
+        assert_eq!(metadata.persistence_version, 1);
+        assert!(!should_persist_mint_info(&metadata));
+    }
+
+    #[test]
+    fn proof_key_material_counts_toward_hard_fetch_cap() {
+        let keysets: Vec<_> = (0..=MAX_UNCACHED_KEYSET_FETCHES_PER_REFRESH as u64)
+            .map(|index| keyset(index, CurrencyUnit::Sat, false))
+            .collect();
+        let protected = keysets.iter().map(|keyset| keyset.id).collect();
+
+        assert!(
+            required_uncached_keysets(&keysets, &HashMap::new(), &protected,)
+                > MAX_UNCACHED_KEYSET_FETCHES_PER_REFRESH
+        );
+    }
+
+    #[test]
+    fn persistence_cap_updates_existing_and_allows_proof_keysets_only() {
+        let existing: HashSet<_> = (0..MAX_PERSISTED_KEYSET_DESCRIPTIONS as u64)
+            .map(id)
+            .collect();
+        let attacker_id = id(20_000);
+        let proof_id = id(20_001);
+        let selected = select_keysets_to_persist(
+            vec![
+                keyset(0, CurrencyUnit::Sat, false),
+                keyset(20_000, CurrencyUnit::Sat, true),
+                keyset(20_001, CurrencyUnit::Sat, false),
+            ],
+            &existing,
+            &HashSet::from([proof_id]),
+        );
+
+        assert!(selected.iter().any(|keyset| keyset.id == id(0)));
+        assert!(selected.iter().any(|keyset| keyset.id == proof_id));
+        assert!(!selected.iter().any(|keyset| keyset.id == attacker_id));
     }
 }

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv};
 use bitcoin::Network;
-use cdk_common::amount::FeeAndAmounts;
+use cdk_common::amount::{FeeAndAmounts, MAX_SPLIT_OUTPUTS};
 use cdk_common::database::{self, WalletDatabase};
 use cdk_common::subscription::WalletParams;
 use cdk_common::wallet::{KeysetLoadPolicy, ProofInfo};
@@ -109,6 +109,18 @@ pub use types::{CrossMintTransferQuote, MeltQuote, MintQuote, SendKind};
 pub use wallet_repository::{TokenData, WalletConfig, WalletRepository, WalletRepositoryBuilder};
 
 use crate::nuts::nut00::ProofsMethods;
+
+/// Validate the aggregate number of outputs generated for one wallet operation.
+pub(crate) fn validate_generated_output_count(output_count: usize) -> Result<(), Error> {
+    if output_count > MAX_SPLIT_OUTPUTS {
+        return Err(Error::MaxOutputsExceeded {
+            actual: output_count,
+            max: MAX_SPLIT_OUTPUTS,
+        });
+    }
+
+    Ok(())
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum DerivationCounterNamespace {
@@ -613,7 +625,7 @@ impl Wallet {
             .get_proofs_with(Some(vec![State::Unspent]), None)
             .await?;
 
-        let amounts_count: HashMap<u64, u64> =
+        let amounts_count: HashMap<u64, usize> =
             unspent_proofs
                 .iter()
                 .fold(HashMap::new(), |mut acc, proof| {
@@ -623,20 +635,27 @@ impl Wallet {
                     acc
                 });
 
-        let needed_amounts =
-            fee_and_amounts
-                .amounts()
-                .iter()
-                .fold(Vec::new(), |mut acc, amount| {
-                    let count_needed = (self.target_proof_count as u64)
-                        .saturating_sub(*amounts_count.get(amount).unwrap_or(&0));
+        // Calculate and validate the exact allocation before constructing it.
+        // `target_proof_count` is public for backwards compatibility, so this
+        // check must not rely on callers having used the builder or setter.
+        let mut needed_count = 0usize;
+        for amount in fee_and_amounts.amounts() {
+            let count_needed = self
+                .target_proof_count
+                .saturating_sub(*amounts_count.get(amount).unwrap_or(&0));
+            needed_count = needed_count
+                .checked_add(count_needed)
+                .ok_or(Error::AmountOverflow)?;
+            validate_generated_output_count(needed_count)?;
+        }
 
-                    for _i in 0..count_needed {
-                        acc.push(Amount::from(*amount));
-                    }
-
-                    acc
-                });
+        let mut needed_amounts = Vec::with_capacity(needed_count);
+        for amount in fee_and_amounts.amounts() {
+            let count_needed = self
+                .target_proof_count
+                .saturating_sub(*amounts_count.get(amount).unwrap_or(&0));
+            needed_amounts.extend(std::iter::repeat_n(Amount::from(*amount), count_needed));
+        }
         Ok(needed_amounts)
     }
 
@@ -1650,6 +1669,32 @@ mod tests {
             matches!(result, Err(Error::AmountOverflow)),
             "expected amount overflow, got {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn state_target_rejects_oversized_allocation_when_builder_is_bypassed() {
+        use crate::wallet::test_utils::{
+            create_test_db, create_test_wallet_with_mock, MockMintConnector,
+        };
+
+        let db = create_test_db().await;
+        let mock_client = Arc::new(MockMintConnector::new());
+        let mut wallet = create_test_wallet_with_mock(db, mock_client).await;
+        // Exercise the public field path retained for backwards compatibility.
+        wallet.target_proof_count = usize::MAX;
+        let fee_and_amounts = FeeAndAmounts::from((0, vec![1, 2]));
+
+        let result = wallet
+            .amounts_needed_for_state_target(&fee_and_amounts)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(Error::MaxOutputsExceeded {
+                max: MAX_SPLIT_OUTPUTS,
+                ..
+            })
+        ));
     }
 
     #[tokio::test]

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -80,7 +80,7 @@ pub use bip321::resolve_bip353_payment_instruction;
 pub use bip321::{
     parse_payment_instruction, Bip321UriBuilder, ParsedPaymentInstruction, PaymentRequestBip321Ext,
 };
-pub use builder::WalletBuilder;
+pub use builder::{WalletBuilder, MAX_TARGET_PROOF_COUNT};
 pub use cdk_common::wallet as types;
 pub use cdk_common::wallet::{
     NUT13Options, P2PKLockedProofSendMode, ReceiveOptions, SendMemo, SendOptions,

--- a/crates/cdk/src/wallet/payment_request.rs
+++ b/crates/cdk/src/wallet/payment_request.rs
@@ -33,6 +33,23 @@ use crate::wallet::ReceiveOptions;
 use crate::wallet::{SendOptions, WalletRepository};
 use crate::Wallet;
 
+/// Maximum size of a decrypted Nostr NUT-18 payment payload.
+pub const MAX_DECRYPTED_PAYMENT_PAYLOAD_BYTES: usize = 64 * 1024;
+
+/// Parse a decrypted Nostr NUT-18 payment payload after enforcing its size limit.
+///
+/// Nostr event contents are untrusted and must be bounded before JSON parsing.
+pub fn parse_nostr_payment_payload(content: &str) -> Result<PaymentRequestPayload, Error> {
+    if content.len() > MAX_DECRYPTED_PAYMENT_PAYLOAD_BYTES {
+        return Err(Error::Custom(format!(
+            "Payment payload exceeds {MAX_DECRYPTED_PAYMENT_PAYLOAD_BYTES} bytes"
+        )));
+    }
+
+    serde_json::from_str(content)
+        .map_err(|e| Error::Custom(format!("Invalid payment payload JSON: {e}")))
+}
+
 /// Optional limits that callers can check before confirming a prepared NUT-18
 /// payment request.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -465,6 +482,30 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
+
+    #[test]
+    fn nostr_payment_payload_rejects_oversized_content_before_json_parsing() {
+        let content = " ".repeat(MAX_DECRYPTED_PAYMENT_PAYLOAD_BYTES + 1);
+
+        let error = parse_nostr_payment_payload(&content).expect_err("payload must be rejected");
+
+        assert!(matches!(
+            error,
+            Error::Custom(message) if message.contains("exceeds 65536 bytes")
+        ));
+    }
+
+    #[test]
+    fn nostr_payment_payload_allows_content_at_size_limit() {
+        let content = " ".repeat(MAX_DECRYPTED_PAYMENT_PAYLOAD_BYTES);
+
+        let error = parse_nostr_payment_payload(&content).expect_err("payload is not valid JSON");
+
+        assert!(matches!(
+            error,
+            Error::Custom(message) if message.starts_with("Invalid payment payload JSON:")
+        ));
+    }
 
     async fn test_repository() -> WalletRepository {
         use cdk_common::database::{Error as DatabaseError, WalletDatabase};
@@ -1836,7 +1877,7 @@ impl WalletRepository {
                 match client.unwrap_gift_wrap(&event).await {
                     Ok(unwrapped) => {
                         let rumor = unwrapped.rumor;
-                        match serde_json::from_str::<PaymentRequestPayload>(&rumor.content) {
+                        match parse_nostr_payment_payload(&rumor.content) {
                             Ok(payload) => {
                                 if !payment_request_mint_policy_accepts_mint(
                                     &mints,

--- a/crates/cdk/src/wallet/receive/saga/mod.rs
+++ b/crates/cdk/src/wallet/receive/saga/mod.rs
@@ -332,9 +332,9 @@ impl<'a> ReceiveSaga<'a, Prepared> {
         )
         .await;
 
-        let mut pre_swap = self
+        let reserved_pre_swap = self
             .wallet
-            .create_swap(
+            .create_swap_with_counter_range(
                 &operation_id,
                 self.state_data.active_keyset_id,
                 &fee_and_amounts,
@@ -348,6 +348,9 @@ impl<'a> ReceiveSaga<'a, Prepared> {
                 ProofReservation::Skip,
             )
             .await?;
+        let counter_start = reserved_pre_swap.counter_start;
+        let counter_end = reserved_pre_swap.counter_end;
+        let mut pre_swap = reserved_pre_swap.pre_swap;
 
         // Determine if SigAll signing is needed
         let sig_flag = self.determine_sig_flag()?;
@@ -360,14 +363,6 @@ impl<'a> ReceiveSaga<'a, Prepared> {
                 }
             }
         }
-
-        // Get counter range for recovery (before the swap request is sent)
-        let counter_end = self
-            .wallet
-            .localstore
-            .increment_keyset_counter(&self.state_data.active_keyset_id, 0)
-            .await?;
-        let counter_start = counter_end.saturating_sub(pre_swap.derived_secret_count);
 
         // Update saga state to SwapRequested BEFORE making the mint call.
         // This is write-ahead logging - if a crash occurs after this, recovery knows

--- a/crates/cdk/src/wallet/recovery.rs
+++ b/crates/cdk/src/wallet/recovery.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
+use cdk_common::amount::MAX_SPLIT_OUTPUTS;
 use cdk_common::wallet::{ProofInfo, WalletSagaState};
 use cdk_common::BlindedMessage;
 use tracing::instrument;
@@ -40,6 +41,79 @@ struct OutputRecoveryParams<'a> {
     counter_start: u32,
     /// Counter end for re-deriving secrets
     counter_end: u32,
+}
+
+/// Maximum number of counters re-derived from persisted saga data in a
+/// single recovery attempt.
+///
+/// Mints accept 1,000 outputs by default. Keep recovery compatible with
+/// moderately larger deployments while bounding deterministic re-derivation
+/// from persisted saga data.
+pub(crate) const MAX_RECOVERY_COUNTER_RANGE: u32 = MAX_SPLIT_OUTPUTS as u32;
+
+/// Validate a persisted counter range before re-deriving secrets from it.
+///
+/// Persisted saga data may be corrupted, so reject reversed or oversized
+/// ranges before [`PreMintSecrets::restore_batch`] derives secrets from them.
+pub(crate) fn validate_recovery_counter_range(
+    counter_start: u32,
+    counter_end: u32,
+) -> Result<(), Error> {
+    let counter_count = counter_end.checked_sub(counter_start).ok_or_else(|| {
+        Error::Custom(format!(
+            "Invalid recovery counter range: end {counter_end} precedes start {counter_start}"
+        ))
+    })?;
+
+    if counter_count > MAX_RECOVERY_COUNTER_RANGE {
+        return Err(Error::Custom(format!(
+            "Invalid recovery counter range: {counter_count} counters exceeds maximum \
+             {MAX_RECOVERY_COUNTER_RANGE}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validate persisted outputs and their deterministic counter range.
+///
+/// This is intentionally performed on borrowed data before a request clones the
+/// messages. All wallet-generated saga output lists use one keyset, and only
+/// seed-derived outputs consume counters.
+pub(crate) fn validate_recovery_output_data(
+    blinded_messages: &[BlindedMessage],
+    counter_start: u32,
+    counter_end: u32,
+) -> Result<(), Error> {
+    validate_recovery_counter_range(counter_start, counter_end)?;
+
+    if blinded_messages.len() > MAX_SPLIT_OUTPUTS {
+        return Err(Error::MaxOutputsExceeded {
+            actual: blinded_messages.len(),
+            max: MAX_SPLIT_OUTPUTS,
+        });
+    }
+
+    let counter_count = (counter_end - counter_start) as usize;
+    if counter_count > blinded_messages.len() {
+        return Err(Error::Custom(format!(
+            "Invalid recovery data: {counter_count} counters for {} blinded messages",
+            blinded_messages.len()
+        )));
+    }
+
+    if let Some(first) = blinded_messages.first() {
+        if blinded_messages
+            .iter()
+            .any(|message| message.keyset_id != first.keyset_id)
+        {
+            return Err(Error::Custom(
+                "Invalid recovery data: blinded messages contain multiple keysets".to_owned(),
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 /// Report of recovery operations performed by [`Wallet::recover_incomplete_sagas`].
@@ -222,12 +296,34 @@ impl RecoveryHelpers for Wallet {
             }
         };
 
+        if let Err(e) = validate_recovery_output_data(blinded_messages, counter_start, counter_end)
+        {
+            tracing::warn!(
+                "{} saga {} - {}. Skipping replay, falling back to other recovery.",
+                saga_type,
+                saga_id,
+                e
+            );
+            return Ok(None);
+        }
+
         // Extract input proofs
         let inputs: Proofs = input_proofs.iter().map(|pi| pi.proof.clone()).collect();
 
         if inputs.is_empty() {
             tracing::debug!(
                 "{} saga {} - no input proofs available, cannot replay",
+                saga_type,
+                saga_id
+            );
+            return Ok(None);
+        }
+
+        let counter_count = (counter_end - counter_start) as usize;
+        if counter_count < blinded_messages.len() {
+            tracing::debug!(
+                "{} saga {} - conditioned outputs cannot be replayed without persisted \
+                 premint secrets; falling back to deterministic output recovery",
                 saga_type,
                 saga_id
             );
@@ -311,12 +407,10 @@ impl Wallet {
         counter_start: Option<u32>,
         counter_end: Option<u32>,
     ) -> Result<OutputRecoveryResult, Error> {
-        let blinded_messages_owned = blinded_messages.map(|bm| bm.to_vec());
-
         let params = match Self::extract_recovery_params(
             saga_id,
             saga_type,
-            blinded_messages_owned.as_ref(),
+            blinded_messages,
             counter_start,
             counter_end,
         ) {
@@ -505,45 +599,61 @@ impl Wallet {
 
         // Match the returned outputs to our premint secrets by B_ value, preserving
         // the mint response order used by the returned signatures.
+        let returned_signature_count = restore_response.signatures.len();
         let matched: Vec<_> = restore_response
             .outputs
-            .iter()
-            .filter_map(|output| {
+            .into_iter()
+            .zip(restore_response.signatures)
+            .filter_map(|(output, signature)| {
                 let premint = premints_by_blinded_secret.get(&output.blinded_secret)?;
                 let requested_output =
                     requested_outputs_by_blinded_secret.get(&output.blinded_secret)?;
-                Some((*premint, *requested_output))
+                Some((signature, *premint, *requested_output))
             })
             .collect();
 
-        if matched.len() != restore_response.signatures.len() {
+        if matched.len() != returned_signature_count {
             tracing::warn!(
-                "{} saga {} - signature count mismatch: {} secrets, {} signatures",
+                "{} saga {} - recovered {} deterministic outputs from {} returned signatures",
                 saga_type,
                 saga_id,
                 matched.len(),
-                restore_response.signatures.len()
+                returned_signature_count
             );
         }
+        if matched.is_empty() {
+            return Ok(OutputRecoveryResult::Unavailable);
+        }
+
+        let matched_signatures: Vec<_> = matched
+            .iter()
+            .map(|(signature, _, _)| signature.clone())
+            .collect();
 
         // Load keyset keys for proof construction
         let keys = self.keyset(keyset_id).await?.keys;
 
         validate_mint_response_signatures(
             self,
-            &restore_response.signatures,
+            &matched_signatures,
             matched
                 .iter()
-                .map(|(_, requested_output)| *requested_output),
+                .map(|(_, _, requested_output)| *requested_output),
             SignatureAmountValidation::AllowZeroAmountPlaceholder,
         )
         .await?;
 
         // Construct proofs from signatures
         let proofs = construct_proofs(
-            restore_response.signatures,
-            matched.iter().map(|(p, _)| p.r.clone()).collect(),
-            matched.iter().map(|(p, _)| p.secret.clone()).collect(),
+            matched_signatures,
+            matched
+                .iter()
+                .map(|(_, premint, _)| premint.r.clone())
+                .collect(),
+            matched
+                .iter()
+                .map(|(_, premint, _)| premint.secret.clone())
+                .collect(),
             &keys,
         )?;
 
@@ -569,7 +679,7 @@ impl Wallet {
     fn extract_recovery_params<'a>(
         saga_id: &uuid::Uuid,
         saga_type: &str,
-        blinded_messages: Option<&'a Vec<BlindedMessage>>,
+        blinded_messages: Option<&'a [BlindedMessage]>,
         counter_start: Option<u32>,
         counter_end: Option<u32>,
     ) -> Option<OutputRecoveryParams<'a>> {
@@ -598,6 +708,17 @@ impl Wallet {
                 return None;
             }
         };
+
+        if let Err(e) = validate_recovery_output_data(blinded_messages, counter_start, counter_end)
+        {
+            tracing::warn!(
+                "{} saga {} - {}. Skipping output recovery.",
+                saga_type,
+                saga_id,
+                e
+            );
+            return None;
+        }
 
         Some(OutputRecoveryParams {
             blinded_messages,
@@ -721,6 +842,7 @@ mod tests {
     use std::str::FromStr;
     use std::sync::Arc;
 
+    use cdk_common::amount::MAX_SPLIT_OUTPUTS;
     use cdk_common::mint_url::MintUrl;
     use cdk_common::nuts::{MeltQuoteBolt11Response, MeltQuoteState, PaymentMethod, State};
     use cdk_common::wallet::{
@@ -729,7 +851,51 @@ mod tests {
     };
     use cdk_common::Amount;
 
+    use super::{validate_recovery_output_data, MAX_RECOVERY_COUNTER_RANGE};
+    use crate::nuts::PreMintSecrets;
     use crate::wallet::test_utils::*;
+    use crate::Error;
+
+    #[test]
+    fn recovery_output_validation_rejects_oversized_messages() {
+        let message = PreMintSecrets::random(
+            test_keyset_id(),
+            Amount::ONE,
+            &cdk_common::amount::SplitTarget::None,
+            &(0, vec![1]).into(),
+        )
+        .expect("premint")
+        .secrets
+        .remove(0)
+        .blinded_message;
+        let messages = vec![message; MAX_SPLIT_OUTPUTS + 1];
+
+        assert!(matches!(
+            validate_recovery_output_data(&messages, 0, 1),
+            Err(Error::MaxOutputsExceeded {
+                actual,
+                max: MAX_SPLIT_OUTPUTS,
+            }) if actual == MAX_SPLIT_OUTPUTS + 1
+        ));
+    }
+
+    #[test]
+    fn recovery_output_validation_accepts_generated_limit() {
+        let message = PreMintSecrets::random(
+            test_keyset_id(),
+            Amount::ONE,
+            &cdk_common::amount::SplitTarget::None,
+            &(0, vec![1]).into(),
+        )
+        .expect("premint")
+        .secrets
+        .remove(0)
+        .blinded_message;
+        let messages = vec![message; MAX_SPLIT_OUTPUTS];
+
+        validate_recovery_output_data(&messages, 0, MAX_RECOVERY_COUNTER_RANGE)
+            .expect("the generation limit must remain recoverable");
+    }
 
     #[tokio::test]
     async fn test_recover_receive_proofs_pending() {

--- a/crates/cdk/src/wallet/streams/nostr.rs
+++ b/crates/cdk/src/wallet/streams/nostr.rs
@@ -11,6 +11,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::error::Error;
+use crate::wallet::payment_request::parse_nostr_payment_payload;
 use crate::wallet::streams::RecvFuture;
 
 #[allow(clippy::type_complexity)]
@@ -79,9 +80,7 @@ impl NostrPaymentEventStream {
                                 match client.unwrap_gift_wrap(&event).await {
                                     Ok(unwrapped) => {
                                         let rumor = unwrapped.rumor;
-                                        match serde_json::from_str::<PaymentRequestPayload>(
-                                            &rumor.content,
-                                        ) {
+                                        match parse_nostr_payment_payload(&rumor.content) {
                                             Ok(payload) => {
                                                 // Best-effort send; if receiver closed, instruct exit
                                                 if tx.send(Ok(payload)).await.is_err() {

--- a/crates/cdk/src/wallet/streams/npubcash.rs
+++ b/crates/cdk/src/wallet/streams/npubcash.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use cdk_common::amount::SplitTarget;
+use cdk_common::amount::{SplitTarget, MAX_SPLIT_OUTPUTS};
 use cdk_common::MintQuoteState;
 use futures::Stream;
 use tokio::sync::mpsc;
@@ -17,6 +17,28 @@ use crate::nuts::{Proofs, SpendingConditions};
 use crate::wallet::types::MintQuote;
 use crate::wallet::wallet_repository::WalletRepository;
 use crate::wallet::Wallet;
+
+fn validate_remote_quote_output_budget(
+    amount: crate::Amount,
+    split_target: &SplitTarget,
+) -> Result<(), Error> {
+    let SplitTarget::Value(target) = split_target else {
+        return Ok(());
+    };
+    if target == &crate::Amount::ZERO {
+        return Ok(());
+    }
+
+    let output_groups = u64::from(amount).div_ceil(u64::from(*target));
+    if output_groups > MAX_SPLIT_OUTPUTS as u64 {
+        return Err(Error::Custom(format!(
+            "NpubCash quote requires at least {output_groups} outputs, maximum is \
+             {MAX_SPLIT_OUTPUTS}"
+        )));
+    }
+
+    Ok(())
+}
 
 /// Stream that continuously polls NpubCash and yields proofs as payments arrive
 #[allow(missing_debug_implementations)]
@@ -50,6 +72,16 @@ impl NpubCashProofStream {
                             Ok(quotes) => {
                                 for quote in quotes {
                                     if matches!(quote.state, MintQuoteState::Paid) {
+                                        let split_budget = validate_remote_quote_output_budget(
+                                            quote.amount_mintable(),
+                                            &split_target,
+                                        );
+                                        if let Err(error) = split_budget {
+                                            if tx.send(Err(error)).await.is_err() {
+                                                return;
+                                            }
+                                            continue;
+                                        }
                                         let quote_id = quote.id.clone();
                                         let mint_url = quote.mint_url.clone();
                                         tracing::info!("Minting NpubCash quote {}...", quote_id);
@@ -136,6 +168,16 @@ impl WalletNpubCashProofStream {
                             Ok(quotes) => {
                                 for quote in quotes {
                                     if matches!(quote.state, MintQuoteState::Paid) {
+                                        let split_budget = validate_remote_quote_output_budget(
+                                            quote.amount_mintable(),
+                                            &split_target,
+                                        );
+                                        if let Err(error) = split_budget {
+                                            if tx.send(Err(error)).await.is_err() {
+                                                return;
+                                            }
+                                            continue;
+                                        }
                                         let quote_id = quote.id.clone();
                                         let mint_url = quote.mint_url.clone();
 
@@ -188,5 +230,23 @@ impl Stream for WalletNpubCashProofStream {
 impl Drop for WalletNpubCashProofStream {
     fn drop(&mut self) {
         self.cancel.cancel();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_quote_output_budget_rejects_oversized_value_split() {
+        let at_limit = crate::Amount::from(MAX_SPLIT_OUTPUTS as u64);
+        assert!(
+            validate_remote_quote_output_budget(at_limit, &SplitTarget::Value(1.into())).is_ok()
+        );
+
+        let over_limit = crate::Amount::from(MAX_SPLIT_OUTPUTS as u64 + 1);
+        assert!(
+            validate_remote_quote_output_budget(over_limit, &SplitTarget::Value(1.into())).is_err()
+        );
     }
 }

--- a/crates/cdk/src/wallet/swap/mod.rs
+++ b/crates/cdk/src/wallet/swap/mod.rs
@@ -30,6 +30,16 @@ pub(crate) enum ProofReservation {
     Skip,
 }
 
+/// A prepared swap together with the exact deterministic counter reservation.
+pub(crate) struct PreSwapWithCounterRange {
+    /// Prepared swap request and secrets.
+    pub pre_swap: PreSwap,
+    /// First reserved counter.
+    pub counter_start: u32,
+    /// Exclusive end of the reserved range.
+    pub counter_end: u32,
+}
+
 impl Wallet {
     /// Swap proofs using the saga pattern.
     ///
@@ -118,10 +128,10 @@ impl Wallet {
         .await
     }
 
-    /// Create Swap Payload
+    /// Create a swap payload and retain its exact counter reservation.
     #[instrument(skip(self, proofs))]
     #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn create_swap(
+    pub(crate) async fn create_swap_with_counter_range(
         &self,
         operation_id: &uuid::Uuid,
         active_keyset_id: Id,
@@ -134,16 +144,11 @@ impl Wallet {
         use_p2bk: bool,
         proofs_fee_breakdown: &ProofsFeeBreakdown,
         proof_reservation: ProofReservation,
-    ) -> Result<PreSwap, Error> {
+    ) -> Result<PreSwapWithCounterRange, Error> {
         tracing::info!("Creating swap");
 
         // Desired amount is either amount passed or value of all proof
         let proofs_total = proofs.total_amount()?;
-
-        if proof_reservation == ProofReservation::Reserve {
-            let ys: Vec<PublicKey> = proofs.ys()?;
-            self.localstore.reserve_proofs(ys, operation_id).await?;
-        }
 
         let total_to_subtract = amount
             .unwrap_or(Amount::ZERO)
@@ -187,26 +192,34 @@ impl Wallet {
             s => s,
         };
 
+        let send_output_count = send_amount
+            .unwrap_or(Amount::ZERO)
+            .split_targeted(&SplitTarget::default(), fee_and_amounts)?
+            .len();
+        let change_output_count = change_amount
+            .split_targeted(&change_split_target, fee_and_amounts)?
+            .len();
+        let aggregate_output_count = send_output_count
+            .checked_add(change_output_count)
+            .ok_or(Error::AmountOverflow)?;
+        crate::wallet::validate_generated_output_count(aggregate_output_count)?;
+
+        if proof_reservation == ProofReservation::Reserve {
+            let ys: Vec<PublicKey> = proofs.ys()?;
+            self.localstore.reserve_proofs(ys, operation_id).await?;
+        }
+
         let derived_secret_count;
 
         // Calculate total secrets needed and atomically reserve counter range
         let total_secrets_needed = match spending_conditions {
             Some(_) => {
                 // For spending conditions, we only need to count change secrets
-                change_amount
-                    .split_targeted(&change_split_target, fee_and_amounts)?
-                    .len() as u32
+                u32::try_from(change_output_count).map_err(|_| Error::AmountOverflow)?
             }
             None => {
                 // For no spending conditions, count both send and change secrets
-                let send_count = send_amount
-                    .unwrap_or(Amount::ZERO)
-                    .split_targeted(&SplitTarget::default(), fee_and_amounts)?
-                    .len() as u32;
-                let change_count = change_amount
-                    .split_targeted(&change_split_target, fee_and_amounts)?
-                    .len() as u32;
-                send_count + change_count
+                u32::try_from(aggregate_output_count).map_err(|_| Error::AmountOverflow)?
             }
         };
 
@@ -227,6 +240,9 @@ impl Wallet {
         } else {
             0
         };
+        let counter_end = starting_counter
+            .checked_add(total_secrets_needed)
+            .ok_or(Error::AmountOverflow)?;
 
         let mut count = starting_counter;
 
@@ -316,17 +332,22 @@ impl Wallet {
 
         // Combine the BlindedMessages totaling the desired amount with change
         desired_messages.combine(change_messages);
+        crate::wallet::validate_generated_output_count(desired_messages.len())?;
         // Sort the premint secrets to avoid finger printing
         desired_messages.sort_secrets();
 
         let swap_request = SwapRequest::new(proofs, desired_messages.blinded_messages());
 
-        Ok(PreSwap {
-            pre_mint_secrets: desired_messages,
-            swap_request,
-            derived_secret_count: derived_secret_count as u32,
-            fee: proofs_fee_breakdown.total,
-            p2bk_secret_keys: p2bk_ephemeral_key,
+        Ok(PreSwapWithCounterRange {
+            pre_swap: PreSwap {
+                pre_mint_secrets: desired_messages,
+                swap_request,
+                derived_secret_count: derived_secret_count as u32,
+                fee: proofs_fee_breakdown.total,
+                p2bk_secret_keys: p2bk_ephemeral_key,
+            },
+            counter_start: starting_counter,
+            counter_end,
         })
     }
 }
@@ -345,6 +366,124 @@ mod tests {
         test_keyset_id, test_mint_url, test_proof, MockMintConnector,
     };
     use crate::Error;
+
+    #[tokio::test]
+    async fn create_swap_rejects_aggregate_outputs_before_counter_reservation() {
+        use cdk_common::amount::{FeeAndAmounts, MAX_SPLIT_OUTPUTS};
+
+        use crate::fees::ProofsFeeBreakdown;
+        use crate::wallet::swap::ProofReservation;
+        use crate::Amount;
+
+        let db = create_test_db().await;
+        let mock = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock).await;
+        let keyset_id = test_keyset_id();
+        let fee_and_amounts = FeeAndAmounts::from((0, vec![1]));
+        let initial_counter = db
+            .increment_keyset_counter(&keyset_id, 0)
+            .await
+            .expect("read counter");
+
+        let proof = test_proof(keyset_id, (MAX_SPLIT_OUTPUTS * 2) as u64);
+        let proof_info = ProofInfo::new(
+            proof.clone(),
+            test_mint_url(),
+            State::Unspent,
+            CurrencyUnit::Sat,
+        )
+        .expect("proof info");
+        let proof_y = proof_info.y;
+        db.update_proofs(vec![proof_info], vec![])
+            .await
+            .expect("store proof");
+
+        let result = wallet
+            .create_swap_with_counter_range(
+                &uuid::Uuid::new_v4(),
+                keyset_id,
+                &fee_and_amounts,
+                Some(Amount::from(MAX_SPLIT_OUTPUTS as u64)),
+                SplitTarget::Value(Amount::ONE),
+                vec![proof],
+                None,
+                false,
+                false,
+                &ProofsFeeBreakdown {
+                    total: Amount::ZERO,
+                    per_keyset: std::collections::HashMap::new(),
+                },
+                ProofReservation::Reserve,
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(Error::MaxOutputsExceeded {
+                actual,
+                max: MAX_SPLIT_OUTPUTS,
+            }) if actual == MAX_SPLIT_OUTPUTS * 2
+        ));
+        assert_eq!(
+            db.increment_keyset_counter(&keyset_id, 0)
+                .await
+                .expect("read counter"),
+            initial_counter
+        );
+        assert_eq!(
+            db.get_proofs_by_ys(vec![proof_y])
+                .await
+                .expect("read proof")[0]
+                .state,
+            State::Unspent
+        );
+    }
+
+    #[tokio::test]
+    async fn create_swap_keeps_exact_reserved_range_after_concurrent_advance() {
+        use cdk_common::amount::FeeAndAmounts;
+
+        use crate::fees::ProofsFeeBreakdown;
+        use crate::wallet::swap::ProofReservation;
+        use crate::Amount;
+
+        let db = create_test_db().await;
+        let wallet =
+            create_test_wallet_with_mock(db.clone(), Arc::new(MockMintConnector::new())).await;
+        let keyset_id = test_keyset_id();
+        let initial_counter = db
+            .increment_keyset_counter(&keyset_id, 0)
+            .await
+            .expect("read counter");
+
+        let reserved = wallet
+            .create_swap_with_counter_range(
+                &uuid::Uuid::new_v4(),
+                keyset_id,
+                &FeeAndAmounts::from((0, vec![1])),
+                Some(Amount::ONE),
+                SplitTarget::Value(Amount::ONE),
+                vec![test_proof(keyset_id, 2)],
+                None,
+                false,
+                false,
+                &ProofsFeeBreakdown {
+                    total: Amount::ZERO,
+                    per_keyset: std::collections::HashMap::new(),
+                },
+                ProofReservation::Skip,
+            )
+            .await
+            .expect("prepare swap");
+
+        db.increment_keyset_counter(&keyset_id, 7)
+            .await
+            .expect("concurrent reservation");
+
+        assert_eq!(reserved.counter_start, initial_counter);
+        assert_eq!(reserved.counter_end, initial_counter + 2);
+        assert_eq!(reserved.pre_swap.derived_secret_count, 2);
+    }
 
     /// When the mint returns InactiveKeyset on a swap and the active keyset
     /// has rotated, the wallet should retry the swap with the new keyset.

--- a/crates/cdk/src/wallet/swap/saga/mod.rs
+++ b/crates/cdk/src/wallet/swap/saga/mod.rs
@@ -123,9 +123,9 @@ impl<'a> SwapSaga<'a, Initial> {
 
         let input_ys = input_proofs.ys()?;
 
-        let pre_swap = self
+        let reserved_pre_swap = self
             .wallet
-            .create_swap(
+            .create_swap_with_counter_range(
                 &self.state_data.operation_id,
                 active_keyset_id,
                 &fee_and_amounts,
@@ -139,16 +139,13 @@ impl<'a> SwapSaga<'a, Initial> {
                 proof_reservation,
             )
             .await?;
+        let pre_swap = reserved_pre_swap.pre_swap;
 
         let fee = pre_swap.fee;
         let input_amount = input_proofs.total_amount()?;
 
-        let counter_end = self
-            .wallet
-            .localstore
-            .increment_keyset_counter(&active_keyset_id, 0)
-            .await?;
-        let counter_start = counter_end.saturating_sub(pre_swap.derived_secret_count);
+        let counter_start = reserved_pre_swap.counter_start;
+        let counter_end = reserved_pre_swap.counter_end;
         let output_amount = input_amount
             .checked_sub(fee)
             .ok_or(Error::InsufficientFunds)?;
@@ -196,6 +193,8 @@ impl<'a> SwapSaga<'a, Initial> {
                 input_ys,
                 spending_conditions,
                 pre_swap,
+                counter_start,
+                counter_end,
                 saga,
             },
         })

--- a/crates/cdk/src/wallet/swap/saga/resume.rs
+++ b/crates/cdk/src/wallet/swap/saga/resume.rs
@@ -16,10 +16,27 @@ use tracing::instrument;
 
 use crate::dhke::hash_to_curve;
 use crate::nuts::{PreMintSecrets, State};
-use crate::wallet::recovery::{RecoveryAction, RecoveryHelpers};
+use crate::wallet::recovery::{validate_recovery_output_data, RecoveryAction, RecoveryHelpers};
 use crate::wallet::saga::{CompensatingAction, RevertProofReservation};
 use crate::wallet::util::escape_log_value;
 use crate::{Error, Wallet};
+
+fn validate_swap_recovery_counter_range(data: &SwapOperationData) -> Result<(), Error> {
+    let (blinded_messages, counter_start, counter_end) = match (
+        data.blinded_messages.as_deref(),
+        data.counter_start,
+        data.counter_end,
+    ) {
+        (Some(blinded_messages), Some(counter_start), Some(counter_end))
+            if !blinded_messages.is_empty() =>
+        {
+            (blinded_messages, counter_start, counter_end)
+        }
+        _ => return Ok(()),
+    };
+
+    validate_recovery_output_data(blinded_messages, counter_start, counter_end)
+}
 
 impl Wallet {
     /// Resume an incomplete swap saga after crash recovery.
@@ -87,6 +104,8 @@ impl Wallet {
         saga_id: &uuid::Uuid,
         data: &SwapOperationData,
     ) -> Result<RecoveryAction, Error> {
+        validate_swap_recovery_counter_range(data)?;
+
         // 1. Fast Path: Check if new proofs are already in the DB (Local Success)
         if self.check_db_for_swap_success(saga_id, data).await? {
             return Ok(RecoveryAction::Recovered);
@@ -304,6 +323,120 @@ mod tests {
 
     use crate::nuts::{PreMintSecrets, SecretKey as NutSecretKey};
     use crate::wallet::test_utils::*;
+
+    fn swap_operation_data_with_counter_range(
+        start: u32,
+        end: u32,
+        blinded_message_count: usize,
+    ) -> SwapOperationData {
+        let keyset_id = test_keyset_id();
+        let blinded_message = PreMintSecrets::random(
+            keyset_id,
+            Amount::ONE,
+            &cdk_common::amount::SplitTarget::None,
+            &(0, vec![1]).into(),
+        )
+        .unwrap()
+        .secrets
+        .remove(0)
+        .blinded_message;
+        let blinded_messages = vec![blinded_message; blinded_message_count];
+
+        SwapOperationData {
+            input_amount: Amount::ONE,
+            output_amount: Amount::ONE,
+            counter_start: Some(start),
+            counter_end: Some(end),
+            blinded_messages: Some(blinded_messages),
+        }
+    }
+
+    #[test]
+    fn test_swap_recovery_rejects_reversed_counter_range() {
+        let data = swap_operation_data_with_counter_range(2, 1, 1);
+        assert!(validate_swap_recovery_counter_range(&data).is_err());
+    }
+
+    #[test]
+    fn test_swap_recovery_rejects_counter_range_output_mismatch() {
+        // More counters than blinded messages can never be valid: every
+        // counter-derived secret produces exactly one output.
+        let data = swap_operation_data_with_counter_range(0, 2, 1);
+        assert!(validate_swap_recovery_counter_range(&data).is_err());
+    }
+
+    #[test]
+    fn test_swap_recovery_rejects_oversized_counter_range() {
+        let data = swap_operation_data_with_counter_range(
+            0,
+            MAX_RECOVERY_COUNTER_RANGE + 1,
+            (MAX_RECOVERY_COUNTER_RANGE + 1) as usize,
+        );
+        assert!(validate_swap_recovery_counter_range(&data).is_err());
+    }
+
+    /// Regression test: swaps with spending conditions (P2PK, HTLC, P2BK)
+    /// derive only their change outputs from the seed counter, so the
+    /// persisted counter range is smaller than the blinded message count.
+    /// Recovery validation must accept these sagas.
+    #[tokio::test]
+    async fn test_swap_recovery_accepts_spending_condition_counter_range() {
+        use std::collections::HashMap;
+
+        use cdk_common::amount::{FeeAndAmounts, SplitTarget};
+        use cdk_common::nuts::SpendingConditions;
+
+        use crate::fees::ProofsFeeBreakdown;
+        use crate::wallet::swap::ProofReservation;
+
+        let db = create_test_db().await;
+        let mock_client = Arc::new(MockMintConnector::new());
+        let wallet = create_test_wallet_with_mock(db.clone(), mock_client).await;
+        let keyset_id = test_keyset_id();
+
+        let proofs = vec![test_proof(keyset_id, 100)];
+        let fee_and_amounts: FeeAndAmounts =
+            (0u64, (0..7).map(|x| 2u64.pow(x)).collect::<Vec<_>>()).into();
+        let fee_breakdown = ProofsFeeBreakdown {
+            total: Amount::ZERO,
+            per_keyset: HashMap::new(),
+        };
+        let conditions = SpendingConditions::new_p2pk(NutSecretKey::generate().public_key(), None);
+
+        let reserved_pre_swap = wallet
+            .create_swap_with_counter_range(
+                &uuid::Uuid::new_v4(),
+                keyset_id,
+                &fee_and_amounts,
+                Some(Amount::from(2)),
+                SplitTarget::None,
+                proofs,
+                Some(conditions),
+                false,
+                false,
+                &fee_breakdown,
+                ProofReservation::Skip,
+            )
+            .await
+            .expect("create_swap with P2PK conditions");
+        let pre_swap = reserved_pre_swap.pre_swap;
+
+        // The counter range covers only the counter-derived change outputs,
+        // fewer than the total blinded messages.
+        assert!((pre_swap.derived_secret_count as usize) < pre_swap.swap_request.outputs().len());
+
+        // Build the saga data exactly as the swap saga persists it.
+        let data = SwapOperationData {
+            input_amount: Amount::from(100),
+            output_amount: Amount::from(100),
+            counter_start: Some(reserved_pre_swap.counter_start),
+            counter_end: Some(reserved_pre_swap.counter_end),
+            blinded_messages: Some(pre_swap.swap_request.outputs().clone()),
+        };
+
+        validate_swap_recovery_counter_range(&data)
+            .expect("spending-condition swap saga must pass recovery validation");
+    }
 
     #[tokio::test]
     async fn test_recover_swap_proofs_reserved() {

--- a/crates/cdk/src/wallet/swap/saga/resume.rs
+++ b/crates/cdk/src/wallet/swap/saga/resume.rs
@@ -321,7 +321,9 @@ mod tests {
     };
     use cdk_common::Amount;
 
+    use super::validate_swap_recovery_counter_range;
     use crate::nuts::{PreMintSecrets, SecretKey as NutSecretKey};
+    use crate::wallet::recovery::MAX_RECOVERY_COUNTER_RANGE;
     use crate::wallet::test_utils::*;
 
     fn swap_operation_data_with_counter_range(

--- a/crates/cdk/src/wallet/swap/saga/state.rs
+++ b/crates/cdk/src/wallet/swap/saga/state.rs
@@ -41,6 +41,10 @@ pub struct Prepared {
     pub spending_conditions: Option<SpendingConditions>,
     /// Pre-swap data (request and secrets)
     pub pre_swap: PreSwap,
+    /// Exact first deterministic counter reserved by swap preparation
+    pub counter_start: u32,
+    /// Exact exclusive end of the deterministic counter reservation
+    pub counter_end: u32,
     /// Ephemeral key if P2BK was used
     /// The persisted saga for optimistic locking (contains recovery data)
     pub saga: WalletSaga,
@@ -86,6 +90,8 @@ impl fmt::Debug for Prepared {
                     .collect::<Vec<_>>(),
             )
             .field("derived_secret_count", &self.pre_swap.derived_secret_count)
+            .field("counter_start", &self.counter_start)
+            .field("counter_end", &self.counter_end)
             .field("fee", &self.pre_swap.fee)
             .field(
                 "p2bk_secret_key_count",
@@ -187,6 +193,8 @@ mod tests {
                 fee: Amount::from(0),
                 p2bk_secret_keys: None,
             },
+            counter_start: 0,
+            counter_end: 1,
             saga: swap_saga(operation_id),
         };
         let finalized = Finalized {


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

Adds defensive bounds around wallet-controlled and remote-controlled inputs to prevent excessive allocation, parsing, network activity, and recovery work.

  This PR:

  - Limits amount splits and NpubCash quote splits to 4,096 outputs.
  - Validates persisted swap recovery counter ranges before re-deriving outputs.
  - Limits Tor response bodies to 10 MiB with a 30-second read timeout.
  - Limits decrypted Nostr payloads to 64 KiB and defaults CLI relay queries to a seven-day lookback.
  - Limits metadata refreshes to 100 keysets and 32 uncached keyset fetches.
  - Caps mint-provided NUT-19 replay TTLs at five minutes.
  - Rejects FFI `target_proof_count` values above 100.

  Boundary, oversized-input, invalid-range, and timeout regression tests are included.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
