### PR TITLE
feat(cdk-mint-rpc): add MintInfoService

### DIFF
--- a/crates/cdk-mint-rpc/build.rs
+++ b/crates/cdk-mint-rpc/build.rs
@@ -17,6 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .compile_protos(
             &[
                 "src/proto/cdk-mint-rpc.proto",
+                "src/proto/info.proto",
                 "src/proto/keyset.proto",
                 "src/proto/payment_method.proto",
                 "src/proto/quote.proto",

--- a/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
+++ b/crates/cdk-mint-rpc/src/bin/mint_rpc_cli.rs
@@ -4,16 +4,14 @@ use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
 use cdk_common::grpc::{VersionInterceptor, VERSION_HEADER};
-use cdk_mint_rpc::cdk_mint_client::CdkMintClient;
+use cdk_mint_rpc::info::mint_info_service_client::MintInfoServiceClient;
 use cdk_mint_rpc::keyset::keyset_service_client::KeysetServiceClient;
 use cdk_mint_rpc::mint_rpc_cli::subcommands;
 use cdk_mint_rpc::payment_method::payment_method_service_client::PaymentMethodServiceClient;
 use cdk_mint_rpc::quote::quote_service_client::QuoteServiceClient;
 use cdk_mint_rpc::wallet::wallet_service_client::WalletServiceClient;
-use cdk_mint_rpc::GetInfoRequest;
 use clap::{Parser, Subcommand};
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
-use tonic::Request;
 use tracing_subscriber::EnvFilter;
 
 /// Common CLI arguments for CDK binaries
@@ -173,73 +171,53 @@ async fn main() -> Result<()> {
     // Shared version header interceptor
     let interceptor =
         VersionInterceptor::new(VERSION_HEADER, cdk_common::MINT_RPC_PROTOCOL_VERSION);
-    let mut client = CdkMintClient::with_interceptor(channel.clone(), interceptor.clone());
     let mut wallet_client =
         WalletServiceClient::with_interceptor(channel.clone(), interceptor.clone());
 
     match cli.command {
         Commands::GetInfo => {
-            let response = client.get_info(Request::new(GetInfoRequest {})).await?;
-            let info = response.into_inner();
-            println!(
-                "name:             {}",
-                info.name.unwrap_or("None".to_string())
-            );
-            println!(
-                "version:          {}",
-                info.version.unwrap_or("None".to_string())
-            );
-            println!(
-                "description:      {}",
-                info.description.unwrap_or("None".to_string())
-            );
-            println!(
-                "long description: {}",
-                info.long_description.unwrap_or("None".to_string())
-            );
-            println!("motd: {}", info.motd.unwrap_or("None".to_string()));
-            println!("icon_url: {}", info.icon_url.unwrap_or("None".to_string()));
-            println!("tos_url: {}", info.tos_url.unwrap_or("None".to_string()));
-
-            for url in info.urls {
-                println!("mint_url: {url}");
-            }
-
-            for contact in info.contact {
-                println!("method: {}, info: {}", contact.method, contact.info);
-            }
-            println!("total issued:     {} sat", info.total_issued);
-            println!("total redeemed:   {} sat", info.total_redeemed);
+            let mut info_client = MintInfoServiceClient::with_interceptor(channel, interceptor);
+            subcommands::get_info(&mut info_client).await?;
         }
         Commands::UpdateMotd(sub_command_args) => {
-            subcommands::update_motd(&mut client, &sub_command_args).await?;
+            let mut info_client = MintInfoServiceClient::with_interceptor(channel, interceptor);
+            subcommands::update_motd(&mut info_client, &sub_command_args).await?;
         }
         Commands::UpdateShortDescription(sub_command_args) => {
-            subcommands::update_short_description(&mut client, &sub_command_args).await?;
+            let mut info_client = MintInfoServiceClient::with_interceptor(channel, interceptor);
+            subcommands::update_short_description(&mut info_client, &sub_command_args).await?;
         }
         Commands::UpdateLongDescription(sub_command_args) => {
-            subcommands::update_long_description(&mut client, &sub_command_args).await?;
+            let mut info_client = MintInfoServiceClient::with_interceptor(channel, interceptor);
+            subcommands::update_long_description(&mut info_client, &sub_command_args).await?;
         }
         Commands::UpdateName(sub_command_args) => {
-            subcommands::update_name(&mut client, &sub_command_args).await?;
+            let mut info_client = MintInfoServiceClient::with_interceptor(channel, interceptor);
+            subcommands::update_name(&mut info_client, &sub_command_args).await?;
         }
         Commands::UpdateIconUrl(sub_command_args) => {
-            subcommands::update_icon_url(&mut client, &sub_command_args).await?;
+            let mut info_client = MintInfoServiceClient::with_interceptor(channel, interceptor);
+            subcommands::update_icon_url(&mut info_client, &sub_command_args).await?;
         }
         Commands::UpdateTosUrl(sub_command_args) => {
-            subcommands::update_tos_url(&mut client, &sub_command_args).await?;
+            let mut info_client = MintInfoServiceClient::with_interceptor(channel, interceptor);
+            subcommands::update_tos_url(&mut info_client, &sub_command_args).await?;
         }
         Commands::AddUrl(sub_command_args) => {
-            subcommands::add_url(&mut client, &sub_command_args).await?;
+            let mut info_client = MintInfoServiceClient::with_interceptor(channel, interceptor);
+            subcommands::add_url(&mut info_client, &sub_command_args).await?;
         }
         Commands::RemoveUrl(sub_command_args) => {
-            subcommands::remove_url(&mut client, &sub_command_args).await?;
+            let mut info_client = MintInfoServiceClient::with_interceptor(channel, interceptor);
+            subcommands::remove_url(&mut info_client, &sub_command_args).await?;
         }
         Commands::AddContact(sub_command_args) => {
-            subcommands::add_contact(&mut client, &sub_command_args).await?;
+            let mut info_client = MintInfoServiceClient::with_interceptor(channel, interceptor);
+            subcommands::add_contact(&mut info_client, &sub_command_args).await?;
         }
         Commands::RemoveContact(sub_command_args) => {
-            subcommands::remove_contact(&mut client, &sub_command_args).await?;
+            let mut info_client = MintInfoServiceClient::with_interceptor(channel, interceptor);
+            subcommands::remove_contact(&mut info_client, &sub_command_args).await?;
         }
         Commands::UpdateMintMethod(sub_command_args) => {
             let mut payment_method_client =

--- a/crates/cdk-mint-rpc/src/lib.rs
+++ b/crates/cdk-mint-rpc/src/lib.rs
@@ -23,6 +23,14 @@ pub type InterceptedCdkMintClient = cdk_mint_client::CdkMintClient<
     >,
 >;
 
+/// Type alias for MintInfoServiceClient with the version header interceptor over a Channel
+pub type InterceptedMintInfoServiceClient = info::mint_info_service_client::MintInfoServiceClient<
+    tonic::codegen::InterceptedService<
+        tonic::transport::Channel,
+        cdk_common::grpc::VersionInterceptor,
+    >,
+>;
+
 /// Type alias for KeysetServiceClient with the version header interceptor over a Channel
 pub type InterceptedKeysetServiceClient = keyset::keyset_service_client::KeysetServiceClient<
     tonic::codegen::InterceptedService<

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/get_info.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/get_info.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+use tonic::Request;
+
+use crate::info::GetInfoRequest;
+use crate::InterceptedMintInfoServiceClient;
+
+/// Executes the get_info command against the mint server
+///
+/// This function fetches the mint's public metadata and prints it.
+///
+/// # Arguments
+/// * `client` - The RPC client used to communicate with the mint
+pub async fn get_info(client: &mut InterceptedMintInfoServiceClient) -> Result<()> {
+    let response = client.get_info(Request::new(GetInfoRequest {})).await?;
+    let info = response.into_inner();
+
+    println!(
+        "name:             {}",
+        info.name.unwrap_or("None".to_string())
+    );
+    println!(
+        "version:          {}",
+        info.version.unwrap_or("None".to_string())
+    );
+    println!(
+        "description:      {}",
+        info.description.unwrap_or("None".to_string())
+    );
+    println!(
+        "long description: {}",
+        info.long_description.unwrap_or("None".to_string())
+    );
+    println!("motd: {}", info.motd.unwrap_or("None".to_string()));
+    println!("icon_url: {}", info.icon_url.unwrap_or("None".to_string()));
+    println!("tos_url: {}", info.tos_url.unwrap_or("None".to_string()));
+
+    for url in info.urls {
+        println!("mint_url: {url}");
+    }
+
+    for contact in info.contact {
+        println!("method: {}, info: {}", contact.method, contact.info);
+    }
+
+    Ok(())
+}

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/mod.rs
@@ -1,5 +1,7 @@
 //! Subcommands for the mint RPC CLI
 
+/// Module for fetching the mint's public metadata
+mod get_info;
 /// Module for rotating to the next keyset
 mod rotate_next_keyset;
 /// Module for updating mint contact information
@@ -31,6 +33,7 @@ mod update_urls;
 /// Module for inspecting the mint's BDK on-chain wallet.
 mod wallet;
 
+pub use get_info::get_info;
 pub use rotate_next_keyset::{rotate_next_keyset, RotateNextKeysetCommand};
 pub use update_contact::{add_contact, remove_contact, AddContactCommand, RemoveContactCommand};
 pub use update_disabled::{update_disabled, UpdateDisabledCommand};

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_contact.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_contact.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use clap::Args;
 use tonic::Request;
 
-use crate::{InterceptedCdkMintClient, UpdateContactRequest};
+use crate::info::{AddContactRequest, RemoveContactRequest};
+use crate::InterceptedMintInfoServiceClient;
 
 /// Command to add a contact method to the mint
 ///
@@ -24,11 +25,11 @@ pub struct AddContactCommand {
 /// * `client` - The RPC client used to communicate with the mint
 /// * `sub_command_args` - The contact method and information to add
 pub async fn add_contact(
-    client: &mut InterceptedCdkMintClient,
+    client: &mut InterceptedMintInfoServiceClient,
     sub_command_args: &AddContactCommand,
 ) -> Result<()> {
     let _response = client
-        .add_contact(Request::new(UpdateContactRequest {
+        .add_contact(Request::new(AddContactRequest {
             method: sub_command_args.method.clone(),
             info: sub_command_args.info.clone(),
         }))
@@ -57,11 +58,11 @@ pub struct RemoveContactCommand {
 /// * `client` - The RPC client used to communicate with the mint
 /// * `sub_command_args` - The contact method and information to remove
 pub async fn remove_contact(
-    client: &mut InterceptedCdkMintClient,
+    client: &mut InterceptedMintInfoServiceClient,
     sub_command_args: &RemoveContactCommand,
 ) -> Result<()> {
     let _response = client
-        .remove_contact(Request::new(UpdateContactRequest {
+        .remove_contact(Request::new(RemoveContactRequest {
             method: sub_command_args.method.clone(),
             info: sub_command_args.info.clone(),
         }))

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_icon_url.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_icon_url.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use clap::Args;
 use tonic::Request;
 
-use crate::{InterceptedCdkMintClient, UpdateIconUrlRequest};
+use crate::info::UpdateIconUrlRequest;
+use crate::InterceptedMintInfoServiceClient;
 
 /// Command to update the mint's icon URL
 ///
@@ -22,7 +23,7 @@ pub struct UpdateIconUrlCommand {
 /// * `client` - The RPC client used to communicate with the mint
 /// * `sub_command_args` - The new icon URL to set
 pub async fn update_icon_url(
-    client: &mut InterceptedCdkMintClient,
+    client: &mut InterceptedMintInfoServiceClient,
     sub_command_args: &UpdateIconUrlCommand,
 ) -> Result<()> {
     let _response = client

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_long_description.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_long_description.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use clap::Args;
 use tonic::Request;
 
-use crate::{InterceptedCdkMintClient, UpdateDescriptionRequest};
+use crate::info::UpdateLongDescriptionRequest;
+use crate::InterceptedMintInfoServiceClient;
 
 /// Command to update the mint's long description
 ///
@@ -22,12 +23,12 @@ pub struct UpdateLongDescriptionCommand {
 /// * `client` - The RPC client used to communicate with the mint
 /// * `sub_command_args` - The new long description to set
 pub async fn update_long_description(
-    client: &mut InterceptedCdkMintClient,
+    client: &mut InterceptedMintInfoServiceClient,
     sub_command_args: &UpdateLongDescriptionCommand,
 ) -> Result<()> {
     let _response = client
-        .update_long_description(Request::new(UpdateDescriptionRequest {
-            description: sub_command_args.description.clone(),
+        .update_long_description(Request::new(UpdateLongDescriptionRequest {
+            long_description: sub_command_args.description.clone(),
         }))
         .await?;
 

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_motd.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_motd.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use clap::Args;
 use tonic::Request;
 
-use crate::{InterceptedCdkMintClient, UpdateMotdRequest};
+use crate::info::UpdateMotdRequest;
+use crate::InterceptedMintInfoServiceClient;
 
 /// Command to update the mint's message of the day
 ///
@@ -22,7 +23,7 @@ pub struct UpdateMotdCommand {
 /// * `client` - The RPC client used to communicate with the mint
 /// * `sub_command_args` - The new message of the day to set
 pub async fn update_motd(
-    client: &mut InterceptedCdkMintClient,
+    client: &mut InterceptedMintInfoServiceClient,
     sub_command_args: &UpdateMotdCommand,
 ) -> Result<()> {
     let _response = client

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_name.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_name.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use clap::Args;
 use tonic::Request;
 
-use crate::{InterceptedCdkMintClient, UpdateNameRequest};
+use crate::info::UpdateNameRequest;
+use crate::InterceptedMintInfoServiceClient;
 
 /// Command to update the mint's name
 ///
@@ -22,7 +23,7 @@ pub struct UpdateNameCommand {
 /// * `client` - The RPC client used to communicate with the mint
 /// * `sub_command_args` - The new name to set for the mint
 pub async fn update_name(
-    client: &mut InterceptedCdkMintClient,
+    client: &mut InterceptedMintInfoServiceClient,
     sub_command_args: &UpdateNameCommand,
 ) -> Result<()> {
     let _response = client

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_short_description.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_short_description.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use clap::Args;
 use tonic::Request;
 
-use crate::{InterceptedCdkMintClient, UpdateDescriptionRequest};
+use crate::info::UpdateShortDescriptionRequest;
+use crate::InterceptedMintInfoServiceClient;
 
 /// Command to update the mint's short description
 ///
@@ -23,11 +24,11 @@ pub struct UpdateShortDescriptionCommand {
 /// * `client` - The RPC client used to communicate with the mint
 /// * `sub_command_args` - The new short description to set
 pub async fn update_short_description(
-    client: &mut InterceptedCdkMintClient,
+    client: &mut InterceptedMintInfoServiceClient,
     sub_command_args: &UpdateShortDescriptionCommand,
 ) -> Result<()> {
     let _response = client
-        .update_short_description(Request::new(UpdateDescriptionRequest {
+        .update_short_description(Request::new(UpdateShortDescriptionRequest {
             description: sub_command_args.description.clone(),
         }))
         .await?;

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_tos_url.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_tos_url.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use clap::Args;
 use tonic::Request;
 
-use crate::{InterceptedCdkMintClient, UpdateTosUrlRequest};
+use crate::info::UpdateTosUrlRequest;
+use crate::InterceptedMintInfoServiceClient;
 
 /// Command to update the mint's terms of service URL
 #[derive(Args, Debug)]
@@ -13,7 +14,7 @@ pub struct UpdateTosUrlCommand {
 
 /// Executes the update_tos_url command against the mint server
 pub async fn update_tos_url(
-    client: &mut InterceptedCdkMintClient,
+    client: &mut InterceptedMintInfoServiceClient,
     sub_command_args: &UpdateTosUrlCommand,
 ) -> Result<()> {
     let _response = client

--- a/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_urls.rs
+++ b/crates/cdk-mint-rpc/src/mint_rpc_cli/subcommands/update_urls.rs
@@ -2,7 +2,8 @@ use anyhow::Result;
 use clap::Args;
 use tonic::Request;
 
-use crate::{InterceptedCdkMintClient, UpdateUrlRequest};
+use crate::info::{AddUrlRequest, RemoveUrlRequest};
+use crate::InterceptedMintInfoServiceClient;
 
 /// Command to add a URL to the mint's list of endpoints
 ///
@@ -23,11 +24,11 @@ pub struct AddUrlCommand {
 /// * `client` - The RPC client used to communicate with the mint
 /// * `sub_command_args` - The URL to add to the mint
 pub async fn add_url(
-    client: &mut InterceptedCdkMintClient,
+    client: &mut InterceptedMintInfoServiceClient,
     sub_command_args: &AddUrlCommand,
 ) -> Result<()> {
     let _response = client
-        .add_url(Request::new(UpdateUrlRequest {
+        .add_url(Request::new(AddUrlRequest {
             url: sub_command_args.url.clone(),
         }))
         .await?;
@@ -53,11 +54,11 @@ pub struct RemoveUrlCommand {
 /// * `client` - The RPC client used to communicate with the mint
 /// * `sub_command_args` - The URL to remove from the mint
 pub async fn remove_url(
-    client: &mut InterceptedCdkMintClient,
+    client: &mut InterceptedMintInfoServiceClient,
     sub_command_args: &RemoveUrlCommand,
 ) -> Result<()> {
     let _response = client
-        .remove_url(Request::new(UpdateUrlRequest {
+        .remove_url(Request::new(RemoveUrlRequest {
             url: sub_command_args.url.clone(),
         }))
         .await?;

--- a/crates/cdk-mint-rpc/src/proto/info.proto
+++ b/crates/cdk-mint-rpc/src/proto/info.proto
@@ -1,0 +1,168 @@
+syntax = "proto3";
+
+package cdk_mint_info_v1;
+
+// Mint metadata administration.
+service MintInfoService {
+    // Returns the mint's public metadata.
+    rpc GetInfo(GetInfoRequest) returns (GetInfoResponse) {}
+    // Sets the mint's name. An empty name clears it.
+    rpc UpdateName(UpdateNameRequest) returns (UpdateNameResponse) {}
+    // Sets the mint's message of the day. An empty message clears it.
+    rpc UpdateMotd(UpdateMotdRequest) returns (UpdateMotdResponse) {}
+    // Sets the mint's short description. An empty description clears it.
+    rpc UpdateShortDescription(UpdateShortDescriptionRequest) returns (UpdateShortDescriptionResponse) {}
+    // Sets the mint's long description. An empty description clears it.
+    rpc UpdateLongDescription(UpdateLongDescriptionRequest) returns (UpdateLongDescriptionResponse) {}
+    // Sets the mint's icon URL. An empty URL clears it.
+    rpc UpdateIconUrl(UpdateIconUrlRequest) returns (UpdateIconUrlResponse) {}
+    // Sets the mint's terms of service URL. An empty URL clears it.
+    rpc UpdateTosUrl(UpdateTosUrlRequest) returns (UpdateTosUrlResponse) {}
+    // Adds a mint URL. Adding a URL that is already listed is a no-op.
+    rpc AddUrl(AddUrlRequest) returns (AddUrlResponse) {}
+    // Removes a mint URL. Removing a URL that is not listed is a no-op.
+    rpc RemoveUrl(RemoveUrlRequest) returns (RemoveUrlResponse) {}
+    // Adds a contact entry. Adding an entry that is already listed is a no-op.
+    rpc AddContact(AddContactRequest) returns (AddContactResponse) {}
+    // Removes a contact entry. Removing an entry that is not listed is a no-op.
+    rpc RemoveContact(RemoveContactRequest) returns (RemoveContactResponse) {}
+}
+
+// A way to reach the mint operator, as defined by NUT-06.
+message ContactInfo {
+    // Contact method, e.g. "email" or "nostr".
+    string method = 1;
+    // Address for the method, e.g. an email address or npub.
+    string info = 2;
+}
+
+message GetInfoRequest {
+}
+
+// The mint's public metadata. Unset fields are absent.
+message GetInfoResponse {
+    // Name of the mint.
+    optional string name = 1;
+    // Version of the mint software.
+    optional string version = 2;
+    // Short description of the mint.
+    optional string description = 3;
+    // Long description of the mint.
+    optional string long_description = 4;
+    // Ways to reach the mint operator.
+    repeated ContactInfo contact = 5;
+    // Message of the day.
+    optional string motd = 6;
+    // URL of the mint's icon.
+    optional string icon_url = 7;
+    // URLs the mint is reachable at.
+    repeated string urls = 8;
+    // URL of the mint's terms of service.
+    optional string tos_url = 9;
+}
+
+message UpdateNameRequest {
+    // New name. Empty clears the name.
+    string name = 1;
+}
+
+// The name in effect after the update, absent when cleared.
+message UpdateNameResponse {
+    optional string name = 1;
+}
+
+message UpdateMotdRequest {
+    // New message of the day. Empty clears the message.
+    string motd = 1;
+}
+
+// The message of the day in effect after the update, absent when cleared.
+message UpdateMotdResponse {
+    optional string motd = 1;
+}
+
+message UpdateShortDescriptionRequest {
+    // New short description. Empty clears the description.
+    string description = 1;
+}
+
+// The short description in effect after the update, absent when cleared.
+message UpdateShortDescriptionResponse {
+    optional string description = 1;
+}
+
+message UpdateLongDescriptionRequest {
+    // New long description. Empty clears the description.
+    string long_description = 1;
+}
+
+// The long description in effect after the update, absent when cleared.
+message UpdateLongDescriptionResponse {
+    optional string long_description = 1;
+}
+
+message UpdateIconUrlRequest {
+    // New icon URL. Empty clears the URL.
+    string icon_url = 1;
+}
+
+// The icon URL in effect after the update, absent when cleared.
+message UpdateIconUrlResponse {
+    optional string icon_url = 1;
+}
+
+message UpdateTosUrlRequest {
+    // New terms of service URL. Empty clears the URL.
+    string tos_url = 1;
+}
+
+// The terms of service URL in effect after the update, absent when cleared.
+message UpdateTosUrlResponse {
+    optional string tos_url = 1;
+}
+
+message AddUrlRequest {
+    // URL to add. An empty URL fails with gRPC status INVALID_ARGUMENT.
+    string url = 1;
+}
+
+// The mint URLs in effect after the update.
+message AddUrlResponse {
+    repeated string urls = 1;
+}
+
+message RemoveUrlRequest {
+    // URL to remove.
+    string url = 1;
+}
+
+// The mint URLs in effect after the update.
+message RemoveUrlResponse {
+    repeated string urls = 1;
+}
+
+message AddContactRequest {
+    // Contact method, e.g. "email" or "nostr". An empty method fails with
+    // gRPC status INVALID_ARGUMENT.
+    string method = 1;
+    // Address for the method. An empty address fails with gRPC status
+    // INVALID_ARGUMENT.
+    string info = 2;
+}
+
+// The contact entries in effect after the update.
+message AddContactResponse {
+    repeated ContactInfo contact = 1;
+}
+
+message RemoveContactRequest {
+    // Contact method of the entry to remove.
+    string method = 1;
+    // Address of the entry to remove.
+    string info = 2;
+}
+
+// The contact entries in effect after the update.
+message RemoveContactResponse {
+    repeated ContactInfo contact = 1;
+}

--- a/crates/cdk-mint-rpc/src/proto/mod.rs
+++ b/crates/cdk-mint-rpc/src/proto/mod.rs
@@ -2,6 +2,11 @@
 
 tonic::include_proto!("cdk_mint_management_v1");
 
+/// Mint metadata administration service
+pub mod info {
+    tonic::include_proto!("cdk_mint_info_v1");
+}
+
 /// Keyset administration service
 pub mod keyset {
     tonic::include_proto!("cdk_mint_keyset_v1");

--- a/crates/cdk-mint-rpc/src/proto/server.rs
+++ b/crates/cdk-mint-rpc/src/proto/server.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use cdk::mint::{Mint, MintKeySetInfo, MintQuote};
 use cdk::nuts::nut04::MintMethodSettings;
 use cdk::nuts::nut05::MeltMethodSettings;
-use cdk::nuts::{CurrencyUnit, MintQuoteState, PaymentMethod};
+use cdk::nuts::{CurrencyUnit, MintInfo, MintQuoteState, PaymentMethod};
 use cdk::types::QuoteTTL;
 use cdk::Amount;
 use cdk_common::grpc::create_version_check_interceptor;
@@ -20,6 +20,7 @@ use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
 use tonic::{Request, Response, Status};
 
 use crate::cdk_mint_server::{CdkMint, CdkMintServer};
+use crate::info::mint_info_service_server::{MintInfoService, MintInfoServiceServer};
 use crate::keyset::keyset_service_server::{KeysetService, KeysetServiceServer};
 use crate::payment_method::payment_method_service_server::{
     PaymentMethodService, PaymentMethodServiceServer,
@@ -227,6 +228,13 @@ impl MintRPCServer {
                             cdk_common::MINT_RPC_PROTOCOL_VERSION,
                         ),
                     ))
+                    .add_service(MintInfoServiceServer::with_interceptor(
+                        self.clone(),
+                        create_version_check_interceptor(
+                            cdk_common::grpc::VERSION_HEADER,
+                            cdk_common::MINT_RPC_PROTOCOL_VERSION,
+                        ),
+                    ))
                     .add_service(KeysetServiceServer::with_interceptor(
                         self.clone(),
                         create_version_check_interceptor(
@@ -260,6 +268,13 @@ impl MintRPCServer {
                 tracing::warn!("No valid TLS configuration found, starting insecure server");
                 Server::builder()
                     .add_service(CdkMintServer::with_interceptor(
+                        self.clone(),
+                        create_version_check_interceptor(
+                            cdk_common::grpc::VERSION_HEADER,
+                            cdk_common::MINT_RPC_PROTOCOL_VERSION,
+                        ),
+                    ))
+                    .add_service(MintInfoServiceServer::with_interceptor(
                         self.clone(),
                         create_version_check_interceptor(
                             cdk_common::grpc::VERSION_HEADER,
@@ -324,6 +339,31 @@ impl MintRPCServer {
 
         tracing::info!("Mint rpc server stopped");
         Ok(())
+    }
+
+    /// Applies a mutation to the mint's info and returns the info in effect
+    /// after the update
+    ///
+    /// Shared by the legacy [`CdkMint`] service and [`MintInfoService`] while
+    /// both are served.
+    async fn update_mint_info_with(
+        &self,
+        mutate: impl FnOnce(&mut MintInfo) + Send,
+    ) -> Result<MintInfo, Status> {
+        let mut info = self
+            .mint
+            .mint_info()
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
+
+        mutate(&mut info);
+
+        self.mint
+            .set_mint_info(info.clone())
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
+
+        Ok(info)
     }
 
     /// Rotates to the next keyset for the given unit
@@ -725,17 +765,8 @@ impl CdkMint for MintRPCServer {
     ) -> Result<Response<UpdateResponse>, Status> {
         self.ensure_mutation_allowed().await?;
         let motd = request.into_inner().motd;
-        let mut info = self
-            .mint
-            .mint_info()
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
-        info.motd = Some(motd);
-
-        self.mint
-            .set_mint_info(info)
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
+        self.update_mint_info_with(|info| info.motd = Some(motd))
+            .await?;
 
         Ok(Response::new(UpdateResponse {}))
     }
@@ -747,18 +778,8 @@ impl CdkMint for MintRPCServer {
     ) -> Result<Response<UpdateResponse>, Status> {
         self.ensure_mutation_allowed().await?;
         let description = request.into_inner().description;
-        let mut info = self
-            .mint
-            .mint_info()
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
-
-        info.description = Some(description);
-
-        self.mint
-            .set_mint_info(info)
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
+        self.update_mint_info_with(|info| info.description = Some(description))
+            .await?;
         Ok(Response::new(UpdateResponse {}))
     }
 
@@ -769,18 +790,8 @@ impl CdkMint for MintRPCServer {
     ) -> Result<Response<UpdateResponse>, Status> {
         self.ensure_mutation_allowed().await?;
         let description = request.into_inner().description;
-        let mut info = self
-            .mint
-            .mint_info()
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
-
-        info.description_long = Some(description);
-
-        self.mint
-            .set_mint_info(info)
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
+        self.update_mint_info_with(|info| info.description_long = Some(description))
+            .await?;
         Ok(Response::new(UpdateResponse {}))
     }
 
@@ -791,18 +802,8 @@ impl CdkMint for MintRPCServer {
     ) -> Result<Response<UpdateResponse>, Status> {
         self.ensure_mutation_allowed().await?;
         let name = request.into_inner().name;
-        let mut info = self
-            .mint
-            .mint_info()
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
-
-        info.name = Some(name);
-
-        self.mint
-            .set_mint_info(info)
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
+        self.update_mint_info_with(|info| info.name = Some(name))
+            .await?;
         Ok(Response::new(UpdateResponse {}))
     }
 
@@ -813,19 +814,8 @@ impl CdkMint for MintRPCServer {
     ) -> Result<Response<UpdateResponse>, Status> {
         self.ensure_mutation_allowed().await?;
         let icon_url = request.into_inner().icon_url;
-
-        let mut info = self
-            .mint
-            .mint_info()
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
-
-        info.icon_url = Some(icon_url);
-
-        self.mint
-            .set_mint_info(info)
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
+        self.update_mint_info_with(|info| info.icon_url = Some(icon_url))
+            .await?;
         Ok(Response::new(UpdateResponse {}))
     }
 
@@ -836,19 +826,8 @@ impl CdkMint for MintRPCServer {
     ) -> Result<Response<UpdateResponse>, Status> {
         self.ensure_mutation_allowed().await?;
         let tos_url = request.into_inner().tos_url;
-
-        let mut info = self
-            .mint
-            .mint_info()
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
-
-        info.tos_url = Some(tos_url);
-
-        self.mint
-            .set_mint_info(info)
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
+        self.update_mint_info_with(|info| info.tos_url = Some(tos_url))
+            .await?;
         Ok(Response::new(UpdateResponse {}))
     }
 
@@ -859,20 +838,8 @@ impl CdkMint for MintRPCServer {
     ) -> Result<Response<UpdateResponse>, Status> {
         self.ensure_mutation_allowed().await?;
         let url = request.into_inner().url;
-        let mut info = self
-            .mint
-            .mint_info()
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
-        let mut urls = info.urls.unwrap_or_default();
-        urls.push(url);
-
-        info.urls = Some(urls.clone());
-
-        self.mint
-            .set_mint_info(info)
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
+        self.update_mint_info_with(|info| info.urls.get_or_insert_with(Vec::new).push(url))
+            .await?;
         Ok(Response::new(UpdateResponse {}))
     }
 
@@ -883,24 +850,12 @@ impl CdkMint for MintRPCServer {
     ) -> Result<Response<UpdateResponse>, Status> {
         self.ensure_mutation_allowed().await?;
         let url = request.into_inner().url;
-        let mut info = self
-            .mint
-            .mint_info()
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
-        let urls = info.urls;
-        let mut urls = urls.clone().unwrap_or_default();
-
-        urls.retain(|u| u != &url);
-
-        let urls = if urls.is_empty() { None } else { Some(urls) };
-
-        info.urls = urls;
-
-        self.mint
-            .set_mint_info(info)
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
+        self.update_mint_info_with(|info| {
+            let mut urls = info.urls.take().unwrap_or_default();
+            urls.retain(|u| u != &url);
+            info.urls = if urls.is_empty() { None } else { Some(urls) };
+        })
+        .await?;
         Ok(Response::new(UpdateResponse {}))
     }
 
@@ -911,23 +866,15 @@ impl CdkMint for MintRPCServer {
     ) -> Result<Response<UpdateResponse>, Status> {
         self.ensure_mutation_allowed().await?;
         let request_inner = request.into_inner();
-        let mut info = self
-            .mint
-            .mint_info()
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
-
-        info.contact
-            .get_or_insert_with(Vec::new)
-            .push(cdk::nuts::ContactInfo::new(
-                request_inner.method,
-                request_inner.info,
-            ));
-
-        self.mint
-            .set_mint_info(info)
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
+        self.update_mint_info_with(|info| {
+            info.contact
+                .get_or_insert_with(Vec::new)
+                .push(cdk::nuts::ContactInfo::new(
+                    request_inner.method,
+                    request_inner.info,
+                ))
+        })
+        .await?;
         Ok(Response::new(UpdateResponse {}))
     }
     /// Removes a contact method from the mint's contact information
@@ -937,22 +884,14 @@ impl CdkMint for MintRPCServer {
     ) -> Result<Response<UpdateResponse>, Status> {
         self.ensure_mutation_allowed().await?;
         let request_inner = request.into_inner();
-        let mut info = self
-            .mint
-            .mint_info()
-            .await
-            .map_err(|err| Status::internal(err.to_string()))?;
-
-        if let Some(contact) = info.contact.as_mut() {
-            let contact_info =
-                cdk::nuts::ContactInfo::new(request_inner.method, request_inner.info);
-            contact.retain(|x| x != &contact_info);
-
-            self.mint
-                .set_mint_info(info)
-                .await
-                .map_err(|err| Status::internal(err.to_string()))?;
-        }
+        self.update_mint_info_with(|info| {
+            if let Some(contact) = info.contact.as_mut() {
+                let contact_info =
+                    cdk::nuts::ContactInfo::new(request_inner.method, request_inner.info);
+                contact.retain(|x| x != &contact_info);
+            }
+        })
+        .await?;
         Ok(Response::new(UpdateResponse {}))
     }
 
@@ -1140,6 +1079,238 @@ impl CdkMint for MintRPCServer {
             unit: keyset_info.unit.to_string(),
             amounts: keyset_info.amounts,
             input_fee_ppk: keyset_info.input_fee_ppk,
+        }))
+    }
+}
+
+/// Converts an empty string to `None`, treating empty updates as clears
+fn non_empty(value: String) -> Option<String> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+/// Maps mint info contacts into their proto representation
+fn info_contacts(contact: Option<Vec<cdk::nuts::ContactInfo>>) -> Vec<crate::info::ContactInfo> {
+    contact
+        .unwrap_or_default()
+        .into_iter()
+        .map(|c| crate::info::ContactInfo {
+            method: c.method,
+            info: c.info,
+        })
+        .collect()
+}
+
+#[tonic::async_trait]
+impl MintInfoService for MintRPCServer {
+    /// Returns the mint's public metadata
+    async fn get_info(
+        &self,
+        _request: Request<crate::info::GetInfoRequest>,
+    ) -> Result<Response<crate::info::GetInfoResponse>, Status> {
+        let info = self
+            .mint
+            .mint_info()
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
+
+        Ok(Response::new(crate::info::GetInfoResponse {
+            name: info.name,
+            version: info.version.map(|v| v.to_string()),
+            description: info.description,
+            long_description: info.description_long,
+            contact: info_contacts(info.contact),
+            motd: info.motd,
+            icon_url: info.icon_url,
+            urls: info.urls.unwrap_or_default(),
+            tos_url: info.tos_url,
+        }))
+    }
+
+    /// Sets the mint's name
+    async fn update_name(
+        &self,
+        request: Request<crate::info::UpdateNameRequest>,
+    ) -> Result<Response<crate::info::UpdateNameResponse>, Status> {
+        self.ensure_mutation_allowed().await?;
+        let name = non_empty(request.into_inner().name);
+        let info = self.update_mint_info_with(|info| info.name = name).await?;
+        Ok(Response::new(crate::info::UpdateNameResponse {
+            name: info.name,
+        }))
+    }
+
+    /// Sets the mint's message of the day
+    async fn update_motd(
+        &self,
+        request: Request<crate::info::UpdateMotdRequest>,
+    ) -> Result<Response<crate::info::UpdateMotdResponse>, Status> {
+        self.ensure_mutation_allowed().await?;
+        let motd = non_empty(request.into_inner().motd);
+        let info = self.update_mint_info_with(|info| info.motd = motd).await?;
+        Ok(Response::new(crate::info::UpdateMotdResponse {
+            motd: info.motd,
+        }))
+    }
+
+    /// Sets the mint's short description
+    async fn update_short_description(
+        &self,
+        request: Request<crate::info::UpdateShortDescriptionRequest>,
+    ) -> Result<Response<crate::info::UpdateShortDescriptionResponse>, Status> {
+        self.ensure_mutation_allowed().await?;
+        let description = non_empty(request.into_inner().description);
+        let info = self
+            .update_mint_info_with(|info| info.description = description)
+            .await?;
+        Ok(Response::new(crate::info::UpdateShortDescriptionResponse {
+            description: info.description,
+        }))
+    }
+
+    /// Sets the mint's long description
+    async fn update_long_description(
+        &self,
+        request: Request<crate::info::UpdateLongDescriptionRequest>,
+    ) -> Result<Response<crate::info::UpdateLongDescriptionResponse>, Status> {
+        self.ensure_mutation_allowed().await?;
+        let long_description = non_empty(request.into_inner().long_description);
+        let info = self
+            .update_mint_info_with(|info| info.description_long = long_description)
+            .await?;
+        Ok(Response::new(crate::info::UpdateLongDescriptionResponse {
+            long_description: info.description_long,
+        }))
+    }
+
+    /// Sets the mint's icon URL
+    async fn update_icon_url(
+        &self,
+        request: Request<crate::info::UpdateIconUrlRequest>,
+    ) -> Result<Response<crate::info::UpdateIconUrlResponse>, Status> {
+        self.ensure_mutation_allowed().await?;
+        let icon_url = non_empty(request.into_inner().icon_url);
+        let info = self
+            .update_mint_info_with(|info| info.icon_url = icon_url)
+            .await?;
+        Ok(Response::new(crate::info::UpdateIconUrlResponse {
+            icon_url: info.icon_url,
+        }))
+    }
+
+    /// Sets the mint's terms of service URL
+    async fn update_tos_url(
+        &self,
+        request: Request<crate::info::UpdateTosUrlRequest>,
+    ) -> Result<Response<crate::info::UpdateTosUrlResponse>, Status> {
+        self.ensure_mutation_allowed().await?;
+        let tos_url = non_empty(request.into_inner().tos_url);
+        let info = self
+            .update_mint_info_with(|info| info.tos_url = tos_url)
+            .await?;
+        Ok(Response::new(crate::info::UpdateTosUrlResponse {
+            tos_url: info.tos_url,
+        }))
+    }
+
+    /// Adds a mint URL
+    async fn add_url(
+        &self,
+        request: Request<crate::info::AddUrlRequest>,
+    ) -> Result<Response<crate::info::AddUrlResponse>, Status> {
+        self.ensure_mutation_allowed().await?;
+        let url = request.into_inner().url;
+        if url.is_empty() {
+            return Err(Status::invalid_argument(
+                "URL must not be empty".to_string(),
+            ));
+        }
+        let info = self
+            .update_mint_info_with(|info| {
+                let urls = info.urls.get_or_insert_with(Vec::new);
+                if !urls.contains(&url) {
+                    urls.push(url);
+                }
+            })
+            .await?;
+        Ok(Response::new(crate::info::AddUrlResponse {
+            urls: info.urls.unwrap_or_default(),
+        }))
+    }
+
+    /// Removes a mint URL
+    async fn remove_url(
+        &self,
+        request: Request<crate::info::RemoveUrlRequest>,
+    ) -> Result<Response<crate::info::RemoveUrlResponse>, Status> {
+        self.ensure_mutation_allowed().await?;
+        let url = request.into_inner().url;
+        let info = self
+            .update_mint_info_with(|info| {
+                let mut urls = info.urls.take().unwrap_or_default();
+                urls.retain(|u| u != &url);
+                info.urls = if urls.is_empty() { None } else { Some(urls) };
+            })
+            .await?;
+        Ok(Response::new(crate::info::RemoveUrlResponse {
+            urls: info.urls.unwrap_or_default(),
+        }))
+    }
+
+    /// Adds a contact entry
+    async fn add_contact(
+        &self,
+        request: Request<crate::info::AddContactRequest>,
+    ) -> Result<Response<crate::info::AddContactResponse>, Status> {
+        self.ensure_mutation_allowed().await?;
+        let request = request.into_inner();
+        if request.method.is_empty() {
+            return Err(Status::invalid_argument(
+                "Contact method must not be empty".to_string(),
+            ));
+        }
+        if request.info.is_empty() {
+            return Err(Status::invalid_argument(
+                "Contact info must not be empty".to_string(),
+            ));
+        }
+        let contact = cdk::nuts::ContactInfo::new(request.method, request.info);
+        let info = self
+            .update_mint_info_with(|info| {
+                let contacts = info.contact.get_or_insert_with(Vec::new);
+                if !contacts.contains(&contact) {
+                    contacts.push(contact);
+                }
+            })
+            .await?;
+        Ok(Response::new(crate::info::AddContactResponse {
+            contact: info_contacts(info.contact),
+        }))
+    }
+
+    /// Removes a contact entry
+    async fn remove_contact(
+        &self,
+        request: Request<crate::info::RemoveContactRequest>,
+    ) -> Result<Response<crate::info::RemoveContactResponse>, Status> {
+        self.ensure_mutation_allowed().await?;
+        let request = request.into_inner();
+        let contact = cdk::nuts::ContactInfo::new(request.method, request.info);
+        let info = self
+            .update_mint_info_with(|info| {
+                if let Some(contacts) = info.contact.as_mut() {
+                    contacts.retain(|c| c != &contact);
+                }
+                if info.contact.as_ref().is_some_and(Vec::is_empty) {
+                    info.contact = None;
+                }
+            })
+            .await?;
+        Ok(Response::new(crate::info::RemoveContactResponse {
+            contact: info_contacts(info.contact),
         }))
     }
 }
@@ -1726,8 +1897,7 @@ mod tests {
     async fn test_get_info_tos_url_none_when_not_set() {
         let server = create_test_rpc_server().await;
 
-        let response = server
-            .get_info(Request::new(GetInfoRequest {}))
+        let response = CdkMint::get_info(&server, Request::new(GetInfoRequest {}))
             .await
             .unwrap();
 
@@ -1743,8 +1913,7 @@ mod tests {
         info.tos_url = Some(tos.to_string());
         server.mint.set_mint_info(info).await.unwrap();
 
-        let response = server
-            .get_info(Request::new(GetInfoRequest {}))
+        let response = CdkMint::get_info(&server, Request::new(GetInfoRequest {}))
             .await
             .unwrap();
 
@@ -2074,19 +2243,236 @@ mod tests {
         let server = create_test_rpc_server().await;
         let tos = "https://example.com/terms";
 
-        server
-            .update_tos_url(Request::new(UpdateTosUrlRequest {
+        CdkMint::update_tos_url(
+            &server,
+            Request::new(UpdateTosUrlRequest {
                 tos_url: tos.to_string(),
-            }))
-            .await
-            .unwrap();
+            }),
+        )
+        .await
+        .unwrap();
 
-        let response = server
-            .get_info(Request::new(GetInfoRequest {}))
+        let response = CdkMint::get_info(&server, Request::new(GetInfoRequest {}))
             .await
             .unwrap();
 
         assert_eq!(response.into_inner().tos_url.unwrap(), tos);
+    }
+
+    #[tokio::test]
+    async fn test_mint_info_service_get_info_round_trip() {
+        let server = create_test_rpc_server().await;
+
+        let response =
+            MintInfoService::get_info(&server, Request::new(crate::info::GetInfoRequest {}))
+                .await
+                .unwrap()
+                .into_inner();
+
+        assert_eq!(response.name.as_deref(), Some("test mint"));
+        assert_eq!(response.description.as_deref(), Some("test mint"));
+        assert!(response.tos_url.is_none());
+        assert!(response.urls.is_empty());
+        assert!(response.contact.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mint_info_service_update_motd_sets_and_clears() {
+        let server = create_test_rpc_server().await;
+
+        let set = MintInfoService::update_motd(
+            &server,
+            Request::new(crate::info::UpdateMotdRequest {
+                motd: "hello".to_owned(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        assert_eq!(set.motd.as_deref(), Some("hello"));
+
+        let cleared = MintInfoService::update_motd(
+            &server,
+            Request::new(crate::info::UpdateMotdRequest {
+                motd: String::new(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        assert!(cleared.motd.is_none());
+
+        let info = MintInfoService::get_info(&server, Request::new(crate::info::GetInfoRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(info.motd.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_mint_info_service_update_tos_url() {
+        let server = create_test_rpc_server().await;
+        let tos = "https://example.com/terms";
+
+        let response = MintInfoService::update_tos_url(
+            &server,
+            Request::new(crate::info::UpdateTosUrlRequest {
+                tos_url: tos.to_owned(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        assert_eq!(response.tos_url.as_deref(), Some(tos));
+
+        let info = MintInfoService::get_info(&server, Request::new(crate::info::GetInfoRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(info.tos_url.as_deref(), Some(tos));
+    }
+
+    #[tokio::test]
+    async fn test_mint_info_service_add_url_is_idempotent() {
+        let server = create_test_rpc_server().await;
+        let url = "https://mint.example.com";
+
+        let first = MintInfoService::add_url(
+            &server,
+            Request::new(crate::info::AddUrlRequest {
+                url: url.to_owned(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        assert_eq!(first.urls, vec![url.to_owned()]);
+
+        let second = MintInfoService::add_url(
+            &server,
+            Request::new(crate::info::AddUrlRequest {
+                url: url.to_owned(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        assert_eq!(second.urls, vec![url.to_owned()]);
+    }
+
+    #[tokio::test]
+    async fn test_mint_info_service_add_url_rejects_empty() {
+        let server = create_test_rpc_server().await;
+
+        let error = MintInfoService::add_url(
+            &server,
+            Request::new(crate::info::AddUrlRequest { url: String::new() }),
+        )
+        .await
+        .expect_err("empty URL should be rejected");
+
+        assert_eq!(error.code(), Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn test_mint_info_service_remove_url_absent_is_noop() {
+        let server = create_test_rpc_server().await;
+        let url = "https://mint.example.com";
+
+        MintInfoService::add_url(
+            &server,
+            Request::new(crate::info::AddUrlRequest {
+                url: url.to_owned(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        let missing = MintInfoService::remove_url(
+            &server,
+            Request::new(crate::info::RemoveUrlRequest {
+                url: "https://absent.example.com".to_owned(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        assert_eq!(missing.urls, vec![url.to_owned()]);
+
+        let removed = MintInfoService::remove_url(
+            &server,
+            Request::new(crate::info::RemoveUrlRequest {
+                url: url.to_owned(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        assert!(removed.urls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mint_info_service_contacts_add_remove_idempotent() {
+        let server = create_test_rpc_server().await;
+
+        let added = MintInfoService::add_contact(
+            &server,
+            Request::new(crate::info::AddContactRequest {
+                method: "email".to_owned(),
+                info: "mint@example.com".to_owned(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        assert_eq!(added.contact.len(), 1);
+
+        let duplicate = MintInfoService::add_contact(
+            &server,
+            Request::new(crate::info::AddContactRequest {
+                method: "email".to_owned(),
+                info: "mint@example.com".to_owned(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        assert_eq!(duplicate.contact.len(), 1);
+
+        let empty_method_error = MintInfoService::add_contact(
+            &server,
+            Request::new(crate::info::AddContactRequest {
+                method: String::new(),
+                info: "mint@example.com".to_owned(),
+            }),
+        )
+        .await
+        .expect_err("empty contact method should be rejected");
+        assert_eq!(empty_method_error.code(), Code::InvalidArgument);
+
+        let removed = MintInfoService::remove_contact(
+            &server,
+            Request::new(crate::info::RemoveContactRequest {
+                method: "email".to_owned(),
+                info: "mint@example.com".to_owned(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        assert!(removed.contact.is_empty());
+
+        let absent = MintInfoService::remove_contact(
+            &server,
+            Request::new(crate::info::RemoveContactRequest {
+                method: "email".to_owned(),
+                info: "mint@example.com".to_owned(),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+        assert!(absent.contact.is_empty());
     }
 
     #[tokio::test]
@@ -2095,12 +2481,14 @@ mod tests {
             .await
             .with_mutation_guard(Arc::new(RejectingMutationGuard));
 
-        let error = server
-            .update_tos_url(Request::new(UpdateTosUrlRequest {
+        let error = CdkMint::update_tos_url(
+            &server,
+            Request::new(UpdateTosUrlRequest {
                 tos_url: "https://example.com/terms".to_owned(),
-            }))
-            .await
-            .expect_err("mutation should be rejected");
+            }),
+        )
+        .await
+        .expect_err("mutation should be rejected");
 
         assert_eq!(error.code(), Code::FailedPrecondition);
         assert_eq!(error.message(), "configuration restart pending");
@@ -2221,8 +2609,29 @@ mod tests {
             deposit_address_error.message(),
             "configuration restart pending"
         );
-        assert!(server
-            .get_info(Request::new(GetInfoRequest {}))
+
+        let info_motd_error = MintInfoService::update_motd(
+            &server,
+            Request::new(crate::info::UpdateMotdRequest {
+                motd: "hello".to_owned(),
+            }),
+        )
+        .await
+        .expect_err("info mutation should be rejected");
+
+        assert_eq!(info_motd_error.code(), Code::FailedPrecondition);
+        assert_eq!(info_motd_error.message(), "configuration restart pending");
+
+        assert!(
+            MintInfoService::get_info(&server, Request::new(crate::info::GetInfoRequest {}))
+                .await
+                .expect("info read should remain available")
+                .into_inner()
+                .motd
+                .is_none()
+        );
+
+        assert!(CdkMint::get_info(&server, Request::new(GetInfoRequest {}))
             .await
             .expect("read should remain available")
             .into_inner()


### PR DESCRIPTION
### Description

Adds `cdk_mint_info_v1.MintInfoService`, the mint-metadata slice of the split of the monolithic `CdkMint` service into per-domain services (follows `KeysetService` #2239, `QuoteService` #2294, `PaymentMethodService` #2355).

- 11 RPCs: `GetInfo` plus ten metadata mutations (name, motd, descriptions, icon URL, ToS URL, URLs, contacts).
- Served alongside the legacy `CdkMint` service; protocol version stays `1.0.0`.
- An empty string clears a field. Duplicate adds and absent removes are no-ops. Empty URL or contact fields return `INVALID_ARGUMENT`. Every mutation returns the state in effect after the update.
- The CLI info subcommands use the new client, and `get-info` moves into its own subcommand module.

-----

### Notes to the reviewers

- Both services share one read-modify-write helper (`update_mint_info_with`). The legacy handlers keep their behavior, except `remove_contact` now writes back unchanged info instead of skipping the write. Parity with siblings, same end state.
- Empty-string-as-clear is new-service-only; the legacy handlers still store `Some("")` and are left alone until removal.
- Existing tests use qualified calls (`CdkMint::get_info(&server, ...)`) because the server now implements two traits with same-named methods.
- CLI `get-info` no longer prints total issued/redeemed. They aren't mint metadata, aren't multi-unit, and will be properly introduced in reporting rpc endpoints. They stay on legacy `CdkMint.GetInfo` until it's removed.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

- cdk-mint-rpc: The mint RPC CLI manages mint metadata through the new `MintInfoService`, and `get-info` no longer prints total issued and total redeemed.

#### ADDED

- cdk-mint-rpc: A dedicated `MintInfoService` exposes mint metadata reads and updates, clears fields on empty values, treats repeated add/remove as no-ops, and returns the metadata in effect after each update.

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
</br>