### PR TITLE
feat: add mobile Nostr identity FFI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- cdk-nostr/cdk-ffi: Mobile wallets can keep a typed Nostr identity in Rust,
+  derive the default NIP-06 key directly from a mnemonic or wallet repository,
+  sign generic/NIP-98 events, perform NIP-44 v2 operations, run a strictly
+  validated restartable NIP-17/NIP-59 inbox with quiescent async shutdown, and
+  give the exact same identity to npub.cash. NWC, NUT-27, proof derivation, and
+  other Cashu P2PK keyring domains remain purpose-separated.
+
 ## [0.18.0-rc.3](https://github.com/cashubtc/cdk/releases/tag/v0.18.0-rc.3)
 
 ### Summary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,6 +1708,8 @@ version = "0.18.0-rc.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "bip39",
+ "bitcoin",
  "cashu",
  "cdk-common",
  "cdk-http-client",

--- a/bindings/kotlin/cdk-jvm/src/test/kotlin/org/cashudevkit/WalletTest.kt
+++ b/bindings/kotlin/cdk-jvm/src/test/kotlin/org/cashudevkit/WalletTest.kt
@@ -131,6 +131,60 @@ class WalletTest {
     }
 
     @Test
+    fun `typed Nostr identity signing NIP-44 and npubcash share one key`() {
+        val mnemonic =
+            "leader monkey parrot ring guide accident before fence cannon height naive bean"
+        val expectedSecret =
+            "7f7ff03d123792d6ac594bfa67bf6d0c0ab55b6b1fdb6249303fe861f1ccba9a"
+        val signer = NostrSigner.fromMnemonic(mnemonic, null)
+        val peer = NostrSigner.generate()
+        val fromNsec = NostrSigner.fromNsec(signer.nsec())
+        val npubCash = NpubCashClient.withSigner("https://npub.cash", signer)
+        val inbox = NostrInbox.withSigner(
+            signer,
+            listOf("wss://relay.example.com"),
+            1_700_000_000UL,
+        )
+
+        try {
+            assertEquals(expectedSecret, signer.secretKeyHex())
+            assertEquals(64, signer.publicKeyHex().length)
+            assertEquals(signer.publicKeyHex(), signer.xOnlyPublicKeyHex())
+            assertEquals("02" + signer.publicKeyHex(), signer.cashuP2pkPublicKey())
+            assertEquals(signer.publicKeyHex(), fromNsec.publicKeyHex())
+
+            val signed = signer.signEvent(
+                NostrUnsignedEvent(
+                    createdAt = 1_700_000_000UL,
+                    kind = 27_235U.toUShort(),
+                    tags = listOf(
+                        listOf("u", "https://example.com/api"),
+                        listOf("method", "POST"),
+                    ),
+                    content = "",
+                ),
+            )
+            assertEquals(signer.publicKeyHex(), signed.pubkey)
+            assertEquals(64, signed.id.length)
+            assertEquals(128, signed.sig.length)
+
+            val payload = signer.nip44Encrypt(peer.publicKeyHex(), "hello cashu")
+            assertEquals(
+                "hello cashu",
+                peer.nip44Decrypt(signer.publicKeyHex(), payload),
+            )
+            assertEquals(signer.publicKeyHex(), npubCash.identityPubkey())
+            assertEquals(signer.publicKeyHex(), inbox.pubkey())
+        } finally {
+            inbox.close()
+            npubCash.close()
+            fromNsec.close()
+            peer.close()
+            signer.close()
+        }
+    }
+
+    @Test
     fun `mint flow`() = runBlocking {
         val quote = wallet.mintQuote(
             paymentMethod = PaymentMethod.Bolt11,

--- a/bindings/swift/Tests/CdkTests.swift
+++ b/bindings/swift/Tests/CdkTests.swift
@@ -107,6 +107,55 @@ struct CdkTests {
         }
     }
 
+    @Test("Typed Nostr identity, signing, NIP-44, and npub.cash share one key")
+    func typedNostrIdentity() throws {
+        let mnemonic = "leader monkey parrot ring guide accident before fence cannon height naive bean"
+        let expectedSecret = "7f7ff03d123792d6ac594bfa67bf6d0c0ab55b6b1fdb6249303fe861f1ccba9a"
+        let signer = try NostrSigner.fromMnemonic(mnemonic: mnemonic, passphrase: nil)
+
+        #expect(signer.secretKeyHex() == expectedSecret)
+        #expect(signer.publicKeyHex().count == 64)
+        #expect(signer.xOnlyPublicKeyHex() == signer.publicKeyHex())
+        #expect(signer.cashuP2pkPublicKey() == "02" + signer.publicKeyHex())
+        #expect(try NostrSigner.fromNsec(nsec: signer.nsec()).publicKeyHex() == signer.publicKeyHex())
+
+        let signed = try signer.signEvent(event: NostrUnsignedEvent(
+            createdAt: 1_700_000_000,
+            kind: 27_235,
+            tags: [
+                ["u", "https://example.com/api"],
+                ["method", "POST"],
+            ],
+            content: ""
+        ))
+        #expect(signed.pubkey == signer.publicKeyHex())
+        #expect(signed.id.count == 64)
+        #expect(signed.sig.count == 128)
+
+        let peer = NostrSigner.generate()
+        let payload = try signer.nip44Encrypt(
+            recipientPubkey: peer.publicKeyHex(),
+            plaintext: "hello cashu"
+        )
+        #expect(try peer.nip44Decrypt(
+            senderPubkey: signer.publicKeyHex(),
+            payload: payload
+        ) == "hello cashu")
+
+        let npubCash = NpubCashClient.withSigner(
+            baseUrl: "https://npub.cash",
+            signer: signer
+        )
+        #expect(npubCash.identityPubkey() == signer.publicKeyHex())
+
+        let inbox = try NostrInbox.withSigner(
+            signer: signer,
+            relays: ["wss://relay.example.com"],
+            since: 1_700_000_000
+        )
+        #expect(inbox.pubkey() == signer.publicKeyHex())
+    }
+
     @Test("Mint flow completes successfully")
     func mintFlow() async throws {
         let quote = try await wallet.mintQuote(

--- a/crates/cdk-ffi/Cargo.toml
+++ b/crates/cdk-ffi/Cargo.toml
@@ -59,5 +59,9 @@ nwc = ["cdk/nwc", "nostr", "cdk-nostr/nwc", "dep:tokio-util"]
 name = "uniffi-bindgen"
 path = "src/bin/uniffi-bindgen.rs"
 
+[[example]]
+name = "mobile_nostr_identity"
+required-features = ["npubcash"]
+
 [lints]
 workspace = true

--- a/crates/cdk-ffi/README.md
+++ b/crates/cdk-ffi/README.md
@@ -53,6 +53,53 @@ just ffi-dev-python
 >>> help(cdk_ffi.generate_mnemonic)  # Get help
 ```
 
+## Mobile Nostr identity
+
+`NostrSigner` is the recommended Swift/Kotlin entry point for the wallet's
+active Nostr identity. It derives NIP-06 path `m/44'/1237'/0'/0/0` from a
+BIP-39 mnemonic entirely in Rust, or can import secret-key hex/`nsec` and
+generate a secure random identity. The same object provides canonical Nostr
+event signing (including NIP-98), NIP-44 v2, a strict restartable NIP-17 inbox,
+the compressed Cashu P2PK public key, and npub.cash authentication.
+Use the existing `generateMnemonic()`/`generate_mnemonic()` binding when
+creating a new mnemonic-backed wallet; mobile code never needs to generate or
+pass BIP-39 seed bytes.
+
+Swift:
+
+```swift
+let signer = try NostrSigner.fromMnemonic(mnemonic: words, passphrase: nil)
+let event = try signer.signEvent(event: NostrUnsignedEvent(
+    createdAt: UInt64(Date().timeIntervalSince1970),
+    kind: 27_235,
+    tags: [["u", url], ["method", "POST"]],
+    content: ""
+))
+let npubCash = NpubCashClient.withSigner(baseUrl: "https://npub.cash", signer: signer)
+let inbox = try NostrInbox.withSigner(signer: signer, relays: relays, since: lookback)
+```
+
+Kotlin:
+
+```kotlin
+val signer = NostrSigner.fromMnemonic(words, null)
+val event = signer.signEvent(
+    NostrUnsignedEvent(now, 27_235U.toUShort(), tags, ""),
+)
+val npubCash = NpubCashClient.withSigner("https://npub.cash", signer)
+val inbox = NostrInbox.withSigner(signer, relays, lookback)
+```
+
+When a `WalletRepository` already exists, use
+`NostrSigner.fromWalletRepository(repository)` so the mnemonic is parsed once
+and its BIP-39 seed never crosses the FFI boundary. `NostrInbox.stop()` is
+async and guarantees that the stopped run cannot invoke another callback after
+it returns.
+
+NWC (`m/44'/1237'/1'/0/0`), NUT-27 backups, Cashu proof derivation, and CDK's
+other deterministic P2PK keyring paths remain separate purpose-specific key
+domains.
+
 ## Live Tests
 
 The live Python test in `tests/test_live_async_onchain_melt.py` covers

--- a/crates/cdk-ffi/examples/mobile_nostr_identity.rs
+++ b/crates/cdk-ffi/examples/mobile_nostr_identity.rs
@@ -1,0 +1,32 @@
+//! Use one typed Rust-owned identity for mobile-facing Nostr operations.
+
+use std::sync::Arc;
+
+use cdk_ffi::{NostrSigner, NostrUnsignedEvent, NpubCashClient};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Public NIP-06 test vector. A real wallet passes its own BIP-39 mnemonic;
+    // the seed is calculated inside Rust and never crosses the FFI boundary.
+    let signer = Arc::new(NostrSigner::from_mnemonic(
+        "leader monkey parrot ring guide accident before fence cannon height naive bean"
+            .to_string(),
+        None,
+    )?);
+
+    let event = signer.sign_event(NostrUnsignedEvent {
+        created_at: 1_700_000_000,
+        kind: 27_235,
+        tags: vec![
+            vec!["u".to_string(), "https://example.com/api".to_string()],
+            vec!["method".to_string(), "POST".to_string()],
+        ],
+        content: String::new(),
+    })?;
+    println!("signed NIP-98 event {} as {}", event.id, event.pubkey);
+    println!("Cashu P2PK key: {}", signer.cashu_p2pk_public_key());
+
+    let npubcash = NpubCashClient::with_signer("https://npub.cash".to_string(), signer);
+    println!("npub.cash identity: {}", npubcash.identity_pubkey());
+
+    Ok(())
+}

--- a/crates/cdk-ffi/src/nostr.rs
+++ b/crates/cdk-ffi/src/nostr.rs
@@ -1,129 +1,358 @@
-//! FFI bindings for Nostr key management, NIP-44 encryption and the NIP-17
-//! inbox listener.
-//!
-//! These functions cover the secp256k1-based cryptography a wallet needs for
-//! Nostr, so foreign-language wallets do not have to bundle a separate
-//! secp256k1 library.
+//! Typed FFI bindings for the wallet's Nostr identity, event signing, NIP-44,
+//! and the restartable NIP-17/NIP-59 inbox.
 
 use std::sync::Arc;
 
 use cdk_nostr::inbox::{Nip17Event, NostrInbox as CdkNostrInbox};
-use cdk_nostr::nostr_sdk::{RelayUrl, Timestamp};
+use cdk_nostr::nostr_sdk::{Event, Keys, Kind, RelayUrl, Tag, Timestamp, ToBech32, UnsignedEvent};
 use cdk_nostr::{keys as nostr_keys, nip44 as cdk_nip44};
 
 use crate::error::FfiError;
+use crate::wallet_repository::WalletRepository;
 
-/// Generate a new random Nostr secret key
+/// A wallet-facing Nostr signer and identity.
 ///
-/// # Returns
+/// The object owns one Nostr keypair and is intended to be shared by Nostr
+/// event signing, NIP-44, the NIP-17 inbox, npub.cash, and the application's
+/// primary Cashu P2PK identity. It is deliberately not used for NWC, NUT-27,
+/// proof derivation, or other purpose-specific CDK key domains.
+#[derive(uniffi::Object)]
+pub struct NostrSigner {
+    keys: Keys,
+}
+
+impl NostrSigner {
+    fn from_keys(keys: Keys) -> Self {
+        Self { keys }
+    }
+
+    pub(crate) fn parse_secret_key(secret_key: &str) -> Result<Self, FfiError> {
+        let secret_key = nostr_keys::parse_secret_key(secret_key)
+            .map_err(|e| FfiError::internal(e.to_string()))?;
+        Ok(Self::from_keys(Keys::new(secret_key)))
+    }
+
+    pub(crate) fn keys(&self) -> &Keys {
+        &self.keys
+    }
+}
+
+/// An unsigned Nostr event supplied by a foreign-language caller.
 ///
-/// The hex-encoded secret key (64 characters)
+/// The signer supplies `pubkey`; CDK uses the Rust Nostr implementation to
+/// perform canonical serialization, event-ID calculation, and signing.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct NostrUnsignedEvent {
+    /// Unix timestamp in seconds.
+    pub created_at: u64,
+    /// Numeric Nostr event kind. NIP-98 uses kind `27235`.
+    pub kind: u16,
+    /// Nostr tags represented as arrays of strings.
+    pub tags: Vec<Vec<String>>,
+    /// Event content.
+    pub content: String,
+}
+
+/// A canonically encoded and BIP-340-signed Nostr event.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct NostrSignedEvent {
+    /// Hex-encoded event ID.
+    pub id: String,
+    /// Hex-encoded x-only author public key.
+    pub pubkey: String,
+    /// Unix timestamp in seconds.
+    pub created_at: u64,
+    /// Numeric Nostr event kind.
+    pub kind: u16,
+    /// Nostr tags represented as arrays of strings.
+    pub tags: Vec<Vec<String>>,
+    /// Event content.
+    pub content: String,
+    /// Hex-encoded BIP-340 Schnorr signature.
+    pub sig: String,
+}
+
+impl From<Event> for NostrSignedEvent {
+    fn from(event: Event) -> Self {
+        Self {
+            id: event.id.to_hex(),
+            pubkey: event.pubkey.to_hex(),
+            created_at: event.created_at.as_secs(),
+            kind: event.kind.as_u16(),
+            tags: event
+                .tags
+                .iter()
+                .map(|tag| tag.as_slice().to_vec())
+                .collect(),
+            content: event.content,
+            sig: event.sig.to_string(),
+        }
+    }
+}
+
+#[uniffi::export]
+impl NostrSigner {
+    /// Derive the default wallet identity from a BIP-39 mnemonic using NIP-06
+    /// path `m/44'/1237'/0'/0/0`.
+    ///
+    /// The mnemonic is parsed and expanded to its seed inside Rust. Callers
+    /// never calculate or pass seed bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an invalid mnemonic or failed derivation.
+    #[uniffi::constructor]
+    pub fn from_mnemonic(mnemonic: String, passphrase: Option<String>) -> Result<Self, FfiError> {
+        let keys = nostr_keys::derive_nip06_keys_from_mnemonic(&mnemonic, passphrase.as_deref())
+            .map_err(|e| FfiError::internal(e.to_string()))?;
+        Ok(Self::from_keys(keys))
+    }
+
+    /// Derive the default NIP-06 identity from an existing wallet repository.
+    ///
+    /// This is the preferred constructor when the repository already parsed
+    /// the wallet mnemonic: its BIP-39 seed never leaves Rust.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if NIP-06 key derivation fails.
+    #[uniffi::constructor]
+    pub fn from_wallet_repository(repository: Arc<WalletRepository>) -> Result<Self, FfiError> {
+        let secret_key = nostr_keys::derive_nip06_secret_key_from_seed(repository.inner().seed())
+            .map_err(|e| FfiError::internal(e.to_string()))?;
+        Ok(Self::from_keys(Keys::new(secret_key)))
+    }
+
+    /// Construct an identity from a 64-character secret-key hex string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for malformed hex, zero, or an out-of-range scalar.
+    #[uniffi::constructor]
+    pub fn from_secret_key_hex(secret_key_hex: String) -> Result<Self, FfiError> {
+        if secret_key_hex.len() != 64
+            || !secret_key_hex.as_bytes().iter().all(u8::is_ascii_hexdigit)
+        {
+            return Err(FfiError::internal(
+                "Nostr secret-key hex must contain exactly 64 hexadecimal characters",
+            ));
+        }
+        Self::parse_secret_key(&secret_key_hex)
+    }
+
+    /// Construct an identity from a bech32 `nsec`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for malformed bech32 or an invalid scalar.
+    #[uniffi::constructor]
+    pub fn from_nsec(nsec: String) -> Result<Self, FfiError> {
+        if !nsec
+            .get(..5)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("nsec1"))
+        {
+            return Err(FfiError::internal("Nostr nsec must start with 'nsec1'"));
+        }
+        Self::parse_secret_key(&nsec)
+    }
+
+    /// Generate a cryptographically secure random Nostr identity.
+    #[uniffi::constructor]
+    pub fn generate() -> Self {
+        Self::from_keys(Keys::generate())
+    }
+
+    /// Return the 64-character secret-key hex string.
+    pub fn secret_key_hex(&self) -> String {
+        self.keys.secret_key().to_secret_hex()
+    }
+
+    /// Return the bech32 `nsec`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if bech32 encoding fails.
+    pub fn nsec(&self) -> Result<String, FfiError> {
+        self.keys
+            .secret_key()
+            .to_bech32()
+            .map_err(FfiError::internal)
+    }
+
+    /// Return the 64-character x-only public-key hex string.
+    pub fn public_key_hex(&self) -> String {
+        self.keys.public_key().to_hex()
+    }
+
+    /// Explicit alias for [`Self::public_key_hex`].
+    pub fn x_only_public_key_hex(&self) -> String {
+        self.public_key_hex()
+    }
+
+    /// Return the bech32 `npub`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if bech32 encoding fails.
+    pub fn npub(&self) -> Result<String, FfiError> {
+        self.keys
+            .public_key()
+            .to_bech32()
+            .map_err(FfiError::internal)
+    }
+
+    /// Return the compressed even-parity Cashu P2PK public key.
+    ///
+    /// BIP-340 x-only public keys use the even-Y representative, so its
+    /// compressed encoding is the `02` prefix followed by the x-only key.
+    pub fn cashu_p2pk_public_key(&self) -> String {
+        format!("02{}", self.public_key_hex())
+    }
+
+    /// Canonically serialize, hash, and BIP-340 sign an unsigned Nostr event.
+    ///
+    /// This generic record supports NIP-98 (kind `27235`) as well as other
+    /// event kinds.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an empty tag or if event signing fails.
+    pub fn sign_event(&self, event: NostrUnsignedEvent) -> Result<NostrSignedEvent, FfiError> {
+        let tags = event
+            .tags
+            .into_iter()
+            .map(Tag::parse)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| FfiError::internal(format!("invalid Nostr tag: {e}")))?;
+        let event = UnsignedEvent::new(
+            self.keys.public_key(),
+            Timestamp::from_secs(event.created_at),
+            Kind::from(event.kind),
+            tags,
+            event.content,
+        )
+        .sign_with_keys(&self.keys)
+        .map_err(|e| FfiError::internal(format!("failed to sign Nostr event: {e}")))?;
+        Ok(event.into())
+    }
+
+    /// Encrypt plaintext for `recipient_pubkey` using NIP-44 v2.
+    ///
+    /// `recipient_pubkey` accepts x-only hex or `npub`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an invalid public key or encryption failure.
+    pub fn nip44_encrypt(
+        &self,
+        recipient_pubkey: String,
+        plaintext: String,
+    ) -> Result<String, FfiError> {
+        let recipient = nostr_keys::parse_public_key(&recipient_pubkey)
+            .map_err(|e| FfiError::internal(e.to_string()))?;
+        cdk_nip44::encrypt(self.keys.secret_key(), &recipient, &plaintext)
+            .map_err(|e| FfiError::internal(e.to_string()))
+    }
+
+    /// Decrypt a NIP-44 v2 payload from `sender_pubkey`.
+    ///
+    /// `sender_pubkey` accepts x-only hex or `npub`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an invalid public key, malformed payload, or MAC
+    /// verification failure.
+    pub fn nip44_decrypt(
+        &self,
+        sender_pubkey: String,
+        payload: String,
+    ) -> Result<String, FfiError> {
+        let sender = nostr_keys::parse_public_key(&sender_pubkey)
+            .map_err(|e| FfiError::internal(e.to_string()))?;
+        cdk_nip44::decrypt(self.keys.secret_key(), &sender, &payload)
+            .map_err(|e| FfiError::internal(e.to_string()))
+    }
+}
+
+/// Generate a new random Nostr secret key.
+///
+/// This compatibility helper returns hex. New mobile code should keep a
+/// [`NostrSigner`] object instead.
 #[uniffi::export]
 pub fn nostr_generate_secret_key() -> String {
     nostr_keys::generate_secret_key().to_secret_hex()
 }
 
-/// Get the public key for a Nostr secret key
-///
-/// # Arguments
-///
-/// * `nostr_secret_key` - Nostr secret key. Accepts either:
-///   - Hex-encoded secret key (64 characters)
-///   - Bech32 `nsec` format (e.g., "nsec1...")
-///
-/// # Returns
-///
-/// The hex-encoded x-only public key (64 characters)
+/// Get the x-only public key for a Nostr secret key in hex or `nsec` form.
 ///
 /// # Errors
 ///
-/// Returns an error if the secret key is invalid
+/// Returns an error if the secret key is invalid.
 #[uniffi::export]
 pub fn nostr_get_pubkey(nostr_secret_key: String) -> Result<String, FfiError> {
-    let secret_key = nostr_keys::parse_secret_key(&nostr_secret_key)
-        .map_err(|e| FfiError::internal(e.to_string()))?;
-    Ok(nostr_keys::public_key(&secret_key).to_hex())
+    Ok(NostrSigner::parse_secret_key(&nostr_secret_key)?.public_key_hex())
 }
 
-/// Encrypt a message with NIP-44 v2
+/// Return whether a x-only hex or bech32 `npub` public key is valid.
+#[uniffi::export]
+pub fn nostr_is_valid_public_key(public_key: String) -> bool {
+    nostr_keys::parse_public_key(&public_key).is_ok()
+}
+
+/// Encrypt with NIP-44 v2 using a secret key in hex or `nsec` form.
 ///
-/// Derives the conversation key via secp256k1 ECDH between `nostr_secret_key`
-/// and `recipient_pubkey` and returns the base64-encoded payload.
-///
-/// # Arguments
-///
-/// * `nostr_secret_key` - Sender secret key (hex or bech32 `nsec`)
-/// * `recipient_pubkey` - Recipient x-only public key (hex, 64 characters)
-/// * `plaintext` - Message to encrypt
+/// This compatibility helper is retained for existing callers. New code
+/// should call [`NostrSigner::nip44_encrypt`].
 ///
 /// # Errors
 ///
-/// Returns an error if a key is invalid or encryption fails
+/// Returns an error for invalid keys or encryption failure.
 #[uniffi::export]
 pub fn nip44_encrypt(
     nostr_secret_key: String,
     recipient_pubkey: String,
     plaintext: String,
 ) -> Result<String, FfiError> {
-    let secret_key = nostr_keys::parse_secret_key(&nostr_secret_key)
-        .map_err(|e| FfiError::internal(e.to_string()))?;
-    let public_key = nostr_keys::parse_public_key(&recipient_pubkey)
-        .map_err(|e| FfiError::internal(e.to_string()))?;
-    cdk_nip44::encrypt(&secret_key, &public_key, &plaintext)
-        .map_err(|e| FfiError::internal(e.to_string()))
+    NostrSigner::parse_secret_key(&nostr_secret_key)?.nip44_encrypt(recipient_pubkey, plaintext)
 }
 
-/// Decrypt a NIP-44 v2 payload
+/// Decrypt with NIP-44 v2 using a secret key in hex or `nsec` form.
 ///
-/// Derives the conversation key via secp256k1 ECDH between `nostr_secret_key`
-/// and `sender_pubkey` and decrypts the base64-encoded payload.
-///
-/// # Arguments
-///
-/// * `nostr_secret_key` - Recipient secret key (hex or bech32 `nsec`)
-/// * `sender_pubkey` - Sender x-only public key (hex, 64 characters)
-/// * `payload` - Base64-encoded NIP-44 v2 payload
+/// This compatibility helper is retained for existing callers. New code
+/// should call [`NostrSigner::nip44_decrypt`].
 ///
 /// # Errors
 ///
-/// Returns an error if a key is invalid, the payload is malformed, or MAC
-/// verification fails
+/// Returns an error for invalid keys or decryption failure.
 #[uniffi::export]
 pub fn nip44_decrypt(
     nostr_secret_key: String,
     sender_pubkey: String,
     payload: String,
 ) -> Result<String, FfiError> {
-    let secret_key = nostr_keys::parse_secret_key(&nostr_secret_key)
-        .map_err(|e| FfiError::internal(e.to_string()))?;
-    let public_key = nostr_keys::parse_public_key(&sender_pubkey)
-        .map_err(|e| FfiError::internal(e.to_string()))?;
-    cdk_nip44::decrypt(&secret_key, &public_key, &payload)
-        .map_err(|e| FfiError::internal(e.to_string()))
+    NostrSigner::parse_secret_key(&nostr_secret_key)?.nip44_decrypt(sender_pubkey, payload)
 }
 
-/// An unwrapped NIP-17 gift wrap received by a [`NostrInbox`]
+/// An unwrapped, fully validated NIP-17 gift wrap.
 ///
-/// All IDs and keys are hex-encoded; timestamps are unix seconds.
-#[derive(uniffi::Record)]
+/// All IDs and keys are hex-encoded; timestamps are Unix seconds.
+#[derive(Debug, Clone, uniffi::Record)]
 pub struct NostrInboxEvent {
-    /// ID of the (ephemeral) kind `1059` gift wrap event. Use it to
-    /// de-duplicate deliveries across relay reconnects and restarts.
+    /// ID of the outer kind `1059` gift wrap, for persistent deduplication.
     pub wrap_id: String,
-    /// `created_at` of the gift wrap (NIP-59 randomizes/backdates it)
+    /// Randomized/backdated `created_at` of the outer gift wrap.
     pub wrap_created_at: u64,
-    /// Author of the verified seal — the real sender of the rumor
+    /// Author of the verified kind `13` seal.
     pub sender_pubkey: String,
-    /// ID of the rumor, if the sender included one
-    pub rumor_id: Option<String>,
-    /// Kind of the rumor (commonly `14` for chat/DM payloads)
+    /// Verified ID of the kind `14` rumor.
+    pub rumor_id: String,
+    /// Kind of the rumor (currently required to be `14`).
     pub rumor_kind: u16,
-    /// Content of the rumor (e.g. a NUT-18 payment request payload for
-    /// kind `14` rumors)
+    /// Content of the rumor.
     pub rumor_content: String,
-    /// `created_at` of the rumor
+    /// `created_at` of the rumor.
     pub rumor_created_at: u64,
-    /// Tags of the rumor
+    /// Tags of the rumor.
     pub rumor_tags: Vec<Vec<String>>,
 }
 
@@ -133,7 +362,7 @@ impl From<Nip17Event> for NostrInboxEvent {
             wrap_id: event.wrap_id.to_hex(),
             wrap_created_at: event.wrap_created_at.as_secs(),
             sender_pubkey: event.sender.to_hex(),
-            rumor_id: event.rumor.id.map(|id| id.to_hex()),
+            rumor_id: event.rumor_id.to_hex(),
             rumor_kind: event.rumor.kind.as_u16(),
             rumor_content: event.rumor.content,
             rumor_created_at: event.rumor.created_at.as_secs(),
@@ -147,17 +376,16 @@ impl From<Nip17Event> for NostrInboxEvent {
     }
 }
 
-/// Callback interface for [`NostrInbox`] events
+/// Callback interface for [`NostrInbox`] events.
 ///
-/// Implementations must be non-blocking; hand expensive work (token claims,
-/// database writes) off to a separate task.
+/// Implementations must be non-blocking; hand expensive work such as token
+/// claiming or database writes to a separate task.
 #[uniffi::export(with_foreign)]
 pub trait NostrInboxListener: Send + Sync {
-    /// Called once per successfully unwrapped gift wrap
+    /// Called once per successfully validated and unwrapped gift wrap.
     fn on_event(&self, event: NostrInboxEvent);
 }
 
-/// Bridge from the Rust listener trait to the FFI callback interface
 struct FfiInboxListener {
     ffi_listener: Arc<dyn NostrInboxListener>,
 }
@@ -168,40 +396,19 @@ impl cdk_nostr::inbox::NostrInboxListener for FfiInboxListener {
     }
 }
 
-/// A standing NIP-17 inbox listener for a single Nostr identity
-///
-/// Subscribes the given relays for gift wraps addressed to the identity's
-/// public key and delivers unwrapped rumors to a [`NostrInboxListener`].
+/// A restartable NIP-17/NIP-59 inbox bound to a typed [`NostrSigner`].
 #[derive(uniffi::Object)]
 pub struct NostrInbox {
     inner: CdkNostrInbox,
+    signer: Arc<NostrSigner>,
 }
 
-#[uniffi::export(async_runtime = "tokio")]
 impl NostrInbox {
-    /// Create a new inbox listener
-    ///
-    /// # Arguments
-    ///
-    /// * `nostr_secret_key` - The identity's secret key (hex or bech32 `nsec`)
-    /// * `relays` - Relay URLs (`ws://`/`wss://`) to subscribe; must be
-    ///   non-empty
-    /// * `since` - Optional unix timestamp lower bound for the relay `since`
-    ///   filter. Because NIP-59 backdates gift wraps, pick a generous lookback
-    ///   window instead of "now".
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the secret key or a relay URL is invalid, or no
-    /// relays are configured.
-    #[uniffi::constructor]
-    pub fn new(
-        nostr_secret_key: String,
+    fn build(
+        signer: Arc<NostrSigner>,
         relays: Vec<String>,
         since: Option<u64>,
     ) -> Result<Self, FfiError> {
-        let secret_key = nostr_keys::parse_secret_key(&nostr_secret_key)
-            .map_err(|e| FfiError::internal(e.to_string()))?;
         let relay_urls = relays
             .iter()
             .map(|relay| {
@@ -209,28 +416,72 @@ impl NostrInbox {
                     .map_err(|e| FfiError::internal(format!("invalid relay {relay}: {e}")))
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let since = since.map(Timestamp::from_secs);
-
-        let inner = CdkNostrInbox::new(secret_key, relay_urls, since)
-            .map_err(|e| FfiError::internal(e.to_string()))?;
-        Ok(Self { inner })
+        let inner = CdkNostrInbox::from_keys(
+            signer.keys().clone(),
+            relay_urls,
+            since.map(Timestamp::from_secs),
+        )
+        .map_err(|e| FfiError::internal(e.to_string()))?;
+        Ok(Self { inner, signer })
     }
+}
 
-    /// Public key of the inbox identity (hex-encoded, x-only)
-    pub fn pubkey(&self) -> String {
-        self.inner.pubkey().to_hex()
-    }
-
-    /// Connect to the relays, activate the subscription and start delivering
-    /// events to `listener` on a background task
+#[uniffi::export(async_runtime = "tokio")]
+impl NostrInbox {
+    /// Compatibility constructor accepting secret-key hex or `nsec`.
     ///
-    /// Returns once the subscription is active. Events are delivered until
-    /// [`NostrInbox::stop`] is called.
+    /// New mobile code should construct one [`NostrSigner`] and pass it to
+    /// [`Self::with_signer`].
+    ///
+    /// `since` is a fixed subscription floor for this object's entire
+    /// lifetime, including relay reconnects and explicit restarts. Use a
+    /// generous lookback because NIP-59 gift wraps are intentionally
+    /// backdated.
     ///
     /// # Errors
     ///
-    /// Returns an error if a relay cannot be added or the subscription cannot
-    /// be created.
+    /// Returns an error for an invalid secret key or relay configuration.
+    #[uniffi::constructor]
+    pub fn new(
+        nostr_secret_key: String,
+        relays: Vec<String>,
+        since: Option<u64>,
+    ) -> Result<Self, FfiError> {
+        Self::build(
+            Arc::new(NostrSigner::parse_secret_key(&nostr_secret_key)?),
+            relays,
+            since,
+        )
+    }
+
+    /// Create an inbox using the shared active Nostr identity.
+    ///
+    /// This is the recommended mobile constructor. The configured `since`
+    /// value remains the fixed subscription floor through reconnects and
+    /// explicit restarts.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid/empty relay configuration.
+    #[uniffi::constructor]
+    pub fn with_signer(
+        signer: Arc<NostrSigner>,
+        relays: Vec<String>,
+        since: Option<u64>,
+    ) -> Result<Self, FfiError> {
+        Self::build(signer, relays, since)
+    }
+
+    /// Public key of the inbox identity (hex-encoded, x-only).
+    pub fn pubkey(&self) -> String {
+        self.signer.public_key_hex()
+    }
+
+    /// Start delivering events. Calling this while running is a no-op.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if relay setup or subscription fails.
     pub async fn start(&self, listener: Arc<dyn NostrInboxListener>) -> Result<(), FfiError> {
         self.inner
             .start(Arc::new(FfiInboxListener {
@@ -240,97 +491,262 @@ impl NostrInbox {
             .map_err(|e| FfiError::internal(e.to_string()))
     }
 
-    /// Stop listening: cancels the background pump and disconnects from the
-    /// relays
-    pub fn stop(&self) {
-        self.inner.stop();
+    /// Stop the current run, then start a new one with `listener`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if relay setup or subscription fails.
+    pub async fn restart(&self, listener: Arc<dyn NostrInboxListener>) -> Result<(), FfiError> {
+        self.inner
+            .restart(Arc::new(FfiInboxListener {
+                ffi_listener: listener,
+            }))
+            .await
+            .map_err(|e| FfiError::internal(e.to_string()))
+    }
+
+    /// Stop listening and await shutdown.
+    ///
+    /// After this method completes, the stopped run is disconnected and can
+    /// never invoke another callback. Calling it while stopped is a no-op.
+    pub async fn stop(&self) {
+        self.inner.stop().await;
+    }
+
+    /// Return whether the inbox currently has an active relay pump.
+    pub async fn is_running(&self) -> bool {
+        self.inner.is_running().await
     }
 }
 
 #[cfg(test)]
 mod tests {
+    #[cfg(any(feature = "npubcash", feature = "nwc"))]
+    use bip39::Mnemonic;
+    use cdk_nostr::nostr_sdk::{JsonUtil, ToBech32};
+
     use super::*;
+    use crate::database::custom_wallet_store;
+    use crate::sqlite::WalletSqliteDatabase;
+
+    const NIP06_MNEMONIC: &str =
+        "leader monkey parrot ring guide accident before fence cannon height naive bean";
+    const NIP06_SECRET_KEY: &str =
+        "7f7ff03d123792d6ac594bfa67bf6d0c0ab55b6b1fdb6249303fe861f1ccba9a";
+    const ONE_SECRET_KEY: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+    const ONE_PUBLIC_KEY: &str = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
 
     #[test]
-    fn nostr_get_pubkey_derives_xonly_hex() {
-        let pubkey = nostr_get_pubkey(
-            "0000000000000000000000000000000000000000000000000000000000000001".to_string(),
-        )
-        .expect("valid secret key");
+    fn public_bip39_vector_derives_expected_nip06_identity() {
+        let signer =
+            NostrSigner::from_mnemonic(NIP06_MNEMONIC.to_string(), None).expect("mnemonic derives");
+        assert_eq!(signer.secret_key_hex(), NIP06_SECRET_KEY);
+    }
+
+    #[test]
+    #[cfg(feature = "npubcash")]
+    fn mnemonic_api_matches_existing_npubcash_derivation() {
+        let mnemonic = Mnemonic::parse_normalized(NIP06_MNEMONIC).expect("valid mnemonic");
+        let seed = mnemonic.to_seed_normalized("");
+        let signer =
+            NostrSigner::from_mnemonic(NIP06_MNEMONIC.to_string(), None).expect("mnemonic derives");
+        let npubcash =
+            cdk::wallet::derive_npubcash_secret_key_from_seed(&seed).expect("npub.cash derives");
+
         assert_eq!(
-            pubkey,
-            "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+            signer.keys().secret_key().as_secret_bytes(),
+            &npubcash.to_secret_bytes()
         );
     }
 
     #[test]
-    fn nip44_roundtrip_via_ffi() {
-        let alice = nostr_generate_secret_key();
-        let bob = nostr_generate_secret_key();
-        let bob_pub = nostr_get_pubkey(bob.clone()).expect("bob pubkey");
-        let alice_pub = nostr_get_pubkey(alice.clone()).expect("alice pubkey");
+    fn repository_identity_matches_direct_mnemonic_identity() {
+        let database =
+            WalletSqliteDatabase::new_in_memory().expect("in-memory wallet database opens");
+        let repository = Arc::new(
+            WalletRepository::new(NIP06_MNEMONIC.to_string(), custom_wallet_store(database))
+                .expect("repository builds"),
+        );
+        let from_repository =
+            NostrSigner::from_wallet_repository(repository).expect("repository identity derives");
+        let from_mnemonic = NostrSigner::from_mnemonic(NIP06_MNEMONIC.to_string(), None)
+            .expect("mnemonic identity derives");
 
-        let payload = nip44_encrypt(alice, bob_pub, "hello cashu".to_string()).expect("encrypt");
-        let decrypted = nip44_decrypt(bob, alice_pub, payload).expect("decrypt");
-        assert_eq!(decrypted, "hello cashu");
+        assert_eq!(
+            from_repository.secret_key_hex(),
+            from_mnemonic.secret_key_hex()
+        );
     }
 
     #[test]
-    fn inbox_rejects_invalid_relay_url() {
-        let secret = nostr_generate_secret_key();
-        let result = NostrInbox::new(secret, vec!["not-a-url".to_string()], None);
-        assert!(result.is_err());
+    fn secret_hex_and_nsec_parsing_reject_invalid_scalars() {
+        let signer =
+            NostrSigner::from_secret_key_hex(ONE_SECRET_KEY.to_string()).expect("valid scalar");
+        let nsec = signer.nsec().expect("nsec encodes");
+        assert_eq!(
+            NostrSigner::from_nsec(nsec)
+                .expect("nsec parses")
+                .secret_key_hex(),
+            ONE_SECRET_KEY
+        );
+        assert_eq!(
+            NostrSigner::from_nsec(signer.nsec().expect("nsec encodes").to_uppercase())
+                .expect("uppercase nsec parses")
+                .secret_key_hex(),
+            ONE_SECRET_KEY
+        );
+
+        assert!(NostrSigner::from_secret_key_hex("00".repeat(32)).is_err());
+        assert!(NostrSigner::from_secret_key_hex("ff".repeat(32)).is_err());
+        assert!(NostrSigner::from_nsec("npub1not-an-nsec".to_string()).is_err());
     }
 
     #[test]
-    fn nostr_get_pubkey_rejects_invalid_key() {
-        assert!(nostr_get_pubkey("definitely-not-a-key".to_string()).is_err());
+    fn generated_identity_and_public_formats_are_valid() {
+        let signer = NostrSigner::generate();
+        assert!(NostrSigner::from_secret_key_hex(signer.secret_key_hex()).is_ok());
+        assert!(NostrSigner::from_nsec(signer.nsec().expect("nsec encodes")).is_ok());
+        assert!(nostr_is_valid_public_key(signer.public_key_hex()));
+        assert!(nostr_is_valid_public_key(
+            signer.npub().expect("npub encodes")
+        ));
+        assert_eq!(signer.public_key_hex().len(), 64);
+        assert_eq!(signer.cashu_p2pk_public_key().len(), 66);
+        assert!(signer.cashu_p2pk_public_key().starts_with("02"));
     }
 
     #[test]
-    fn nip44_encrypt_rejects_invalid_recipient_pubkey() {
-        let alice = nostr_generate_secret_key();
-        assert!(nip44_encrypt(alice, "not-a-pubkey".to_string(), "hi".to_string()).is_err());
+    fn public_key_of_one_has_expected_hex_npub_and_p2pk_encoding() {
+        let signer =
+            NostrSigner::from_secret_key_hex(ONE_SECRET_KEY.to_string()).expect("valid scalar");
+        assert_eq!(signer.public_key_hex(), ONE_PUBLIC_KEY);
+        assert_eq!(
+            signer.npub().expect("npub encodes"),
+            signer.keys().public_key().to_bech32().expect("npub")
+        );
+        assert_eq!(
+            signer.cashu_p2pk_public_key(),
+            format!("02{ONE_PUBLIC_KEY}")
+        );
     }
 
     #[test]
-    fn nip44_decrypt_rejects_wrong_recipient_key() {
-        let alice = nostr_generate_secret_key();
-        let bob = nostr_generate_secret_key();
-        let eve = nostr_generate_secret_key();
-        let bob_pub = nostr_get_pubkey(bob).expect("bob pubkey");
-        let alice_pub = nostr_get_pubkey(alice.clone()).expect("alice pubkey");
-
-        let payload = nip44_encrypt(alice, bob_pub, "secret".to_string()).expect("encrypt");
-        assert!(nip44_decrypt(eve, alice_pub, payload).is_err());
+    fn signed_event_id_and_signature_verify() {
+        let signer =
+            NostrSigner::from_secret_key_hex(ONE_SECRET_KEY.to_string()).expect("valid scalar");
+        let signed = signer
+            .sign_event(NostrUnsignedEvent {
+                created_at: 1_700_000_000,
+                kind: 27_235,
+                tags: vec![
+                    vec!["u".to_string(), "https://example.com/api".to_string()],
+                    vec!["method".to_string(), "POST".to_string()],
+                ],
+                content: String::new(),
+            })
+            .expect("event signs");
+        let json = serde_json::json!({
+            "id": signed.id,
+            "pubkey": signed.pubkey,
+            "created_at": signed.created_at,
+            "kind": signed.kind,
+            "tags": signed.tags,
+            "content": signed.content,
+            "sig": signed.sig,
+        })
+        .to_string();
+        let event = Event::from_json(json).expect("signed event parses");
+        event.verify().expect("event ID and signature verify");
     }
 
     #[test]
-    fn inbox_requires_at_least_one_relay() {
-        let secret = nostr_generate_secret_key();
-        assert!(NostrInbox::new(secret, vec![], None).is_err());
-    }
-
-    #[test]
-    fn inbox_rejects_invalid_secret_key() {
-        assert!(NostrInbox::new(
-            "bad-key".to_string(),
-            vec!["wss://relay.example.com".to_string()],
-            None
+    fn nip44_official_vector_and_cross_party_roundtrip() {
+        let receiver = NostrSigner::from_secret_key_hex(
+            "0000000000000000000000000000000000000000000000000000000000000001".to_string(),
         )
-        .is_err());
+        .expect("receiver key");
+        let sender = NostrSigner::from_secret_key_hex(
+            "0000000000000000000000000000000000000000000000000000000000000002".to_string(),
+        )
+        .expect("sender key");
+        let vector = "AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABee0G5VSK0/9YypIObAtDKfYEAjD35uVkHyB0F4DwrcNaCXlCWZKaArsGrY6M9wnuTMxWfp1RTN9Xga8no+kF5Vsb";
+        assert_eq!(
+            receiver
+                .nip44_decrypt(sender.public_key_hex(), vector.to_string())
+                .expect("official vector decrypts"),
+            "a"
+        );
+
+        let payload = sender
+            .nip44_encrypt(receiver.public_key_hex(), "hello cashu".to_string())
+            .expect("encrypts");
+        assert_eq!(
+            receiver
+                .nip44_decrypt(sender.public_key_hex(), payload)
+                .expect("decrypts"),
+            "hello cashu"
+        );
     }
 
     #[test]
-    fn inbox_pubkey_matches_identity_key() {
-        let secret = nostr_generate_secret_key();
-        let expected = nostr_get_pubkey(secret.clone()).expect("pubkey derives");
-        let inbox = NostrInbox::new(
-            secret,
+    #[cfg(feature = "nwc")]
+    fn domain_separated_identities_remain_distinct() {
+        let mnemonic = Mnemonic::parse_normalized(NIP06_MNEMONIC).expect("valid mnemonic");
+        let seed = mnemonic.to_seed_normalized("");
+        let signer =
+            NostrSigner::from_mnemonic(NIP06_MNEMONIC.to_string(), None).expect("mnemonic derives");
+        let nwc = cdk::wallet::derive_nwc_secret_key_from_seed(&seed).expect("NWC derives");
+        let backup = cdk::nuts::nut27::derive_nostr_keys(&seed).expect("NUT-27 derives");
+
+        assert_ne!(
+            signer.keys().secret_key().as_secret_bytes(),
+            &nwc.to_secret_bytes()
+        );
+        assert_ne!(signer.secret_key_hex(), backup.secret_key().to_secret_hex());
+    }
+
+    #[test]
+    fn compatibility_helpers_still_work() {
+        assert_eq!(
+            nostr_get_pubkey(ONE_SECRET_KEY.to_string()).expect("public key derives"),
+            ONE_PUBLIC_KEY
+        );
+        let alice = nostr_generate_secret_key();
+        let bob = nostr_generate_secret_key();
+        let payload = nip44_encrypt(
+            alice.clone(),
+            nostr_get_pubkey(bob.clone()).expect("bob pubkey"),
+            "hello".to_string(),
+        )
+        .expect("encrypts");
+        assert_eq!(
+            nip44_decrypt(bob, nostr_get_pubkey(alice).expect("alice pubkey"), payload,)
+                .expect("decrypts"),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn inbox_constructors_validate_inputs_and_share_signer() {
+        let signer = Arc::new(NostrSigner::generate());
+        assert!(NostrInbox::with_signer(signer.clone(), Vec::new(), None).is_err());
+        assert!(
+            NostrInbox::with_signer(signer.clone(), vec!["not-a-url".to_string()], None).is_err()
+        );
+        let inbox = NostrInbox::with_signer(
+            signer.clone(),
             vec!["wss://relay.example.com".to_string()],
             Some(1_700_000_000),
         )
-        .expect("valid inbox builds without connecting");
-        assert_eq!(inbox.pubkey(), expected);
+        .expect("inbox builds without connecting");
+        assert_eq!(inbox.pubkey(), signer.public_key_hex());
+
+        let compatibility = NostrInbox::new(
+            signer.secret_key_hex(),
+            vec!["wss://relay.example.com".to_string()],
+            None,
+        )
+        .expect("legacy constructor remains available");
+        assert_eq!(compatibility.pubkey(), signer.public_key_hex());
     }
 }

--- a/crates/cdk-ffi/src/npubcash.rs
+++ b/crates/cdk-ffi/src/npubcash.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use cdk_nostr::npubcash::{JwtAuthProvider, NpubCashClient as CdkNpubCashClient};
 
 use crate::error::FfiError;
+use crate::nostr::NostrSigner;
 use crate::types::MintQuote;
 
 /// FFI-compatible NpubCash client
@@ -17,6 +18,20 @@ use crate::types::MintQuote;
 #[derive(uniffi::Object)]
 pub struct NpubCashClient {
     inner: Arc<CdkNpubCashClient>,
+    identity_pubkey: String,
+}
+
+impl NpubCashClient {
+    fn build(base_url: String, keys: cdk_nostr::nostr_sdk::Keys) -> Self {
+        let identity_pubkey = keys.public_key().to_hex();
+        let auth_provider = Arc::new(JwtAuthProvider::new(base_url.clone(), keys));
+        let client = CdkNpubCashClient::new(base_url, auth_provider);
+
+        Self {
+            inner: Arc::new(client),
+            identity_pubkey,
+        }
+    }
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -35,13 +50,24 @@ impl NpubCashClient {
     /// Returns an error if the secret key is invalid or cannot be parsed
     #[uniffi::constructor]
     pub fn new(base_url: String, nostr_secret_key: String) -> Result<Self, FfiError> {
-        let keys = parse_nostr_secret_key(&nostr_secret_key)?;
-        let auth_provider = Arc::new(JwtAuthProvider::new(base_url.clone(), keys));
-        let client = CdkNpubCashClient::new(base_url, auth_provider);
+        let signer = NostrSigner::parse_secret_key(&nostr_secret_key)?;
+        Ok(Self::build(base_url, signer.keys().clone()))
+    }
 
-        Ok(Self {
-            inner: Arc::new(client),
-        })
+    /// Create a client using an existing typed Nostr identity.
+    ///
+    /// This is the recommended mobile constructor. The exact supplied signer
+    /// is used for npub.cash authentication, so a mnemonic-derived, imported,
+    /// or generated active identity can be shared with event signing, NIP-44,
+    /// the NIP-17 inbox, and the application's primary P2PK identity.
+    #[uniffi::constructor]
+    pub fn with_signer(base_url: String, signer: Arc<NostrSigner>) -> Self {
+        Self::build(base_url, signer.keys().clone())
+    }
+
+    /// Hex-encoded x-only public key used for npub.cash authentication.
+    pub fn identity_pubkey(&self) -> String {
+        self.identity_pubkey.clone()
     }
 
     /// Fetch quotes from NpubCash
@@ -261,10 +287,11 @@ impl From<cdk_nostr::npubcash::UserResponse> for NpubCashUserResponse {
     }
 }
 
-/// Derive Nostr keys from a wallet seed
+/// Derive Nostr keys from a wallet seed for Rust compatibility.
 ///
-/// This function derives the same Nostr keys that a wallet would use for NpubCash
-/// authentication, using the NIP-06 path `m/44'/1237'/0'/0/0`.
+/// This is deliberately not exported through UniFFI: Swift and Kotlin should
+/// use `NostrSigner.fromMnemonic` or `NostrSigner.fromWalletRepository` so a
+/// BIP-39 seed never crosses the language boundary.
 ///
 /// # Arguments
 ///
@@ -277,7 +304,6 @@ impl From<cdk_nostr::npubcash::UserResponse> for NpubCashUserResponse {
 /// # Errors
 ///
 /// Returns an error if the seed is too short or key derivation fails
-#[uniffi::export]
 pub fn npubcash_derive_secret_key_from_seed(seed: Vec<u8>) -> Result<String, FfiError> {
     if seed.len() < 64 {
         return Err(FfiError::internal(
@@ -311,22 +337,7 @@ pub fn npubcash_derive_secret_key_from_seed(seed: Vec<u8>) -> Result<String, Ffi
 /// Returns an error if the secret key is invalid
 #[uniffi::export]
 pub fn npubcash_get_pubkey(nostr_secret_key: String) -> Result<String, FfiError> {
-    let keys = parse_nostr_secret_key(&nostr_secret_key)?;
-    Ok(keys.public_key().to_hex())
-}
-
-/// Parse a Nostr secret key from either hex or nsec format
-fn parse_nostr_secret_key(key: &str) -> Result<cdk_nostr::nostr_sdk::Keys, FfiError> {
-    // Try parsing as nsec (bech32) first
-    if key.starts_with("nsec") {
-        cdk_nostr::nostr_sdk::Keys::parse(key)
-            .map_err(|e| FfiError::internal(format!("Invalid nsec key: {}", e)))
-    } else {
-        // Try parsing as hex
-        let secret_key = cdk_nostr::nostr_sdk::SecretKey::parse(key)
-            .map_err(|e| FfiError::internal(format!("Invalid hex secret key: {}", e)))?;
-        Ok(cdk_nostr::nostr_sdk::Keys::new(secret_key))
-    }
+    Ok(NostrSigner::parse_secret_key(&nostr_secret_key)?.public_key_hex())
 }
 
 #[cfg(test)]
@@ -382,6 +393,41 @@ mod tests {
     fn client_rejects_invalid_secret_key() {
         assert!(
             NpubCashClient::new("https://npub.cash".to_string(), "invalid".to_string()).is_err()
+        );
+    }
+
+    #[test]
+    fn client_uses_exactly_the_supplied_typed_signer() {
+        let signer = Arc::new(
+            NostrSigner::from_secret_key_hex(HEX_SECRET_KEY.to_string())
+                .expect("typed signer parses"),
+        );
+        let client = NpubCashClient::with_signer("https://npub.cash".to_string(), signer.clone());
+
+        assert_eq!(client.identity_pubkey(), signer.public_key_hex());
+        assert_eq!(client.identity_pubkey(), HEX_PUBLIC_KEY);
+    }
+
+    #[test]
+    fn client_accepts_mnemonic_derived_and_generated_identities() {
+        let mnemonic = Arc::new(
+            NostrSigner::from_mnemonic(
+                "leader monkey parrot ring guide accident before fence cannon height naive bean"
+                    .to_string(),
+                None,
+            )
+            .expect("mnemonic signer derives"),
+        );
+        let mnemonic_client =
+            NpubCashClient::with_signer("https://npub.cash".to_string(), mnemonic.clone());
+        assert_eq!(mnemonic_client.identity_pubkey(), mnemonic.public_key_hex());
+
+        let generated = Arc::new(NostrSigner::generate());
+        let generated_client =
+            NpubCashClient::with_signer("https://npub.cash".to_string(), generated.clone());
+        assert_eq!(
+            generated_client.identity_pubkey(),
+            generated.public_key_hex()
         );
     }
 

--- a/crates/cdk-ffi/src/wallet_repository.rs
+++ b/crates/cdk-ffi/src/wallet_repository.rs
@@ -33,6 +33,12 @@ pub struct WalletRepository {
     inner: Arc<CdkWalletRepository>,
 }
 
+impl WalletRepository {
+    pub(crate) fn inner(&self) -> &CdkWalletRepository {
+        &self.inner
+    }
+}
+
 #[uniffi::export(async_runtime = "tokio")]
 impl WalletRepository {
     /// Create a new WalletRepository from locally persisted wallet state.

--- a/crates/cdk-integration-tests/tests/nip17_inbox_e2e.rs
+++ b/crates/cdk-integration-tests/tests/nip17_inbox_e2e.rs
@@ -10,6 +10,8 @@
 //! - `nostr-rs-relay` must be on `PATH` (provided by the Nix `regtest`
 //!   devShell); the test skips gracefully otherwise.
 
+use std::io;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
@@ -22,9 +24,22 @@ use tokio::sync::mpsc;
 struct NostrRelay {
     child: Option<Child>,
     port: u16,
+    config_path: PathBuf,
+    db_dir: PathBuf,
 }
 
 impl NostrRelay {
+    fn spawn_child(config_path: &Path, db_dir: &Path) -> io::Result<Child> {
+        Command::new("nostr-rs-relay")
+            .arg("--config")
+            .arg(config_path)
+            .arg("--db")
+            .arg(db_dir)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+    }
+
     /// Start a local `nostr-rs-relay` on a free TCP port.
     ///
     /// Returns `None` if `nostr-rs-relay` is not on `PATH` (e.g. running
@@ -46,20 +61,27 @@ address = "127.0.0.1"
         );
         std::fs::write(&config_path, config).ok()?;
 
-        let child = Command::new("nostr-rs-relay")
-            .arg("--config")
-            .arg(&config_path)
-            .arg("--db")
-            .arg(&db_dir)
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .spawn()
-            .ok()?;
+        let child = Self::spawn_child(&config_path, &db_dir).ok()?;
 
         Some(Self {
             child: Some(child),
             port,
+            config_path,
+            db_dir,
         })
+    }
+
+    fn stop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+
+    fn restart(&mut self) -> io::Result<()> {
+        self.stop();
+        self.child = Some(Self::spawn_child(&self.config_path, &self.db_dir)?);
+        Ok(())
     }
 
     fn ws_url(&self) -> String {
@@ -69,10 +91,7 @@ address = "127.0.0.1"
 
 impl Drop for NostrRelay {
     fn drop(&mut self) {
-        if let Some(mut child) = self.child.take() {
-            let _ = child.kill();
-            let _ = child.wait();
-        }
+        self.stop();
     }
 }
 
@@ -173,7 +192,7 @@ async fn recv_until(
 
 #[tokio::test]
 async fn nip17_inbox_receives_unwrapped_rumor_and_survives_restart() {
-    let Some(relay) = NostrRelay::start() else {
+    let Some(mut relay) = NostrRelay::start() else {
         eprintln!("nostr-rs-relay not on PATH; skipping nip17_inbox_e2e");
         return;
     };
@@ -211,13 +230,33 @@ async fn nip17_inbox_receives_unwrapped_rumor_and_survives_restart() {
     assert_eq!(event.rumor.kind, Kind::from_u16(14));
     assert_eq!(event.rumor.pubkey, sender.public_key());
     assert_eq!(event.rumor.content, content_one);
-    // NIP-59: rumors carry an id (ensured by make_seal) but are unsigned
-    assert!(event.rumor.id.is_some());
+    // NIP-59 rumors are unsigned but their ID is present and was verified by
+    // the inbox before delivery.
+    assert_eq!(event.rumor.id, Some(event.rumor_id));
+
+    // Relay reconnect: interrupt the transport without restarting the inbox.
+    // nostr-sdk must reconnect with its bounded adaptive backoff and replay the
+    // same fixed subscription floor.
+    relay.restart().expect("restart relay process");
+    assert!(
+        wait_for_relay(relay.port, Duration::from_secs(15)).await,
+        "restarted relay did not start listening"
+    );
+
+    let reconnect_content = r#"{"id":"request-after-reconnect"}"#;
+    let reconnect_wrap = publish_gift_wrap(&relay_url, &sender, &receiver, reconnect_content).await;
+    assert!(
+        wait_for_gift_wrap(&relay_url, reconnect_wrap, Duration::from_secs(10)).await,
+        "gift wrap after reconnect not stored by relay"
+    );
+    let event = recv_until(&mut rx, reconnect_wrap, Duration::from_secs(15)).await;
+    assert_eq!(event.rumor.content, reconnect_content);
 
     // Restart: stop, then start again; a wrap published meanwhile must still
     // be delivered (the relay stores it and the fresh subscription replays
     // the window).
-    inbox.stop();
+    inbox.stop().await;
+    while rx.try_recv().is_ok() {}
 
     let content_two =
         r#"{"id":"request-two","mint":"http://localhost:3338","unit":"sat","proofs":[]}"#;
@@ -225,6 +264,11 @@ async fn nip17_inbox_receives_unwrapped_rumor_and_survives_restart() {
     assert!(
         wait_for_gift_wrap(&relay_url, wrap_two, Duration::from_secs(10)).await,
         "gift wrap two not stored by relay"
+    );
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    assert!(
+        rx.try_recv().is_err(),
+        "the stopped inbox invoked a callback after stop completed"
     );
 
     inbox
@@ -236,5 +280,5 @@ async fn nip17_inbox_receives_unwrapped_rumor_and_survives_restart() {
     assert_eq!(event.wrap_id, wrap_two);
     assert_eq!(event.rumor.content, content_two);
 
-    inbox.stop();
+    inbox.stop().await;
 }

--- a/crates/cdk-nostr/Cargo.toml
+++ b/crates/cdk-nostr/Cargo.toml
@@ -27,7 +27,8 @@ npubcash = [
 ]
 
 [dependencies]
-nostr-sdk = { workspace = true }
+bitcoin = { version = "0.32.2", default-features = false, features = ["std"] }
+nostr-sdk = { workspace = true, features = ["nip06"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
@@ -43,6 +44,7 @@ url = { workspace = true, optional = true }
 web-time = { workspace = true, optional = true }
 
 [dev-dependencies]
+bip39 = { version = "2.0", default-features = false, features = ["std"] }
 chrono = "0.4"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "test-util"] }
 tracing-subscriber = { workspace = true }

--- a/crates/cdk-nostr/README.md
+++ b/crates/cdk-nostr/README.md
@@ -4,11 +4,14 @@ Nostr support for the Cashu Development Kit in a single crate.
 
 ## Modules
 
-- **`keys`** — secret key generation/parsing and x-only public key derivation.
+- **`keys`** — secret key generation/parsing, x-only public key derivation,
+  and default NIP-06 identity derivation (`m/44'/1237'/0'/0/0`) from a BIP-39
+  mnemonic or seed.
 - **`nip44`** — NIP-44 v2 authenticated encryption between Nostr keys.
 - **`inbox`** — standing NIP-17 inbox listener: subscribes relays for gift
-  wraps addressed to an identity, unwraps them, and delivers the rumors to a
-  `NostrInboxListener` callback.
+  wraps addressed to an identity, strictly validates every NIP-59 layer, and
+  delivers verified rumors to a `NostrInboxListener` callback. Start, stop,
+  and restart are idempotent; async stop waits until callbacks are quiescent.
 - **`nwc`** (feature `nwc`) — NIP-47 Nostr Wallet Connect wallet service.
 - **`npubcash`** (feature `npubcash`) — npub.cash API client (quotes, settings,
   NIP-98/JWT auth).
@@ -32,25 +35,33 @@ impl NostrInboxListener for Printer {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let secret_key = keys::generate_secret_key();
-    let pubkey = keys::public_key(&secret_key);
+    let identity = keys::derive_nip06_keys_from_mnemonic(
+        "leader monkey parrot ring guide accident before fence cannon height naive bean",
+        None,
+    )?;
+    let pubkey = identity.public_key();
     println!("npub: {pubkey}");
 
     let one_week_ago = Timestamp::from_secs(
         Timestamp::now().as_secs().saturating_sub(7 * 24 * 60 * 60),
     );
-    let inbox = NostrInbox::new(
-        secret_key,
+    let inbox = NostrInbox::from_keys(
+        identity,
         vec![RelayUrl::parse("wss://relay.damus.io")?],
         Some(one_week_ago),
     )?;
     inbox.start(Arc::new(Printer)).await?;
 
     // ... run until done, then:
-    inbox.stop();
+    inbox.stop().await;
     Ok(())
 }
 ```
+
+The `since` value is a fixed floor for the inbox lifetime. Keep a generous
+lookback because NIP-59 intentionally randomizes and backdates gift-wrap
+timestamps. Relay reconnection uses bounded adaptive backoff and reuses the
+same subscription filter.
 
 ## License
 

--- a/crates/cdk-nostr/src/error.rs
+++ b/crates/cdk-nostr/src/error.rs
@@ -8,6 +8,14 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Errors for key handling, NIP-44 encryption and the NIP-17 inbox listener
 #[derive(Debug, Error)]
 pub enum Error {
+    /// The BIP-39 mnemonic is not valid
+    #[error("invalid mnemonic: {0}")]
+    InvalidMnemonic(String),
+
+    /// NIP-06 BIP-32 key derivation failed
+    #[error("nip06 key derivation failed: {0}")]
+    KeyDerivation(String),
+
     /// The secret key is not valid (bad hex/bech32 or out of range)
     #[error("invalid secret key: {0}")]
     InvalidSecretKey(String),
@@ -31,4 +39,24 @@ pub enum Error {
     /// Failed to subscribe to the relay pool
     #[error("subscription error: {0}")]
     Subscription(String),
+
+    /// The outer NIP-59 gift wrap is malformed or fails verification
+    #[error("invalid gift wrap: {0}")]
+    InvalidGiftWrap(String),
+
+    /// The NIP-59 seal is malformed or fails verification
+    #[error("invalid seal: {0}")]
+    InvalidSeal(String),
+
+    /// The NIP-17 rumor is malformed or fails verification
+    #[error("invalid rumor: {0}")]
+    InvalidRumor(String),
+
+    /// The gift wrap is not tagged for the inbox identity
+    #[error("gift wrap is not addressed to the inbox identity")]
+    WrongRecipient,
+
+    /// The rumor author does not match the verified seal author
+    #[error("rumor author does not match seal author")]
+    SenderMismatch,
 }

--- a/crates/cdk-nostr/src/inbox.rs
+++ b/crates/cdk-nostr/src/inbox.rs
@@ -10,13 +10,15 @@
 //! rumor's kind and content are for the consumer to handle (e.g. a NUT-18
 //! payment request payload for kind `14` rumors).
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::time::Duration;
 
 use nostr_sdk::{
-    Client, EventId, Filter, Keys, Kind, PublicKey, RelayPoolNotification, RelayUrl, SecretKey,
-    Timestamp, UnsignedEvent,
+    Client, Event, EventId, Filter, JsonUtil, Keys, Kind, PublicKey, RelayOptions,
+    RelayPoolNotification, RelayUrl, SecretKey, Timestamp, UnsignedEvent,
 };
-use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::{broadcast::error::RecvError, Mutex};
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::error::{Error, Result};
@@ -32,8 +34,90 @@ pub struct Nip17Event {
     pub wrap_created_at: Timestamp,
     /// Author of the verified seal — the real sender of the rumor
     pub sender: PublicKey,
+    /// Verified ID of the rumor
+    pub rumor_id: EventId,
     /// The unwrapped, unsigned rumor (commonly kind `14` for chat/DM payloads)
     pub rumor: UnsignedEvent,
+}
+
+/// Strictly validate and unwrap a NIP-17/NIP-59 gift wrap.
+///
+/// This performs the checks needed at the mobile trust boundary in this order:
+/// the outer kind, ID, signature and recipient tag; the seal kind, ID and
+/// signature; then the rumor kind, ID and author binding to the seal.
+///
+/// # Errors
+///
+/// Returns an error when any envelope layer is malformed, fails cryptographic
+/// verification, has the wrong kind, targets another identity, or has an
+/// inconsistent author.
+pub fn unwrap_gift_wrap(keys: &Keys, gift_wrap: &Event) -> Result<Nip17Event> {
+    if gift_wrap.kind != Kind::GiftWrap {
+        return Err(Error::InvalidGiftWrap(format!(
+            "expected kind {}, got {}",
+            Kind::GiftWrap.as_u16(),
+            gift_wrap.kind.as_u16()
+        )));
+    }
+
+    gift_wrap
+        .verify()
+        .map_err(|e| Error::InvalidGiftWrap(e.to_string()))?;
+
+    let recipient = keys.public_key().to_hex();
+    let addressed_to_identity = gift_wrap.tags.iter().any(|tag| {
+        let values = tag.as_slice();
+        values.first().is_some_and(|value| value == "p")
+            && values.get(1).is_some_and(|value| value == &recipient)
+    });
+    if !addressed_to_identity {
+        return Err(Error::WrongRecipient);
+    }
+
+    let seal_json = crate::nip44::decrypt(keys.secret_key(), &gift_wrap.pubkey, &gift_wrap.content)
+        .map_err(|e| Error::InvalidSeal(e.to_string()))?;
+    let seal = Event::from_json(seal_json).map_err(|e| Error::InvalidSeal(e.to_string()))?;
+
+    if seal.kind != Kind::Seal {
+        return Err(Error::InvalidSeal(format!(
+            "expected kind {}, got {}",
+            Kind::Seal.as_u16(),
+            seal.kind.as_u16()
+        )));
+    }
+    seal.verify()
+        .map_err(|e| Error::InvalidSeal(e.to_string()))?;
+
+    let rumor_json = crate::nip44::decrypt(keys.secret_key(), &seal.pubkey, &seal.content)
+        .map_err(|e| Error::InvalidRumor(e.to_string()))?;
+    let rumor =
+        UnsignedEvent::from_json(rumor_json).map_err(|e| Error::InvalidRumor(e.to_string()))?;
+
+    if rumor.kind != Kind::PrivateDirectMessage {
+        return Err(Error::InvalidRumor(format!(
+            "expected kind {}, got {}",
+            Kind::PrivateDirectMessage.as_u16(),
+            rumor.kind.as_u16()
+        )));
+    }
+    let rumor_id = rumor
+        .id
+        .ok_or_else(|| Error::InvalidRumor("missing event ID".to_string()))?;
+    rumor
+        .verify_id()
+        .map_err(|e| Error::InvalidRumor(e.to_string()))?;
+
+    if rumor.pubkey != seal.pubkey {
+        return Err(Error::SenderMismatch);
+    }
+
+    Ok(Nip17Event {
+        wrap_id: gift_wrap.id,
+        wrap_created_at: gift_wrap.created_at,
+        sender: seal.pubkey,
+        rumor_id,
+        rumor,
+    })
 }
 
 /// Callback receiving unwrapped inbox events
@@ -45,7 +129,13 @@ pub trait NostrInboxListener: Send + Sync {
     fn on_event(&self, event: Nip17Event);
 }
 
-/// A standing NIP-17 inbox listener for a single Nostr identity
+#[derive(Debug)]
+struct InboxRun {
+    cancel: CancellationToken,
+    handle: JoinHandle<()>,
+}
+
+/// A standing NIP-17 inbox listener for a single Nostr identity.
 ///
 /// Create with [`NostrInbox::new`], then call [`NostrInbox::start`] to spawn
 /// the relay pump and [`NostrInbox::stop`] to shut it down.
@@ -54,11 +144,7 @@ pub struct NostrInbox {
     keys: Keys,
     relays: Vec<RelayUrl>,
     since: Option<Timestamp>,
-    /// Token of the current run. `CancellationToken::cancel()` is permanent,
-    /// so `start()` replaces it with a fresh one — otherwise a pump started
-    /// after `stop()` would observe the stale cancellation and exit
-    /// immediately.
-    cancel: Mutex<CancellationToken>,
+    run: Mutex<Option<InboxRun>>,
 }
 
 impl NostrInbox {
@@ -81,14 +167,26 @@ impl NostrInbox {
         relays: Vec<RelayUrl>,
         since: Option<Timestamp>,
     ) -> Result<Self> {
+        Self::from_keys(Keys::new(secret_key), relays, since)
+    }
+
+    /// Create an inbox from an existing Nostr identity.
+    ///
+    /// This is the preferred constructor when the caller already owns a typed
+    /// identity and wants the inbox and other Nostr clients to share it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NoRelays`] if `relays` is empty.
+    pub fn from_keys(keys: Keys, relays: Vec<RelayUrl>, since: Option<Timestamp>) -> Result<Self> {
         if relays.is_empty() {
             return Err(Error::NoRelays);
         }
         Ok(Self {
-            keys: Keys::new(secret_key),
+            keys,
             relays,
             since,
-            cancel: Mutex::new(CancellationToken::new()),
+            run: Mutex::new(None),
         })
     }
 
@@ -101,38 +199,64 @@ impl NostrInbox {
     /// background pump that delivers events to `listener`
     ///
     /// Returns once the subscription is active. Events are delivered until
-    /// [`NostrInbox::stop`] is called. `start()` replaces any previous run:
-    /// calling it on an already-running inbox stops the old pump before
-    /// starting the new one, and restarting after [`NostrInbox::stop`] works
-    /// as expected.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the internal cancel-token mutex is poisoned.
+    /// [`NostrInbox::stop`] is called. Calling `start()` while the inbox is
+    /// already running is an idempotent no-op. Use [`NostrInbox::restart`] to
+    /// replace the active listener and connection explicitly.
     ///
     /// # Errors
     ///
     /// Returns an error if a relay cannot be added or the subscription cannot
     /// be created.
     pub async fn start(&self, listener: Arc<dyn NostrInboxListener>) -> Result<()> {
-        // Arm a fresh token for this run, stopping any previous run first. A
-        // cancelled token can never be "un-cancelled", so reusing it would
-        // make the new pump exit immediately.
-        let cancel = {
-            let mut current = self
-                .cancel
-                .lock()
-                .expect("inbox cancel token mutex poisoned");
-            current.cancel();
-            *current = CancellationToken::new();
-            current.clone()
-        };
+        let mut current = self.run.lock().await;
+        match current.as_ref() {
+            Some(run) if !run.handle.is_finished() => return Ok(()),
+            Some(_) => {
+                if let Some(run) = current.take() {
+                    let _ = run.handle.await;
+                }
+            }
+            None => {}
+        }
+
+        *current = Some(self.spawn_run(listener).await?);
+        Ok(())
+    }
+
+    /// Stop any active run and start a fresh subscription with `listener`.
+    ///
+    /// The configured `since` floor is reused unchanged, including across
+    /// reconnects and explicit restarts.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a relay cannot be added or the subscription cannot
+    /// be created.
+    pub async fn restart(&self, listener: Arc<dyn NostrInboxListener>) -> Result<()> {
+        let mut current = self.run.lock().await;
+        if let Some(run) = current.take() {
+            Self::shutdown_run(run).await;
+        }
+        *current = Some(self.spawn_run(listener).await?);
+        Ok(())
+    }
+
+    async fn spawn_run(&self, listener: Arc<dyn NostrInboxListener>) -> Result<InboxRun> {
+        let cancel = CancellationToken::new();
 
         let client = Client::new(self.keys.clone());
 
         for relay in &self.relays {
+            // nostr-sdk automatically replays subscriptions after reconnect.
+            // Its adaptive retry interval is bounded at 60 seconds; start at
+            // two seconds so a mobile connection recovers promptly.
+            let options = RelayOptions::new()
+                .reconnect(true)
+                .retry_interval(Duration::from_secs(2))
+                .adjust_retry_interval(true);
             client
-                .add_relay(relay.clone())
+                .pool()
+                .add_relay(relay.clone(), options)
                 .await
                 .map_err(|e| Error::Relay(format!("add relay {relay}: {e}")))?;
         }
@@ -150,31 +274,33 @@ impl NostrInbox {
         // between subscription creation and the receive loop.
         let mut notifications = client.notifications();
 
-        client
-            .subscribe(filter, None)
-            .await
-            .map_err(|e| Error::Subscription(e.to_string()))?;
+        if let Err(e) = client.subscribe(filter, None).await {
+            client.shutdown().await;
+            return Err(Error::Subscription(e.to_string()));
+        }
 
-        tokio::spawn(async move {
+        let run_cancel = cancel.clone();
+        let keys = self.keys.clone();
+        let handle = tokio::spawn(async move {
             loop {
                 let notification = tokio::select! {
-                    _ = cancel.cancelled() => break,
+                    biased;
+                    _ = run_cancel.cancelled() => break,
                     notification = notifications.recv() => notification,
                 };
 
                 match notification {
                     Ok(RelayPoolNotification::Event { event, .. }) => {
-                        // Defense in depth: never trust a relay to honor the filter.
-                        if event.kind != Kind::GiftWrap {
-                            continue;
-                        }
-                        match client.unwrap_gift_wrap(&event).await {
-                            Ok(unwrapped) => listener.on_event(Nip17Event {
-                                wrap_id: event.id,
-                                wrap_created_at: event.created_at,
-                                sender: unwrapped.sender,
-                                rumor: unwrapped.rumor,
-                            }),
+                        match unwrap_gift_wrap(&keys, &event) {
+                            Ok(unwrapped) => {
+                                // Cancellation can race with validation. Check
+                                // once more immediately before crossing the
+                                // callback boundary.
+                                if run_cancel.is_cancelled() {
+                                    break;
+                                }
+                                listener.on_event(unwrapped);
+                            }
                             Err(e) => {
                                 // Not encrypted for us or malformed — log and keep going
                                 tracing::debug!("inbox: unwrap gift wrap {} failed: {e}", event.id);
@@ -188,22 +314,34 @@ impl NostrInbox {
                     Err(RecvError::Closed) => break,
                 }
             }
-            client.disconnect().await;
+            client.shutdown().await;
         });
 
-        Ok(())
+        Ok(InboxRun { cancel, handle })
     }
 
-    /// Stop listening: cancels the pump and disconnects from the relays
-    ///
-    /// # Panics
-    ///
-    /// Panics if the internal cancel-token mutex is poisoned.
-    pub fn stop(&self) {
-        self.cancel
+    async fn shutdown_run(run: InboxRun) {
+        run.cancel.cancel();
+        let _ = run.handle.await;
+    }
+
+    /// Stop listening and wait for the pump and any in-progress callback to
+    /// finish. When this method returns, the stopped run cannot invoke another
+    /// callback. Calling it while stopped is an idempotent no-op.
+    pub async fn stop(&self) {
+        let mut current = self.run.lock().await;
+        if let Some(run) = current.take() {
+            Self::shutdown_run(run).await;
+        }
+    }
+
+    /// Return whether an inbox pump is currently active.
+    pub async fn is_running(&self) -> bool {
+        self.run
             .lock()
-            .expect("inbox cancel token mutex poisoned")
-            .cancel();
+            .await
+            .as_ref()
+            .is_some_and(|run| !run.handle.is_finished())
     }
 }
 
@@ -213,14 +351,22 @@ impl Drop for NostrInbox {
     /// client and listener, so without this the task (and its relay
     /// connections) would leak for the lifetime of the process.
     fn drop(&mut self) {
-        if let Ok(token) = self.cancel.lock() {
-            token.cancel();
+        if let Ok(mut current) = self.run.try_lock() {
+            if let Some(run) = current.take() {
+                run.cancel.cancel();
+                run.handle.abort();
+            }
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use nostr_sdk::nips::nip44::Version;
+    use nostr_sdk::{EventBuilder, Tag};
+
     use super::*;
     use crate::keys;
 
@@ -228,6 +374,62 @@ mod tests {
 
     impl NostrInboxListener for NoopListener {
         fn on_event(&self, _event: Nip17Event) {}
+    }
+
+    fn rumor(author: PublicKey, receiver: PublicKey, kind: Kind, content: &str) -> UnsignedEvent {
+        let mut rumor = UnsignedEvent::new(
+            author,
+            Timestamp::from_secs(1_700_000_000),
+            kind,
+            [Tag::public_key(receiver)],
+            content,
+        );
+        rumor.ensure_id();
+        rumor
+    }
+
+    fn make_seal(sender: &Keys, receiver: PublicKey, rumor: &UnsignedEvent, kind: Kind) -> Event {
+        let content = nostr_sdk::nips::nip44::encrypt(
+            sender.secret_key(),
+            &receiver,
+            rumor.as_json(),
+            Version::V2,
+        )
+        .expect("rumor encrypts");
+        EventBuilder::new(kind, content)
+            .custom_created_at(Timestamp::from_secs(1_700_000_001))
+            .sign_with_keys(sender)
+            .expect("seal signs")
+    }
+
+    fn wrap_seal(receiver: PublicKey, recipient_tag: PublicKey, seal: &Event) -> Event {
+        let ephemeral = Keys::generate();
+        let content = nostr_sdk::nips::nip44::encrypt(
+            ephemeral.secret_key(),
+            &receiver,
+            seal.as_json(),
+            Version::V2,
+        )
+        .expect("seal encrypts");
+        EventBuilder::new(Kind::GiftWrap, content)
+            .tag(Tag::public_key(recipient_tag))
+            .custom_created_at(Timestamp::from_secs(1_700_000_002))
+            .sign_with_keys(&ephemeral)
+            .expect("gift wrap signs")
+    }
+
+    fn valid_envelope() -> (Keys, Keys, UnsignedEvent, Event, Event) {
+        let sender = Keys::generate();
+        let receiver = Keys::generate();
+        let rumor = rumor(
+            sender.public_key(),
+            receiver.public_key(),
+            Kind::PrivateDirectMessage,
+            "cashuAexample",
+        );
+        let seal = make_seal(&sender, receiver.public_key(), &rumor, Kind::Seal);
+        let wrap = wrap_seal(receiver.public_key(), receiver.public_key(), &seal);
+        (sender, receiver, rumor, seal, wrap)
     }
 
     #[test]
@@ -251,14 +453,148 @@ mod tests {
         );
     }
 
-    /// Regression test: a `CancellationToken` stays cancelled forever, so a
-    /// pump started after `stop()` used to exit immediately while `start()`
-    /// still reported success. `start()` must arm a fresh token per run.
+    #[test]
+    fn strict_unwrap_returns_verified_rumor_and_outer_id() {
+        let (sender, receiver, rumor, _seal, wrap) = valid_envelope();
+
+        let unwrapped = unwrap_gift_wrap(&receiver, &wrap).expect("gift wrap unwraps");
+
+        assert_eq!(unwrapped.wrap_id, wrap.id);
+        assert_eq!(unwrapped.sender, sender.public_key());
+        assert_eq!(unwrapped.rumor_id, rumor.id.expect("rumor ID"));
+        assert_eq!(unwrapped.rumor.content, "cashuAexample");
+    }
+
+    #[test]
+    fn strict_unwrap_rejects_invalid_outer_id_and_signature() {
+        let (_sender, receiver, _rumor, _seal, wrap) = valid_envelope();
+
+        let mut invalid_id = wrap.clone();
+        invalid_id.content.push('x');
+        assert!(matches!(
+            unwrap_gift_wrap(&receiver, &invalid_id),
+            Err(Error::InvalidGiftWrap(_))
+        ));
+
+        let mut invalid_signature = wrap;
+        invalid_signature.sig = EventBuilder::text_note("other")
+            .sign_with_keys(&Keys::generate())
+            .expect("other event signs")
+            .sig;
+        assert!(matches!(
+            unwrap_gift_wrap(&receiver, &invalid_signature),
+            Err(Error::InvalidGiftWrap(_))
+        ));
+    }
+
+    #[test]
+    fn strict_unwrap_rejects_invalid_seal_id_and_signature() {
+        let (_sender, receiver, _rumor, seal, _wrap) = valid_envelope();
+
+        let mut invalid_id = seal.clone();
+        invalid_id.content.push('x');
+        let wrap = wrap_seal(receiver.public_key(), receiver.public_key(), &invalid_id);
+        assert!(matches!(
+            unwrap_gift_wrap(&receiver, &wrap),
+            Err(Error::InvalidSeal(_))
+        ));
+
+        let mut invalid_signature = seal;
+        invalid_signature.sig = EventBuilder::text_note("other")
+            .sign_with_keys(&Keys::generate())
+            .expect("other event signs")
+            .sig;
+        let wrap = wrap_seal(
+            receiver.public_key(),
+            receiver.public_key(),
+            &invalid_signature,
+        );
+        assert!(matches!(
+            unwrap_gift_wrap(&receiver, &wrap),
+            Err(Error::InvalidSeal(_))
+        ));
+    }
+
+    #[test]
+    fn strict_unwrap_rejects_incorrect_kinds() {
+        let (sender, receiver, valid_rumor, _seal, wrap) = valid_envelope();
+
+        let mut wrong_outer_kind = wrap;
+        wrong_outer_kind.kind = Kind::TextNote;
+        assert!(matches!(
+            unwrap_gift_wrap(&receiver, &wrong_outer_kind),
+            Err(Error::InvalidGiftWrap(_))
+        ));
+
+        let wrong_seal = make_seal(&sender, receiver.public_key(), &valid_rumor, Kind::TextNote);
+        let wrap = wrap_seal(receiver.public_key(), receiver.public_key(), &wrong_seal);
+        assert!(matches!(
+            unwrap_gift_wrap(&receiver, &wrap),
+            Err(Error::InvalidSeal(_))
+        ));
+
+        let wrong_rumor = rumor(
+            sender.public_key(),
+            receiver.public_key(),
+            Kind::TextNote,
+            "not a NIP-17 rumor",
+        );
+        let seal = make_seal(&sender, receiver.public_key(), &wrong_rumor, Kind::Seal);
+        let wrap = wrap_seal(receiver.public_key(), receiver.public_key(), &seal);
+        assert!(matches!(
+            unwrap_gift_wrap(&receiver, &wrap),
+            Err(Error::InvalidRumor(_))
+        ));
+    }
+
+    #[test]
+    fn strict_unwrap_rejects_bad_rumor_id_and_author_mismatch() {
+        let (sender, receiver, mut invalid_id, _seal, _wrap) = valid_envelope();
+        invalid_id.content.push('x');
+        let seal = make_seal(&sender, receiver.public_key(), &invalid_id, Kind::Seal);
+        let wrap = wrap_seal(receiver.public_key(), receiver.public_key(), &seal);
+        assert!(matches!(
+            unwrap_gift_wrap(&receiver, &wrap),
+            Err(Error::InvalidRumor(_))
+        ));
+
+        let impersonated = Keys::generate();
+        let mismatched = rumor(
+            impersonated.public_key(),
+            receiver.public_key(),
+            Kind::PrivateDirectMessage,
+            "spoofed",
+        );
+        let seal = make_seal(&sender, receiver.public_key(), &mismatched, Kind::Seal);
+        let wrap = wrap_seal(receiver.public_key(), receiver.public_key(), &seal);
+        assert!(matches!(
+            unwrap_gift_wrap(&receiver, &wrap),
+            Err(Error::SenderMismatch)
+        ));
+    }
+
+    #[test]
+    fn strict_unwrap_requires_recipient_tag_and_rumor_id() {
+        let (sender, receiver, mut rumor, seal, _wrap) = valid_envelope();
+        let other = Keys::generate();
+        let wrong_recipient_tag = wrap_seal(receiver.public_key(), other.public_key(), &seal);
+        assert!(matches!(
+            unwrap_gift_wrap(&receiver, &wrong_recipient_tag),
+            Err(Error::WrongRecipient)
+        ));
+
+        rumor.id = None;
+        let seal = make_seal(&sender, receiver.public_key(), &rumor, Kind::Seal);
+        let wrap = wrap_seal(receiver.public_key(), receiver.public_key(), &seal);
+        assert!(matches!(
+            unwrap_gift_wrap(&receiver, &wrap),
+            Err(Error::InvalidRumor(_))
+        ));
+    }
+
     #[tokio::test]
-    async fn restart_after_stop_arms_a_fresh_token() {
+    async fn start_stop_and_restart_are_idempotent() {
         let secret = keys::generate_secret_key();
-        // Unreachable relay: connect/subscribe are best-effort in the pool,
-        // so `start()` still succeeds without network access.
         let relay = RelayUrl::parse("ws://127.0.0.1:1").expect("valid relay url");
         let inbox = NostrInbox::new(secret, vec![relay], None).expect("inbox");
 
@@ -266,29 +602,80 @@ mod tests {
             .start(Arc::new(NoopListener))
             .await
             .expect("first start");
-        inbox.stop();
-        assert!(inbox.cancel.lock().expect("mutex").is_cancelled());
+        assert!(inbox.is_running().await);
+        let first_cancel = inbox
+            .run
+            .lock()
+            .await
+            .as_ref()
+            .expect("active run")
+            .cancel
+            .clone();
 
-        inbox.start(Arc::new(NoopListener)).await.expect("restart");
-        assert!(!inbox.cancel.lock().expect("mutex").is_cancelled());
+        inbox
+            .start(Arc::new(NoopListener))
+            .await
+            .expect("second start is a no-op");
+        assert!(!first_cancel.is_cancelled());
 
-        inbox.stop();
+        inbox
+            .restart(Arc::new(NoopListener))
+            .await
+            .expect("restart");
+        assert!(first_cancel.is_cancelled());
+        assert!(inbox.is_running().await);
+
+        inbox.stop().await;
+        assert!(!inbox.is_running().await);
+        inbox.stop().await;
+
+        inbox
+            .start(Arc::new(NoopListener))
+            .await
+            .expect("start after stop");
+        assert!(inbox.is_running().await);
+        inbox.stop().await;
     }
 
-    /// Dropping a running inbox must cancel the pump's token: dropping a
-    /// `CancellationToken` alone does not cancel it, and the pump holds its
-    /// own clone.
     #[tokio::test]
     async fn drop_cancels_running_pump() {
         let secret = keys::generate_secret_key();
         let relay = RelayUrl::parse("ws://127.0.0.1:1").expect("valid relay url");
         let inbox = NostrInbox::new(secret, vec![relay], None).expect("inbox");
 
-        // Grab the run's token before dropping the inbox.
-        let token = inbox.cancel.lock().expect("mutex").clone();
         inbox.start(Arc::new(NoopListener)).await.expect("start");
+        let token = inbox
+            .run
+            .lock()
+            .await
+            .as_ref()
+            .expect("active run")
+            .cancel
+            .clone();
         drop(inbox);
 
         assert!(token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn stop_waits_for_run_and_prevents_later_work() {
+        let secret = keys::generate_secret_key();
+        let relay = RelayUrl::parse("ws://127.0.0.1:1").expect("valid relay url");
+        let inbox = NostrInbox::new(secret, vec![relay], None).expect("inbox");
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+        let completions = Arc::new(AtomicUsize::new(0));
+        let task_completions = completions.clone();
+        let handle = tokio::spawn(async move {
+            task_cancel.cancelled().await;
+            tokio::task::yield_now().await;
+            task_completions.fetch_add(1, Ordering::SeqCst);
+        });
+        *inbox.run.lock().await = Some(InboxRun { cancel, handle });
+
+        inbox.stop().await;
+        assert_eq!(completions.load(Ordering::SeqCst), 1);
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert_eq!(completions.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/cdk-nostr/src/keys.rs
+++ b/crates/cdk-nostr/src/keys.rs
@@ -1,8 +1,54 @@
 //! Nostr key helpers: generation, parsing and public key derivation
 
+use bitcoin::bip32::{DerivationPath, Xpriv};
+use bitcoin::Network;
+use nostr_sdk::nips::nip06::{Error as Nip06Error, FromMnemonic};
 use nostr_sdk::{Keys, PublicKey, SecretKey};
 
 use crate::error::{Error, Result};
+
+/// Default NIP-06 identity derivation path.
+pub const DEFAULT_NIP06_DERIVATION_PATH: &str = "m/44'/1237'/0'/0/0";
+
+/// Derive the default NIP-06 Nostr secret key from a 64-byte BIP-39 seed.
+///
+/// This uses [`DEFAULT_NIP06_DERIVATION_PATH`]. The seed remains in Rust and
+/// only the derived Nostr key is returned.
+///
+/// # Errors
+///
+/// Returns [`Error::KeyDerivation`] if the BIP-32 root or child key cannot be
+/// derived.
+pub fn derive_nip06_secret_key_from_seed(seed: &[u8; 64]) -> Result<SecretKey> {
+    let path = DEFAULT_NIP06_DERIVATION_PATH
+        .parse::<DerivationPath>()
+        .map_err(|e| Error::KeyDerivation(e.to_string()))?;
+
+    let root = Xpriv::new_master(Network::Bitcoin, seed)
+        .map_err(|e| Error::KeyDerivation(e.to_string()))?;
+    let child = root
+        .derive_priv(nostr_sdk::SECP256K1, &path)
+        .map_err(|e| Error::KeyDerivation(e.to_string()))?;
+
+    SecretKey::from_slice(&child.private_key.secret_bytes())
+        .map_err(|e| Error::KeyDerivation(e.to_string()))
+}
+
+/// Derive the default NIP-06 Nostr keys from a BIP-39 mnemonic and optional
+/// passphrase.
+///
+/// The mnemonic is parsed and expanded to its BIP-39 seed entirely in Rust.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidMnemonic`] for an invalid mnemonic, or
+/// [`Error::KeyDerivation`] if NIP-06 derivation fails.
+pub fn derive_nip06_keys_from_mnemonic(mnemonic: &str, passphrase: Option<&str>) -> Result<Keys> {
+    Keys::from_mnemonic(mnemonic, passphrase).map_err(|e| match e {
+        Nip06Error::BIP39(e) => Error::InvalidMnemonic(e.to_string()),
+        Nip06Error::BIP32(e) => Error::KeyDerivation(e.to_string()),
+    })
+}
 
 /// Generate a fresh random Nostr secret key
 pub fn generate_secret_key() -> SecretKey {
@@ -35,6 +81,8 @@ pub fn public_key(secret_key: &SecretKey) -> PublicKey {
 
 #[cfg(test)]
 mod tests {
+    use bip39::Mnemonic;
+
     use super::*;
 
     #[test]
@@ -46,6 +94,37 @@ mod tests {
             public_key(&secret).to_hex(),
             "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
         );
+    }
+
+    #[test]
+    fn public_nip06_mnemonic_matches_vector() {
+        let keys = derive_nip06_keys_from_mnemonic(
+            "leader monkey parrot ring guide accident before fence cannon height naive bean",
+            None,
+        )
+        .expect("public NIP-06 mnemonic derives");
+
+        assert_eq!(
+            keys.secret_key().to_secret_hex(),
+            "7f7ff03d123792d6ac594bfa67bf6d0c0ab55b6b1fdb6249303fe861f1ccba9a"
+        );
+    }
+
+    #[test]
+    fn mnemonic_and_seed_derivation_match() {
+        let mnemonic = Mnemonic::parse_normalized(
+            "leader monkey parrot ring guide accident before fence cannon height naive bean",
+        )
+        .expect("valid mnemonic");
+        let seed = mnemonic.to_seed_normalized("cashu");
+        let from_mnemonic = derive_nip06_keys_from_mnemonic(
+            "leader monkey parrot ring guide accident before fence cannon height naive bean",
+            Some("cashu"),
+        )
+        .expect("mnemonic derives");
+        let from_seed = derive_nip06_secret_key_from_seed(&seed).expect("seed derives");
+
+        assert_eq!(from_mnemonic.secret_key(), &from_seed);
     }
 
     #[test]

--- a/crates/cdk-nostr/src/lib.rs
+++ b/crates/cdk-nostr/src/lib.rs
@@ -2,7 +2,8 @@
 //!
 //! Nostr support for the Cashu Development Kit in a single crate:
 //!
-//! - [`keys`]: secret key generation/parsing and public key derivation.
+//! - [`keys`]: secret key generation/parsing, public key derivation, and the
+//!   default NIP-06 wallet identity.
 //! - [`nip44`]: NIP-44 v2 encryption and decryption.
 //! - [`inbox`]: a standing NIP-17 inbox listener that subscribes a set of
 //!   relays for gift wraps addressed to a Nostr identity and delivers the
@@ -26,7 +27,7 @@ pub mod npubcash;
 pub mod nwc;
 
 pub use error::{Error, Result};
-pub use inbox::{Nip17Event, NostrInbox, NostrInboxListener};
+pub use inbox::{unwrap_gift_wrap, Nip17Event, NostrInbox, NostrInboxListener};
 // Re-export the underlying SDK so downstream crates depend on a single source
 // of truth without pulling `nostr_sdk` into their own dependency lists.
 pub use nostr_sdk;

--- a/crates/cdk/src/wallet/npubcash.rs
+++ b/crates/cdk/src/wallet/npubcash.rs
@@ -6,9 +6,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv};
-use bitcoin::Network;
-use cdk_common::{database, SECP256K1};
+use cdk_common::database;
 use cdk_nostr::npubcash::{JwtAuthProvider, NpubCashClient, Quote};
 use tracing::instrument;
 
@@ -82,19 +80,9 @@ fn merge_npubcash_quote(mut incoming: MintQuote, existing: MintQuote) -> MintQuo
 ///
 /// Returns an error if the key derivation fails
 pub fn derive_npubcash_secret_key_from_seed(seed: &[u8; 64]) -> Result<SecretKey, Error> {
-    let path = DerivationPath::from(vec![
-        ChildNumber::from_hardened_idx(44)?,
-        ChildNumber::from_hardened_idx(1237)?,
-        ChildNumber::from_hardened_idx(0)?,
-        ChildNumber::from_normal_idx(0)?,
-        ChildNumber::from_normal_idx(0)?,
-    ]);
-
-    let xpriv = Xpriv::new_master(Network::Bitcoin, seed)?;
-
-    Ok(SecretKey::from(
-        xpriv.derive_priv(&SECP256K1, &path)?.private_key,
-    ))
+    let nostr_secret = cdk_nostr::keys::derive_nip06_secret_key_from_seed(seed)
+        .map_err(|e| Error::Custom(e.to_string()))?;
+    Ok(SecretKey::from_slice(nostr_secret.as_secret_bytes())?)
 }
 
 impl Wallet {
@@ -763,7 +751,10 @@ mod tests {
     use std::str::FromStr;
     use std::sync::Arc;
 
+    use bitcoin::bip32::{DerivationPath, Xpriv};
+    use bitcoin::Network;
     use cdk_common::database::{self, WalletDatabase};
+    use cdk_common::SECP256K1;
 
     use super::*;
     use crate::mint_url::MintUrl;


### PR DESCRIPTION
### Description

Add a typed, Rust-owned Nostr identity as the recommended mobile API so Swift
and Kotlin can use CDK as the single source of truth for Nostr/Cashu-facing
identity and cryptography.

- Add UniFFI NostrSigner constructors for BIP-39 mnemonics, WalletRepository,
  secret-key hex, nsec, and secure random generation.
- Expose canonical generic event signing, NIP-44 v2, npub/nsec/x-only/P2PK
  formatting, and exact-signer npub.cash construction.
- Harden and export the restartable NIP-17/NIP-59 inbox with fixed-since relay
  subscriptions, bounded reconnect backoff, strict envelope validation, outer
  wrap IDs, idempotent lifecycle operations, and quiescent async shutdown.
- Centralize npub.cash NIP-06 derivation in cdk-nostr while keeping NWC,
  NUT-27, proof derivation, and other P2PK keyring domains separate.
- Add Rust, Swift, Kotlin, and relay integration coverage plus mobile-facing
  documentation and an example.

-----

### Notes to the reviewers

The default wallet identity uses NIP-06 path m/44'/1237'/0'/0/0. Mobile callers
never calculate or pass a BIP-39 seed; deriving through WalletRepository keeps
the already-parsed seed inside Rust.

The inbox validates the outer gift-wrap ID/signature and recipient, the kind 13
seal ID/signature, and the kind 14 rumor ID/author binding before invoking the
callback. Its since value is immutable for the inbox lifetime so reconnects and
restarts retain the caller's lookback floor.

The live relay E2E target compiles. Its runtime test skips gracefully on this
host because nostr-rs-relay is not installed.

-----

### Suggested CHANGELOG Updates

#### ADDED

- Typed mobile Nostr identity/signing, NIP-44 v2, strict restartable NIP-17
  inbox support, and exact-identity npub.cash construction, with explicit key
  domain separation.

#### CHANGED

- The mobile-facing NIP-17 inbox stop operation is async and waits until the
  stopped run can no longer invoke callbacks.

#### REMOVED

- Seed-byte npub.cash derivation is no longer exported through UniFFI; the Rust
  compatibility helper remains available internally.

#### FIXED

- NIP-17 envelope validation now rejects invalid IDs/signatures, wrong kinds,
  missing rumor IDs, and seal/rumor author mismatches.

----

### Testing

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --lib --workspace --exclude cdk-postgres --exclude cdk-integration-tests
- cargo test -p cdk-nostr --all-features --lib
- cargo test --doc
- cargo test -p cdk-integration-tests --test nip17_inbox_e2e --no-run
- Generated Swift binding tests
- Generated Kotlin/JVM binding tests

The standalone typos and Nix formatter tools used by the just quick-check
wrapper are not installed on this host; no Nix files are changed.

### Checklist

* [x] I followed the code style guidelines
* [ ] I ran just quick-check before committing (equivalent Rust gates listed
  above passed; standalone typos/Nix tools were unavailable)
* [x] Wallet-facing API changes are reflected in cdk-ffi
