### PR TITLE
Improve logging

### DIFF
--- a/crates/cdk-common/src/mint.rs
+++ b/crates/cdk-common/src/mint.rs
@@ -651,7 +651,6 @@ impl MintQuote {
     }
 
     /// Amount paid
-    #[instrument(skip(self))]
     pub fn amount_paid(&self) -> Amount<CurrencyUnit> {
         self.amount_paid.clone()
     }
@@ -705,7 +704,6 @@ impl MintQuote {
     }
 
     /// Amount issued
-    #[instrument(skip(self))]
     pub fn amount_issued(&self) -> Amount<CurrencyUnit> {
         self.amount_issued.clone()
     }
@@ -731,7 +729,6 @@ impl MintQuote {
     }
 
     /// Get state of mint quote
-    #[instrument(skip(self))]
     pub fn state(&self) -> MintQuoteState {
         self.compute_quote_state()
     }
@@ -818,7 +815,6 @@ impl MintQuote {
     }
 
     /// Compute quote state
-    #[instrument(skip(self))]
     fn compute_quote_state(&self) -> MintQuoteState {
         let zero_amount = Amount::new(0, self.unit.clone());
 

--- a/crates/cdk-lnd/src/lib.rs
+++ b/crates/cdk-lnd/src/lib.rs
@@ -517,6 +517,10 @@ impl MintPayment for Lnd {
                             None => {
                                 // Invoice carries no amount; a local parse
                                 // failure before any dispatch.
+                                tracing::warn!(
+                                    payment_lookup_id = %payment_lookup_id,
+                                    "LND MPP payment rejected before dispatch: invoice has no amount",
+                                );
                                 return Ok(outgoing_payment_failure_response(
                                     unit,
                                     payment_lookup_id,
@@ -558,6 +562,15 @@ impl MintPayment for Lnd {
                                     .lightning()
                                     .query_routes(route_req)
                                     .await
+                                    .inspect_err(|err| {
+                                        tracing::warn!(
+                                            payment_lookup_id = %payment_lookup_id,
+                                            attempt = attempt + 1,
+                                            rpc_code = %err.code(),
+                                            error = %err.message(),
+                                            "LND MPP route query failed",
+                                        );
+                                    })
                                     .map_err(Error::LndError)?
                                     .into_inner();
 
@@ -567,6 +580,11 @@ impl MintPayment for Lnd {
                                 let route = match routes_response.routes.first_mut() {
                                     Some(route) => route,
                                     None => {
+                                        tracing::warn!(
+                                            payment_lookup_id = %payment_lookup_id,
+                                            attempt = attempt + 1,
+                                            "LND MPP route query returned no routes",
+                                        );
                                         return Ok(outgoing_payment_failure_response(
                                             unit,
                                             payment_lookup_id,
@@ -578,6 +596,11 @@ impl MintPayment for Lnd {
                                 let last_hop: &mut Hop = match route.hops.last_mut() {
                                     Some(last_hop) => last_hop,
                                     None => {
+                                        tracing::warn!(
+                                            payment_lookup_id = %payment_lookup_id,
+                                            attempt = attempt + 1,
+                                            "LND MPP route has no hops",
+                                        );
                                         return Ok(outgoing_payment_failure_response(
                                             unit,
                                             payment_lookup_id,
@@ -598,17 +621,38 @@ impl MintPayment for Lnd {
                                         ..Default::default()
                                     })
                                     .await
+                                    .inspect_err(|err| {
+                                        tracing::warn!(
+                                            payment_lookup_id = %payment_lookup_id,
+                                            attempt = attempt + 1,
+                                            rpc_code = %err.code(),
+                                            error = %err.message(),
+                                            "LND MPP dispatch RPC failed; payment outcome requires verification",
+                                        );
+                                    })
                                     .map_err(Error::LndError)?
                                     .into_inner();
 
                                 if let Some(failure) = payment_response.failure {
                                     if failure.code == 15 {
                                         tracing::debug!(
-                                            "Attempt number {}: route has failed. Re-querying...",
-                                            attempt + 1
+                                            payment_lookup_id = %payment_lookup_id,
+                                            attempt = attempt + 1,
+                                            failure_code = failure.code,
+                                            failure_reason = failure.code().as_str_name(),
+                                            failure_source_index = failure.failure_source_index,
+                                            "LND MPP route failed; querying another route",
                                         );
                                         continue;
                                     }
+                                    tracing::warn!(
+                                        payment_lookup_id = %payment_lookup_id,
+                                        attempt = attempt + 1,
+                                        failure_code = failure.code,
+                                        failure_reason = failure.code().as_str_name(),
+                                        failure_source_index = failure.failure_source_index,
+                                        "LND MPP attempt returned a failure",
+                                    );
                                 }
 
                                 // Get status and maybe the preimage
@@ -638,9 +682,12 @@ impl MintPayment for Lnd {
                             }
 
                             // "We have exhausted all tactical options" -- STEM, Upgrade (2018)
-                            // Every route query ended in a no-route result, so
-                            // no payment was ever dispatched.
-                            tracing::error!("Limit of retries reached, payment couldn't succeed.");
+                            // All route attempts returned retryable failures.
+                            tracing::warn!(
+                                payment_lookup_id = %payment_lookup_id,
+                                attempts = Self::MAX_ROUTE_RETRIES,
+                                "LND MPP payment exhausted route retries",
+                            );
                             Ok(outgoing_payment_failure_response(unit, payment_lookup_id))
                         }
                     }
@@ -658,6 +705,12 @@ impl MintPayment for Lnd {
                                         // Invoice/request amount disagreement is
                                         // a local validation failure, before any
                                         // dispatch to LND.
+                                        tracing::warn!(
+                                            payment_lookup_id = %payment_lookup_id,
+                                            invoice_amount_msat = invoice_amount,
+                                            requested_amount_msat = u64::from(amount_msat),
+                                            "LND payment rejected before dispatch: invoice and requested amounts differ",
+                                        );
                                         return Ok(outgoing_payment_failure_response(
                                             unit,
                                             payment_lookup_id,
@@ -688,7 +741,12 @@ impl MintPayment for Lnd {
                             .send_payment_v2(pay_req)
                             .await
                             .map_err(|err| {
-                                tracing::warn!("Lightning payment dispatch error: {}", err);
+                                tracing::warn!(
+                                    payment_lookup_id = %payment_lookup_id,
+                                    rpc_code = %err.code(),
+                                    error = %err.message(),
+                                    "LND payment dispatch RPC failed; payment outcome requires verification",
+                                );
                                 // A gRPC error here may arrive after LND accepted
                                 // the payment; the dispatch outcome is unknown.
                                 Error::AmbiguousDispatch
@@ -696,7 +754,12 @@ impl MintPayment for Lnd {
                             .into_inner();
 
                         while let Some(update) = payment_stream.message().await.map_err(|err| {
-                            tracing::warn!("Lightning payment stream error: {}", err);
+                            tracing::warn!(
+                                payment_lookup_id = %payment_lookup_id,
+                                rpc_code = %err.code(),
+                                error = %err.message(),
+                                "LND payment stream failed after dispatch; payment may still settle",
+                            );
                             // The stream dropped after dispatch began; the payment
                             // may still settle.
                             Error::AmbiguousDispatch
@@ -708,7 +771,15 @@ impl MintPayment for Lnd {
                                     continue;
                                 }
                                 PaymentStatus::Succeeded => MeltQuoteState::Paid,
-                                PaymentStatus::Failed => MeltQuoteState::Failed,
+                                PaymentStatus::Failed => {
+                                    tracing::warn!(
+                                        payment_lookup_id = %payment_lookup_id,
+                                        failure_code = update.failure_reason,
+                                        failure_reason = update.failure_reason().as_str_name(),
+                                        "LND outgoing payment failed",
+                                    );
+                                    MeltQuoteState::Failed
+                                }
                                 #[allow(deprecated)]
                                 PaymentStatus::Unknown => MeltQuoteState::Unknown,
                             };
@@ -735,6 +806,10 @@ impl MintPayment for Lnd {
                             });
                         }
 
+                        tracing::warn!(
+                            payment_lookup_id = %payment_lookup_id,
+                            "LND payment stream ended without a terminal result; payment outcome remains unknown",
+                        );
                         Err(Error::UnknownPaymentStatus.into())
                     }
                 }
@@ -857,6 +932,10 @@ impl MintPayment for Lnd {
             Err(err) => {
                 let err_code = err.code();
                 if err_code == tonic::Code::NotFound {
+                    tracing::debug!(
+                        payment_lookup_id = %payment_identifier,
+                        "LND does not know this outgoing payment; reporting Unknown because absence is not authoritative proof of permanent failure",
+                    );
                     return Ok(MakePaymentResponse {
                         payment_lookup_id: payment_identifier.clone(),
                         payment_proof: None,
@@ -864,6 +943,12 @@ impl MintPayment for Lnd {
                         total_spent: Amount::new(0, self.unit.clone()),
                     });
                 } else {
+                    tracing::warn!(
+                        payment_lookup_id = %payment_identifier,
+                        rpc_code = %err_code,
+                        error = %err.message(),
+                        "LND outgoing payment status RPC failed; payment outcome remains unknown",
+                    );
                     return Err(payment::Error::UnknownPaymentState);
                 }
             }
@@ -896,24 +981,44 @@ impl MintPayment for Lnd {
                                 total_spent,
                             }
                         }
-                        PaymentStatus::Failed => MakePaymentResponse {
-                            payment_lookup_id: payment_identifier.clone(),
-                            payment_proof: Some(update.payment_preimage),
-                            status: MeltQuoteState::Failed,
-                            total_spent: Amount::new(0, self.unit.clone()),
-                        },
+                        PaymentStatus::Failed => {
+                            // Status checks also run before dispatch and may
+                            // repeatedly observe the same recorded failure.
+                            tracing::debug!(
+                                payment_lookup_id = %payment_identifier,
+                                failure_code = update.failure_reason,
+                                failure_reason = update.failure_reason().as_str_name(),
+                                "LND outgoing payment status is failed",
+                            );
+                            MakePaymentResponse {
+                                payment_lookup_id: payment_identifier.clone(),
+                                payment_proof: Some(update.payment_preimage),
+                                status: MeltQuoteState::Failed,
+                                total_spent: Amount::new(0, self.unit.clone()),
+                            }
+                        }
                     };
 
                     return Ok(response);
                 }
-                Err(_) => {
+                Err(err) => {
                     // Handle the case where the update itself is an error (e.g., stream failure)
+                    tracing::warn!(
+                        payment_lookup_id = %payment_identifier,
+                        rpc_code = %err.code(),
+                        error = %err.message(),
+                        "LND outgoing payment status stream failed; payment outcome remains unknown",
+                    );
                     return Err(Error::UnknownPaymentStatus.into());
                 }
             }
         }
 
         // If the stream is exhausted without a final status
+        tracing::warn!(
+            payment_lookup_id = %payment_identifier,
+            "LND outgoing payment status stream ended without a terminal result; payment outcome remains unknown",
+        );
         Err(Error::UnknownPaymentStatus.into())
     }
 }

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -408,7 +408,27 @@ pub fn setup_tracing(
     work_dir: &Path,
     logging_config: &config::LoggingConfig,
 ) -> Result<Option<tracing_appender::non_blocking::WorkerGuard>> {
-    let default_filter = "debug";
+    use config::LoggingOutput;
+
+    let console_level = logging_config
+        .console_level
+        .as_deref()
+        .unwrap_or("info")
+        .parse::<tracing::Level>()
+        .unwrap_or(tracing::Level::INFO);
+    let file_level = logging_config
+        .file_level
+        .as_deref()
+        .unwrap_or("debug")
+        .parse::<tracing::Level>()
+        .unwrap_or(tracing::Level::DEBUG);
+    // Enable spans and events up to the most verbose active output. Writer
+    // filters below still enforce each output's individual level.
+    let default_filter = match logging_config.output {
+        LoggingOutput::Stderr => console_level,
+        LoggingOutput::File => file_level,
+        LoggingOutput::Both => console_level.max(file_level),
+    };
     let hyper_filter = "hyper=warn,rustls=warn,reqwest=warn";
     let h2_filter = "h2=warn";
     let tower_filter = "tower=warn";
@@ -421,17 +441,9 @@ pub fn setup_tracing(
         "{default_filter},{hyper_filter},{h2_filter},{tower_filter},{tower_http},{rustls},{tungstenite},{tokio_postgres}"
     ));
 
-    use config::LoggingOutput;
     match logging_config.output {
         LoggingOutput::Stderr => {
             // Console output only (stderr)
-            let console_level = logging_config
-                .console_level
-                .as_deref()
-                .unwrap_or("info")
-                .parse::<tracing::Level>()
-                .unwrap_or(tracing::Level::INFO);
-
             let stderr = std::io::stderr.with_max_level(console_level);
 
             tracing_subscriber::fmt()
@@ -445,13 +457,6 @@ pub fn setup_tracing(
         }
         LoggingOutput::File => {
             // File output only
-            let file_level = logging_config
-                .file_level
-                .as_deref()
-                .unwrap_or("debug")
-                .parse::<tracing::Level>()
-                .unwrap_or(tracing::Level::DEBUG);
-
             // Create logs directory in work_dir if it doesn't exist
             let logs_dir = work_dir.join("logs");
             std::fs::create_dir_all(&logs_dir)?;
@@ -477,19 +482,6 @@ pub fn setup_tracing(
         }
         LoggingOutput::Both => {
             // Both console and file output (stderr + file)
-            let console_level = logging_config
-                .console_level
-                .as_deref()
-                .unwrap_or("info")
-                .parse::<tracing::Level>()
-                .unwrap_or(tracing::Level::INFO);
-            let file_level = logging_config
-                .file_level
-                .as_deref()
-                .unwrap_or("debug")
-                .parse::<tracing::Level>()
-                .unwrap_or(tracing::Level::DEBUG);
-
             // Create logs directory in work_dir if it doesn't exist
             let logs_dir = work_dir.join("logs");
             std::fs::create_dir_all(&logs_dir)?;

--- a/crates/cdk/src/mint/issue/mod.rs
+++ b/crates/cdk/src/mint/issue/mod.rs
@@ -466,11 +466,12 @@ impl Mint {
                 .get_mint_quote_by_request_lookup_id(&wait_payment_response.payment_identifier)
                 .await
             {
+                let previous_state = mint_quote.state();
                 let notify = self
                     .pay_mint_quote(&mut tx, &mut mint_quote, wait_payment_response)
                     .await?;
                 if notify {
-                    Some((mint_quote.clone(), mint_quote.amount_paid()))
+                    Some((mint_quote.clone(), mint_quote.amount_paid(), previous_state))
                 } else {
                     None
                 }
@@ -485,7 +486,19 @@ impl Mint {
             tx.commit().await?;
 
             // Publish notification AFTER transaction commits
-            if let Some((quote, amount_paid)) = should_notify {
+            if let Some((quote, amount_paid, previous_state)) = should_notify {
+                tracing::info!(
+                    quote_id = %quote.id,
+                    method = %quote.payment_method,
+                    unit = %quote.unit,
+                    request_lookup_id = %quote.request_lookup_id,
+                    previous_state = %previous_state,
+                    new_state = %quote.state(),
+                    amount_paid = %amount_paid,
+                    amount_issued = %quote.amount_issued(),
+                    amount_mintable = %quote.amount_mintable(),
+                    "mint quote payment notification committed",
+                );
                 self.pubsub_manager.mint_quote_payment(&quote, amount_paid);
             }
 
@@ -924,6 +937,7 @@ impl Mint {
             // locks. The database returns the quotes in request order, while locking
             // them by ID, so reversed batch requests cannot deadlock each other.
             let locked_quotes = tx.get_mint_quotes_by_ids(&quote_ids).await?;
+            let mut issuance_events = Vec::with_capacity(quote_ids.len());
 
             // For batch minting, outputs are shared across all quotes and should be persisted once.
             if input.is_batch() {
@@ -983,6 +997,7 @@ impl Mint {
 
                 mint_quote.add_issuance(amount_issued)?;
                 tx.update_mint_quote(&mut mint_quote).await?;
+                issuance_events.push(mint_quote.clone());
 
                 // Mint operations have no input fees
                 // Only persist operation for non-batch mints (batch operations are persisted above)
@@ -994,6 +1009,20 @@ impl Mint {
             }
 
             tx.commit().await?;
+
+            for mint_quote in &issuance_events {
+                tracing::info!(
+                    quote_id = %mint_quote.id,
+                    method = %mint_quote.payment_method,
+                    unit = %mint_quote.unit,
+                    request_lookup_id = %mint_quote.request_lookup_id,
+                    new_state = %mint_quote.state(),
+                    amount_paid = %mint_quote.amount_paid(),
+                    amount_issued = %mint_quote.amount_issued(),
+                    amount_mintable = %mint_quote.amount_mintable(),
+                    "mint quote issuance committed",
+                );
+            }
 
             let localstore = Arc::clone(&self.localstore);
             let pubsub_manager = Arc::clone(&self.pubsub_manager);

--- a/crates/cdk/src/mint/issue/mod.rs
+++ b/crates/cdk/src/mint/issue/mod.rs
@@ -368,18 +368,20 @@ impl Mint {
                 Some(create_invoice_response.extra_json.unwrap_or_default()),
             );
 
-            tracing::debug!(
-                "New {} mint quote {} for {:?} {} with request id {:?}",
-                payment_method,
-                quote.id,
-                amount,
-                unit,
-                create_invoice_response.request_lookup_id.to_string(),
-            );
-
             let mut tx = self.localstore.begin_transaction().await?;
             tx.add_mint_quote(quote.clone()).await?;
             tx.commit().await?;
+
+            tracing::info!(
+                quote_id = %quote.id,
+                method = %payment_method,
+                unit = %unit,
+                amount = ?amount,
+                request_lookup_id = %create_invoice_response.request_lookup_id,
+                expiry = quote.expiry,
+                state = %quote.state(),
+                "mint quote created and persisted",
+            );
 
             if payment_method.is_bolt11() {
                 let res: MintQuoteBolt11Response<QuoteId> = quote.clone().into();

--- a/crates/cdk/src/mint/melt/melt_saga/mod.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/mod.rs
@@ -405,6 +405,18 @@ impl MeltSaga<Initial> {
         }
 
         tx.commit().await?;
+
+        tracing::info!(
+            quote_id = %quote.id,
+            saga_id = %self.operation_id,
+            previous_state = %previous_state,
+            new_state = %MeltQuoteState::Pending,
+            proof_count = input_ys.len(),
+            change_output_count = blinded_secrets.len(),
+            request_lookup_id = ?quote.request_lookup_id,
+            "melt setup committed; quote and proofs are reserved pending payment",
+        );
+
         // Publish proof state changes
         for pk in input_ys.iter() {
             self.pubsub.proof_state((*pk, State::Pending));
@@ -674,22 +686,23 @@ impl MeltSaga<SetupComplete> {
                 match response.status {
                     MeltQuoteState::Paid => response,
                     MeltQuoteState::Unpaid | MeltQuoteState::Failed => {
-                        tracing::info!("Payment for quote {} failed.", self.state_data.quote.id);
+                        tracing::warn!(
+                            quote_id = %self.state_data.quote.id,
+                            saga_id = %self.operation_id,
+                            payment_lookup_id = %response.payment_lookup_id,
+                            payment_status = %response.status,
+                            "payment failed authoritatively; rolling back the melt and releasing reserved proofs",
+                        );
                         self.compensate_all().await?;
                         return Err(Error::PaymentFailed);
                     }
                     MeltQuoteState::Unknown => {
-                        tracing::warn!("Payment for quote {} unknown.", self.state_data.quote.id);
                         return Ok(PaymentOutcome::Pending {
                             #[cfg(feature = "prometheus")]
                             metrics: self.metrics,
                         });
                     }
                     MeltQuoteState::Pending => {
-                        tracing::warn!(
-                            "Payment pending, proofs remain pending for quote: {}",
-                            self.state_data.quote.id
-                        );
                         return Ok(PaymentOutcome::Pending {
                             #[cfg(feature = "prometheus")]
                             metrics: self.metrics,
@@ -772,6 +785,14 @@ impl MeltSaga<SetupComplete> {
             tx.commit().await?;
         }
 
+        tracing::info!(
+            quote_id = %self.state_data.quote.id,
+            saga_id = %self.operation_id,
+            request_lookup_id = ?self.state_data.quote.request_lookup_id,
+            saga_state = %MeltSagaState::PaymentAttempted,
+            "payment attempt recorded before backend dispatch",
+        );
+
         // The process-local quote guard owned by `Mint::melt` serializes live
         // dispatch, payment events, and reconciliation for this quote. Do not
         // hold a database connection across payment-backend network I/O: a few
@@ -799,11 +820,32 @@ impl MeltSaga<SetupComplete> {
         let quote = &self.state_data.quote;
         let payment_options = OutgoingPaymentOptions::from_melt_quote_with_fee(quote.clone())?;
 
+        tracing::info!(
+            quote_id = %quote.id,
+            saga_id = %self.operation_id,
+            method = %quote.payment_method,
+            unit = %quote.unit,
+            amount = %quote.amount(),
+            fee_reserve = %quote.fee_reserve(),
+            request_lookup_id = ?quote.request_lookup_id,
+            "dispatching outgoing payment to backend",
+        );
+
         match payment_backend
             .make_payment(&quote.unit, payment_options)
             .await
         {
-            Ok(pay) if pay.status == MeltQuoteState::Paid => Ok((pay, true)),
+            Ok(pay) if pay.status == MeltQuoteState::Paid => {
+                tracing::info!(
+                    quote_id = %quote.id,
+                    saga_id = %self.operation_id,
+                    status = %pay.status,
+                    total_spent = %pay.total_spent,
+                    payment_lookup_id = %pay.payment_lookup_id,
+                    "payment backend returned an authoritative result",
+                );
+                Ok((pay, true))
+            }
             Ok(pay) => {
                 let response = self.verify_ambiguous_payment(payment_backend, pay).await?;
                 let acknowledged = response.status != MeltQuoteState::Unknown;
@@ -824,12 +866,12 @@ impl MeltSaga<SetupComplete> {
         >,
         pay: MakePaymentResponse,
     ) -> Result<MakePaymentResponse, Error> {
-        tracing::warn!(
-            "Got {} status when paying melt quote {} for {} {}. Verifying with backend...",
-            pay.status,
-            self.state_data.quote.id,
-            self.state_data.quote.amount(),
-            self.state_data.quote.unit
+        tracing::debug!(
+            quote_id = %self.state_data.quote.id,
+            saga_id = %self.operation_id,
+            payment_lookup_id = %pay.payment_lookup_id,
+            payment_status = %pay.status,
+            "verifying non-paid payment result with backend",
         );
 
         let check_response = self
@@ -839,8 +881,12 @@ impl MeltSaga<SetupComplete> {
         if check_response.status == MeltQuoteState::Paid {
             // Race condition: Payment succeeded during verification
             tracing::info!(
-                "Payment initially returned {} but confirmed as Paid. Proceeding to finalize.",
-                pay.status
+                quote_id = %self.state_data.quote.id,
+                saga_id = %self.operation_id,
+                payment_lookup_id = %check_response.payment_lookup_id,
+                initial_status = %pay.status,
+                verified_status = %check_response.status,
+                "payment verified as paid; proceeding to finalization",
             );
             return Ok(check_response);
         }
@@ -852,8 +898,12 @@ impl MeltSaga<SetupComplete> {
         if check_response.status == MeltQuoteState::Unknown && pay.status != MeltQuoteState::Unknown
         {
             tracing::warn!(
-                "Payment was initially {} but verification returned Unknown. Keeping the initial status for safety.",
-                pay.status,
+                quote_id = %self.state_data.quote.id,
+                saga_id = %self.operation_id,
+                payment_lookup_id = %pay.payment_lookup_id,
+                initial_status = %pay.status,
+                verified_status = %check_response.status,
+                "verification was inconclusive; preserving the initial authoritative status",
             );
             return Ok(pay);
         }
@@ -872,13 +922,20 @@ impl MeltSaga<SetupComplete> {
         err: cdk_common::payment::Error,
     ) -> Result<MakePaymentResponse, Error> {
         if matches!(err, crate::cdk_payment::Error::InvoiceAlreadyPaid) {
-            tracing::info!("Invoice already paid, verifying payment status");
+            tracing::info!(
+                quote_id = %self.state_data.quote.id,
+                saga_id = %self.operation_id,
+                error = %err,
+                "payment backend reports invoice already paid; verifying payment status",
+            );
         } else {
             // Other error - check if payment actually succeeded
             tracing::error!(
-                "Error returned attempting to pay: {} {}",
-                self.state_data.quote.id,
-                err
+                quote_id = %self.state_data.quote.id,
+                saga_id = %self.operation_id,
+                request_lookup_id = ?self.state_data.quote.request_lookup_id,
+                error = %err,
+                "payment backend returned an error after dispatch; verifying before changing reserved proof state",
             );
         }
 
@@ -889,8 +946,9 @@ impl MeltSaga<SetupComplete> {
             .as_ref()
             .ok_or_else(|| {
                 tracing::error!(
-                    "No payment id, cannot verify payment status for {} after error",
-                    self.state_data.quote.id
+                    quote_id = %self.state_data.quote.id,
+                    saga_id = %self.operation_id,
+                    "payment errored without a lookup id; status cannot be verified and proofs remain pending",
                 );
                 Error::Internal
             })?;
@@ -898,9 +956,11 @@ impl MeltSaga<SetupComplete> {
         let check_response = self.check_payment_state(payment_backend, lookup_id).await?;
 
         tracing::info!(
-            "Initial payment attempt for {} errored. Follow up check status: {}",
-            self.state_data.quote.id,
-            check_response.status
+            quote_id = %self.state_data.quote.id,
+            saga_id = %self.operation_id,
+            payment_lookup_id = %check_response.payment_lookup_id,
+            verified_status = %check_response.status,
+            "payment status checked after backend error",
         );
 
         // make_payment returned no result of its own. The follow-up status
@@ -936,13 +996,8 @@ impl MeltSaga<SetupComplete> {
             .await?
             .ok_or(Error::UnknownQuote)?;
 
+        let previous_payment_lookup_id = quote.request_lookup_id.clone();
         if quote.request_lookup_id.as_ref() != Some(payment_lookup_id) {
-            tracing::info!(
-                "Updating payment lookup id for pending melt quote {} from {:?} to {}",
-                quote_id,
-                quote.request_lookup_id,
-                payment_lookup_id
-            );
             tx.update_melt_quote_request_lookup_id(&mut quote, payment_lookup_id)
                 .await?;
         }
@@ -964,12 +1019,43 @@ impl MeltSaga<SetupComplete> {
             _ => None,
         };
 
-        if let Some(next_state) = next_state {
-            tx.update_acquired_saga(&mut saga, SagaStateEnum::Melt(next_state))
+        if let Some(next_state) = next_state.as_ref() {
+            tx.update_acquired_saga(&mut saga, SagaStateEnum::Melt(next_state.clone()))
                 .await?;
         }
 
         tx.commit().await?;
+
+        match next_state {
+            Some(MeltSagaState::PaymentFailed) => tracing::warn!(
+                quote_id = %quote_id,
+                saga_id = %self.operation_id,
+                payment_lookup_id = %payment_lookup_id,
+                previous_payment_lookup_id = ?previous_payment_lookup_id,
+                payment_status = %payment_response.status,
+                saga_state = %MeltSagaState::PaymentFailed,
+                "authoritative payment failure persisted; compensation may safely release proofs",
+            ),
+            Some(MeltSagaState::PaymentPending) => tracing::info!(
+                quote_id = %quote_id,
+                saga_id = %self.operation_id,
+                payment_lookup_id = %payment_lookup_id,
+                previous_payment_lookup_id = ?previous_payment_lookup_id,
+                payment_status = %payment_response.status,
+                saga_state = %MeltSagaState::PaymentPending,
+                "in-flight payment persisted; quote and proofs remain pending",
+            ),
+            _ => tracing::warn!(
+                quote_id = %quote_id,
+                saga_id = %self.operation_id,
+                payment_lookup_id = %payment_lookup_id,
+                previous_payment_lookup_id = ?previous_payment_lookup_id,
+                payment_status = %payment_response.status,
+                saga_state = %MeltSagaState::PaymentAttempted,
+                "payment outcome remains ambiguous; quote and proofs remain pending",
+            ),
+        }
+
         Ok(())
     }
 
@@ -992,6 +1078,16 @@ impl MeltSaga<SetupComplete> {
             return Err(err);
         }
         tx.commit().await?;
+
+        tracing::info!(
+            quote_id = %self.state_data.quote.id,
+            saga_id = %self.operation_id,
+            payment_lookup_id = %payment_response.payment_lookup_id,
+            payment_status = %payment_response.status,
+            saga_state = %MeltSagaState::Finalizing,
+            "paid payment persisted; melt is ready for finalization",
+        );
+
         Ok(())
     }
 
@@ -1007,10 +1103,12 @@ impl MeltSaga<SetupComplete> {
             Ok(response) => Ok(response),
             Err(check_err) => {
                 tracing::error!(
-                    "Could not check the status of payment for {}. Proofs stuck as pending",
-                    lookup_id
+                    quote_id = %self.state_data.quote.id,
+                    saga_id = %self.operation_id,
+                    payment_lookup_id = %lookup_id,
+                    error = %check_err,
+                    "payment status check failed; quote and proofs remain pending",
                 );
-                tracing::error!("Checking payment error: {}", check_err);
                 Err(Error::Internal)
             }
         }
@@ -1062,7 +1160,12 @@ impl MeltSaga<PaymentConfirmed> {
     /// - `UnitMismatch`: Failed to convert payment amount to quote unit
     #[instrument(skip_all)]
     pub async fn finalize(mut self) -> Result<MeltQuoteResponse<QuoteId>, Error> {
-        tracing::info!("TX2: Finalizing melt (mark spent + change)");
+        tracing::debug!(
+            quote_id = %self.state_data.quote.id,
+            saga_id = %self.operation_id,
+            payment_lookup_id = %self.state_data.payment_result.payment_lookup_id,
+            "finalizing paid melt; marking proofs spent and issuing change",
+        );
 
         let total_spent: Amount<CurrencyUnit> = self.state_data.payment_result.total_spent;
         let total_spent =
@@ -1098,6 +1201,14 @@ impl MeltSaga<PaymentConfirmed> {
             tx.commit().await?;
         }
 
+        tracing::debug!(
+            quote_id = %self.state_data.quote.id,
+            saga_id = %self.operation_id,
+            payment_lookup_id = %payment_lookup_id,
+            saga_state = %MeltSagaState::Finalizing,
+            "melt finalization handoff persisted",
+        );
+
         // Delegate to the single shared finalization path which handles:
         // - Core finalization (mark proofs spent, update quote to Paid)
         // - Change signing
@@ -1119,9 +1230,11 @@ impl MeltSaga<PaymentConfirmed> {
             // Do NOT compensate here - payment was already confirmed as Paid
             // Startup check will retry finalization on next recovery cycle
             tracing::error!(
-                "Finalize failed for paid melt quote {} - will retry on startup: {}",
-                self.state_data.quote.id,
-                err
+                quote_id = %self.state_data.quote.id,
+                saga_id = %self.operation_id,
+                payment_lookup_id = %payment_lookup_id,
+                error = %err,
+                "paid melt finalization failed; proofs remain reserved and recovery will retry",
             );
             err
         })?;

--- a/crates/cdk/src/mint/melt/melt_saga/mod.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/mod.rs
@@ -1234,7 +1234,7 @@ impl MeltSaga<PaymentConfirmed> {
                 saga_id = %self.operation_id,
                 payment_lookup_id = %payment_lookup_id,
                 error = %err,
-                "paid melt finalization failed; proofs remain reserved and recovery will retry",
+                "paid melt finalization failed; recovery will retry remaining finalization work",
             );
             err
         })?;

--- a/crates/cdk/src/mint/melt/mod.rs
+++ b/crates/cdk/src/mint/melt/mod.rs
@@ -351,18 +351,21 @@ impl Mint {
                 payment_quote.estimated_blocks,
             );
 
-            tracing::debug!(
-                "New {} melt quote {} for {} {} with request id {:?}",
-                quote.payment_method,
-                quote.id,
-                quote_amount,
-                unit,
-                payment_quote.request_lookup_id
-            );
-
             let mut tx = self.localstore.begin_transaction().await?;
             tx.add_melt_quote(quote.clone()).await?;
             tx.commit().await?;
+
+            tracing::info!(
+                quote_id = %quote.id,
+                method = %quote.payment_method,
+                unit = %quote.unit,
+                amount = %quote.amount(),
+                fee_reserve = %quote.fee_reserve(),
+                request_lookup_id = ?quote.request_lookup_id,
+                expiry = quote.expiry,
+                state = %quote.state,
+                "melt quote created and persisted",
+            );
 
             Ok(quote.into())
         }
@@ -467,18 +470,21 @@ impl Mint {
                 payment_quote.estimated_blocks,
             );
 
-            tracing::debug!(
-                "New {} melt quote {} for {} {} with request id {:?}",
-                quote.payment_method,
-                quote.id,
-                quote_amount,
-                unit,
-                payment_quote.request_lookup_id
-            );
-
             let mut tx = self.localstore.begin_transaction().await?;
             tx.add_melt_quote(quote.clone()).await?;
             tx.commit().await?;
+
+            tracing::info!(
+                quote_id = %quote.id,
+                method = %quote.payment_method,
+                unit = %quote.unit,
+                amount = %quote.amount(),
+                fee_reserve = %quote.fee_reserve(),
+                request_lookup_id = ?quote.request_lookup_id,
+                expiry = quote.expiry,
+                state = %quote.state,
+                "melt quote created and persisted",
+            );
 
             Ok(quote.into())
         }
@@ -614,6 +620,18 @@ impl Mint {
             tx.add_melt_quote(quote.clone()).await?;
             tx.commit().await?;
 
+            tracing::info!(
+                quote_id = %quote.id,
+                method = %quote.payment_method,
+                unit = %quote.unit,
+                amount = %quote.amount(),
+                fee_reserve = %quote.fee_reserve(),
+                request_lookup_id = ?quote.request_lookup_id,
+                expiry = quote.expiry,
+                state = %quote.state,
+                "melt quote created and persisted",
+            );
+
             Ok(quote.into())
         }
         .await;
@@ -730,18 +748,21 @@ impl Mint {
                 payment_quote.estimated_blocks,
             );
 
-            tracing::debug!(
-                "New {} melt quote {} for {} {} with request id {:?}",
-                method,
-                quote.id,
-                quote_amount,
-                unit,
-                payment_quote.request_lookup_id
-            );
-
             let mut tx = self.localstore.begin_transaction().await?;
             tx.add_melt_quote(quote.clone()).await?;
             tx.commit().await?;
+
+            tracing::info!(
+                quote_id = %quote.id,
+                method = %quote.payment_method,
+                unit = %quote.unit,
+                amount = %quote.amount(),
+                fee_reserve = %quote.fee_reserve(),
+                request_lookup_id = ?quote.request_lookup_id,
+                expiry = quote.expiry,
+                state = %quote.state,
+                "melt quote created and persisted",
+            );
 
             Ok(quote.into())
         }
@@ -1055,7 +1076,7 @@ impl Mint {
 
             match &result {
                 Ok(_) => {
-                    tracing::info!(
+                    tracing::debug!(
                         "Background melt completed successfully for quote: {}",
                         quote_id_for_log
                     );

--- a/crates/cdk/src/mint/melt/shared.rs
+++ b/crates/cdk/src/mint/melt/shared.rs
@@ -374,14 +374,19 @@ async fn rollback_melt_quote_inner(
         }
     }
 
+    let quote_reset = quote_option.is_some();
     if let Some(quote) = quote_option {
         pubsub.melt_quote_status(&quote, None, None, MeltQuoteState::Unpaid);
     }
 
     tracing::info!(
-        "Successfully rolled back melt quote {} and deleted saga {}",
-        quote_id,
-        operation_id
+        quote_id = %quote_id,
+        saga_id = %operation_id,
+        quote_state_reset_to_unpaid = quote_reset,
+        proof_count = input_ys.len(),
+        proofs_recovered,
+        change_output_count = blinded_secrets.len(),
+        "melt rollback committed; reservation cleanup completed",
     );
 
     Ok(())
@@ -834,7 +839,7 @@ pub async fn finalize_melt_quote(
     payment_lookup_id: &cdk_common::payment::PaymentIdentifier,
     operation_id: Option<uuid::Uuid>,
 ) -> Result<Option<Vec<BlindSignature>>, Error> {
-    tracing::info!("Finalizing melt quote {}", quote.id);
+    tracing::debug!("Finalizing melt quote {}", quote.id);
 
     let total_spent = total_spent_for_quote_unit(&total_spent, &quote.unit)?;
 
@@ -1074,7 +1079,16 @@ pub async fn finalize_melt_quote(
         MeltQuoteState::Paid,
     );
 
-    tracing::info!("Successfully finalized melt quote {}", quote.id);
+    tracing::info!(
+        quote_id = %quote.id,
+        saga_id = ?operation_id,
+        payment_lookup_id = %payment_lookup_id,
+        new_quote_state = %MeltQuoteState::Paid,
+        total_spent = %total_spent,
+        proof_count = input_ys.len(),
+        change_signature_count = change_sigs.as_ref().map_or(0, Vec::len),
+        "melt finalized; quote is paid and input proofs are spent",
+    );
 
     #[cfg(feature = "prometheus")]
     if should_record_payment_metrics {

--- a/crates/cdk/src/mint/melt/shared.rs
+++ b/crates/cdk/src/mint/melt/shared.rs
@@ -501,22 +501,35 @@ pub(super) async fn process_melt_change(
         .and_then(|rem| rem.checked_sub(&inputs_fee).ok())
     {
         Some(amt) if amt.value() > 0 => amt.into(),
-        Some(_) => {
+        Some(change_target) => {
+            tracing::debug!(
+                quote_id = %quote_id,
+                inputs_amount = %inputs_amount,
+                total_spent = %total_spent,
+                inputs_fee = %inputs_fee,
+                change_target = %change_target,
+                "melt has no change to return after payment and input fees",
+            );
             return begin_melt_change_without_signatures(db, quote_id).await;
         }
         None => {
             tracing::warn!(
-                "Fee was too high for quote {}. inputs_amount: {}, total_spent: {}, inputs_fee: {}",
-                quote_id,
-                inputs_amount,
-                total_spent,
-                inputs_fee
+                quote_id = %quote_id,
+                inputs_amount = %inputs_amount,
+                total_spent = %total_spent,
+                inputs_fee = %inputs_fee,
+                "payment and input fees exceed the provided melt inputs; no change can be returned",
             );
             return begin_melt_change_without_signatures(db, quote_id).await;
         }
     };
 
     if change_outputs.is_empty() {
+        tracing::info!(
+            quote_id = %quote_id,
+            change_target = %change_target,
+            "melt has refundable change but the wallet supplied no change outputs",
+        );
         return begin_melt_change_without_signatures(db, quote_id).await;
     }
 
@@ -527,10 +540,12 @@ pub(super) async fn process_melt_change(
     let mut amounts: Vec<Amount> = change_target.split(&fee_and_amounts)?;
 
     if change_outputs.len() < amounts.len() {
-        tracing::debug!(
-            "Providing change requires {} blinded messages, but only {} provided",
-            amounts.len(),
-            change_outputs.len()
+        tracing::info!(
+            quote_id = %quote_id,
+            change_target = %change_target,
+            required_change_output_count = amounts.len(),
+            provided_change_output_count = change_outputs.len(),
+            "wallet supplied too few change outputs; returned change may be less than the available amount",
         );
         amounts.sort_by(|a, b| b.cmp(a));
     }
@@ -543,7 +558,18 @@ pub(super) async fn process_melt_change(
     }
 
     // External call: sign change outputs (no DB transaction held)
-    let change_sigs = mint.blind_sign(blinded_messages_to_sign.clone()).await?;
+    let change_sigs = mint
+        .blind_sign(blinded_messages_to_sign.clone())
+        .await
+        .inspect_err(|err| {
+            tracing::error!(
+                quote_id = %quote_id,
+                change_target = %change_target,
+                change_output_count = blinded_messages_to_sign.len(),
+                error = %err,
+                "melt change signing failed; paid melt remains available for finalization recovery",
+            );
+        })?;
 
     // Open a transaction with quote, melt-request, and change-output locks
     // acquired in the same order as finalization and rollback.
@@ -1001,6 +1027,11 @@ pub async fn finalize_melt_quote(
         }
     };
 
+    let change_amount_for_log = change_sigs
+        .as_ref()
+        .and_then(|sigs| Amount::try_sum(sigs.iter().map(|s| s.amount)).ok());
+    let payment_fee_for_log = total_spent.checked_sub(&quote.amount()).ok();
+
     // Compute the fee breakdown from the spent proofs before cleanup.
     // We reuse the cloned proofs from TX1 / recovery so TX2 can atomically
     // persist the completed operation with the rest of the post-payment work.
@@ -1084,8 +1115,15 @@ pub async fn finalize_melt_quote(
         saga_id = ?operation_id,
         payment_lookup_id = %payment_lookup_id,
         new_quote_state = %MeltQuoteState::Paid,
+        quote_amount = %quote.amount(),
+        fee_reserve = %quote.fee_reserve(),
+        payment_fee = ?payment_fee_for_log,
+        input_fee = %melt_request_info.inputs_fee,
+        inputs_amount = %melt_request_info.inputs_amount,
         total_spent = %total_spent,
+        change_amount = ?change_amount_for_log,
         proof_count = input_ys.len(),
+        requested_change_output_count = melt_request_info.change_outputs.len(),
         change_signature_count = change_sigs.as_ref().map_or(0, Vec::len),
         "melt finalized; quote is paid and input proofs are spent",
     );

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1147,11 +1147,12 @@ impl Mint {
             .get_mint_quote_by_request_lookup_id(&wait_payment_response.payment_identifier)
             .await
         {
+            let previous_state = mint_quote.state();
             let notify =
                 Self::handle_mint_quote_payment(&mut tx, &mut mint_quote, wait_payment_response)
                     .await?;
             if notify {
-                Some((mint_quote.clone(), mint_quote.amount_paid()))
+                Some((mint_quote.clone(), mint_quote.amount_paid(), previous_state))
             } else {
                 None
             }
@@ -1167,7 +1168,19 @@ impl Mint {
 
         // Publish notification AFTER transaction commits so subscribers
         // see the committed state when they query.
-        if let Some((quote, amount_paid)) = should_notify {
+        if let Some((quote, amount_paid, previous_state)) = should_notify {
+            tracing::info!(
+                quote_id = %quote.id,
+                method = %quote.payment_method,
+                unit = %quote.unit,
+                request_lookup_id = %quote.request_lookup_id,
+                previous_state = %previous_state,
+                new_state = %quote.state(),
+                amount_paid = %amount_paid,
+                amount_issued = %quote.amount_issued(),
+                amount_mintable = %quote.amount_mintable(),
+                "mint quote payment notification committed",
+            );
             pubsub_manager.mint_quote_payment(&quote, amount_paid);
         }
 
@@ -1200,7 +1213,7 @@ impl Mint {
             if mint_quote.payment_method.is_bolt11()
                 && (quote_state == MintQuoteState::Issued || quote_state == MintQuoteState::Paid)
             {
-                tracing::info!("Received payment notification for already issued quote.");
+                tracing::debug!("Received payment notification for already issued quote.");
             } else {
                 let payment_amount_quote_unit: Amount<CurrencyUnit> = wait_payment_response
                     .payment_amount
@@ -1227,7 +1240,7 @@ impl Mint {
                         return Ok(true);
                     }
                     Err(Error::DuplicatePaymentId) => {
-                        tracing::info!(
+                        tracing::debug!(
                             "Payment ID {} already processed (caught race condition)",
                             wait_payment_response.payment_id
                         );
@@ -1237,7 +1250,7 @@ impl Mint {
                 }
             }
         } else {
-            tracing::info!("Received payment notification for already seen payment.");
+            tracing::debug!("Received payment notification for already seen payment.");
         }
 
         Ok(false)

--- a/crates/cdk/src/mint/payment_backend.rs
+++ b/crates/cdk/src/mint/payment_backend.rs
@@ -48,6 +48,12 @@ impl Mint {
             )
             .await?;
         if !claimed {
+            tracing::trace!(
+                quote_id = %quote.id,
+                request_lookup_id = %quote.request_lookup_id,
+                check_interval_seconds = MINT_QUOTE_PAYMENT_CHECK_INTERVAL_SECS,
+                "mint quote payment check skipped because another recent check holds the rate limit",
+            );
             return Ok(());
         }
         quote.set_last_checked(now);
@@ -66,9 +72,27 @@ impl Mint {
 
         let payment_status = payment_backend
             .check_incoming_payment_status(&quote.request_lookup_id)
-            .await?;
+            .await
+            .inspect_err(|err| {
+                tracing::warn!(
+                    quote_id = %quote.id,
+                    method = %quote.payment_method,
+                    unit = %quote.unit,
+                    request_lookup_id = %quote.request_lookup_id,
+                    error = %err,
+                    "mint quote payment status check failed; quote state is unchanged",
+                );
+            })?;
 
         if payment_status.is_empty() {
+            tracing::trace!(
+                quote_id = %quote.id,
+                method = %quote.payment_method,
+                unit = %quote.unit,
+                request_lookup_id = %quote.request_lookup_id,
+                quote_state = %quote.state(),
+                "mint quote payment check found no new payments",
+            );
             return Ok(());
         }
 
@@ -90,6 +114,7 @@ impl Mint {
         }
 
         let mut should_notify = false;
+        let mut recorded_payment_count = 0usize;
 
         for payment in payment_status {
             if !new_quote.payment_ids().contains(&&payment.payment_id)
@@ -108,6 +133,7 @@ impl Mint {
                     Ok(()) => {
                         tx.update_mint_quote(&mut new_quote).await?;
                         should_notify = true;
+                        recorded_payment_count += 1;
                     }
                     Err(crate::Error::DuplicatePaymentId) => {
                         tracing::debug!(
@@ -122,6 +148,22 @@ impl Mint {
         }
 
         tx.commit().await?;
+
+        if should_notify {
+            tracing::info!(
+                quote_id = %new_quote.id,
+                method = %new_quote.payment_method,
+                unit = %new_quote.unit,
+                request_lookup_id = %new_quote.request_lookup_id,
+                previous_state = %current_state,
+                new_state = %new_quote.state(),
+                recorded_payment_count,
+                amount_paid = %new_quote.amount_paid(),
+                amount_issued = %new_quote.amount_issued(),
+                amount_mintable = %new_quote.amount_mintable(),
+                "mint quote payment committed after backend status check",
+            );
+        }
 
         // Publish notification AFTER transaction commits so subscribers
         // see the committed state when they query.

--- a/crates/cdk/src/mint/saga_recovery.rs
+++ b/crates/cdk/src/mint/saga_recovery.rs
@@ -83,7 +83,7 @@ pub(crate) async fn process_melt_saga_outcome(
         }
         MeltQuoteState::Pending => {
             persist_pending_after_dispatch(saga, quote, payment_response, db).await?;
-            tracing::debug!(
+            tracing::trace!(
                 "Melt quote {} (saga {}) payment remains Pending",
                 quote.id,
                 saga.operation_id
@@ -91,11 +91,13 @@ pub(crate) async fn process_melt_saga_outcome(
             Ok(())
         }
         MeltQuoteState::Unknown => {
-            tracing::debug!(
-                "Melt quote {} (saga {}) payment status still {}, skipping action",
-                quote.id,
-                saga.operation_id,
-                payment_response.status
+            // Dispatch and startup recovery report unresolved outcomes at WARN.
+            // Status requests can repeat indefinitely without a state change.
+            tracing::trace!(
+                quote_id = %quote.id,
+                saga_id = %saga.operation_id,
+                payment_lookup_id = %payment_response.payment_lookup_id,
+                "payment status is unknown; quote and proofs remain pending because payment failure is not authoritative",
             );
             Ok(())
         }

--- a/crates/cdk/src/mint/start_up_check.rs
+++ b/crates/cdk/src/mint/start_up_check.rs
@@ -104,7 +104,7 @@ impl Mint {
                 Error::Internal
             })?;
 
-        tracing::info!(
+        tracing::debug!(
             "Payment status for melt quote {}: {}",
             quote.id,
             pay_invoice_response.status
@@ -429,11 +429,12 @@ impl Mint {
 
         for saga in incomplete_sagas {
             tracing::info!(
-                "Recovering melt saga {} in state '{}' (created: {}, updated: {})",
-                saga.operation_id,
-                saga.state.state(),
-                saga.created_at,
-                saga.updated_at
+                saga_id = %saga.operation_id,
+                quote_id = ?saga.quote_id,
+                saga_state = %saga.state.state(),
+                created_at = saga.created_at,
+                updated_at = saga.updated_at,
+                "recovering incomplete melt saga",
             );
 
             // Look up input_ys and blinded_secrets from the proof and blind_signature tables
@@ -792,11 +793,13 @@ impl Mint {
                             MeltQuoteState::Pending | MeltQuoteState::Unknown => {
                                 // Not authoritative: an orchestrator may be
                                 // between payment attempts.
-                                tracing::info!(
-                                    "Saga {} for quote {} - payment {} on the payment backend, skipping",
-                                    saga.operation_id,
-                                    quote_id,
-                                    payment_response.status
+                                tracing::warn!(
+                                    saga_id = %saga.operation_id,
+                                    quote_id = %quote_id,
+                                    payment_lookup_id = %payment_response.payment_lookup_id,
+                                    payment_status = %payment_response.status,
+                                    proof_count = input_ys.len(),
+                                    "recovery cannot prove payment failure; quote and proofs remain pending",
                                 );
                                 continue; // Skip this saga
                             }

--- a/crates/cdk/src/mint/start_up_check.rs
+++ b/crates/cdk/src/mint/start_up_check.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use cdk_common::database::DynMintTransaction;
 use cdk_common::mint::{MeltPaymentRequest, OperationKind, Saga};
 use cdk_common::payment::PaymentIdentifier;
+use cdk_common::util::unix_time;
 use cdk_common::{PublicKey, QuoteId, State};
 
 use super::{Error, Mint};
@@ -420,20 +421,30 @@ impl Mint {
             .await?;
 
         if incomplete_sagas.is_empty() {
-            tracing::info!("No incomplete melt sagas found to recover.");
+            tracing::info!(
+                incomplete_saga_count = 0,
+                "melt saga recovery found no incomplete operations",
+            );
             return Ok(());
         }
 
         let total_sagas = incomplete_sagas.len();
-        tracing::info!("Found {} incomplete melt sagas to recover.", total_sagas);
+        let recovery_started_at = unix_time();
+        tracing::info!(
+            incomplete_saga_count = total_sagas,
+            "melt saga recovery inventory loaded",
+        );
 
         for saga in incomplete_sagas {
+            let observed_at = unix_time();
             tracing::info!(
                 saga_id = %saga.operation_id,
                 quote_id = ?saga.quote_id,
                 saga_state = %saga.state.state(),
                 created_at = saga.created_at,
                 updated_at = saga.updated_at,
+                age_seconds = observed_at.saturating_sub(saga.created_at),
+                idle_seconds = observed_at.saturating_sub(saga.updated_at),
                 "recovering incomplete melt saga",
             );
 
@@ -793,14 +804,24 @@ impl Mint {
                             MeltQuoteState::Pending | MeltQuoteState::Unknown => {
                                 // Not authoritative: an orchestrator may be
                                 // between payment attempts.
-                                tracing::warn!(
-                                    saga_id = %saga.operation_id,
-                                    quote_id = %quote_id,
-                                    payment_lookup_id = %payment_response.payment_lookup_id,
-                                    payment_status = %payment_response.status,
-                                    proof_count = input_ys.len(),
-                                    "recovery cannot prove payment failure; quote and proofs remain pending",
-                                );
+                                if payment_response.status == MeltQuoteState::Unknown {
+                                    tracing::warn!(
+                                        saga_id = %saga.operation_id,
+                                        quote_id = %quote_id,
+                                        payment_lookup_id = %payment_response.payment_lookup_id,
+                                        payment_status = %payment_response.status,
+                                        proof_count = input_ys.len(),
+                                        "recovery cannot prove payment failure; quote and proofs remain pending",
+                                    );
+                                } else {
+                                    tracing::info!(
+                                        saga_id = %saga.operation_id,
+                                        quote_id = %quote_id,
+                                        payment_lookup_id = %payment_response.payment_lookup_id,
+                                        proof_count = input_ys.len(),
+                                        "recovery found an in-flight payment; quote and proofs remain pending",
+                                    );
+                                }
                                 continue; // Skip this saga
                             }
                         }
@@ -869,8 +890,9 @@ impl Mint {
         }
 
         tracing::info!(
-            "Successfully recovered {} incomplete melt sagas.",
-            total_sagas
+            examined_saga_count = total_sagas,
+            recovery_duration_seconds = unix_time().saturating_sub(recovery_started_at),
+            "melt saga recovery pass completed; individual outcomes are logged by quote and saga id",
         );
 
         Ok(())


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

Improve mint logging so operators can trace a quote from creation through
  payment, issuance, finalization, or rollback—and understand why a melt and
  its proofs remain pending.

  - Log persisted mint/melt quote creation with searchable identifiers.
  - Record committed payment, issuance, and proof reservation outcomes.
  - Explain ambiguous payment results and why proofs cannot safely be released.
  - Report incomplete melt saga age and recovery decisions.
  - Include melt fees, change amounts, and finalization failures.
  - Log LND failure reasons, MPP route failures, and RPC/stream error details.
  - Reduce duplicate messages and move routine polling to DEBUG/TRACE.
  - Fix mintd filtering so configured TRACE output is available.

  Payment-state handling is unchanged. This improves diagnostics; it does not
  automatically resolve pending payments or reconstruct historical logs.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
