### PR TITLE
fix: disable gRPC quote state overrides by default

### DIFF
--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -78,6 +78,7 @@ pub struct MintRPCServer {
     socket_addr: SocketAddr,
     mint: Arc<Mint>,
     mutation_guard: Option<Arc<dyn MintMutationGuard>>,
+    allow_mint_quote_payment_override: bool,
     wallet_info_provider: Option<DynWalletInfoProvider>,
     shutdown: Arc<Notify>,
     handle: Option<Arc<JoinHandle<Result<(), Error>>>>,
@@ -95,6 +96,7 @@ impl MintRPCServer {
             socket_addr: format!("{addr}:{port}").parse()?,
             mint,
             mutation_guard: None,
+            allow_mint_quote_payment_override: false,
             wallet_info_provider: None,
             shutdown: Arc::new(Notify::new()),
             handle: None,
@@ -104,6 +106,16 @@ impl MintRPCServer {
     /// Adds a guard that runs before every mutating management RPC.
     pub fn with_mutation_guard(mut self, guard: Arc<dyn MintMutationGuard>) -> Self {
         self.mutation_guard = Some(guard);
+        self
+    }
+
+    /// Enables or disables management RPC mint quote state overrides.
+    ///
+    /// This includes the legacy quote-state update endpoint and is disabled by
+    /// default because the paid state records a payment without confirmation
+    /// from the configured payment backend.
+    pub fn with_mint_quote_payment_override(mut self, enabled: bool) -> Self {
+        self.allow_mint_quote_payment_override = enabled;
         self
     }
 
@@ -118,6 +130,16 @@ impl MintRPCServer {
             }
             MintMutationGuardError::Internal(message) => Status::internal(message),
         })
+    }
+
+    fn ensure_mint_quote_state_override_allowed(&self) -> Result<(), Status> {
+        if !self.allow_mint_quote_payment_override {
+            return Err(Status::permission_denied(
+                "Mint quote state override is disabled",
+            ));
+        }
+
+        Ok(())
     }
 
     /// Configures the on-chain wallet management provider.
@@ -370,6 +392,8 @@ impl MintRPCServer {
     /// Returns the quote as it stands after the update. Shared by the legacy
     /// [`CdkMint`] service and [`QuoteService`] while both are served.
     async fn set_mint_quote_paid(&self, quote_id: &str) -> Result<MintQuote, Status> {
+        self.ensure_mint_quote_state_override_allowed()?;
+
         let quote_id = quote_id
             .parse()
             .map_err(|_| Status::invalid_argument("Invalid quote id".to_string()))?;
@@ -1018,6 +1042,7 @@ impl CdkMint for MintRPCServer {
         request: Request<UpdateNut04QuoteRequest>,
     ) -> Result<Response<UpdateNut04QuoteRequest>, Status> {
         self.ensure_mutation_allowed().await?;
+        self.ensure_mint_quote_state_override_allowed()?;
         let request = request.into_inner();
 
         let state = MintQuoteState::from_str(&request.state)
@@ -1596,6 +1621,7 @@ mod tests {
             socket_addr: "127.0.0.1:0".parse().unwrap(),
             mint: Arc::new(mint),
             mutation_guard: None,
+            allow_mint_quote_payment_override: false,
             wallet_info_provider: None,
             shutdown: Arc::new(Notify::new()),
             handle: None,
@@ -1854,7 +1880,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_quote_service_update_mint_quote_state_marks_quote_paid() {
-        let server = create_test_rpc_server_with_payment_delay(3600).await;
+        let server = create_test_rpc_server_with_payment_delay(3600)
+            .await
+            .with_mint_quote_payment_override(true);
         let quote_id = create_test_mint_quote(&server, 100).await;
 
         assert_eq!(amount_paid(&server, &quote_id).await, 0);
@@ -1877,7 +1905,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_quote_service_update_mint_quote_state_paid_twice_pays_once() {
-        let server = create_test_rpc_server_with_payment_delay(3600).await;
+        let server = create_test_rpc_server_with_payment_delay(3600)
+            .await
+            .with_mint_quote_payment_override(true);
         let quote_id = create_test_mint_quote(&server, 100).await;
 
         for _ in 0..2 {
@@ -1900,7 +1930,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_quote_service_update_mint_quote_state_reports_state_of_issued_quote() {
-        let server = create_test_rpc_server_with_payment_delay(3600).await;
+        let server = create_test_rpc_server_with_payment_delay(3600)
+            .await
+            .with_mint_quote_payment_override(true);
         let quote_id = create_test_mint_quote(&server, 32).await;
 
         QuoteService::update_mint_quote_state(
@@ -1970,7 +2002,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_quote_service_update_mint_quote_state_unknown_quote() {
-        let server = create_test_rpc_server().await;
+        let server = create_test_rpc_server()
+            .await
+            .with_mint_quote_payment_override(true);
 
         let status = QuoteService::update_mint_quote_state(
             &server,
@@ -1984,6 +2018,49 @@ mod tests {
 
         assert_eq!(status.code(), tonic::Code::InvalidArgument);
         assert_eq!(status.message(), "Could not find quote");
+    }
+
+    #[tokio::test]
+    async fn test_mint_quote_state_overrides_are_disabled_by_default() {
+        let server = create_test_rpc_server_with_payment_delay(3600).await;
+        let quote_id = create_test_mint_quote(&server, 100).await;
+
+        let status = QuoteService::update_mint_quote_state(
+            &server,
+            Request::new(crate::quote::UpdateMintQuoteStateRequest {
+                quote_id: quote_id.clone(),
+                state: crate::quote::MintQuoteState::Paid.into(),
+            }),
+        )
+        .await
+        .expect_err("payment override should be disabled");
+
+        assert_eq!(status.code(), tonic::Code::PermissionDenied);
+        assert_eq!(status.message(), "Mint quote state override is disabled");
+        assert_eq!(amount_paid(&server, &quote_id).await, 0);
+
+        for state in [
+            MintQuoteState::Unpaid,
+            MintQuoteState::Paid,
+            MintQuoteState::Issued,
+        ] {
+            let legacy_status = CdkMint::update_nut04_quote(
+                &server,
+                Request::new(UpdateNut04QuoteRequest {
+                    quote_id: quote_id.clone(),
+                    state: state.to_string(),
+                }),
+            )
+            .await
+            .expect_err("legacy quote state override should be disabled");
+
+            assert_eq!(legacy_status.code(), tonic::Code::PermissionDenied);
+            assert_eq!(
+                legacy_status.message(),
+                "Mint quote state override is disabled"
+            );
+        }
+        assert_eq!(amount_paid(&server, &quote_id).await, 0);
     }
 
     #[tokio::test]

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -48,6 +48,9 @@ enabled = false
 # port = 8086
 # tls_dir = "/path/to/tls"
 # allow_insecure = false
+# Permits RPC callers to override mint quote state, including recording a
+# payment without confirmation from the payment backend.
+# allow_mint_quote_payment_override = false
 
 #[prometheus]
 #enabled = true

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -1222,6 +1222,12 @@ pub struct MintManagementRpc {
     pub tls_dir: Option<PathBuf>,
     #[serde(default)]
     pub allow_insecure: bool,
+    /// Allow management RPC callers to use mint quote state override endpoints.
+    ///
+    /// This includes marking quotes paid without backend confirmation and is
+    /// disabled by default.
+    #[serde(default)]
+    pub allow_mint_quote_payment_override: bool,
 }
 
 impl Settings {
@@ -1419,6 +1425,33 @@ mod tests {
         assert!(auth_debug.contains("postgres://db.example.com/cdk"));
         assert!(!database_debug.contains(secret));
         assert!(!auth_debug.contains(secret));
+    }
+
+    #[cfg(feature = "management-rpc")]
+    #[test]
+    fn mint_quote_payment_override_is_explicitly_opt_in() {
+        let default_settings =
+            Settings::try_from_toml("").expect("default settings should deserialize");
+        assert!(
+            !default_settings
+                .mint_management_rpc
+                .unwrap_or_default()
+                .allow_mint_quote_payment_override
+        );
+
+        let enabled_settings = Settings::try_from_toml(
+            r#"
+[mint_management_rpc]
+allow_mint_quote_payment_override = true
+"#,
+        )
+        .expect("management RPC payment override should deserialize");
+        assert!(
+            enabled_settings
+                .mint_management_rpc
+                .expect("management RPC settings should be present")
+                .allow_mint_quote_payment_override
+        );
     }
 
     #[cfg(feature = "ldk-node")]

--- a/crates/cdk-mintd/src/env_vars/management_rpc.rs
+++ b/crates/cdk-mintd/src/env_vars/management_rpc.rs
@@ -11,6 +11,8 @@ pub const ENV_MINT_MANAGEMENT_ADDRESS: &str = "CDK_MINTD_MANAGEMENT_ADDRESS";
 pub const ENV_MINT_MANAGEMENT_PORT: &str = "CDK_MINTD_MANAGEMENT_PORT";
 pub const ENV_MINT_MANAGEMENT_TLS_DIR: &str = "CDK_MINTD_MANAGEMENT_TLS_DIR";
 pub const ENV_MINT_MANAGEMENT_ALLOW_INSECURE: &str = "CDK_MINTD_MANAGEMENT_ALLOW_INSECURE";
+pub const ENV_MINT_MANAGEMENT_ALLOW_MINT_QUOTE_PAYMENT_OVERRIDE: &str =
+    "CDK_MINTD_MANAGEMENT_ALLOW_MINT_QUOTE_PAYMENT_OVERRIDE";
 
 impl MintManagementRpc {
     pub fn from_env(mut self) -> Self {
@@ -42,6 +44,11 @@ impl MintManagementRpc {
             }
         }
 
+        if let Ok(allow_override) = env::var(ENV_MINT_MANAGEMENT_ALLOW_MINT_QUOTE_PAYMENT_OVERRIDE)
+        {
+            self.allow_mint_quote_payment_override = allow_override.parse().unwrap_or(false);
+        }
+
         self
     }
 }
@@ -64,6 +71,7 @@ mod tests {
         env::remove_var(ENV_MINT_MANAGEMENT_PORT);
         env::remove_var(ENV_MINT_MANAGEMENT_TLS_DIR);
         env::remove_var(ENV_MINT_MANAGEMENT_ALLOW_INSECURE);
+        env::remove_var(ENV_MINT_MANAGEMENT_ALLOW_MINT_QUOTE_PAYMENT_OVERRIDE);
     }
 
     #[test]
@@ -74,6 +82,7 @@ mod tests {
             ENV_MINT_MANAGEMENT_PORT,
             ENV_MINT_MANAGEMENT_TLS_DIR,
             ENV_MINT_MANAGEMENT_ALLOW_INSECURE,
+            ENV_MINT_MANAGEMENT_ALLOW_MINT_QUOTE_PAYMENT_OVERRIDE,
         ];
 
         let prefixes: BTreeSet<&str> = names
@@ -103,6 +112,10 @@ mod tests {
         env::set_var(ENV_MINT_MANAGEMENT_PORT, "10000");
         env::set_var(ENV_MINT_MANAGEMENT_TLS_DIR, "/var/lib/cdk/tls");
         env::set_var(ENV_MINT_MANAGEMENT_ALLOW_INSECURE, "true");
+        env::set_var(
+            ENV_MINT_MANAGEMENT_ALLOW_MINT_QUOTE_PAYMENT_OVERRIDE,
+            "true",
+        );
 
         let management_rpc = MintManagementRpc::default().from_env();
 
@@ -114,6 +127,7 @@ mod tests {
             Some(PathBuf::from("/var/lib/cdk/tls"))
         );
         assert!(management_rpc.allow_insecure);
+        assert!(management_rpc.allow_mint_quote_payment_override);
 
         clear_env_vars();
     }
@@ -144,6 +158,36 @@ mod tests {
         assert!(management_rpc.enabled);
         assert_eq!(management_rpc.tls_dir, None);
         assert!(!management_rpc.allow_insecure);
+        assert!(!management_rpc.allow_mint_quote_payment_override);
+
+        clear_env_vars();
+    }
+
+    #[test]
+    fn management_rpc_payment_override_env_fails_closed() {
+        let _guard = env_lock();
+        clear_env_vars();
+        let management_rpc = MintManagementRpc {
+            allow_mint_quote_payment_override: true,
+            ..Default::default()
+        };
+
+        env::set_var(
+            ENV_MINT_MANAGEMENT_ALLOW_MINT_QUOTE_PAYMENT_OVERRIDE,
+            "false",
+        );
+        assert!(
+            !management_rpc
+                .clone()
+                .from_env()
+                .allow_mint_quote_payment_override
+        );
+
+        env::set_var(
+            ENV_MINT_MANAGEMENT_ALLOW_MINT_QUOTE_PAYMENT_OVERRIDE,
+            "not-a-boolean",
+        );
+        assert!(!management_rpc.from_env().allow_mint_quote_payment_override);
 
         clear_env_vars();
     }

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -2038,7 +2038,10 @@ impl PreparedMintd {
                 if rpc_settings.enabled {
                     let addr = rpc_settings.address.unwrap_or("127.0.0.1".to_string());
                     let port = rpc_settings.port.unwrap_or(8086);
-                    let mut mint_rpc = cdk_mint_rpc::MintRPCServer::new(&addr, port, mint.clone())?;
+                    let mut mint_rpc = cdk_mint_rpc::MintRPCServer::new(&addr, port, mint.clone())?
+                        .with_mint_quote_payment_override(
+                            rpc_settings.allow_mint_quote_payment_override,
+                        );
                     if let Some(activation) = activation.as_ref() {
                         mint_rpc =
                             mint_rpc.with_mutation_guard(Arc::new(ConfigurationMutationGuard {


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
