### PR TITLE
Sign with inactive keysets

### DIFF
--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -360,9 +360,6 @@ impl Signatory for DbSignatory {
                 } = blinded_message;
 
                 let (info, key) = keysets.by_id.get(&keyset_id).ok_or(Error::UnknownKeySet)?;
-                if !info.active {
-                    return Err(Error::InactiveKeyset);
-                }
                 if info.is_expired() {
                     return Err(Error::ExpiredKeyset);
                 }
@@ -726,6 +723,50 @@ mod test {
             "expected ExpiredKeyset error, got: {:?}",
             result
         );
+    }
+
+    #[tokio::test]
+    async fn blind_sign_accepts_inactive_keyset() {
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let signatory = DbSignatory::new(
+            store,
+            b"test-seed-inactive-signing",
+            Default::default(),
+            Default::default(),
+        )
+        .await
+        .expect("DbSignatory::new");
+
+        let args = RotateKeyArguments {
+            unit: CurrencyUnit::Sat,
+            amounts: vec![1, 2, 4, 8],
+            input_fee_ppk: 0,
+            keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+            final_expiry: None,
+        };
+        let first = signatory
+            .rotate_keyset(args.clone())
+            .await
+            .expect("first rotation");
+        signatory
+            .rotate_keyset(args)
+            .await
+            .expect("second rotation deactivates the first");
+
+        let blinded_secret = SecretKey::generate().public_key();
+        let msg = BlindedMessage::new(Amount::from(1), first.id, blinded_secret);
+
+        let signatures = signatory
+            .blind_sign(vec![msg])
+            .await
+            .expect("inactive keysets still sign");
+
+        assert_eq!(signatures.len(), 1);
+        assert_eq!(signatures[0].keyset_id, first.id);
     }
 
     /// Keyset rows are insert-only today, so the mutated info is handed to

--- a/crates/cdk-signatory/src/signatory.rs
+++ b/crates/cdk-signatory/src/signatory.rs
@@ -145,6 +145,10 @@ pub trait Signatory {
     /// Blind sign a message.
     ///
     /// The message can be for a coin or an auth token.
+    ///
+    /// Expired keysets are refused here. A rotated-out keyset still signs:
+    /// whether an inactive keyset may issue depends on what the request is
+    /// for, which only the mint knows.
     async fn blind_sign(
         &self,
         blinded_messages: Vec<BlindedMessage>,

--- a/crates/cdk/src/mint/melt/melt_saga/tests.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/tests.rs
@@ -24,6 +24,7 @@ use cdk_common::{
     Amount, CurrencyUnit, MintQuoteBolt11Request, PaymentMethod, ProofsMethods, State,
 };
 use cdk_fake_wallet::{create_fake_invoice, FakeInvoiceDescription};
+use cdk_signatory::signatory::SignatoryKeySet;
 
 use crate::mint::melt::melt_saga::{MeltSaga, PaymentOutcome};
 use crate::mint::melt::shared::{
@@ -3241,6 +3242,96 @@ async fn test_concurrent_duplicate_melt_finalization_is_idempotent() {
         .unwrap();
     assert_eq!(finalized_quote.state, MeltQuoteState::Paid);
     assert_saga_not_exists(&mint, &operation_id).await;
+}
+
+/// A keyset that rotates out between the melt request and settlement must
+/// still sign the change, using its own denominations rather than the fallback
+/// set. The inactive-keyset carve-out exists for exactly this case.
+#[tokio::test]
+async fn test_melt_change_signed_on_keyset_that_went_inactive() {
+    use crate::test_helpers::mint::create_test_blinded_messages;
+
+    let mint = create_test_mint().await.unwrap();
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let quote = create_test_melt_quote(&mint, Amount::from(9_000)).await;
+    let (change_outputs, _premint) = create_test_blinded_messages(&mint, Amount::from(1_023))
+        .await
+        .unwrap();
+    let melt_request = MeltRequest::new(quote.id.clone(), proofs, Some(change_outputs));
+
+    let verification = mint.verify_inputs(melt_request.inputs()).await.unwrap();
+    let saga = MeltSaga::new(
+        std::sync::Arc::new(mint.clone()),
+        mint.localstore(),
+        mint.pubsub_manager(),
+    );
+    let setup_saga = saga
+        .setup_melt(
+            &melt_request,
+            verification,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+        )
+        .await
+        .unwrap();
+
+    let operation_id = setup_saga.operation_id;
+    let (payment_saga, decision) = setup_saga
+        .attempt_internal_settlement(&melt_request)
+        .await
+        .unwrap();
+    let PaymentOutcome::Confirmed(confirmed_saga) =
+        payment_saga.make_payment(decision).await.unwrap()
+    else {
+        panic!("Expected Confirmed")
+    };
+    let payment_result = confirmed_saga.state_data.payment_result.clone();
+
+    let rotated_out: Vec<SignatoryKeySet> = mint
+        .keysets
+        .load()
+        .as_ref()
+        .clone()
+        .into_iter()
+        .map(|mut ks| {
+            ks.active = false;
+            ks.amounts.retain(|amount| *amount <= 64);
+            ks
+        })
+        .collect();
+    mint.keysets.store(std::sync::Arc::new(rotated_out));
+
+    let db = mint.localstore();
+    let change = finalize_melt_quote(
+        &mint,
+        &db,
+        &mint.pubsub_manager(),
+        &quote,
+        payment_result.total_spent,
+        payment_result.payment_proof,
+        &payment_result.payment_lookup_id,
+        Some(operation_id),
+    )
+    .await
+    .unwrap()
+    .expect("change signed on the rotated-out keyset");
+
+    assert!(!change.is_empty());
+    assert!(
+        change.iter().all(|sig| sig.amount <= Amount::from(64)),
+        "change must be split with the keyset's own amounts, got: {:?}",
+        change.iter().map(|sig| sig.amount).collect::<Vec<_>>()
+    );
+
+    let keyset_id = mint.keysets.load()[0].id;
+    assert!(change.iter().all(|sig| sig.keyset_id == keyset_id));
+
+    let finalized = mint
+        .localstore
+        .get_melt_quote(&quote.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(finalized.state, MeltQuoteState::Paid);
 }
 
 #[tokio::test]

--- a/crates/cdk/src/mint/melt/shared.rs
+++ b/crates/cdk/src/mint/melt/shared.rs
@@ -22,8 +22,12 @@ use crate::Mint;
 
 /// Retrieves fee and amount configuration for the keyset matching the change outputs.
 ///
-/// Searches active keysets for one matching the first output's keyset_id.
-/// Used during change calculation for melts.
+/// Searches every known keyset for one matching the first output's keyset_id.
+/// Used during change calculation for melts. Inactive keysets are included:
+/// change outputs are committed at melt-request time and signed after
+/// settlement, so the keyset may have rotated out in between, and falling back
+/// to the default denominations would split the change into amounts the keyset
+/// has no key for.
 ///
 /// # Arguments
 ///
@@ -41,7 +45,7 @@ pub fn get_keyset_fee_and_amounts(
         .load()
         .iter()
         .filter_map(|keyset| {
-            if keyset.active && Some(keyset.id) == outputs.first().map(|x| x.keyset_id) {
+            if Some(keyset.id) == outputs.first().map(|x| x.keyset_id) {
                 Some((keyset.input_fee_ppk, keyset.amounts.clone()).into())
             } else {
                 None

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -2675,6 +2675,95 @@ mod tests {
         );
     }
 
+    /// Marks every keyset in the mint's snapshot inactive, as a rotation would.
+    fn deactivate_keysets(mint: &Mint) {
+        let inactive: Vec<SignatoryKeySet> = mint
+            .keysets
+            .load()
+            .as_ref()
+            .clone()
+            .into_iter()
+            .map(|mut ks| {
+                ks.active = false;
+                ks
+            })
+            .collect();
+        mint.keysets.store(Arc::new(inactive));
+    }
+
+    /// The inactive-keyset carve-out is for melt change only. A swap must keep
+    /// requiring an active output keyset, otherwise a rotated-out keyset could
+    /// go on issuing indefinitely.
+    #[tokio::test]
+    async fn swap_rejects_outputs_on_inactive_keyset() {
+        use cdk_common::nuts::SwapRequest;
+
+        use crate::test_helpers::mint::create_test_blinded_messages;
+
+        let mint = create_test_mint().await.unwrap();
+        let proofs = mint_test_proofs(&mint, Amount::from(64)).await.unwrap();
+        let (outputs, _premint) = create_test_blinded_messages(&mint, Amount::from(64))
+            .await
+            .unwrap();
+
+        deactivate_keysets(&mint);
+
+        let result = mint
+            .process_swap_request(SwapRequest::new(proofs, outputs))
+            .await;
+
+        assert!(
+            matches!(result, Err(Error::InactiveKeyset)),
+            "expected InactiveKeyset error, got: {:?}",
+            result
+        );
+    }
+
+    /// Same for issuance: only melt change may name a rotated-out keyset.
+    #[tokio::test]
+    async fn issue_rejects_outputs_on_inactive_keyset() {
+        use cdk_common::nuts::MintRequest;
+        use cdk_common::MintQuoteBolt11Request;
+
+        use crate::test_helpers::mint::create_test_blinded_messages;
+
+        let mint = create_test_mint().await.unwrap();
+        let quote: MintQuoteBolt11Response<_> = mint
+            .get_mint_quote(
+                MintQuoteBolt11Request {
+                    amount: Amount::from(64),
+                    unit: CurrencyUnit::Sat,
+                    description: None,
+                    pubkey: None,
+                }
+                .into(),
+            )
+            .await
+            .unwrap()
+            .into();
+
+        let (outputs, _premint) = create_test_blinded_messages(&mint, Amount::from(64))
+            .await
+            .unwrap();
+
+        deactivate_keysets(&mint);
+
+        let request = MintRequest {
+            quote: quote.quote,
+            outputs,
+            signature: None,
+        };
+        let result = mint
+            .process_mint_request(MintInput::Single(request.try_into().unwrap()))
+            .await;
+
+        assert!(
+            matches!(result, Err(Error::InactiveKeyset)),
+            "expected InactiveKeyset error, got: {:?}",
+            result
+        );
+    }
+
     #[tokio::test]
     async fn verify_inputs_keyset_rejects_expired_keyset() {
         use cdk_common::nuts::{Proof, SecretKey};


### PR DESCRIPTION


### Description

This solution supersedes #2448 by fixing #2447. This solution works because [expired keysets are not valid to swap from](https://github.com/cashubtc/cdk/blob/beaa3c522ca5b200a8246dd59e2c4d7199fbba05/crates/cdk/src/mint/verification.rs#L145-L151), but [rotated keysets (inactive) are](https://github.com/cashubtc/cdk/blob/beaa3c522ca5b200a8246dd59e2c4d7199fbba05/crates/cdk/src/mint/verification.rs#L145-L151).

A melt commits its change outputs when the request is accepted, but they are signed after settlement. If the keyset rotates in between, the signatory refused to sign and the user lost their change. Expired keysets are still refused: they are also rejected as inputs, so signing one would hand back unspendable proofs.

The mint continues to verify swap and issuance outputs against the active keyset, so this only widens what melt change can land on.

Change on a rotated-out keyset also has to be split with that keyset's own fee and denominations. The fallback set produced amounts the keyset had no key for, failing after the payment had already gone out.

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
