### PR TITLE
fix(mintd)!: require explicit mint initialization mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ Key highlights include:
     ```bash
     cdk-mintd config migrate --file /path/to/legacy-config.toml --output /path/to/migrated-config.toml
     cdk-mintd config validate --file /path/to/migrated-config.toml
-    cdk-mintd config init --file /path/to/migrated-config.toml
+    cdk-mintd config init --existing-mint --file /path/to/migrated-config.toml
     cdk-mintd
     ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- cdk-mintd: Existing-mint initialization, configuration apply, and ordinary restarts fail closed when a configured BDK wallet database is missing, uninitialized, or does not match the configured mnemonic and network; intentional wallet creation requires a one-shot `--allow-new-bdk-wallet` permission.
+
 ## [0.18.0-rc.2](https://github.com/cashubtc/cdk/releases/tag/v0.18.0-rc.2)
 
 ### Summary

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -123,7 +123,7 @@ override.
 ```bash
 export CDK_MINTD_MNEMONIC="your stable BIP39 mnemonic"
 cargo run --bin cdk-mintd -- config validate --file crates/cdk-mintd/example.config.toml
-cargo run --bin cdk-mintd -- config init --file crates/cdk-mintd/example.config.toml
+cargo run --bin cdk-mintd -- config init --new-mint --file crates/cdk-mintd/example.config.toml
 cargo run --bin cdk-mintd
 ```
 

--- a/crates/cdk-bdk/src/error.rs
+++ b/crates/cdk-bdk/src/error.rs
@@ -1,5 +1,7 @@
 //! CDK BDK onchain backend errors
 
+use std::path::PathBuf;
+
 use cdk_common::CurrencyUnit;
 use thiserror::Error;
 use uuid::Uuid;
@@ -62,6 +64,20 @@ pub enum Error {
     /// Database error
     #[error("Database error: {0}")]
     Database(#[from] bdk_wallet::rusqlite::Error),
+
+    /// An existing-mint migration did not find the persisted BDK wallet.
+    #[error("Persisted BDK wallet database is missing at {path}")]
+    ExistingWalletMissing {
+        /// Expected BDK wallet database path.
+        path: PathBuf,
+    },
+
+    /// A BDK SQLite file exists but does not contain an initialized wallet.
+    #[error("Persisted BDK wallet database at {path} does not contain an initialized wallet")]
+    ExistingWalletNotInitialized {
+        /// BDK wallet database path.
+        path: PathBuf,
+    },
 
     /// Wallet error
     #[error("Wallet error: {0}")]

--- a/crates/cdk-bdk/src/lib.rs
+++ b/crates/cdk-bdk/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc = include_str!("../README.md")]
 
 use std::future::Future;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -16,9 +16,9 @@ use async_trait::async_trait;
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::keys::bip39::Mnemonic;
 use bdk_wallet::keys::{DerivableKey, ExtendedKey};
-use bdk_wallet::rusqlite::Connection;
+use bdk_wallet::rusqlite::{Connection, OpenFlags};
 use bdk_wallet::template::Bip84;
-use bdk_wallet::{KeychainKind, PersistedWallet, Update, Wallet};
+use bdk_wallet::{ChangeSet, KeychainKind, PersistedWallet, Update, Wallet};
 use cdk_common::amount::MSAT_IN_SAT;
 use cdk_common::common::FeeReserve;
 use cdk_common::database::KVStore;
@@ -61,6 +61,56 @@ pub use crate::wallet_info::{
 };
 
 const MAX_RECEIVE_ADDRESS_RESERVATION_ATTEMPTS: usize = 100;
+
+/// Verify that an existing BDK wallet is present and belongs to the configured
+/// mnemonic and network without modifying its database.
+pub fn validate_existing_wallet(
+    mnemonic: Mnemonic,
+    network: Network,
+    storage_dir_path: &Path,
+) -> Result<(), Error> {
+    let wallet_path = storage_dir_path.join("bdk_wallet/bdk_wallet.sqlite");
+    match fs::metadata(&wallet_path) {
+        Ok(metadata) if metadata.is_file() => {}
+        Ok(_) => return Err(Error::ExistingWalletNotInitialized { path: wallet_path }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(Error::ExistingWalletMissing { path: wallet_path });
+        }
+        Err(error) => return Err(Error::Io(error)),
+    }
+
+    let mut db = Connection::open_with_flags(&wallet_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let has_wallet_table = db.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'bdk_wallet')",
+        [],
+        |row| row.get::<_, bool>(0),
+    )?;
+    if !has_wallet_table {
+        return Err(Error::ExistingWalletNotInitialized { path: wallet_path });
+    }
+
+    let changeset = {
+        let transaction = db.transaction()?;
+        ChangeSet::from_sqlite(&transaction)?
+    };
+
+    let xkey: ExtendedKey = mnemonic.into_extended_key()?;
+    let xprv = xkey.into_xprv(network.into()).ok_or(Error::Path)?;
+    let descriptor = Bip84(xprv, KeychainKind::External);
+    let change_descriptor = Bip84(xprv, KeychainKind::Internal);
+    let wallet = Wallet::load()
+        .descriptor(KeychainKind::External, Some(descriptor))
+        .descriptor(KeychainKind::Internal, Some(change_descriptor))
+        .extract_keys()
+        .check_network(network)
+        .load_wallet_no_persist(changeset)
+        .map_err(|e| Error::Wallet(e.to_string()))?;
+
+    match wallet {
+        Some(_) => Ok(()),
+        None => Err(Error::ExistingWalletNotInitialized { path: wallet_path }),
+    }
+}
 
 /// Wrapper struct that combines wallet and database to prevent deadlocks
 pub(crate) struct WalletWithDb {
@@ -925,6 +975,7 @@ impl MintPayment for CdkBdk {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::str::FromStr;
 
     use bdk_wallet::bitcoin::hashes::Hash as _;
@@ -938,6 +989,55 @@ mod tests {
 
     use super::*;
     use crate::fee::apply_quote_fee_safety;
+
+    const TEST_MNEMONIC: &str =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const OTHER_TEST_MNEMONIC: &str =
+        "legal winner thank year wave sausage worth useful legal winner thank yellow";
+
+    #[tokio::test]
+    async fn existing_wallet_preflight_requires_matching_persisted_wallet() {
+        let (backend, tempdir) = build_test_instance_with_tempdir(5).await;
+        drop(backend);
+
+        let mnemonic = Mnemonic::from_str(TEST_MNEMONIC).expect("test mnemonic");
+        validate_existing_wallet(mnemonic, Network::Regtest, tempdir.path())
+            .expect("matching wallet should pass preflight");
+
+        let other_mnemonic = Mnemonic::from_str(OTHER_TEST_MNEMONIC).expect("other mnemonic");
+        assert!(matches!(
+            validate_existing_wallet(other_mnemonic, Network::Regtest, tempdir.path()),
+            Err(Error::Wallet(_))
+        ));
+        assert!(matches!(
+            validate_existing_wallet(
+                Mnemonic::from_str(TEST_MNEMONIC).expect("test mnemonic"),
+                Network::Signet,
+                tempdir.path(),
+            ),
+            Err(Error::Wallet(_))
+        ));
+    }
+
+    #[test]
+    fn existing_wallet_preflight_does_not_create_missing_or_empty_wallet() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let mnemonic = Mnemonic::from_str(TEST_MNEMONIC).expect("test mnemonic");
+        let wallet_path = tempdir.path().join("bdk_wallet/bdk_wallet.sqlite");
+        assert!(matches!(
+            validate_existing_wallet(mnemonic.clone(), Network::Regtest, tempdir.path()),
+            Err(Error::ExistingWalletMissing { .. })
+        ));
+        assert!(!wallet_path.exists());
+
+        fs::create_dir_all(wallet_path.parent().expect("wallet directory"))
+            .expect("create wallet directory");
+        drop(Connection::open(&wallet_path).expect("create empty sqlite file"));
+        assert!(matches!(
+            validate_existing_wallet(mnemonic, Network::Regtest, tempdir.path()),
+            Err(Error::ExistingWalletNotInitialized { .. })
+        ));
+    }
 
     /// Build a `CdkBdk` instance pointed at a bogus Esplora URL so the sync
     /// loop spins without needing a real backend. The ticks are short so
@@ -982,10 +1082,7 @@ mod tests {
         chain_source: ChainSource,
     ) -> Result<(CdkBdk, tempfile::TempDir), Error> {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let mnemonic = Mnemonic::from_str(
-            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-        )
-        .expect("mnemonic");
+        let mnemonic = Mnemonic::from_str(TEST_MNEMONIC).expect("mnemonic");
 
         let kv = cdk_sqlite::mint::memory::empty()
             .await

--- a/crates/cdk-mintd/README.md
+++ b/crates/cdk-mintd/README.md
@@ -125,11 +125,18 @@ cdk-mintd config init --new-mint --file /path/to/config.toml
 # Import configuration into an existing mint database
 cdk-mintd config init --existing-mint --file /path/to/config.toml
 
+# Add BDK during the first v0.18 import
+cdk-mintd config init --existing-mint --allow-new-bdk-wallet \
+  --file /path/to/config.toml
+
 # Validate against the stored database and signer without writing
 cdk-mintd config apply --file /path/to/config.toml --validate-only
 
 # Atomically replace the document used by the next start
 cdk-mintd config apply --file /path/to/config.toml
+
+# Add BDK to an already initialized v0.18 mint
+cdk-mintd config apply --allow-new-bdk-wallet --file /path/to/config.toml
 
 # Discard a pending document or restore the previous applied document
 cdk-mintd config rollback
@@ -148,8 +155,10 @@ references. Literal secrets in the legacy TOML are copied into owner-only files
 under `cdk-mintd-secrets/` beside the output document and become absolute
 `file:` references. Use `--secrets-dir <path>` to choose another directory and
 `--force` to replace files created by an earlier migration attempt. If the old
-service used `--seed-file`, pass the same global option to `config migrate`; the
-generated document references that existing file directly.
+service actually used the global `--seed-file` BIP39 mnemonic option, pass the
+same option to `config migrate`; the generated document references that existing
+file directly. Do not pass it merely because an LDK storage directory contains
+the unrelated binary `keys_seed` file.
 
 The migrated document is normalized and includes effective defaults, so comments
 and the original TOML layout are not preserved. Review it and run `config
@@ -166,6 +175,148 @@ previous applied document and always requires another restart. This remains
 true when rolling back a pending replacement because a failed startup may have
 partially updated canonical database state. Only one previous applied document
 is retained.
+
+When BDK is selected for a new mint, `config init --new-mint` automatically
+permits its first wallet creation. Existing-mint initialization and apply
+instead require a persisted `<work-dir>/bdk_wallet/bdk_wallet.sqlite` whose
+descriptors and network match the configured mnemonic and network. The check is
+read-only and runs before the document is stored. Use
+`--allow-new-bdk-wallet` only when intentionally adding BDK or performing
+last-resort mnemonic recovery after confirming that the original wallet
+database is lost. The flag permits an absent wallet but does not bypass an
+invalid or mismatched one. Set `wallet_rescan_from_height` for Bitcoin RPC
+mnemonic recovery so the fresh wallet does not start scanning at the current
+chain tip. The creation permission is cleared after the first successful daemon
+startup, so later restarts fail if the BDK wallet disappears. For an already
+initialized v0.18 mint, use `config apply`, not `config init`, as described
+below.
+
+### Adding BDK to an Existing Mint
+
+Use this procedure for a v0.18 mint whose database-backed configuration is
+already initialized and whose Lightning backend is working. `config apply`
+replaces the complete authoritative document, so retain every existing field,
+especially `[payment_backend]` and the corresponding `[lnd]` or `[ldk_node]`
+section.
+
+First export the active unresolved document and record the current mint public
+key, complete keyset list, and Lightning node ID:
+
+```bash
+cdk-mintd --work-dir /var/lib/cdk-mintd \
+  config export --file /var/lib/cdk-mintd/config-with-bdk.toml
+```
+
+Stop the daemon and back up the primary database and complete working directory
+before changing the document. An embedded LDK deployment must include its
+entire configured storage directory. An LND deployment must be backed up using
+LND's own node and channel-backup procedure because its identity and channel
+state are external to `cdk-mintd`.
+
+Add an on-chain backend and BDK section to the exported document:
+
+```toml
+[onchain]
+onchain_backend = "bdk"
+
+[bdk]
+mnemonic = "file:/run/secrets/bdk-mnemonic"
+network = "mainnet"
+chain_source_type = "bitcoinrpc"
+bitcoind_rpc_host = "127.0.0.1"
+bitcoind_rpc_port = 8332
+bitcoind_rpc_user = "cdk-mintd"
+bitcoind_rpc_password = "file:/run/secrets/bitcoin-rpc-password"
+```
+
+Use the network served by the existing Lightning deployment. The BDK mnemonic
+should normally be a new secret distinct from the mint signer and any embedded
+LDK mnemonic. Protect and back it up before allowing the wallet to receive
+funds.
+
+Keep the existing Lightning selection unchanged. For LND, the relevant shape
+remains:
+
+```toml
+[payment_backend]
+backend = "lnd"
+unit = "sat"
+
+[lnd]
+address = "https://127.0.0.1:10009"
+cert_file = "/run/secrets/lnd-tls.cert"
+macaroon_file = "/run/secrets/lnd-admin.macaroon"
+```
+
+For embedded LDK, retain its complete section, storage path, and original
+identity source:
+
+```toml
+[payment_backend]
+backend = "ldk-node"
+unit = "sat"
+
+[ldk_node]
+bitcoin_network = "mainnet"
+storage_dir_path = "/var/lib/cdk-mintd/ldk-node"
+ldk_node_mnemonic = "file:/run/secrets/ldk-node-mnemonic"
+```
+
+Most nodes use a dedicated BIP39 mnemonic. Preserve its exact secret reference;
+changing it changes the node identity and wallet descriptors. Only omit
+`ldk_node_mnemonic` for a legacy node that was created from
+`<storage_dir_path>/keys_seed`, and preserve that file with the complete storage
+directory. LDK's binary `keys_seed` file is not the same as the legacy global
+`cdk-mintd --seed-file` option, which contains a BIP39 mnemonic. Never replace
+either LDK identity source with the mint mnemonic.
+
+For a genuinely new BDK wallet, confirm that the expected path does not already
+contain wallet data, then validate and stage the document with explicit
+creation intent:
+
+```bash
+test ! -e /var/lib/cdk-mintd/bdk_wallet/bdk_wallet.sqlite
+
+cdk-mintd --work-dir /var/lib/cdk-mintd \
+  config apply --validate-only --allow-new-bdk-wallet \
+  --file /var/lib/cdk-mintd/config-with-bdk.toml
+
+cdk-mintd --work-dir /var/lib/cdk-mintd \
+  config apply --allow-new-bdk-wallet \
+  --file /var/lib/cdk-mintd/config-with-bdk.toml
+```
+
+Do not use `--allow-new-bdk-wallet` when the mint previously used BDK. Restore
+the original `<work-dir>/bdk_wallet` directory and apply without the flag. If
+the database has been lost and mnemonic recovery is unavoidable, use the same
+BDK mnemonic and set `wallet_rescan_from_height` to a known wallet birthday for
+Bitcoin RPC before explicitly allowing creation. Reconcile all previous BDK
+quotes, transactions, and funds before serving users.
+
+Start the daemon and verify all of the following before considering the change
+complete:
+
+- the mint public key and every active and inactive keyset are unchanged;
+- the LND or LDK node ID is unchanged and Lightning mint/melt tests succeed;
+- `<work-dir>/bdk_wallet/bdk_wallet.sqlite` exists with the service user's
+  ownership;
+- the BDK address network, wallet balance, and synchronization status are
+  correct; and
+- small on-chain mint and melt tests succeed at the configured confirmation
+  threshold.
+
+The new-wallet permission remains pending if startup fails and is cleared only
+after all backends start and the daemon binds its listener. A retry validates
+any BDK wallet created by the failed attempt. To abandon the pending document,
+stop the daemon, inspect the failure, and run:
+
+```bash
+cdk-mintd --work-dir /var/lib/cdk-mintd config rollback
+```
+
+Restart to activate the restored document. Rollback does not delete a BDK
+wallet created during a partial startup; retain it until any addresses, quotes,
+or payments from the failed attempt have been assessed.
 
 `cdk-mintd` is not an RPC client. Immediate field-level mint management
 (`get-info`, `update-motd`, `rotate-next-keyset`, and related commands) is
@@ -340,6 +491,7 @@ esplora_url = "https://mutinynet.com/api"
 rgs_url = "https://rgs.mutinynet.com/snapshot/0"
 gossip_source_type = "rgs"
 storage_dir_path = "/var/lib/cdk-mintd/ldk-node"
+ldk_node_mnemonic = "env:CDK_MINTD_LDK_NODE_MNEMONIC"
 ```
 
 ### With CLN Lightning Backend
@@ -450,13 +602,15 @@ After setup and first run, your directory will look like:
 ```
 ~/.cdk-mintd/                    # Working directory (create manually)
 ├── config.toml                  # Optional import/export document; not read at startup
-├── cdk-mintd.db                # SQLite database (created automatically)
+├── cdk-mintd.sqlite            # Primary SQLite database (when selected)
+├── bdk_wallet/                 # BDK state (when using the BDK backend)
+│   └── bdk_wallet.sqlite
 ├── logs/                       # Log files (created automatically if enabled)
 │   ├── cdk-mintd.2024-01-01.log
 │   └── cdk-mintd.2024-01-02.log
 └── ldk-node/                   # LDK Node data (if using LDK backend)
-    ├── wallet/
-    └── graph/
+    ├── keys_seed                 # Legacy entropy source, when applicable
+    └── ...                       # Wallet, channel, and graph state
 ```
 
 **What you must create manually:**
@@ -588,8 +742,9 @@ mint replicas.
 Other environment variables are read only when explicitly named by an
 `env:VARIABLE` secret reference in the persisted document. They do not act as
 automatic operational overrides. The legacy `--config` and `--seed-file` flags
-are rejected for every command, with guidance to use `config init` or
-`config apply`.
+are rejected as normal startup inputs. `--seed-file` is accepted only by
+`config migrate` to reproduce a deployment that actually used that legacy
+mnemonic override.
 
 For complete configuration options, see the [example configuration file](./example.config.toml).
 

--- a/crates/cdk-mintd/README.md
+++ b/crates/cdk-mintd/README.md
@@ -92,11 +92,14 @@ mkdir -p ~/.cdk-mintd
 cp example.config.toml ~/.cdk-mintd/config.toml
 # Edit the document and provide any env: secrets it references.
 cdk-mintd config validate --file ~/.cdk-mintd/config.toml
-cdk-mintd config init --file ~/.cdk-mintd/config.toml
+cdk-mintd config init --new-mint --file ~/.cdk-mintd/config.toml
 cdk-mintd
 ```
 
-`config init` refuses to replace an existing record. On the first start, mintd
+`config init` requires `--new-mint` for a database that has never served a mint
+or `--existing-mint` when importing configuration during an upgrade. Each mode
+validates the selected database state and refuses to replace an existing
+configuration record. On the first start, mintd
 applies the imported mint metadata and quote TTL and marks that document
 applied. Later starts preserve canonical database values changed through the
 management RPC while loading the remaining daemon settings from the stored
@@ -116,8 +119,11 @@ cdk-mintd config migrate \
 # Validate locally; no database or RPC mutation
 cdk-mintd config validate --file /path/to/config.toml
 
-# Initialize the bootstrap-selected configuration database directly
-cdk-mintd config init --file /path/to/config.toml
+# Initialize a database that has never served a mint
+cdk-mintd config init --new-mint --file /path/to/config.toml
+
+# Import configuration into an existing mint database
+cdk-mintd config init --existing-mint --file /path/to/config.toml
 
 # Validate against the stored database and signer without writing
 cdk-mintd config apply --file /path/to/config.toml --validate-only
@@ -187,8 +193,11 @@ database. `config apply
 
 `config init` opens the database selected by the same bootstrap settings as
 normal startup and rejects an import document whose primary database settings
-do not match it. All other TOML and environment values are operational settings
-and are loaded from the database during normal startup.
+do not match it. `--new-mint` rejects existing mint identity or keyset state;
+`--existing-mint` requires persisted identity and, for embedded signatories,
+keyset history. Remote signatory keysets remain in the signatory database. All
+other TOML and environment values are operational settings and are loaded from
+the database during normal startup.
 
 Primary database settings are immutable through `config apply`: moving the
 authoritative database requires a separate data-migration procedure.
@@ -281,7 +290,8 @@ and defaults to `unit = "sat"`. For multiple fake wallet units, use one
 `[[payment_backend]]` entry per unit.
 
 For Docker setups, put these operational values in the TOML import document and
-run `config init` once against the persistent database. Setting the former
+run `config init` once against the persistent database with the appropriate
+new- or existing-mint mode. Setting the former
 `CDK_MINTD_FAKE_WALLET_*` variables when starting mintd does not override the
 database-backed configuration.
 
@@ -468,6 +478,7 @@ CDK Mintd provides ready-to-use Docker images with multiple payment backend opti
 #### Standard mint with fakewallet backend (testing only):
 ```bash
 export CDK_MINTD_MNEMONIC="your stable BIP39 mnemonic"
+export CDK_MINTD_INIT_MODE=new
 docker compose up
 ```
 
@@ -475,6 +486,7 @@ docker compose up
 ```bash
 export CDK_MINTD_MNEMONIC="your stable mint BIP39 mnemonic"
 export CDK_MINTD_LDK_NODE_MNEMONIC="your distinct stable LDK Node BIP39 mnemonic"
+export CDK_MINTD_INIT_MODE=new
 docker compose -f docker-compose.ldk-node.yaml up
 ```
 
@@ -493,19 +505,22 @@ by `env:` secret references.
 ```yaml
 environment:
   - CDK_MINTD_DATABASE=sqlite
+  - CDK_MINTD_INIT_MODE=new
   - CDK_MINTD_WORK_DIR=/data
 volumes:
   - mint-data:/data
   - ./mint.toml:/config/mint.toml:ro
 ```
 
-Run `cdk-mintd config init --file /config/mint.toml` once with the same
-persistent volume before starting `cdk-mintd`. Later file changes are activated
-only by an explicit `config apply` followed by a restart.
+Run `cdk-mintd config init --new-mint --file /config/mint.toml` once with the
+same persistent volume before starting a new mint. Use `--existing-mint` when
+importing configuration into a database from an earlier version. Later file
+changes are activated only by an explicit `config apply` followed by a restart.
 
-The repository Compose files automate only that idempotent first initialization
-using the documents under `misc/docker-configs/`. They never apply later edits
-automatically.
+The repository Compose files perform that one-shot initialization only when
+`CDK_MINTD_INIT_MODE` is explicitly set to `new` or `existing`. With no mode,
+an uninitialized or unreadable configuration fails closed. They never apply
+later edits automatically.
 
 ### Monitoring
 
@@ -543,7 +558,7 @@ For detailed Docker documentation, see [README-ldk-node.md](../../README-ldk-nod
 cdk-mintd
 
 # Initialize once from a TOML import document
-cdk-mintd config init --file /path/to/config.toml
+cdk-mintd config init --new-mint --file /path/to/config.toml
 
 # Validate or explicitly stage a changed document directly
 cdk-mintd config validate --file /path/to/config.toml

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -253,12 +253,14 @@ onchain_backend = "fakewallet"
 # bitcoin_network = "signet"  # REQUIRED: mainnet, testnet, signet, regtest (no default)
 # chain_source_type = "esplora"  # esplora, electrum, bitcoinrpc
 # 
-# # IMPORTANT: LDK Node Seed Configuration
-# # For NEW nodes: ldk_node_mnemonic MUST be set. This is the BIP39 mnemonic used to derive
-# # the LDK node's keys. Keep this secure and backed up!
-# # For EXISTING nodes: If omitted, the node will use its stored seed from the storage directory.
-# # This maintains backward compatibility with nodes created before this configuration was added.
+# # IMPORTANT: LDK Node Identity Configuration
+# # New nodes MUST use a dedicated, stable BIP39 mnemonic. Existing
+# # mnemonic-based nodes MUST retain the exact mnemonic they originally used;
+# # changing it changes the node identity and wallet descriptors.
 # ldk_node_mnemonic = "env:CDK_MINTD_LDK_NODE_MNEMONIC"
+# # Legacy nodes created from <storage_dir_path>/keys_seed must instead preserve
+# # that complete storage directory and omit ldk_node_mnemonic. LDK's binary
+# # keys_seed file is different from cdk-mintd's legacy --seed-file mnemonic.
 # 
 # # Mutinynet configuration (recommended for testing)
 # esplora_url = "https://mutinynet.com/api"

--- a/crates/cdk-mintd/src/cli.rs
+++ b/crates/cdk-mintd/src/cli.rs
@@ -100,6 +100,9 @@ pub struct InitConfigArgs {
         conflicts_with = "new_mint"
     )]
     pub existing_mint: bool,
+    /// Permit an existing mint to create a BDK wallet when no wallet database exists.
+    #[arg(long, requires = "existing_mint", conflicts_with = "new_mint")]
+    pub allow_new_bdk_wallet: bool,
 }
 
 /// Arguments for migrating a legacy configuration.
@@ -147,6 +150,9 @@ pub struct ApplyConfigArgs {
     /// Validate the document and persisted constraints without writing it.
     #[arg(long)]
     pub validate_only: bool,
+    /// Permit creation of a BDK wallet when no wallet database exists.
+    #[arg(long)]
+    pub allow_new_bdk_wallet: bool,
 }
 
 #[cfg(test)]
@@ -276,6 +282,36 @@ mod tests {
             "/tmp/mint.toml",
         ])
         .is_err());
+        assert!(CLIArgs::try_parse_from([
+            "cdk-mintd",
+            "config",
+            "init",
+            "--new-mint",
+            "--allow-new-bdk-wallet",
+            "--file",
+            "/tmp/mint.toml",
+        ])
+        .is_err());
+
+        let args = CLIArgs::try_parse_from([
+            "cdk-mintd",
+            "config",
+            "init",
+            "--existing-mint",
+            "--allow-new-bdk-wallet",
+            "--file",
+            "/tmp/mint.toml",
+        ])
+        .expect("existing mint may explicitly allow a new BDK wallet");
+        assert!(matches!(
+            args.command,
+            Some(Commands::Config(ConfigArgs {
+                command: ConfigCommands::Init(InitConfigArgs {
+                    allow_new_bdk_wallet: true,
+                    ..
+                }),
+            }))
+        ));
     }
 
     #[test]

--- a/crates/cdk-mintd/src/cli.rs
+++ b/crates/cdk-mintd/src/cli.rs
@@ -67,7 +67,7 @@ pub enum ConfigCommands {
     /// Convert a legacy TOML plus environment overrides into an import document.
     Migrate(MigrateConfigArgs),
     /// Initialize an unconfigured database from a TOML document.
-    Init(ConfigFileArgs),
+    Init(InitConfigArgs),
     /// Validate a TOML document without changing the database.
     Validate(ConfigFileArgs),
     /// Replace the configuration used by the next mintd start.
@@ -78,6 +78,28 @@ pub enum ConfigCommands {
     Show,
     /// Export the stored configuration document.
     Export(ExportConfigArgs),
+}
+
+/// Arguments for initializing database-backed configuration.
+#[derive(Debug, Args)]
+pub struct InitConfigArgs {
+    /// TOML document to import.
+    #[arg(long)]
+    pub file: PathBuf,
+    /// Initialize a database that has never served a mint.
+    #[arg(
+        long,
+        required_unless_present = "existing_mint",
+        conflicts_with = "existing_mint"
+    )]
+    pub new_mint: bool,
+    /// Import configuration into a database containing an existing mint.
+    #[arg(
+        long,
+        required_unless_present = "new_mint",
+        conflicts_with = "new_mint"
+    )]
+    pub existing_mint: bool,
 }
 
 /// Arguments for migrating a legacy configuration.
@@ -133,10 +155,32 @@ mod tests {
 
     #[test]
     fn parses_configuration_commands() {
-        for command in ["init", "validate"] {
-            CLIArgs::try_parse_from(["cdk-mintd", "config", command, "--file", "/tmp/mint.toml"])
-                .expect("configuration command should parse");
-        }
+        CLIArgs::try_parse_from([
+            "cdk-mintd",
+            "config",
+            "init",
+            "--new-mint",
+            "--file",
+            "/tmp/mint.toml",
+        ])
+        .expect("new-mint initialization should parse");
+        CLIArgs::try_parse_from([
+            "cdk-mintd",
+            "config",
+            "init",
+            "--existing-mint",
+            "--file",
+            "/tmp/mint.toml",
+        ])
+        .expect("existing-mint initialization should parse");
+        CLIArgs::try_parse_from([
+            "cdk-mintd",
+            "config",
+            "validate",
+            "--file",
+            "/tmp/mint.toml",
+        ])
+        .expect("configuration validation should parse");
 
         let args =
             CLIArgs::try_parse_from(["cdk-mintd", "config", "export", "--file", "/tmp/mint.toml"])
@@ -210,6 +254,28 @@ mod tests {
         ])
         .expect("legacy seed-file migration should parse");
         assert_eq!(args.seed_file, Some(PathBuf::from("/tmp/seed.txt")));
+    }
+
+    #[test]
+    fn initialization_requires_exactly_one_mint_mode() {
+        assert!(CLIArgs::try_parse_from([
+            "cdk-mintd",
+            "config",
+            "init",
+            "--file",
+            "/tmp/mint.toml",
+        ])
+        .is_err());
+        assert!(CLIArgs::try_parse_from([
+            "cdk-mintd",
+            "config",
+            "init",
+            "--new-mint",
+            "--existing-mint",
+            "--file",
+            "/tmp/mint.toml",
+        ])
+        .is_err());
     }
 
     #[test]

--- a/crates/cdk-mintd/src/config_service.rs
+++ b/crates/cdk-mintd/src/config_service.rs
@@ -1,6 +1,7 @@
 //! Validation and lifecycle rules for database-backed mintd configuration.
 
 use std::fmt;
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -15,7 +16,7 @@ use thiserror::Error;
 use crate::config::{Database, DatabaseEngine, Settings};
 use crate::config_store::{ConfigEnvelope, ConfigRepository, ConfigStoreError, DocumentState};
 use crate::secret::{SecretRef, SecretRefError, SecretResolveError};
-use crate::MintInitializationMode;
+use crate::{BdkWalletPolicy, MintInitializationMode};
 
 const SIGNING_IDENTITY_DOMAIN: &[u8] = b"cdk-mintd/signing-identity/v1\0";
 
@@ -52,6 +53,7 @@ pub(crate) struct StartupConfiguration {
     pub(crate) revision: u64,
     pub(crate) signing_identity: SigningIdentity,
     pub(crate) remote_signatory: Option<Arc<cdk_signatory::SignatoryRpcClient>>,
+    pub(crate) bdk_wallet_policy: BdkWalletPolicy,
 }
 
 impl fmt::Debug for StartupConfiguration {
@@ -62,6 +64,7 @@ impl fmt::Debug for StartupConfiguration {
             .field("revision", &self.revision)
             .field("signing_identity", &self.signing_identity)
             .field("remote_signatory", &self.remote_signatory.is_some())
+            .field("bdk_wallet_policy", &self.bdk_wallet_policy)
             .finish()
     }
 }
@@ -163,6 +166,11 @@ pub enum ConfigurationServiceError {
     )]
     ExistingMintMissingKeysets,
 
+    /// BDK wallet state did not satisfy an existing-wallet preflight.
+    #[cfg(feature = "bdk")]
+    #[error("BDK wallet preflight failed: {0}")]
+    BdkWalletPreflight(#[source] cdk_bdk::Error),
+
     /// Persistent configuration storage failed.
     #[error(transparent)]
     Store(#[from] ConfigStoreError),
@@ -213,6 +221,8 @@ impl ConfigurationService {
         mode: MintInitializationMode,
         database_pubkey: Option<cdk::nuts::PublicKey>,
         has_keysets: bool,
+        work_dir: &Path,
+        bdk_wallet_policy: BdkWalletPolicy,
     ) -> Result<(), ConfigurationServiceError> {
         let (resolved, signing_identity) = Self::validated_import(document).await?;
         self.require_primary_database(&resolved.settings.database)?;
@@ -225,11 +235,22 @@ impl ConfigurationService {
         if database_pubkey.is_some_and(|pubkey| pubkey != signing_identity.pubkey) {
             return Err(ConfigurationServiceError::SigningIdentityChange);
         }
+        let effective_bdk_wallet_policy = match mode {
+            MintInitializationMode::New if has_bdk_wallet(&resolved.settings) => {
+                BdkWalletPolicy::AllowNew
+            }
+            MintInitializationMode::New => BdkWalletPolicy::RequireExisting,
+            MintInitializationMode::Existing => {
+                require_existing_bdk_wallet(&resolved.settings, work_dir, bdk_wallet_policy)?
+            }
+        };
         self.repository
-            .initialize(ConfigEnvelope::new(
-                resolved.document,
-                signing_identity.fingerprint,
-            ))
+            .initialize(
+                ConfigEnvelope::new(resolved.document, signing_identity.fingerprint)
+                    .with_new_bdk_wallet_allowed(
+                        effective_bdk_wallet_policy == BdkWalletPolicy::AllowNew,
+                    ),
+            )
             .await?;
         Ok(())
     }
@@ -239,6 +260,8 @@ impl ConfigurationService {
         &self,
         document: &str,
         validate_only: bool,
+        work_dir: &Path,
+        bdk_wallet_policy: BdkWalletPolicy,
     ) -> Result<ApplyOutcome, ConfigurationServiceError> {
         let (resolved, signing_identity) = Self::validated_import(document).await?;
         self.require_primary_database(&resolved.settings.database)?;
@@ -246,9 +269,15 @@ impl ConfigurationService {
         if current.signing_identity != signing_identity.fingerprint {
             return Err(ConfigurationServiceError::SigningIdentityChange);
         }
+        let effective_bdk_wallet_policy =
+            require_existing_bdk_wallet(&resolved.settings, work_dir, bdk_wallet_policy)?;
         if !validate_only {
             self.repository
-                .replace(resolved.document, &signing_identity.fingerprint)
+                .replace_with_bdk_policy(
+                    resolved.document,
+                    &signing_identity.fingerprint,
+                    effective_bdk_wallet_policy == BdkWalletPolicy::AllowNew,
+                )
                 .await?;
         }
         Ok(ApplyOutcome {
@@ -272,6 +301,10 @@ impl ConfigurationService {
             revision: envelope.revision,
             signing_identity: signing_resolution.identity,
             remote_signatory: signing_resolution.remote_signatory,
+            bdk_wallet_policy: match envelope.allow_new_bdk_wallet {
+                true => BdkWalletPolicy::AllowNew,
+                false => BdkWalletPolicy::RequireExisting,
+            },
         })
     }
 
@@ -324,6 +357,55 @@ impl ConfigurationService {
         validate_authored_mint_pubkey(&resolved.settings, &signing_identity)?;
         Ok((resolved, signing_identity))
     }
+}
+
+#[cfg(feature = "bdk")]
+fn has_bdk_wallet(settings: &Settings) -> bool {
+    settings.bdk.is_some()
+}
+
+#[cfg(not(feature = "bdk"))]
+fn has_bdk_wallet(_settings: &Settings) -> bool {
+    false
+}
+
+#[cfg(feature = "bdk")]
+pub(crate) fn require_existing_bdk_wallet(
+    settings: &Settings,
+    work_dir: &Path,
+    bdk_wallet_policy: BdkWalletPolicy,
+) -> Result<BdkWalletPolicy, ConfigurationServiceError> {
+    let Some(bdk) = settings.bdk.as_ref() else {
+        return Ok(BdkWalletPolicy::RequireExisting);
+    };
+    let wallet_path = work_dir.join("bdk_wallet/bdk_wallet.sqlite");
+    if bdk_wallet_policy == BdkWalletPolicy::AllowNew {
+        match std::fs::metadata(&wallet_path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                bdk.validate_wallet_identity()
+                    .map_err(ConfigurationServiceError::BdkWalletPreflight)?;
+                return Ok(BdkWalletPolicy::AllowNew);
+            }
+            Err(error) => {
+                return Err(ConfigurationServiceError::BdkWalletPreflight(
+                    cdk_bdk::Error::Io(error),
+                ));
+            }
+            Ok(_) => {}
+        }
+    }
+    bdk.validate_existing_wallet(work_dir)
+        .map_err(ConfigurationServiceError::BdkWalletPreflight)?;
+    Ok(BdkWalletPolicy::RequireExisting)
+}
+
+#[cfg(not(feature = "bdk"))]
+pub(crate) fn require_existing_bdk_wallet(
+    _settings: &Settings,
+    _work_dir: &Path,
+    _bdk_wallet_policy: BdkWalletPolicy,
+) -> Result<BdkWalletPolicy, ConfigurationServiceError> {
+    Ok(BdkWalletPolicy::RequireExisting)
 }
 
 fn require_initialization_state(
@@ -955,7 +1037,14 @@ url = "postgresql://operator:plaintext-secret@localhost/cdk"
 
         assert!(matches!(
             service
-                .initialize(&document, MintInitializationMode::New, None, false)
+                .initialize(
+                    &document,
+                    MintInitializationMode::New,
+                    None,
+                    false,
+                    Path::new("."),
+                    BdkWalletPolicy::RequireExisting,
+                )
                 .await,
             Err(ConfigurationServiceError::LiteralSecret {
                 field: "database.postgres.url"
@@ -1008,12 +1097,26 @@ url = "postgresql://operator:plaintext-secret@localhost/cdk"
         let second = document(&secret_reference, "second");
 
         service
-            .initialize(&first, MintInitializationMode::New, None, false)
+            .initialize(
+                &first,
+                MintInitializationMode::New,
+                None,
+                false,
+                Path::new("."),
+                BdkWalletPolicy::RequireExisting,
+            )
             .await
             .expect("initialize configuration");
         assert!(matches!(
             service
-                .initialize(&first, MintInitializationMode::New, None, false)
+                .initialize(
+                    &first,
+                    MintInitializationMode::New,
+                    None,
+                    false,
+                    Path::new("."),
+                    BdkWalletPolicy::RequireExisting,
+                )
                 .await,
             Err(ConfigurationServiceError::Store(
                 ConfigStoreError::AlreadyInitialized
@@ -1021,7 +1124,12 @@ url = "postgresql://operator:plaintext-secret@localhost/cdk"
         ));
 
         let outcome = service
-            .apply(&second, true)
+            .apply(
+                &second,
+                true,
+                Path::new("."),
+                BdkWalletPolicy::RequireExisting,
+            )
             .await
             .expect("validate replacement");
         assert!(!outcome.restart_required);
@@ -1033,7 +1141,12 @@ url = "postgresql://operator:plaintext-secret@localhost/cdk"
             .await
             .expect("mark first document applied"));
         let outcome = service
-            .apply(&second, false)
+            .apply(
+                &second,
+                false,
+                Path::new("."),
+                BdkWalletPolicy::RequireExisting,
+            )
             .await
             .expect("replace configuration");
         assert!(outcome.restart_required);
@@ -1239,13 +1352,27 @@ url = "file:{}"
         let service = service().await;
         let first = document(&format!("file:{}", signer_path.display()), "first");
         service
-            .initialize(&first, MintInitializationMode::New, None, false)
+            .initialize(
+                &first,
+                MintInitializationMode::New,
+                None,
+                false,
+                Path::new("."),
+                BdkWalletPolicy::RequireExisting,
+            )
             .await
             .expect("initialize configuration");
 
         std::fs::write(&signer_path, TEST_MNEMONIC_TWO).expect("replace signing secret");
         assert!(matches!(
-            service.apply(&first, false).await,
+            service
+                .apply(
+                    &first,
+                    false,
+                    Path::new("."),
+                    BdkWalletPolicy::RequireExisting,
+                )
+                .await,
             Err(ConfigurationServiceError::SigningIdentityChange)
         ));
 
@@ -1270,7 +1397,14 @@ url = "file:{}"
             postgres_path.display()
         );
         assert!(matches!(
-            service.apply(&postgres, false).await,
+            service
+                .apply(
+                    &postgres,
+                    false,
+                    Path::new("."),
+                    BdkWalletPolicy::RequireExisting,
+                )
+                .await,
             Err(ConfigurationServiceError::PrimaryDatabaseChange)
         ));
 
@@ -1562,6 +1696,8 @@ engine = "sqlite"
                     MintInitializationMode::Existing,
                     Some(other.pubkey),
                     true,
+                    Path::new("."),
+                    BdkWalletPolicy::RequireExisting,
                 )
                 .await,
             Err(ConfigurationServiceError::SigningIdentityChange)
@@ -1573,6 +1709,8 @@ engine = "sqlite"
                 MintInitializationMode::Existing,
                 Some(identity.pubkey),
                 true,
+                Path::new("."),
+                BdkWalletPolicy::RequireExisting,
             )
             .await
             .expect("initialize with matching mint pubkey");
@@ -1596,7 +1734,12 @@ engine = "sqlite"
 
         let second = document(&format!("file:{}", secret_path.display()), "second");
         service
-            .apply(&second, false)
+            .apply(
+                &second,
+                false,
+                Path::new("."),
+                BdkWalletPolicy::RequireExisting,
+            )
             .await
             .expect("replace document");
         assert!(service

--- a/crates/cdk-mintd/src/config_service.rs
+++ b/crates/cdk-mintd/src/config_service.rs
@@ -15,6 +15,7 @@ use thiserror::Error;
 use crate::config::{Database, DatabaseEngine, Settings};
 use crate::config_store::{ConfigEnvelope, ConfigRepository, ConfigStoreError, DocumentState};
 use crate::secret::{SecretRef, SecretRefError, SecretResolveError};
+use crate::MintInitializationMode;
 
 const SIGNING_IDENTITY_DOMAIN: &[u8] = b"cdk-mintd/signing-identity/v1\0";
 
@@ -144,6 +145,24 @@ pub enum ConfigurationServiceError {
     )]
     SigningIdentityChange,
 
+    /// New-mint initialization targeted a database containing mint state.
+    #[error(
+        "refusing new-mint initialization because the selected database contains existing mint identity or keyset state"
+    )]
+    NewMintHasExistingState,
+
+    /// Existing-mint initialization targeted a database without a mint identity.
+    #[error(
+        "refusing existing-mint initialization because the selected database does not contain a mint identity; verify the database URL and work directory"
+    )]
+    ExistingMintMissingIdentity,
+
+    /// An embedded-signatory mint database had no historical keysets.
+    #[error(
+        "refusing existing-mint initialization because the selected embedded-signatory database does not contain keyset history; verify the database URL and work directory"
+    )]
+    ExistingMintMissingKeysets,
+
     /// Persistent configuration storage failed.
     #[error(transparent)]
     Store(#[from] ConfigStoreError),
@@ -191,10 +210,18 @@ impl ConfigurationService {
     pub(crate) async fn initialize(
         &self,
         document: &str,
+        mode: MintInitializationMode,
         database_pubkey: Option<cdk::nuts::PublicKey>,
+        has_keysets: bool,
     ) -> Result<(), ConfigurationServiceError> {
         let (resolved, signing_identity) = Self::validated_import(document).await?;
         self.require_primary_database(&resolved.settings.database)?;
+        require_initialization_state(
+            mode,
+            database_pubkey,
+            has_keysets,
+            resolved.settings.enabled_signatory().is_some(),
+        )?;
         if database_pubkey.is_some_and(|pubkey| pubkey != signing_identity.pubkey) {
             return Err(ConfigurationServiceError::SigningIdentityChange);
         }
@@ -296,6 +323,26 @@ impl ConfigurationService {
         let signing_identity = discover_signing_identity_async(&resolved.settings).await?;
         validate_authored_mint_pubkey(&resolved.settings, &signing_identity)?;
         Ok((resolved, signing_identity))
+    }
+}
+
+fn require_initialization_state(
+    mode: MintInitializationMode,
+    database_pubkey: Option<cdk::nuts::PublicKey>,
+    has_keysets: bool,
+    uses_remote_signatory: bool,
+) -> Result<(), ConfigurationServiceError> {
+    match mode {
+        MintInitializationMode::New if database_pubkey.is_some() || has_keysets => {
+            Err(ConfigurationServiceError::NewMintHasExistingState)
+        }
+        MintInitializationMode::Existing if database_pubkey.is_none() => {
+            Err(ConfigurationServiceError::ExistingMintMissingIdentity)
+        }
+        MintInitializationMode::Existing if !uses_remote_signatory && !has_keysets => {
+            Err(ConfigurationServiceError::ExistingMintMissingKeysets)
+        }
+        MintInitializationMode::New | MintInitializationMode::Existing => Ok(()),
     }
 }
 
@@ -907,7 +954,9 @@ url = "postgresql://operator:plaintext-secret@localhost/cdk"
         );
 
         assert!(matches!(
-            service.initialize(&document, None).await,
+            service
+                .initialize(&document, MintInitializationMode::New, None, false)
+                .await,
             Err(ConfigurationServiceError::LiteralSecret {
                 field: "database.postgres.url"
             })
@@ -959,11 +1008,13 @@ url = "postgresql://operator:plaintext-secret@localhost/cdk"
         let second = document(&secret_reference, "second");
 
         service
-            .initialize(&first, None)
+            .initialize(&first, MintInitializationMode::New, None, false)
             .await
             .expect("initialize configuration");
         assert!(matches!(
-            service.initialize(&first, None).await,
+            service
+                .initialize(&first, MintInitializationMode::New, None, false)
+                .await,
             Err(ConfigurationServiceError::Store(
                 ConfigStoreError::AlreadyInitialized
             ))
@@ -1188,7 +1239,7 @@ url = "file:{}"
         let service = service().await;
         let first = document(&format!("file:{}", signer_path.display()), "first");
         service
-            .initialize(&first, None)
+            .initialize(&first, MintInitializationMode::New, None, false)
             .await
             .expect("initialize configuration");
 
@@ -1450,6 +1501,34 @@ engine = "sqlite"
         assert!(!same_primary_database(&sqlite, &left));
     }
 
+    #[test]
+    fn initialization_state_allows_remote_keysets_to_remain_external() {
+        let pubkey = cdk::nuts::PublicKey::from_hex(
+            "02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619",
+        )
+        .expect("static pubkey");
+
+        require_initialization_state(MintInitializationMode::Existing, Some(pubkey), false, true)
+            .expect("remote signatory keysets remain in the signatory database");
+        assert!(matches!(
+            require_initialization_state(
+                MintInitializationMode::Existing,
+                Some(pubkey),
+                false,
+                false,
+            ),
+            Err(ConfigurationServiceError::ExistingMintMissingKeysets)
+        ));
+        assert!(matches!(
+            require_initialization_state(MintInitializationMode::Existing, None, false, true),
+            Err(ConfigurationServiceError::ExistingMintMissingIdentity)
+        ));
+        assert!(matches!(
+            require_initialization_state(MintInitializationMode::New, Some(pubkey), false, false,),
+            Err(ConfigurationServiceError::NewMintHasExistingState)
+        ));
+    }
+
     #[cfg(all(feature = "sqlite", feature = "fakewallet"))]
     #[tokio::test]
     async fn initialize_rejects_existing_mint_pubkey_mismatch_and_mark_applied_tracks_document() {
@@ -1477,12 +1556,24 @@ engine = "sqlite"
         std::fs::write(&secret_path, TEST_MNEMONIC_ONE).expect("restore mnemonic");
 
         assert!(matches!(
-            service.initialize(&first, Some(other.pubkey)).await,
+            service
+                .initialize(
+                    &first,
+                    MintInitializationMode::Existing,
+                    Some(other.pubkey),
+                    true,
+                )
+                .await,
             Err(ConfigurationServiceError::SigningIdentityChange)
         ));
 
         service
-            .initialize(&first, Some(identity.pubkey))
+            .initialize(
+                &first,
+                MintInitializationMode::Existing,
+                Some(identity.pubkey),
+                true,
+            )
             .await
             .expect("initialize with matching mint pubkey");
         assert!(service

--- a/crates/cdk-mintd/src/config_store.rs
+++ b/crates/cdk-mintd/src/config_store.rs
@@ -104,7 +104,9 @@ pub enum ConfigStoreError {
     AlreadyInitialized,
 
     /// Configuration has not been initialized.
-    #[error("mintd configuration is not initialized; run `cdk-mintd config init --file <path>`")]
+    #[error(
+        "mintd configuration is not initialized; run `cdk-mintd config init --new-mint --file <path>` for a new mint or `cdk-mintd config init --existing-mint --file <path>` for an existing mint"
+    )]
     NotInitialized,
 
     /// A replacement attempted to change the immutable signer.

--- a/crates/cdk-mintd/src/config_store.rs
+++ b/crates/cdk-mintd/src/config_store.rs
@@ -56,6 +56,8 @@ pub(crate) struct ConfigEnvelope {
     pub(crate) previous_applied_toml: Option<String>,
     pub(crate) signing_identity: String,
     pub(crate) applied: bool,
+    #[serde(default)]
+    pub(crate) allow_new_bdk_wallet: bool,
 }
 
 impl ConfigEnvelope {
@@ -67,7 +69,13 @@ impl ConfigEnvelope {
             previous_applied_toml: None,
             signing_identity,
             applied: false,
+            allow_new_bdk_wallet: false,
         }
+    }
+
+    pub(crate) fn with_new_bdk_wallet_allowed(mut self, allowed: bool) -> Self {
+        self.allow_new_bdk_wallet = allowed;
+        self
     }
 
     /// Lifecycle state of the stored document.
@@ -219,10 +227,21 @@ impl ConfigRepository {
     ///
     /// Transition: `Pending | Applied` → `Pending`. The currently applied
     /// document, when there is one, is retained for rollback.
+    #[cfg(test)]
     pub(crate) async fn replace(
         &self,
         toml: String,
         signing_identity: &str,
+    ) -> Result<(), ConfigStoreError> {
+        self.replace_with_bdk_policy(toml, signing_identity, false)
+            .await
+    }
+
+    pub(crate) async fn replace_with_bdk_policy(
+        &self,
+        toml: String,
+        signing_identity: &str,
+        allow_new_bdk_wallet: bool,
     ) -> Result<(), ConfigStoreError> {
         for _ in 0..MAX_CAS_ATTEMPTS {
             let (current_bytes, current) = self.active_record().await?;
@@ -245,6 +264,7 @@ impl ConfigRepository {
                 previous_applied_toml,
                 signing_identity: current.signing_identity,
                 applied: false,
+                allow_new_bdk_wallet,
             }
             .encode()?;
             if self
@@ -286,6 +306,7 @@ impl ConfigRepository {
                 current.previous_applied_toml = Some(current.toml);
             }
             current.applied = false;
+            current.allow_new_bdk_wallet = false;
             current.toml = previous;
             let replacement = current.encode()?;
             if self
@@ -319,10 +340,11 @@ impl ConfigRepository {
             if current.revision != expected_revision {
                 return Ok(false);
             }
-            if current.state() == DocumentState::Applied {
+            if current.state() == DocumentState::Applied && !current.allow_new_bdk_wallet {
                 return Ok(true);
             }
             current.applied = true;
+            current.allow_new_bdk_wallet = false;
             let replacement = current.encode()?;
             if self
                 .store
@@ -392,6 +414,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn successful_startup_clears_new_bdk_wallet_permission() {
+        let repository = repository().await;
+        repository
+            .initialize(
+                ConfigEnvelope::new("first".to_owned(), "signer".to_owned())
+                    .with_new_bdk_wallet_allowed(true),
+            )
+            .await
+            .expect("initialize configuration");
+        let pending = repository
+            .active()
+            .await
+            .expect("read pending configuration");
+        assert!(pending.allow_new_bdk_wallet);
+
+        assert!(repository
+            .mark_applied(pending.revision)
+            .await
+            .expect("mark configuration applied"));
+        let applied = repository
+            .active()
+            .await
+            .expect("read applied configuration");
+        assert!(applied.applied);
+        assert!(!applied.allow_new_bdk_wallet);
+    }
+
+    #[tokio::test]
     async fn older_startup_cannot_mark_replacement_applied() {
         let repository = repository().await;
         repository
@@ -458,6 +508,7 @@ mod tests {
             previous_applied_toml: None,
             signing_identity: "signer".to_owned(),
             applied: false,
+            allow_new_bdk_wallet: false,
         })
         .expect("encode test record");
         write_raw(&repository, &unsupported).await;
@@ -715,6 +766,7 @@ mod tests {
         let active = repository.active().await.expect("decode legacy record");
         assert_eq!(active.revision, 0);
         assert!(active.previous_applied_toml.is_none());
+        assert!(!active.allow_new_bdk_wallet);
         assert!(repository
             .mark_applied(0)
             .await

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -383,6 +383,15 @@ async fn initial_setup(
     Ok((localstore, keystore, kv, configuration_store))
 }
 
+/// Operator intent for the mint database targeted by `config init`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MintInitializationMode {
+    /// Initialize a database that has never served a mint.
+    New,
+    /// Import configuration into a database containing an existing mint.
+    Existing,
+}
+
 /// Sets up and initializes a tracing subscriber with custom log filtering.
 /// Logs can be configured to output to stdout only, file only, or both.
 /// Returns a guard that must be kept alive and properly dropped on shutdown.
@@ -2699,16 +2708,21 @@ pub async fn validate_configuration_document(document: &str) -> Result<()> {
 pub async fn initialize_configuration(
     work_dir: &Path,
     document: &str,
+    mode: MintInitializationMode,
     db_password: Option<String>,
 ) -> Result<()> {
     let bootstrap = load_database_bootstrap_settings()?;
-    let (localstore, _keystore, _kv, configuration_store) =
+    let (localstore, keystore, _kv, configuration_store) =
         initial_setup(work_dir, &bootstrap, db_password).await?;
     let mut mint_builder = MintBuilder::new(localstore);
     mint_builder.init_from_db_if_present().await?;
     let database_pubkey = mint_builder.current_mint_info().pubkey;
+    let mut keyset_transaction = keystore.begin_transaction().await?;
+    let has_keysets = !keyset_transaction.get_keyset_infos().await?.is_empty();
+    keyset_transaction.commit().await?;
+
     configuration_service(configuration_store, &bootstrap)
-        .initialize(document, database_pubkey)
+        .initialize(document, mode, database_pubkey, has_keysets)
         .await?;
     Ok(())
 }
@@ -2824,6 +2838,28 @@ mod tests {
 
     fn temp_seed_file(name: &str) -> PathBuf {
         std::env::temp_dir().join(format!("cdk_mintd_{name}_{}", std::process::id()))
+    }
+
+    #[cfg(all(feature = "sqlite", feature = "fakewallet"))]
+    fn sqlite_configuration_document(secret_path: &Path, name: &str) -> String {
+        format!(
+            r#"
+[info]
+mnemonic = "file:{}"
+
+[mint_info]
+name = "{name}"
+
+[payment_backend]
+backend = "fakewallet"
+
+[fake_wallet]
+
+[database]
+engine = "sqlite"
+"#,
+            secret_path.display()
+        )
     }
 
     #[cfg(feature = "sqlite")]
@@ -3056,32 +3092,20 @@ mod tests {
         #[cfg(not(feature = "sqlcipher"))]
         let password: Option<String> = None;
 
-        let first = format!(
-            r#"
-[info]
-mnemonic = "file:{}"
-
-[mint_info]
-name = "first-public"
-
-[payment_backend]
-backend = "fakewallet"
-
-[fake_wallet]
-
-[database]
-engine = "sqlite"
-"#,
-            secret_path.display()
-        );
+        let first = sqlite_configuration_document(&secret_path, "first-public");
         let second = first.replace("first-public", "second-public");
 
         validate_configuration_document(&first)
             .await
             .expect("validate first document");
-        initialize_configuration(&work_dir, &first, password.clone())
-            .await
-            .expect("initialize configuration");
+        initialize_configuration(
+            &work_dir,
+            &first,
+            MintInitializationMode::New,
+            password.clone(),
+        )
+        .await
+        .expect("initialize configuration");
         assert_eq!(
             stored_configuration_document(&work_dir, password.clone())
                 .await
@@ -3114,6 +3138,95 @@ engine = "sqlite"
         let bootstrap = load_database_bootstrap_settings().expect("bootstrap settings");
         assert_eq!(bootstrap.database.engine, DatabaseEngine::Sqlite);
         assert!(bootstrap.database.postgres.is_none());
+
+        let _ = fs::remove_dir_all(&work_dir);
+    }
+
+    #[cfg(all(feature = "sqlite", feature = "fakewallet"))]
+    #[tokio::test]
+    async fn existing_mint_initialization_rejects_empty_database_with_matching_mnemonic() {
+        let work_dir = crate::test_utils::unique_temp_path("cdk_mintd_empty_existing_init");
+        fs::create_dir_all(&work_dir).expect("create work dir");
+        let secret_path = work_dir.join("mnemonic.secret");
+        fs::write(&secret_path, TEST_MNEMONIC).expect("write mnemonic secret");
+        let document = sqlite_configuration_document(&secret_path, "empty-existing");
+
+        #[cfg(feature = "sqlcipher")]
+        let password = Some("test-password".to_string());
+        #[cfg(not(feature = "sqlcipher"))]
+        let password: Option<String> = None;
+
+        let error = initialize_configuration(
+            &work_dir,
+            &document,
+            MintInitializationMode::Existing,
+            password,
+        )
+        .await
+        .expect_err("an empty database must not be accepted as an existing mint");
+        assert!(
+            error
+                .to_string()
+                .contains("does not contain a mint identity"),
+            "unexpected error: {error}"
+        );
+
+        let _ = fs::remove_dir_all(&work_dir);
+    }
+
+    #[cfg(all(feature = "sqlite", feature = "fakewallet"))]
+    #[tokio::test]
+    async fn initialization_mode_distinguishes_existing_mint_state() {
+        let work_dir = crate::test_utils::unique_temp_path("cdk_mintd_existing_init");
+        fs::create_dir_all(&work_dir).expect("create work dir");
+        let secret_path = work_dir.join("mnemonic.secret");
+        fs::write(&secret_path, TEST_MNEMONIC).expect("write mnemonic secret");
+        let document = sqlite_configuration_document(&secret_path, "existing");
+
+        #[cfg(feature = "sqlcipher")]
+        let password = Some("test-password".to_string());
+        #[cfg(not(feature = "sqlcipher"))]
+        let password: Option<String> = None;
+
+        let bootstrap = load_database_bootstrap_settings().expect("bootstrap settings");
+        let (localstore, keystore, _kv, _configuration_store) =
+            initial_setup(&work_dir, &bootstrap, password.clone())
+                .await
+                .expect("initialize database");
+        let mut builder = MintBuilder::new(localstore);
+        builder
+            .configure_unit(CurrencyUnit::Sat, Default::default())
+            .expect("configure sat unit");
+        let mnemonic = Mnemonic::parse(TEST_MNEMONIC).expect("test mnemonic");
+        let mint = builder
+            .build_with_seed(keystore, &mnemonic.to_seed_normalized(""))
+            .await
+            .expect("create existing mint state");
+        drop(mint);
+
+        let error = initialize_configuration(
+            &work_dir,
+            &document,
+            MintInitializationMode::New,
+            password.clone(),
+        )
+        .await
+        .expect_err("existing state must not be accepted as a new mint");
+        assert!(
+            error
+                .to_string()
+                .contains("contains existing mint identity or keyset state"),
+            "unexpected error: {error}"
+        );
+
+        initialize_configuration(
+            &work_dir,
+            &document,
+            MintInitializationMode::Existing,
+            password,
+        )
+        .await
+        .expect("matching existing mint state should initialize");
 
         let _ = fs::remove_dir_all(&work_dir);
     }

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -392,6 +392,15 @@ pub enum MintInitializationMode {
     Existing,
 }
 
+/// Operator intent for BDK wallet persistence during configuration changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BdkWalletPolicy {
+    /// Require a matching, initialized BDK wallet database.
+    RequireExisting,
+    /// Permit creation of a BDK wallet only when its database is absent.
+    AllowNew,
+}
+
 /// Sets up and initializes a tracing subscriber with custom log filtering.
 /// Logs can be configured to output to stdout only, file only, or both.
 /// Returns a guard that must be kept alive and properly dropped on shutdown.
@@ -2709,6 +2718,7 @@ pub async fn initialize_configuration(
     work_dir: &Path,
     document: &str,
     mode: MintInitializationMode,
+    bdk_wallet_policy: BdkWalletPolicy,
     db_password: Option<String>,
 ) -> Result<()> {
     let bootstrap = load_database_bootstrap_settings()?;
@@ -2722,7 +2732,14 @@ pub async fn initialize_configuration(
     keyset_transaction.commit().await?;
 
     configuration_service(configuration_store, &bootstrap)
-        .initialize(document, mode, database_pubkey, has_keysets)
+        .initialize(
+            document,
+            mode,
+            database_pubkey,
+            has_keysets,
+            work_dir,
+            bdk_wallet_policy,
+        )
         .await?;
     Ok(())
 }
@@ -2732,13 +2749,14 @@ pub async fn apply_configuration(
     work_dir: &Path,
     document: &str,
     validate_only: bool,
+    bdk_wallet_policy: BdkWalletPolicy,
     db_password: Option<String>,
 ) -> Result<ApplyOutcome> {
     let bootstrap = load_database_bootstrap_settings()?;
     let (_localstore, _keystore, _kv, configuration_store) =
         initial_setup(work_dir, &bootstrap, db_password).await?;
     Ok(configuration_service(configuration_store, &bootstrap)
-        .apply(document, validate_only)
+        .apply(document, validate_only, work_dir, bdk_wallet_policy)
         .await?)
 }
 
@@ -2781,6 +2799,11 @@ pub async fn run_mintd_from_database(
         initial_setup(work_dir, &bootstrap, db_password.clone()).await?;
     let service = configuration_service(configuration_store, &bootstrap);
     let startup = service.startup().await?;
+    config_service::require_existing_bdk_wallet(
+        &startup.resolved.settings,
+        work_dir,
+        startup.bdk_wallet_policy,
+    )?;
     let validated_signing_source = Some(ValidatedSigningSource {
         expected_pubkey: startup.signing_identity.pubkey,
         remote_signatory: startup
@@ -2858,6 +2881,34 @@ backend = "fakewallet"
 [database]
 engine = "sqlite"
 "#,
+            secret_path.display()
+        )
+    }
+
+    #[cfg(all(feature = "sqlite", feature = "bdk"))]
+    fn sqlite_bdk_configuration_document(secret_path: &Path, name: &str) -> String {
+        format!(
+            r#"
+[info]
+mnemonic = "file:{}"
+
+[mint_info]
+name = "{name}"
+
+[payment_backend]
+backend = "none"
+
+[onchain]
+onchain_backend = "bdk"
+
+[bdk]
+network = "regtest"
+mnemonic = "file:{}"
+
+[database]
+engine = "sqlite"
+"#,
+            secret_path.display(),
             secret_path.display()
         )
     }
@@ -3102,6 +3153,7 @@ engine = "sqlite"
             &work_dir,
             &first,
             MintInitializationMode::New,
+            BdkWalletPolicy::RequireExisting,
             password.clone(),
         )
         .await
@@ -3113,9 +3165,15 @@ engine = "sqlite"
             first
         );
 
-        let validate_only = apply_configuration(&work_dir, &second, true, password.clone())
-            .await
-            .expect("validate-only apply");
+        let validate_only = apply_configuration(
+            &work_dir,
+            &second,
+            true,
+            BdkWalletPolicy::RequireExisting,
+            password.clone(),
+        )
+        .await
+        .expect("validate-only apply");
         assert!(!validate_only.restart_required);
         assert_eq!(
             stored_configuration_document(&work_dir, password.clone())
@@ -3124,9 +3182,15 @@ engine = "sqlite"
             first
         );
 
-        let applied = apply_configuration(&work_dir, &second, false, password.clone())
-            .await
-            .expect("apply replacement");
+        let applied = apply_configuration(
+            &work_dir,
+            &second,
+            false,
+            BdkWalletPolicy::RequireExisting,
+            password.clone(),
+        )
+        .await
+        .expect("apply replacement");
         assert!(applied.restart_required);
         assert_eq!(
             stored_configuration_document(&work_dir, password)
@@ -3160,6 +3224,7 @@ engine = "sqlite"
             &work_dir,
             &document,
             MintInitializationMode::Existing,
+            BdkWalletPolicy::RequireExisting,
             password,
         )
         .await
@@ -3208,6 +3273,7 @@ engine = "sqlite"
             &work_dir,
             &document,
             MintInitializationMode::New,
+            BdkWalletPolicy::RequireExisting,
             password.clone(),
         )
         .await
@@ -3223,10 +3289,85 @@ engine = "sqlite"
             &work_dir,
             &document,
             MintInitializationMode::Existing,
+            BdkWalletPolicy::RequireExisting,
             password,
         )
         .await
         .expect("matching existing mint state should initialize");
+
+        let _ = fs::remove_dir_all(&work_dir);
+    }
+
+    #[cfg(all(feature = "sqlite", feature = "bdk"))]
+    #[tokio::test]
+    async fn existing_mint_requires_explicit_new_bdk_wallet_intent() {
+        let work_dir = crate::test_utils::unique_temp_path("cdk_mintd_existing_bdk_init");
+        fs::create_dir_all(&work_dir).expect("create work dir");
+        let secret_path = work_dir.join("mnemonic.secret");
+        fs::write(&secret_path, TEST_MNEMONIC).expect("write mnemonic secret");
+        let document = sqlite_bdk_configuration_document(&secret_path, "existing-with-missing-bdk");
+
+        #[cfg(feature = "sqlcipher")]
+        let password = Some("test-password".to_string());
+        #[cfg(not(feature = "sqlcipher"))]
+        let password: Option<String> = None;
+
+        let bootstrap = load_database_bootstrap_settings().expect("bootstrap settings");
+        let (localstore, keystore, _kv, _configuration_store) =
+            initial_setup(&work_dir, &bootstrap, password.clone())
+                .await
+                .expect("initialize database");
+        let mut builder = MintBuilder::new(localstore);
+        builder
+            .configure_unit(CurrencyUnit::Sat, Default::default())
+            .expect("configure sat unit");
+        let mnemonic = Mnemonic::parse(TEST_MNEMONIC).expect("test mnemonic");
+        drop(
+            builder
+                .build_with_seed(keystore, &mnemonic.to_seed_normalized(""))
+                .await
+                .expect("create existing mint state"),
+        );
+
+        let error = initialize_configuration(
+            &work_dir,
+            &document,
+            MintInitializationMode::Existing,
+            BdkWalletPolicy::RequireExisting,
+            password.clone(),
+        )
+        .await
+        .expect_err("missing BDK wallet must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("Persisted BDK wallet database is missing"),
+            "unexpected error: {error}"
+        );
+
+        initialize_configuration(
+            &work_dir,
+            &document,
+            MintInitializationMode::Existing,
+            BdkWalletPolicy::AllowNew,
+            password.clone(),
+        )
+        .await
+        .expect("explicit new-wallet intent should permit initialization");
+
+        let error = apply_configuration(
+            &work_dir,
+            &document,
+            true,
+            BdkWalletPolicy::RequireExisting,
+            password,
+        )
+        .await
+        .expect_err("apply preflight must also reject a missing BDK wallet");
+        assert!(error
+            .to_string()
+            .contains("Persisted BDK wallet database is missing"));
+        assert!(!work_dir.join("bdk_wallet/bdk_wallet.sqlite").exists());
 
         let _ = fs::remove_dir_all(&work_dir);
     }

--- a/crates/cdk-mintd/src/main.rs
+++ b/crates/cdk-mintd/src/main.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
 use cdk_mintd::cli::{CLIArgs, Commands, ConfigCommands};
-use cdk_mintd::get_work_directory;
+use cdk_mintd::{get_work_directory, MintInitializationMode};
 use clap::Parser;
 use tokio::runtime::Runtime;
 
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
         );
         if args.config.is_some() || (args.seed_file.is_some() && !is_migration) {
             bail!(
-                "--config and --seed-file are no longer startup inputs; migrate a legacy document with `cdk-mintd config migrate --file <old> --output <new>`, import one with `cdk-mintd config init --file <path>`, or replace it with `cdk-mintd config apply --file <path>`"
+                "--config and --seed-file are no longer startup inputs; migrate a legacy document with `cdk-mintd config migrate --file <old> --output <new>`, import one with `cdk-mintd config init --existing-mint --file <path>`, initialize a new mint with `cdk-mintd config init --new-mint --file <path>`, or replace it with `cdk-mintd config apply --file <path>`"
             );
         }
         let work_dir = if matches!(
@@ -73,12 +73,18 @@ fn main() -> Result<()> {
                     );
                     Ok(())
                 }
-                ConfigCommands::Init(file) => {
+                ConfigCommands::Init(init) => {
                     let work_dir = work_dir
                         .as_deref()
                         .expect("database commands have a work directory");
-                    let document = read_document(&file.file)?;
-                    cdk_mintd::initialize_configuration(work_dir, &document, password).await?;
+                    let document = read_document(&init.file)?;
+                    let mode = match (init.new_mint, init.existing_mint) {
+                        (true, false) => MintInitializationMode::New,
+                        (false, true) => MintInitializationMode::Existing,
+                        _ => bail!("exactly one mint initialization mode is required"),
+                    };
+                    cdk_mintd::initialize_configuration(work_dir, &document, mode, password)
+                        .await?;
                     println!("Configuration initialized. Start cdk-mintd to apply it.");
                     Ok(())
                 }

--- a/crates/cdk-mintd/src/main.rs
+++ b/crates/cdk-mintd/src/main.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
 use cdk_mintd::cli::{CLIArgs, Commands, ConfigCommands};
-use cdk_mintd::{get_work_directory, MintInitializationMode};
+use cdk_mintd::{get_work_directory, BdkWalletPolicy, MintInitializationMode};
 use clap::Parser;
 use tokio::runtime::Runtime;
 
@@ -83,8 +83,18 @@ fn main() -> Result<()> {
                         (false, true) => MintInitializationMode::Existing,
                         _ => bail!("exactly one mint initialization mode is required"),
                     };
-                    cdk_mintd::initialize_configuration(work_dir, &document, mode, password)
-                        .await?;
+                    let bdk_wallet_policy = match init.allow_new_bdk_wallet {
+                        true => BdkWalletPolicy::AllowNew,
+                        false => BdkWalletPolicy::RequireExisting,
+                    };
+                    cdk_mintd::initialize_configuration(
+                        work_dir,
+                        &document,
+                        mode,
+                        bdk_wallet_policy,
+                        password,
+                    )
+                    .await?;
                     println!("Configuration initialized. Start cdk-mintd to apply it.");
                     Ok(())
                 }
@@ -99,10 +109,15 @@ fn main() -> Result<()> {
                         .as_deref()
                         .expect("database commands have a work directory");
                     let document = read_document(&apply.file)?;
+                    let bdk_wallet_policy = match apply.allow_new_bdk_wallet {
+                        true => BdkWalletPolicy::AllowNew,
+                        false => BdkWalletPolicy::RequireExisting,
+                    };
                     cdk_mintd::apply_configuration(
                         work_dir,
                         &document,
                         apply.validate_only,
+                        bdk_wallet_policy,
                         password,
                     )
                     .await?;

--- a/crates/cdk-mintd/src/setup.rs
+++ b/crates/cdk-mintd/src/setup.rs
@@ -603,6 +603,41 @@ impl PaymentBackendSetup for config::LdkNode {
 
 #[cfg(feature = "bdk")]
 impl crate::config::Bdk {
+    fn wallet_identity(&self) -> Result<(bip39::Mnemonic, bitcoin::Network), cdk_bdk::Error> {
+        let network_str = self.network.as_ref().ok_or_else(|| {
+            cdk_bdk::Error::InvalidConfig("BDK network must be set in [bdk].network".to_string())
+        })?;
+        let network = match network_str.to_lowercase().as_str() {
+            "mainnet" | "bitcoin" => bitcoin::Network::Bitcoin,
+            "testnet" => bitcoin::Network::Testnet,
+            "signet" => bitcoin::Network::Signet,
+            "regtest" => bitcoin::Network::Regtest,
+            _ => {
+                return Err(cdk_bdk::Error::InvalidConfig(format!(
+                    "Unknown BDK network: {network_str}"
+                )));
+            }
+        };
+        let mnemonic = self
+            .mnemonic
+            .as_ref()
+            .ok_or_else(|| cdk_bdk::Error::InvalidConfig("BDK mnemonic must be set".to_string()))?;
+        let mnemonic = bip39::Mnemonic::parse(mnemonic)
+            .map_err(|error| cdk_bdk::Error::InvalidConfig(error.to_string()))?;
+
+        Ok((mnemonic, network))
+    }
+
+    pub(crate) fn validate_wallet_identity(&self) -> Result<(), cdk_bdk::Error> {
+        self.wallet_identity().map(|_| ())
+    }
+
+    pub(crate) fn validate_existing_wallet(&self, work_dir: &Path) -> Result<(), cdk_bdk::Error> {
+        let (mnemonic, network) = self.wallet_identity()?;
+        cdk_bdk::validate_existing_wallet(mnemonic, network, work_dir)?;
+        Ok(())
+    }
+
     fn chain_source(&self) -> anyhow::Result<cdk_bdk::ChainSource> {
         use anyhow::bail;
 
@@ -779,10 +814,6 @@ impl OnchainBackendSetup for crate::config::Bdk {
         work_dir: &Path,
         kv_store: Option<Arc<dyn KVStore<Err = cdk::cdk_database::Error> + Send + Sync>>,
     ) -> anyhow::Result<cdk_bdk::CdkBdk> {
-        use anyhow::bail;
-        use bip39::Mnemonic;
-        use bitcoin::Network;
-
         self.validate().map_err(anyhow::Error::msg)?;
 
         let fee_reserve = FeeReserve {
@@ -790,25 +821,9 @@ impl OnchainBackendSetup for crate::config::Bdk {
             percent_fee_reserve: self.fee_percent,
         };
 
-        let network_str = self
-            .network
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("BDK network must be set in [bdk].network"))?;
-
-        let network = match network_str.to_lowercase().as_str() {
-            "mainnet" | "bitcoin" => Network::Bitcoin,
-            "testnet" => Network::Testnet,
-            "signet" => Network::Signet,
-            "regtest" => Network::Regtest,
-            _ => bail!("Unknown BDK network: {}", network_str),
-        };
+        let (mnemonic, network) = self.wallet_identity()?;
 
         let chain_source = self.chain_source()?;
-
-        let mnemonic = match &self.mnemonic {
-            Some(m) => Mnemonic::parse(m)?,
-            None => bail!("BDK mnemonic must be set"),
-        };
 
         let min_receive_amount_sat = settings
             .onchain

--- a/docker-compose.ldk-node.yaml
+++ b/docker-compose.ldk-node.yaml
@@ -1,5 +1,7 @@
-# Before starting, export distinct stable BIP39 values for
-# CDK_MINTD_MNEMONIC and CDK_MINTD_LDK_NODE_MNEMONIC.
+# Before a new mint's first start, export CDK_MINTD_INIT_MODE=new and distinct
+# stable BIP39 values for CDK_MINTD_MNEMONIC and
+# CDK_MINTD_LDK_NODE_MNEMONIC. Existing-mint upgrades must seed the persistent
+# database and use CDK_MINTD_INIT_MODE=existing.
 services:
   # CDK Mint service with LDK Node backend
 
@@ -49,6 +51,7 @@ services:
       - "127.0.0.1:8091:8091" # LDK admin dashboard; host-local only because it has no authentication
     environment:
       CDK_MINTD_DATABASE: sqlite
+      CDK_MINTD_INIT_MODE: "${CDK_MINTD_INIT_MODE:-}"
       CDK_MINTD_MNEMONIC: "${CDK_MINTD_MNEMONIC:?Set CDK_MINTD_MNEMONIC to a stable BIP39 mnemonic}"
       CDK_MINTD_LDK_NODE_MNEMONIC: "${CDK_MINTD_LDK_NODE_MNEMONIC:?Set CDK_MINTD_LDK_NODE_MNEMONIC to a stable BIP39 mnemonic}"
 

--- a/docker-compose.postgres.yaml
+++ b/docker-compose.postgres.yaml
@@ -1,6 +1,8 @@
 # Docker Compose configuration for CDK Mint with PostgreSQL
 # Usage: docker-compose -f docker-compose.postgres.yaml up
-# Before starting, export CDK_MINTD_MNEMONIC with a stable BIP39 mnemonic.
+# Before a new mint's first start, export CDK_MINTD_INIT_MODE=new and
+# CDK_MINTD_MNEMONIC with a stable BIP39 mnemonic. Existing-mint upgrades must
+# preserve the database and use CDK_MINTD_INIT_MODE=existing.
 
 services:
   # CDK Mint service with PostgreSQL
@@ -13,6 +15,7 @@ services:
       - "8085:8085"
     environment:
       CDK_MINTD_DATABASE: postgres
+      CDK_MINTD_INIT_MODE: "${CDK_MINTD_INIT_MODE:-}"
       CDK_MINTD_POSTGRES_URL: "${CDK_MINTD_POSTGRES_URL:-postgresql://cdk_user:cdk_password@postgres:5432/cdk_mint}"
       CDK_MINTD_MNEMONIC: "${CDK_MINTD_MNEMONIC:?Set CDK_MINTD_MNEMONIC to a stable BIP39 mnemonic}"
     volumes:

--- a/docker-compose.tor.yaml
+++ b/docker-compose.tor.yaml
@@ -1,4 +1,6 @@
-# Before starting, export CDK_MINTD_MNEMONIC with a stable BIP39 mnemonic.
+# Before a new mint's first start, export CDK_MINTD_INIT_MODE=new and
+# CDK_MINTD_MNEMONIC with a stable BIP39 mnemonic. Existing-mint upgrades must
+# seed the persistent database and use CDK_MINTD_INIT_MODE=existing.
 services:
   mint:
     image: cashubtc/mintd:latest
@@ -10,6 +12,7 @@ services:
       - "8085:8085"
     environment:
       CDK_MINTD_DATABASE: sqlite
+      CDK_MINTD_INIT_MODE: "${CDK_MINTD_INIT_MODE:-}"
       CDK_MINTD_MNEMONIC: "${CDK_MINTD_MNEMONIC:?Set CDK_MINTD_MNEMONIC to a stable BIP39 mnemonic}"
     volumes:
       - ./misc/docker-configs/tor-fakewallet-sqlite.toml:/etc/cdk-mintd/config.toml:ro

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,6 @@
-# Before starting, export CDK_MINTD_MNEMONIC with a stable BIP39 mnemonic.
+# Before a new mint's first start, export CDK_MINTD_INIT_MODE=new and
+# CDK_MINTD_MNEMONIC with a stable BIP39 mnemonic. Existing-mint upgrades must
+# seed the persistent database and use CDK_MINTD_INIT_MODE=existing.
 services:
   # CDK Mint service
 
@@ -43,6 +45,7 @@ services:
       - "8085:8085"
     environment:
       CDK_MINTD_DATABASE: sqlite
+      CDK_MINTD_INIT_MODE: "${CDK_MINTD_INIT_MODE:-}"
       CDK_MINTD_MNEMONIC: "${CDK_MINTD_MNEMONIC:?Set CDK_MINTD_MNEMONIC to a stable BIP39 mnemonic}"
     volumes:
       - ./misc/docker-configs/fakewallet-sqlite.toml:/etc/cdk-mintd/config.toml:ro

--- a/docs/migrations/v0.18.md
+++ b/docs/migrations/v0.18.md
@@ -26,7 +26,8 @@ existing database.
 ## Before Upgrading
 
 1. Record the current mint binary version, mint public key, and complete
-   `/v1/keysets` response, including inactive keysets.
+   `/v1/keysets` response, including inactive keysets. If using LDK, also record
+   the Lightning node ID.
 2. Save the active configuration file and the environment variables used by
    the mint service.
 3. If management RPC is enabled, record the current RPC-managed values before
@@ -47,9 +48,11 @@ existing database.
    mint database. The legacy `[database.sqlite].path` field was not used to
    select the SQLite file.
 5. Stop `cdk-mintd`.
-6. Back up the complete mint database and working directory. For PostgreSQL,
-   take a database backup using the normal PostgreSQL tooling. For SQLite, copy
-   the database only after the daemon has stopped.
+6. Back up the complete mint database and working directory. Preserve the
+   complete BDK and embedded LDK storage directories, including any paths
+   configured outside the mint working directory. For PostgreSQL, take a
+   database backup using the normal PostgreSQL tooling. For SQLite, copy the
+   database only after the daemon has stopped.
 
 Keep this backup until the upgraded mint has been verified. Rolling back may
 require restoring it because the new binary can run database migrations while
@@ -86,8 +89,9 @@ Secret handling is deliberately different:
 - list-valued Redis cluster-node environment configuration is copied into one
   secret file per effective node because the new document represents those
   values as a list; and
-- a legacy `--seed-file` can be supplied to the migration command and is
-  referenced directly:
+- if the old daemon actually started with the legacy global `--seed-file`
+  option, supply that same option to the migration command so its BIP39
+  mnemonic is referenced directly:
 
   ```bash
   cdk-mintd --seed-file /run/secrets/mint-mnemonic \
@@ -95,6 +99,11 @@ Secret handling is deliberately different:
     --file /path/to/legacy-config.toml \
     --output /path/to/migrated-config.toml
   ```
+
+The global `--seed-file` is a legacy BIP39 mnemonic override for the mint and
+its active embedded wallet backends. It is not LDK's binary
+`<storage_dir_path>/keys_seed` file. Do not pass `--seed-file` merely because an
+LDK storage directory contains `keys_seed`.
 
 Use `--secrets-dir /absolute/path` to choose another secret location. Migration
 refuses to overwrite the source, output, or generated secret files by default;
@@ -167,6 +176,77 @@ mint. Signer migration is not supported by `config init` or `config apply`.
 The same mnemonic used with an empty or incorrectly selected database produces
 the same root public key, so signer identity alone cannot prove that historical
 keyset and proof state is present.
+
+### Preserve the LDK Node Identity
+
+Preserve the complete configured LDK `storage_dir_path` and the identity source
+that the existing node actually used. Record the node ID before shutdown and
+verify the same ID before reopening the mint to users.
+
+Most LDK nodes use a BIP39 `ldk_node_mnemonic`. Keep its exact `env:` or
+`file:` reference in the migrated document and ensure it resolves to the
+original LDK mnemonic. Supplying a different mnemonic changes the derived node
+identity and wallet descriptors and can make startup fail against the existing
+wallet database. New deployments should use a dedicated LDK mnemonic rather
+than the mint mnemonic. During migration, preserve the value the old daemon
+actually used, including the uncommon case where the legacy global
+`--seed-file` deliberately supplied the same mnemonic to both.
+
+Older nodes may instead have been created using LDK's default binary seed at:
+
+```text
+<storage_dir_path>/keys_seed
+```
+
+For that legacy case, preserve the complete storage directory and omit
+`ldk_node_mnemonic`; LDK will read the stored `keys_seed`. This file is distinct
+from the legacy `cdk-mintd --seed-file` BIP39 mnemonic option described above.
+Do not convert a `keys_seed` node to a mnemonic as part of the v0.18 migration.
+
+After startup, confirm the node ID, on-chain wallet, channel state, and a small
+Lightning mint and melt before considering the migration complete.
+
+### Preserve the BDK Wallet
+
+The BDK backend has state in two places. Payment intents and recovery records
+are stored in the primary mint database, while descriptors, revealed address
+indexes, transactions, and chain checkpoints are stored at:
+
+```text
+<effective-work-directory>/bdk_wallet/bdk_wallet.sqlite
+```
+
+Preserve both stores together, along with the exact BDK mnemonic and Bitcoin
+network. `config init --existing-mint` and `config apply` open the BDK wallet
+read-only before storing the document. They refuse a missing or uninitialized
+wallet and reject a mnemonic or network whose descriptors do not match the
+persisted wallet.
+
+If BDK is intentionally being added to an existing mint, explicitly permit the
+first wallet creation:
+
+```bash
+cdk-mintd --work-dir /var/lib/cdk-mintd \
+  config init --existing-mint --allow-new-bdk-wallet \
+  --file /path/to/migrated-config.toml
+```
+
+The same flag is available on `config apply`. It permits only an absent wallet;
+it does not bypass corruption, descriptor, or network errors. Do not use it for
+a mint that previously used BDK unless the original wallet database is confirmed
+lost and mnemonic recovery is unavoidable. For Bitcoin RPC recovery, use the
+same BDK mnemonic and set `[bdk].wallet_rescan_from_height` to a known wallet
+birthday before using the flag. Without an explicit height, a newly created
+Bitcoin RPC wallet starts at the current chain tip and does not discover older
+activity. Permission to create the wallet is stored only until one daemon
+startup completes successfully. Later restarts fail closed if the BDK wallet
+volume or file is missing.
+
+`config validate` remains document-only because it has no selected work
+directory. Use `config init` or `config apply --validate-only` for persisted BDK
+wallet preflight. For an already initialized v0.18 mint, follow the
+[`Adding BDK to an Existing Mint`](../../crates/cdk-mintd/README.md#adding-bdk-to-an-existing-mint)
+operator runbook.
 
 ### Match the Primary Database Bootstrap
 
@@ -283,8 +363,8 @@ docker cp mint:/root/.cdk-mintd ./cdk-mintd-v017-workdir
 
 Back up and inspect the extracted directory before proceeding. Seed the v0.18
 volume mounted at `/var/lib/cdk-mintd` with the *contents* of the extracted
-directory so that `cdk-mintd.sqlite` is directly under that mount. Preserve any
-explicit LDK or BDK storage directories as well.
+directory so that `cdk-mintd.sqlite` is directly under that mount. Preserve the
+`bdk_wallet` subdirectory and any explicit LDK storage directories as well.
 
 The repository Compose entrypoint initializes only when
 `CDK_MINTD_INIT_MODE` is explicitly set. Use `existing` for an upgrade and

--- a/docs/migrations/v0.18.md
+++ b/docs/migrations/v0.18.md
@@ -15,7 +15,7 @@ cdk-mintd config migrate \
   --file /path/to/legacy-config.toml \
   --output /path/to/migrated-config.toml
 cdk-mintd config validate --file /path/to/migrated-config.toml
-cdk-mintd config init --file /path/to/migrated-config.toml
+cdk-mintd config init --existing-mint --file /path/to/migrated-config.toml
 cdk-mintd
 ```
 
@@ -25,7 +25,8 @@ existing database.
 
 ## Before Upgrading
 
-1. Record the current mint binary version.
+1. Record the current mint binary version, mint public key, and complete
+   `/v1/keysets` response, including inactive keysets.
 2. Save the active configuration file and the environment variables used by
    the mint service.
 3. If management RPC is enabled, record the current RPC-managed values before
@@ -40,8 +41,13 @@ existing database.
    Copy the reported name, descriptions, MOTD, icon, URLs, contacts, terms of
    service URL, and quote TTL into the import document. The first database-backed
    start treats that document as authoritative.
-4. Stop `cdk-mintd`.
-5. Back up the complete mint database and working directory. For PostgreSQL,
+4. Record the effective v0.17 working directory from the startup log. Its
+   precedence is `--work-dir`, then `CDK_MINTD_WORK_DIR`, then
+   `$HOME/.cdk-mintd`. A systemd `WorkingDirectory=` setting does not select the
+   mint database. The legacy `[database.sqlite].path` field was not used to
+   select the SQLite file.
+5. Stop `cdk-mintd`.
+6. Back up the complete mint database and working directory. For PostgreSQL,
    take a database backup using the normal PostgreSQL tooling. For SQLite, copy
    the database only after the daemon has stopped.
 
@@ -158,6 +164,9 @@ remain on the signatory host.
 
 Initialization fails rather than attaching a different signer to an existing
 mint. Signer migration is not supported by `config init` or `config apply`.
+The same mnemonic used with an empty or incorrectly selected database produces
+the same root public key, so signer identity alone cannot prove that historical
+keyset and proof state is present.
 
 ### Match the Primary Database Bootstrap
 
@@ -167,7 +176,8 @@ database before they can read its stored document.
 For SQLite, use the existing working directory:
 
 ```bash
-cdk-mintd --work-dir /var/lib/cdk-mintd config init --file /path/to/config.toml
+cdk-mintd --work-dir /var/lib/cdk-mintd \
+  config init --existing-mint --file /path/to/config.toml
 ```
 
 For PostgreSQL, set the same bootstrap settings used by the document:
@@ -205,12 +215,17 @@ Initialize the configuration record against the existing database:
 
 ```bash
 cdk-mintd --work-dir /var/lib/cdk-mintd \
-  config init --file /path/to/migrated-config.toml
+  config init --existing-mint --file /path/to/migrated-config.toml
 ```
 
-`config init` refuses to replace an existing configuration record. If it reports
-that configuration is already initialized, inspect it with `config show` rather
-than retrying initialization.
+Initialization requires explicit operator intent. `--existing-mint` requires a
+persisted mint identity and, for an embedded signatory, keyset history. Remote
+signatory keysets remain in the signatory database. The mode therefore rejects
+an empty primary database even when the configured mnemonic is correct.
+`--new-mint` does the opposite and rejects a database containing existing
+identity or keysets. Neither mode replaces an existing configuration record. If
+initialization reports that configuration is already initialized, inspect it
+with `config show` rather than retrying initialization.
 
 Inspect the stored unresolved document:
 
@@ -236,7 +251,10 @@ Before reopening the mint to users, verify:
 - the mint URL and HTTP listen address;
 - mint name, descriptions, MOTD, icon, URLs, contacts, and terms of service;
 - quote TTL values;
-- active keysets and the mint public key;
+- the mint public key and every active and inactive keyset recorded before the
+  upgrade;
+- redemption of an unspent proof from each historical keyset for which a test
+  proof is available;
 - every configured Lightning and on-chain payment backend;
 - authentication, caching, metrics, and management RPC; and
 - logs for configuration, signer, database, or backend errors.
@@ -245,6 +263,42 @@ Use `config show` to confirm that the intended document is active. Use
 `config export --file <path>` to make a portable copy containing secret
 references, not resolved values. Export refuses to overwrite an existing file;
 pass `--force` only when replacing it intentionally.
+
+## Docker and Compose Upgrades
+
+The released v0.17.5 images ran as root and defaulted to
+`/root/.cdk-mintd`. The v0.17.5 SQLite Compose service did not persist that
+directory. Its LDK Compose file declared a volume at
+`/usr/src/app/ldk_node_data`, but the default LDK storage path was
+`/root/.cdk-mintd/ldk-node`, so the declared volume did not protect the default
+mint database or LDK state.
+
+Before removing or recreating a v0.17 container, stop it and copy its complete
+effective working directory:
+
+```bash
+docker stop mint
+docker cp mint:/root/.cdk-mintd ./cdk-mintd-v017-workdir
+```
+
+Back up and inspect the extracted directory before proceeding. Seed the v0.18
+volume mounted at `/var/lib/cdk-mintd` with the *contents* of the extracted
+directory so that `cdk-mintd.sqlite` is directly under that mount. Preserve any
+explicit LDK or BDK storage directories as well.
+
+The repository Compose entrypoint initializes only when
+`CDK_MINTD_INIT_MODE` is explicitly set. Use `existing` for an upgrade and
+`new` only for a mint that has never served users:
+
+```bash
+export CDK_MINTD_INIT_MODE=existing
+docker compose up
+```
+
+With no mode, an uninitialized or unreadable configuration fails closed. An
+incorrectly selected empty database also fails in `existing` mode instead of
+starting a new mint. PostgreSQL upgrades use the same mode but must preserve the
+exact database URL, TLS, pool, and connection bootstrap settings.
 
 ## Later Configuration Changes
 

--- a/misc/docker-mintd-entrypoint.sh
+++ b/misc/docker-mintd-entrypoint.sh
@@ -3,11 +3,29 @@ set -eu
 
 config_file=${CDK_MINTD_CONFIG_FILE:-/etc/cdk-mintd/config.toml}
 work_dir=${CDK_MINTD_WORK_DIR:-/var/lib/cdk-mintd}
+init_mode=${CDK_MINTD_INIT_MODE:-}
 
-# Initialization is intentionally one-shot. Once the database contains a
-# configuration, edit the import document and use `config apply` explicitly.
+# Initialization is intentionally one-shot and requires explicit operator
+# intent. Once the database contains a configuration, edit the import document
+# and use `config apply` explicitly.
 if ! cdk-mintd --work-dir "$work_dir" config show >/dev/null 2>&1; then
-    cdk-mintd --work-dir "$work_dir" config init --file "$config_file"
+    case "$init_mode" in
+        new)
+            init_flag=--new-mint
+            ;;
+        existing)
+            init_flag=--existing-mint
+            ;;
+        "")
+            echo "cdk-mintd configuration is absent or unreadable; set CDK_MINTD_INIT_MODE=new for a new mint or CDK_MINTD_INIT_MODE=existing for an existing mint" >&2
+            exit 1
+            ;;
+        *)
+            echo "invalid CDK_MINTD_INIT_MODE '$init_mode'; expected 'new' or 'existing'" >&2
+            exit 1
+            ;;
+    esac
+    cdk-mintd --work-dir "$work_dir" config init "$init_flag" --file "$config_file"
 fi
 
 exec cdk-mintd --work-dir "$work_dir"

--- a/misc/interactive_regtest_mprocs.sh
+++ b/misc/interactive_regtest_mprocs.sh
@@ -329,7 +329,7 @@ echo "Database type: \$CDK_MINTD_DATABASE"
 echo "---"
 
 if ! cargo run --bin cdk-mintd -- --work-dir "\$CDK_MINTD_WORK_DIR" config show >/dev/null 2>&1; then
-    cargo run --bin cdk-mintd -- --work-dir "\$CDK_MINTD_WORK_DIR" config init --file "\$CDK_MINTD_WORK_DIR/config.toml"
+    cargo run --bin cdk-mintd -- --work-dir "\$CDK_MINTD_WORK_DIR" config init --new-mint --file "\$CDK_MINTD_WORK_DIR/config.toml"
 fi
 
 exec cargo run --bin cdk-mintd -- --work-dir "\$CDK_MINTD_WORK_DIR"
@@ -353,7 +353,7 @@ echo "Database type: \$CDK_MINTD_DATABASE"
 echo "---"
 
 if ! cargo run --bin cdk-mintd -- --work-dir "\$CDK_MINTD_WORK_DIR" config show >/dev/null 2>&1; then
-    cargo run --bin cdk-mintd -- --work-dir "\$CDK_MINTD_WORK_DIR" config init --file "\$CDK_MINTD_WORK_DIR/config.toml"
+    cargo run --bin cdk-mintd -- --work-dir "\$CDK_MINTD_WORK_DIR" config init --new-mint --file "\$CDK_MINTD_WORK_DIR/config.toml"
 fi
 
 exec cargo run --bin cdk-mintd -- --work-dir "\$CDK_MINTD_WORK_DIR"
@@ -380,7 +380,7 @@ echo "Database type: \$CDK_MINTD_DATABASE"
 echo "---"
 
 if ! cargo run --bin cdk-mintd --features ldk-node -- --work-dir "\$CDK_MINTD_WORK_DIR" config show >/dev/null 2>&1; then
-    cargo run --bin cdk-mintd --features ldk-node -- --work-dir "\$CDK_MINTD_WORK_DIR" config init --file "\$CDK_MINTD_WORK_DIR/config.toml"
+    cargo run --bin cdk-mintd --features ldk-node -- --work-dir "\$CDK_MINTD_WORK_DIR" config init --new-mint --file "\$CDK_MINTD_WORK_DIR/config.toml"
 fi
 
 exec cargo run --bin cdk-mintd --features ldk-node -- --work-dir "\$CDK_MINTD_WORK_DIR"

--- a/misc/itest_helpers.sh
+++ b/misc/itest_helpers.sh
@@ -180,12 +180,12 @@ run_mintd_bg() {
 
     if command -v cdk-mintd &>/dev/null; then
         echo "Using pre-built binary: cdk-mintd"
-        cdk-mintd --work-dir "$work_dir" config init --file "$config_file" || return 1
+        cdk-mintd --work-dir "$work_dir" config init --new-mint --file "$config_file" || return 1
         cdk-mintd --work-dir "$work_dir" &
     else
         echo "Pre-built cdk-mintd not found, falling back to cargo run"
         cargo run --bin cdk-mintd --no-default-features --features grpc-processor,sqlite -- \
-            --work-dir "$work_dir" config init --file "$config_file" || return 1
+            --work-dir "$work_dir" config init --new-mint --file "$config_file" || return 1
         cargo run --bin cdk-mintd --no-default-features --features grpc-processor,sqlite -- \
             --work-dir "$work_dir" &
     fi

--- a/misc/nutshell_wallet_itest.sh
+++ b/misc/nutshell_wallet_itest.sh
@@ -82,7 +82,7 @@ cargo build --bin cdk-mintd
 
 echo "Initializing mintd configuration"
 cargo run --bin cdk-mintd -- \
-  --work-dir "$CDK_MINTD_WORK_DIR" config init --file "$MINTD_CONFIG_FILE"
+  --work-dir "$CDK_MINTD_WORK_DIR" config init --new-mint --file "$MINTD_CONFIG_FILE"
 
 echo "Starting fake mintd"
 cargo run --bin cdk-mintd -- --work-dir "$CDK_MINTD_WORK_DIR" &


### PR DESCRIPTION
Require operators to select --new-mint or --existing-mint when importing configuration. Validate persisted mint identity and keyset history before storing the document so a matching mnemonic cannot hide an empty or incorrectly selected database.

Make the Docker entrypoint require CDK_MINTD_INIT_MODE for uninitialized databases and fail closed when intent is absent. Update Compose examples, development scripts, and the v0.18 migration guide with v0.17 work-directory, backup, volume-seeding, keyset, and rollback guidance.

Add regression coverage for empty and existing databases, CLI mode exclusivity, and remote-signatory keyset storage.

BREAKING CHANGE: cdk-mintd config init now requires exactly one of --new-mint or --existing-mint.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
