### PR TITLE
Refactor/ffi conversion cleanup

### DIFF
--- a/crates/cdk-ffi/src/database.rs
+++ b/crates/cdk-ffi/src/database.rs
@@ -13,6 +13,15 @@ use crate::postgres::WalletPostgresDatabase;
 use crate::sqlite::WalletSqliteDatabase;
 use crate::types::*;
 
+// Keep foreign callback and conversion failures in the existing database error
+// category, preserving their display text at the Rust database boundary.
+fn into_database_error<E>(error: E) -> cdk::cdk_database::Error
+where
+    E: std::fmt::Display,
+{
+    cdk::cdk_database::Error::Database(error.to_string().into())
+}
+
 /// FFI-compatible wallet database trait with all read and write operations
 /// This trait mirrors the CDK WalletDatabase trait structure
 #[uniffi::export(with_foreign)]
@@ -307,7 +316,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
                 key.to_string(),
             )
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn kv_list(
@@ -321,7 +330,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
                 secondary_namespace.to_string(),
             )
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     // Mint Management
@@ -334,11 +343,11 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_mint(ffi_mint_url)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            .map_err(into_database_error)?;
         result
             .map(TryInto::try_into)
             .transpose()
-            .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn get_mints(
@@ -347,21 +356,15 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         HashMap<cdk::mint_url::MintUrl, Option<cdk::nuts::MintInfo>>,
         cdk::cdk_database::Error,
     > {
-        let result = self
-            .ffi_db
-            .get_mints()
-            .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+        let result = self.ffi_db.get_mints().await.map_err(into_database_error)?;
 
         let mut cdk_result = HashMap::new();
         for (ffi_mint_url, mint_info_opt) in result {
-            let cdk_url = ffi_mint_url
-                .try_into()
-                .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            let cdk_url = ffi_mint_url.try_into().map_err(into_database_error)?;
             let cdk_mint_info = mint_info_opt
                 .map(TryInto::try_into)
                 .transpose()
-                .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+                .map_err(into_database_error)?;
             cdk_result.insert(cdk_url, cdk_mint_info);
         }
         Ok(cdk_result)
@@ -377,7 +380,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_mint_keysets(ffi_mint_url)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            .map_err(into_database_error)?;
         let cdk_keysets = result
             .map(|keysets| {
                 keysets
@@ -386,7 +389,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
                     .collect::<Result<Vec<_>, _>>()
             })
             .transpose()
-            .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            .map_err(into_database_error)?;
 
         Ok(cdk_keysets)
     }
@@ -400,11 +403,11 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_keyset_by_id(ffi_id)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            .map_err(into_database_error)?;
         let cdk_keyset = result
             .map(TryInto::try_into)
             .transpose()
-            .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            .map_err(into_database_error)?;
 
         Ok(cdk_keyset)
     }
@@ -418,13 +421,11 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_mint_quote(quote_id.to_string())
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
-        Ok(result
-            .map(|q| {
-                q.try_into()
-                    .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))
-            })
-            .transpose()?)
+            .map_err(into_database_error)?;
+        result
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(into_database_error)
     }
 
     async fn get_mint_quotes(
@@ -434,14 +435,12 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_mint_quotes()
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
-        Ok(result
+            .map_err(into_database_error)?;
+        result
             .into_iter()
-            .map(|q| {
-                q.try_into()
-                    .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))
-            })
-            .collect::<Result<Vec<_>, _>>()?)
+            .map(TryInto::try_into)
+            .collect::<Result<_, FfiError>>()
+            .map_err(into_database_error)
     }
 
     async fn get_unissued_mint_quotes(
@@ -451,14 +450,12 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_unissued_mint_quotes()
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
-        Ok(result
+            .map_err(into_database_error)?;
+        result
             .into_iter()
-            .map(|q| {
-                q.try_into()
-                    .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))
-            })
-            .collect::<Result<Vec<_>, _>>()?)
+            .map(TryInto::try_into)
+            .collect::<Result<_, FfiError>>()
+            .map_err(into_database_error)
     }
 
     // Melt Quote Management
@@ -470,13 +467,11 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_melt_quote(quote_id.to_string())
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
-        Ok(result
-            .map(|q| {
-                q.try_into()
-                    .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))
-            })
-            .transpose()?)
+            .map_err(into_database_error)?;
+        result
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(into_database_error)
     }
 
     async fn get_melt_quotes(
@@ -486,14 +481,12 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_melt_quotes()
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
-        Ok(result
+            .map_err(into_database_error)?;
+        result
             .into_iter()
-            .map(|q| {
-                q.try_into()
-                    .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))
-            })
-            .collect::<Result<Vec<_>, _>>()?)
+            .map(TryInto::try_into)
+            .collect::<Result<_, FfiError>>()
+            .map_err(into_database_error)
     }
 
     // Keys Management
@@ -506,16 +499,13 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_keys(ffi_id)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            .map_err(into_database_error)?;
 
         // Convert FFI Keys back to CDK Keys using TryFrom
         result
-            .map(|ffi_keys| {
-                ffi_keys
-                    .try_into()
-                    .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))
-            })
+            .map(TryInto::try_into)
             .transpose()
+            .map_err(into_database_error)
     }
 
     // Proof Management
@@ -536,47 +526,13 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_proofs(ffi_mint_url, ffi_unit, ffi_state, ffi_spending_conditions)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            .map_err(into_database_error)?;
 
-        // Convert back to CDK ProofInfo
-        let cdk_result: Result<Vec<cdk::types::ProofInfo>, cdk::cdk_database::Error> = result
+        result
             .into_iter()
-            .map(|info| {
-                Ok(cdk::types::ProofInfo {
-                    proof: info.proof.try_into().map_err(|e: FfiError| {
-                        cdk::cdk_database::Error::Database(e.to_string().into())
-                    })?,
-                    y: info.y.try_into().map_err(|e: FfiError| {
-                        cdk::cdk_database::Error::Database(e.to_string().into())
-                    })?,
-                    mint_url: info.mint_url.try_into().map_err(|e: FfiError| {
-                        cdk::cdk_database::Error::Database(e.to_string().into())
-                    })?,
-                    state: info.state.into(),
-                    spending_condition: info
-                        .spending_condition
-                        .map(|sc| sc.try_into())
-                        .transpose()
-                        .map_err(|e: FfiError| {
-                            cdk::cdk_database::Error::Database(e.to_string().into())
-                        })?,
-                    unit: info.unit.into(),
-                    derivation_index: info.derivation_index,
-                    used_by_operation: info
-                        .used_by_operation
-                        .map(|id| uuid::Uuid::parse_str(&id))
-                        .transpose()
-                        .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?,
-                    created_by_operation: info
-                        .created_by_operation
-                        .map(|id| uuid::Uuid::parse_str(&id))
-                        .transpose()
-                        .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?,
-                })
-            })
-            .collect();
-
-        cdk_result
+            .map(TryInto::try_into)
+            .collect::<Result<_, FfiError>>()
+            .map_err(into_database_error)
     }
 
     async fn get_proofs_by_ys(
@@ -589,47 +545,13 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_proofs_by_ys(ffi_ys)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            .map_err(into_database_error)?;
 
-        // Convert back to CDK ProofInfo
-        let cdk_result: Result<Vec<cdk::types::ProofInfo>, cdk::cdk_database::Error> = result
+        result
             .into_iter()
-            .map(|info| {
-                Ok(cdk::types::ProofInfo {
-                    proof: info.proof.try_into().map_err(|e: FfiError| {
-                        cdk::cdk_database::Error::Database(e.to_string().into())
-                    })?,
-                    y: info.y.try_into().map_err(|e: FfiError| {
-                        cdk::cdk_database::Error::Database(e.to_string().into())
-                    })?,
-                    mint_url: info.mint_url.try_into().map_err(|e: FfiError| {
-                        cdk::cdk_database::Error::Database(e.to_string().into())
-                    })?,
-                    state: info.state.into(),
-                    spending_condition: info
-                        .spending_condition
-                        .map(|sc| sc.try_into())
-                        .transpose()
-                        .map_err(|e: FfiError| {
-                            cdk::cdk_database::Error::Database(e.to_string().into())
-                        })?,
-                    unit: info.unit.into(),
-                    derivation_index: info.derivation_index,
-                    used_by_operation: info
-                        .used_by_operation
-                        .map(|id| uuid::Uuid::parse_str(&id))
-                        .transpose()
-                        .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?,
-                    created_by_operation: info
-                        .created_by_operation
-                        .map(|id| uuid::Uuid::parse_str(&id))
-                        .transpose()
-                        .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?,
-                })
-            })
-            .collect();
-
-        cdk_result
+            .map(TryInto::try_into)
+            .collect::<Result<_, FfiError>>()
+            .map_err(into_database_error)
     }
 
     async fn get_balance(
@@ -645,7 +567,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .get_balance(ffi_mint_url, ffi_unit, ffi_state)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     // Transaction Management
@@ -658,12 +580,12 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_transaction(ffi_id)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            .map_err(into_database_error)?;
 
         result
-            .map(|tx| tx.try_into())
+            .map(TryInto::try_into)
             .transpose()
-            .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn list_transactions(
@@ -680,13 +602,13 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .list_transactions(ffi_mint_url, ffi_direction, ffi_unit)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            .map_err(into_database_error)?;
 
         result
             .into_iter()
-            .map(|tx| tx.try_into())
+            .map(TryInto::try_into)
             .collect::<Result<Vec<_>, FfiError>>()
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     // P2PK methods
@@ -702,7 +624,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .add_p2pk_key(ffi_pubkey, ffi_derivation_path, derivation_index)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn list_p2pk_keys(
@@ -712,15 +634,12 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .list_p2pk_keys()
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
-        Ok(result
+            .map_err(into_database_error)?;
+        result
             .into_iter()
-            .map(|k| {
-                k.try_into().map_err(|e: crate::error::FfiError| {
-                    cdk::cdk_database::Error::Database(e.to_string().into())
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?)
+            .map(TryInto::try_into)
+            .collect::<Result<_, FfiError>>()
+            .map_err(into_database_error)
     }
 
     async fn latest_p2pk(
@@ -730,14 +649,11 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .latest_p2pk()
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
-        Ok(result
-            .map(|k| {
-                k.try_into().map_err(|e: crate::error::FfiError| {
-                    cdk::cdk_database::Error::Database(e.to_string().into())
-                })
-            })
-            .transpose()?)
+            .map_err(into_database_error)?;
+        result
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(into_database_error)
     }
 
     async fn get_p2pk_key(
@@ -749,14 +665,11 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_p2pk_key(ffi_pubkey)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
-        Ok(result
-            .map(|k| {
-                k.try_into().map_err(|e: crate::error::FfiError| {
-                    cdk::cdk_database::Error::Database(e.to_string().into())
-                })
-            })
-            .transpose()?)
+            .map_err(into_database_error)?;
+        result
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(into_database_error)
     }
 
     // Write methods (non-transactional)
@@ -771,7 +684,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .update_proofs(ffi_added, ffi_removed_ys)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn update_proofs_state(
@@ -784,7 +697,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .update_proofs_state(ffi_ys, ffi_state)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn add_transaction(
@@ -795,7 +708,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .add_transaction(ffi_transaction)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn update_mint_url(
@@ -808,7 +721,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .update_mint_url(ffi_old, ffi_new)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn increment_keyset_counter(
@@ -820,7 +733,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .increment_keyset_counter(ffi_id, count)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn increment_derivation_counter(
@@ -831,7 +744,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .increment_derivation_counter(namespace.to_owned(), count)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn add_mint(
@@ -844,7 +757,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .add_mint(ffi_mint_url, ffi_mint_info)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn remove_mint(
@@ -855,7 +768,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .remove_mint(ffi_mint_url)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn add_mint_keysets(
@@ -868,7 +781,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .add_mint_keysets(ffi_mint_url, ffi_keysets)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn add_mint_quote(
@@ -879,14 +792,14 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .add_mint_quote(ffi_quote)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn remove_mint_quote(&self, quote_id: &str) -> Result<(), cdk::cdk_database::Error> {
         self.ffi_db
             .remove_mint_quote(quote_id.to_string())
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn add_melt_quote(
@@ -897,14 +810,14 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .add_melt_quote(ffi_quote)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn remove_melt_quote(&self, quote_id: &str) -> Result<(), cdk::cdk_database::Error> {
         self.ffi_db
             .remove_melt_quote(quote_id.to_string())
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn add_keys(&self, keyset: cdk::nuts::KeySet) -> Result<(), cdk::cdk_database::Error> {
@@ -912,7 +825,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .add_keys(ffi_keyset)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn remove_keys(&self, id: &cdk::nuts::Id) -> Result<(), cdk::cdk_database::Error> {
@@ -920,7 +833,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .remove_keys(ffi_id)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn remove_transaction(
@@ -931,16 +844,15 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .remove_transaction(ffi_id)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn add_saga(&self, saga: WalletSaga) -> Result<(), cdk::cdk_database::Error> {
-        let json = serde_json::to_string(&saga)
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+        let json = serde_json::to_string(&saga).map_err(into_database_error)?;
         self.ffi_db
             .add_saga(json)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn get_saga(
@@ -951,12 +863,11 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_saga(id.to_string())
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            .map_err(into_database_error)?;
 
         match json_opt {
             Some(json) => {
-                let saga: WalletSaga = serde_json::from_str(&json)
-                    .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+                let saga: WalletSaga = serde_json::from_str(&json).map_err(into_database_error)?;
                 Ok(Some(saga))
             }
             None => Ok(None),
@@ -964,19 +875,18 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
     }
 
     async fn update_saga(&self, saga: WalletSaga) -> Result<bool, cdk::cdk_database::Error> {
-        let json = serde_json::to_string(&saga)
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+        let json = serde_json::to_string(&saga).map_err(into_database_error)?;
         self.ffi_db
             .update_saga(json)
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn delete_saga(&self, id: &uuid::Uuid) -> Result<(), cdk::cdk_database::Error> {
         self.ffi_db
             .delete_saga(id.to_string())
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn get_incomplete_sagas(&self) -> Result<Vec<WalletSaga>, cdk::cdk_database::Error> {
@@ -984,14 +894,11 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_incomplete_sagas()
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            .map_err(into_database_error)?;
 
         json_vec
             .into_iter()
-            .map(|json| {
-                serde_json::from_str(&json)
-                    .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
-            })
+            .map(|json| serde_json::from_str(&json).map_err(into_database_error))
             .collect()
     }
 
@@ -1004,7 +911,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .reserve_proofs(ffi_ys, operation_id.to_string())
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn release_proofs(
@@ -1014,7 +921,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .release_proofs(operation_id.to_string())
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn get_reserved_proofs(
@@ -1025,44 +932,13 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .ffi_db
             .get_reserved_proofs(operation_id.to_string())
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            .map_err(into_database_error)?;
 
         result
             .into_iter()
-            .map(|info| {
-                Ok(cdk::types::ProofInfo {
-                    proof: info.proof.try_into().map_err(|e: FfiError| {
-                        cdk::cdk_database::Error::Database(e.to_string().into())
-                    })?,
-                    y: info.y.try_into().map_err(|e: FfiError| {
-                        cdk::cdk_database::Error::Database(e.to_string().into())
-                    })?,
-                    mint_url: info.mint_url.try_into().map_err(|e: FfiError| {
-                        cdk::cdk_database::Error::Database(e.to_string().into())
-                    })?,
-                    state: info.state.into(),
-                    spending_condition: info
-                        .spending_condition
-                        .map(|sc| sc.try_into())
-                        .transpose()
-                        .map_err(|e: FfiError| {
-                            cdk::cdk_database::Error::Database(e.to_string().into())
-                        })?,
-                    unit: info.unit.into(),
-                    derivation_index: info.derivation_index,
-                    used_by_operation: info
-                        .used_by_operation
-                        .map(|id| uuid::Uuid::parse_str(&id))
-                        .transpose()
-                        .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?,
-                    created_by_operation: info
-                        .created_by_operation
-                        .map(|id| uuid::Uuid::parse_str(&id))
-                        .transpose()
-                        .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?,
-                })
-            })
-            .collect()
+            .map(TryInto::try_into)
+            .collect::<Result<_, FfiError>>()
+            .map_err(into_database_error)
     }
 
     async fn reserve_melt_quote(
@@ -1073,7 +949,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .reserve_melt_quote(quote_id.to_string(), operation_id.to_string())
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn release_melt_quote(
@@ -1083,7 +959,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .release_melt_quote(operation_id.to_string())
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn reserve_mint_quote(
@@ -1094,7 +970,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .reserve_mint_quote(quote_id.to_string(), operation_id.to_string())
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn release_mint_quote(
@@ -1104,7 +980,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
         self.ffi_db
             .release_mint_quote(operation_id.to_string())
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn kv_write(
@@ -1122,7 +998,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
                 value.to_vec(),
             )
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 
     async fn kv_remove(
@@ -1138,7 +1014,7 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
                 key.to_string(),
             )
             .await
-            .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))
+            .map_err(into_database_error)
     }
 }
 
@@ -1505,33 +1381,8 @@ where
         added: Vec<ProofInfo>,
         removed_ys: Vec<PublicKey>,
     ) -> Result<(), FfiError> {
-        let cdk_added: Result<Vec<cdk::types::ProofInfo>, FfiError> = added
-            .into_iter()
-            .map(|info| {
-                Ok::<cdk::types::ProofInfo, FfiError>(cdk::types::ProofInfo {
-                    proof: info.proof.try_into()?,
-                    y: info.y.try_into()?,
-                    mint_url: info.mint_url.try_into()?,
-                    state: info.state.into(),
-                    spending_condition: info
-                        .spending_condition
-                        .map(|sc| sc.try_into())
-                        .transpose()?,
-                    unit: info.unit.into(),
-                    derivation_index: info.derivation_index,
-                    used_by_operation: info
-                        .used_by_operation
-                        .map(|id| uuid::Uuid::parse_str(&id))
-                        .transpose()
-                        .map_err(|e| FfiError::internal(e.to_string()))?,
-                    created_by_operation: info
-                        .created_by_operation
-                        .map(|id| uuid::Uuid::parse_str(&id))
-                        .transpose()
-                        .map_err(|e| FfiError::internal(e.to_string()))?,
-                })
-            })
-            .collect();
+        let cdk_added: Result<Vec<cdk::types::ProofInfo>, FfiError> =
+            added.into_iter().map(TryInto::try_into).collect();
         let cdk_added = cdk_added?;
 
         let cdk_removed_ys: Result<Vec<cdk::nuts::PublicKey>, FfiError> =
@@ -2285,4 +2136,151 @@ pub fn create_cdk_database_from_ffi(
     ffi_db: Arc<dyn WalletDatabase>,
 ) -> Arc<dyn CdkWalletDatabase<cdk::cdk_database::Error> + Send + Sync> {
     Arc::new(WalletDatabaseBridge::new(ffi_db))
+}
+
+#[cfg(test)]
+mod tests {
+    use cdk::nuts::{Proof as CdkProof, SecretKey as CdkSecretKey, State};
+    use cdk::types::ProofInfo as CdkProofInfo;
+
+    use super::*;
+
+    fn proof_info() -> CdkProofInfo {
+        let key = CdkSecretKey::generate();
+        let proof = CdkProof {
+            amount: 42.into(),
+            keyset_id: "00916bbf7ef91a36".parse().unwrap(),
+            secret: "ffi-conversion-proof".parse().unwrap(),
+            c: key.public_key(),
+            witness: Some(cdk::nuts::Witness::P2PKWitness(
+                cdk::nuts::nut11::P2PKWitness {
+                    signatures: vec!["signature".to_string()],
+                },
+            )),
+            dleq: Some(cdk::nuts::nut12::ProofDleq::new(
+                key.clone(),
+                key.clone(),
+                key.clone(),
+            )),
+            p2pk_e: Some(key.public_key()),
+        };
+        let mut info = CdkProofInfo::new(
+            proof,
+            "https://mint.example.com".parse().unwrap(),
+            State::Reserved,
+            cdk::nuts::CurrencyUnit::Sat,
+        )
+        .unwrap();
+        info.spending_condition = Some(cdk::nuts::SpendingConditions::P2PKConditions {
+            data: key.public_key(),
+            conditions: None,
+        });
+        info.derivation_index = Some(17);
+        info.used_by_operation = Some(uuid::Uuid::new_v4());
+        info.created_by_operation = Some(uuid::Uuid::new_v4());
+        info
+    }
+
+    #[tokio::test]
+    async fn proof_conversion_paths_preserve_metadata() {
+        let native = cdk_sqlite::wallet::memory::empty().await.unwrap();
+        let foreign = FfiWalletDatabaseWrapper::new(native);
+        let bridge = WalletDatabaseBridge::new(foreign.clone());
+        let expected = proof_info();
+
+        foreign
+            .update_proofs(vec![expected.clone().into()], vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            bridge.get_proofs(None, None, None, None).await.unwrap(),
+            vec![expected.clone()]
+        );
+        assert_eq!(
+            bridge.get_proofs_by_ys(vec![expected.y]).await.unwrap(),
+            vec![expected.clone()]
+        );
+        assert_eq!(
+            bridge
+                .get_reserved_proofs(&expected.used_by_operation.unwrap())
+                .await
+                .unwrap(),
+            vec![expected.clone()]
+        );
+
+        let json = encode_proof_info(expected.clone().into()).unwrap();
+        assert_eq!(json, serde_json::to_string(&expected).unwrap());
+        let decoded: CdkProofInfo = decode_proof_info(json).unwrap().try_into().unwrap();
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn proof_conversion_preserves_absent_metadata() {
+        let mut expected = proof_info();
+        expected.spending_condition = None;
+        expected.derivation_index = None;
+        expected.used_by_operation = None;
+        expected.created_by_operation = None;
+        expected.proof.witness = None;
+        expected.proof.dleq = None;
+        expected.proof.p2pk_e = None;
+        let ffi: ProofInfo = expected.clone().into();
+
+        let converted: CdkProofInfo = ffi.clone().try_into().unwrap();
+        assert_eq!(converted, expected);
+        assert_eq!(
+            encode_proof_info(ffi).unwrap(),
+            serde_json::to_string(&expected).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_proof_conversion_leaves_database_untouched() {
+        let native = cdk_sqlite::wallet::memory::empty().await.unwrap();
+        let foreign = FfiWalletDatabaseWrapper::new(native);
+        let bridge = WalletDatabaseBridge::new(foreign.clone());
+        let expected = proof_info();
+        bridge
+            .update_proofs(vec![expected.clone()], vec![])
+            .await
+            .unwrap();
+        let mut new_proof = expected.clone();
+        new_proof.proof.secret = "ffi-conversion-new-proof".parse().unwrap();
+        new_proof.y = new_proof.proof.y().unwrap();
+        let valid: ProofInfo = new_proof.into();
+
+        // Both operation IDs must be validated, and nested conversion errors
+        // must propagate before either adding proofs or removing existing ones.
+        let mut invalid_used_by = valid.clone();
+        invalid_used_by.used_by_operation = Some("invalid".to_string());
+        let mut invalid_created_by = valid.clone();
+        invalid_created_by.created_by_operation = Some("invalid".to_string());
+        let mut invalid_key = valid.clone();
+        invalid_key.y.hex = "invalid".to_string();
+        let mut invalid_proof = valid.clone();
+        invalid_proof.proof.keyset_id = "invalid".to_string();
+
+        for invalid in [
+            invalid_used_by,
+            invalid_created_by,
+            invalid_key,
+            invalid_proof,
+        ] {
+            let conversion_error = CdkProofInfo::try_from(invalid.clone()).unwrap_err();
+            assert!(matches!(conversion_error, FfiError::Internal { .. }));
+            let encoding_error = encode_proof_info(invalid.clone()).unwrap_err();
+            let write_error = foreign
+                .update_proofs(vec![valid.clone(), invalid], vec![expected.y.into()])
+                .await
+                .unwrap_err();
+
+            assert_eq!(encoding_error.to_string(), conversion_error.to_string());
+            assert_eq!(write_error.to_string(), conversion_error.to_string());
+            assert_eq!(
+                bridge.get_proofs(None, None, None, None).await.unwrap(),
+                vec![expected.clone()]
+            );
+        }
+    }
 }

--- a/crates/cdk-ffi/src/supabase.rs
+++ b/crates/cdk-ffi/src/supabase.rs
@@ -35,14 +35,10 @@ impl WalletSupabaseDatabase {
     /// set tokens, or use one of the other constructors for automatic refresh.
     #[uniffi::constructor]
     pub async fn new(url: String, api_key: String) -> Result<Arc<Self>, FfiError> {
-        let url = url::Url::parse(&url).map_err(|e| FfiError::Internal {
-            error_message: e.to_string(),
-        })?;
+        let url = url::Url::parse(&url).map_err(FfiError::internal)?;
         let db = SupabaseWalletDatabase::new(url, api_key)
             .await
-            .map_err(|e| FfiError::Internal {
-                error_message: e.to_string(),
-            })?;
+            .map_err(FfiError::internal)?;
         Ok(Arc::new(WalletSupabaseDatabase {
             inner: FfiWalletDatabaseWrapper::new(db),
         }))
@@ -56,14 +52,10 @@ impl WalletSupabaseDatabase {
     /// `/auth/v1/token` endpoint automatically.
     #[uniffi::constructor]
     pub async fn with_supabase_auth(url: String, api_key: String) -> Result<Arc<Self>, FfiError> {
-        let url = url::Url::parse(&url).map_err(|e| FfiError::Internal {
-            error_message: e.to_string(),
-        })?;
+        let url = url::Url::parse(&url).map_err(FfiError::internal)?;
         let db = SupabaseWalletDatabase::with_supabase_auth(url, api_key)
             .await
-            .map_err(|e| FfiError::Internal {
-                error_message: e.to_string(),
-            })?;
+            .map_err(FfiError::internal)?;
         Ok(Arc::new(WalletSupabaseDatabase {
             inner: FfiWalletDatabaseWrapper::new(db),
         }))
@@ -80,15 +72,11 @@ impl WalletSupabaseDatabase {
         openid_discovery: String,
         client_id: Option<String>,
     ) -> Result<Arc<Self>, FfiError> {
-        let url = url::Url::parse(&url).map_err(|e| FfiError::Internal {
-            error_message: e.to_string(),
-        })?;
+        let url = url::Url::parse(&url).map_err(FfiError::internal)?;
         let oidc_client = OidcClient::new(openid_discovery, client_id);
         let db = SupabaseWalletDatabase::with_oidc(url, api_key, oidc_client)
             .await
-            .map_err(|e| FfiError::Internal {
-                error_message: e.to_string(),
-            })?;
+            .map_err(FfiError::internal)?;
         Ok(Arc::new(WalletSupabaseDatabase {
             inner: FfiWalletDatabaseWrapper::new(db),
         }))
@@ -117,9 +105,7 @@ impl WalletSupabaseDatabase {
             .inner()
             .set_encryption_password(&password)
             .await
-            .map_err(|e| FfiError::Internal {
-                error_message: e.to_string(),
-            })
+            .map_err(FfiError::internal)
     }
 
     /// Check that the database schema is compatible with this SDK version
@@ -138,9 +124,7 @@ impl WalletSupabaseDatabase {
             .inner()
             .check_schema_compatibility()
             .await
-            .map_err(|e| FfiError::Internal {
-                error_message: e.to_string(),
-            })
+            .map_err(FfiError::internal)
     }
 
     /// Refresh the access token using the stored refresh token
@@ -157,9 +141,7 @@ impl WalletSupabaseDatabase {
             .inner()
             .refresh_access_token()
             .await
-            .map_err(|e| FfiError::Internal {
-                error_message: e.to_string(),
-            })
+            .map_err(FfiError::internal)
     }
 
     /// Call a Supabase RPC function
@@ -188,9 +170,7 @@ impl WalletSupabaseDatabase {
             .inner()
             .call_rpc(&function_name, &params_json)
             .await
-            .map_err(|e| FfiError::Internal {
-                error_message: e.to_string(),
-            })
+            .map_err(FfiError::internal)
     }
 
     /// Sign up a new user and automatically set tokens if returned
@@ -200,9 +180,7 @@ impl WalletSupabaseDatabase {
             .inner()
             .signup(&email, &password)
             .await
-            .map_err(|e| FfiError::Internal {
-                error_message: e.to_string(),
-            })?;
+            .map_err(FfiError::internal)?;
         Ok(response.into())
     }
 
@@ -213,9 +191,7 @@ impl WalletSupabaseDatabase {
             .inner()
             .signin(&email, &password)
             .await
-            .map_err(|e| FfiError::Internal {
-                error_message: e.to_string(),
-            })?;
+            .map_err(FfiError::internal)?;
         Ok(response.into())
     }
 }
@@ -269,15 +245,11 @@ pub async fn supabase_signup(
     email: String,
     password: String,
 ) -> Result<AuthResponse, FfiError> {
-    let url = url::Url::parse(&url).map_err(|e| FfiError::Internal {
-        error_message: e.to_string(),
-    })?;
+    let url = url::Url::parse(&url).map_err(FfiError::internal)?;
 
     let response = cdk_supabase::SupabaseAuth::signup(&url, &api_key, &email, &password)
         .await
-        .map_err(|e| FfiError::Internal {
-            error_message: e.to_string(),
-        })?;
+        .map_err(FfiError::internal)?;
 
     Ok(response.into())
 }
@@ -290,15 +262,11 @@ pub async fn supabase_signin(
     email: String,
     password: String,
 ) -> Result<AuthResponse, FfiError> {
-    let url = url::Url::parse(&url).map_err(|e| FfiError::Internal {
-        error_message: e.to_string(),
-    })?;
+    let url = url::Url::parse(&url).map_err(FfiError::internal)?;
 
     let response = cdk_supabase::SupabaseAuth::signin(&url, &api_key, &email, &password)
         .await
-        .map_err(|e| FfiError::Internal {
-            error_message: e.to_string(),
-        })?;
+        .map_err(FfiError::internal)?;
 
     Ok(response.into())
 }

--- a/crates/cdk-ffi/src/token.rs
+++ b/crates/cdk-ffi/src/token.rs
@@ -46,9 +46,7 @@ impl Token {
     /// Create a new Token from string
     #[uniffi::constructor]
     pub fn from_string(encoded_token: String) -> Result<Token, FfiError> {
-        let token = cdk::nuts::Token::from_str(&encoded_token)
-            .map_err(|e| FfiError::internal(format!("Invalid token: {}", e)))?;
-        Ok(Token { inner: token })
+        Self::from_str(&encoded_token)
     }
 
     /// Get the total value of the token
@@ -74,9 +72,7 @@ impl Token {
     /// Get proofs from the token (simplified - no keyset filtering for now)
     pub fn proofs_simple(&self) -> Result<Proofs, FfiError> {
         // For now, return empty keysets to get all proofs
-        let empty_keysets = vec![];
-        let proofs = self.inner.proofs(&empty_keysets)?;
-        Ok(proofs.into_iter().map(|p| p.into()).collect())
+        self.proofs(vec![])
     }
 
     /// Get proofs from the token

--- a/crates/cdk-ffi/src/types/keys.rs
+++ b/crates/cdk-ffi/src/types/keys.rs
@@ -172,12 +172,7 @@ impl From<cdk::nuts::KeySet> for KeySet {
             unit: keyset.unit.into(),
             active: keyset.active,
             input_fee_ppk: keyset.input_fee_ppk,
-            keys: keyset
-                .keys
-                .keys()
-                .iter()
-                .map(|(amount, pubkey)| (u64::from(*amount), pubkey.to_string()))
-                .collect(),
+            keys: Keys::from(keyset.keys).keys,
             final_expiry: keyset.final_expiry,
         }
     }
@@ -187,7 +182,6 @@ impl TryFrom<KeySet> for cdk::nuts::KeySet {
     type Error = FfiError;
 
     fn try_from(keyset: KeySet) -> Result<Self, Self::Error> {
-        use std::collections::BTreeMap;
         use std::str::FromStr;
 
         // Convert id
@@ -198,16 +192,9 @@ impl TryFrom<KeySet> for cdk::nuts::KeySet {
         let unit: cdk::nuts::CurrencyUnit = keyset.unit.into();
 
         // Convert keys
-        let mut keys_map = BTreeMap::new();
-        for (amount_u64, pubkey_hex) in keyset.keys {
-            let amount = cdk::Amount::from(amount_u64);
-            let pubkey = cdk::nuts::PublicKey::from_str(&pubkey_hex)
-                .map_err(|e| FfiError::internal(format!("Invalid public key: {}", e)))?;
-            keys_map.insert(amount, pubkey);
-        }
-        let keys = cdk::nuts::Keys::new(keys_map);
+        let keys = Keys { keys: keyset.keys }.try_into()?;
 
-        Ok(cdk::nuts::KeySet {
+        Ok(Self {
             id,
             unit,
             active: keyset.active,

--- a/crates/cdk-ffi/src/types/payment_request.rs
+++ b/crates/cdk-ffi/src/types/payment_request.rs
@@ -388,21 +388,7 @@ impl fmt::Debug for CreateRequestParams {
 
 impl Default for CreateRequestParams {
     fn default() -> Self {
-        Self {
-            amount: None,
-            unit: "sat".to_string(),
-            description: None,
-            pubkeys: None,
-            num_sigs: 1,
-            hash: None,
-            preimage: None,
-            transport: "none".to_string(),
-            http_url: None,
-            nostr_relays: None,
-            mints: None,
-            mint_preferred: None,
-            supported_methods: vec![],
-        }
+        cdk::wallet::payment_request::CreateRequestParams::default().into()
     }
 }
 

--- a/crates/cdk-ffi/src/types/proof.rs
+++ b/crates/cdk-ffi/src/types/proof.rs
@@ -562,6 +562,32 @@ impl From<cdk::types::ProofInfo> for ProofInfo {
     }
 }
 
+impl TryFrom<ProofInfo> for cdk::types::ProofInfo {
+    type Error = FfiError;
+
+    fn try_from(info: ProofInfo) -> Result<Self, Self::Error> {
+        Ok(Self {
+            proof: info.proof.try_into()?,
+            y: info.y.try_into()?,
+            mint_url: info.mint_url.try_into()?,
+            state: info.state.into(),
+            spending_condition: info.spending_condition.map(TryInto::try_into).transpose()?,
+            unit: info.unit.into(),
+            derivation_index: info.derivation_index,
+            used_by_operation: info
+                .used_by_operation
+                .map(|id| uuid::Uuid::parse_str(&id))
+                .transpose()
+                .map_err(FfiError::internal)?,
+            created_by_operation: info
+                .created_by_operation
+                .map(|id| uuid::Uuid::parse_str(&id))
+                .transpose()
+                .map_err(FfiError::internal)?,
+        })
+    }
+}
+
 /// Decode ProofInfo from JSON string
 #[uniffi::export]
 pub fn decode_proof_info(json: String) -> Result<ProofInfo, FfiError> {
@@ -572,27 +598,7 @@ pub fn decode_proof_info(json: String) -> Result<ProofInfo, FfiError> {
 /// Encode ProofInfo to JSON string
 #[uniffi::export]
 pub fn encode_proof_info(info: ProofInfo) -> Result<String, FfiError> {
-    use std::str::FromStr;
-    // Convert to cdk::types::ProofInfo for serialization
-    let cdk_info = cdk::types::ProofInfo {
-        proof: info.proof.try_into()?,
-        y: info.y.try_into()?,
-        mint_url: info.mint_url.try_into()?,
-        state: info.state.into(),
-        spending_condition: info.spending_condition.map(TryInto::try_into).transpose()?,
-        unit: info.unit.into(),
-        derivation_index: info.derivation_index,
-        used_by_operation: info
-            .used_by_operation
-            .map(|id| uuid::Uuid::from_str(&id))
-            .transpose()
-            .map_err(|e| FfiError::internal(e.to_string()))?,
-        created_by_operation: info
-            .created_by_operation
-            .map(|id| uuid::Uuid::from_str(&id))
-            .transpose()
-            .map_err(|e| FfiError::internal(e.to_string()))?,
-    };
+    let cdk_info: cdk::types::ProofInfo = info.try_into()?;
     Ok(serde_json::to_string(&cdk_info)?)
 }
 

--- a/crates/cdk-ffi/src/types/quote.rs
+++ b/crates/cdk-ffi/src/types/quote.rs
@@ -76,13 +76,13 @@ impl fmt::Debug for MintQuote {
 impl From<cdk::wallet::MintQuote> for MintQuote {
     fn from(quote: cdk::wallet::MintQuote) -> Self {
         Self {
-            id: quote.id.clone(),
+            id: quote.id,
             amount: quote.amount.map(Into::into),
-            unit: quote.unit.clone().into(),
-            request: quote.request.clone(),
+            unit: quote.unit.into(),
+            request: quote.request,
             state: quote.state.into(),
             expiry: quote.expiry,
-            mint_url: quote.mint_url.clone().into(),
+            mint_url: quote.mint_url.into(),
             amount_issued: quote.amount_issued.into(),
             amount_paid: quote.amount_paid.into(),
             updated_at: quote.updated_at,

--- a/crates/cdk-ffi/src/types/wallet.rs
+++ b/crates/cdk-ffi/src/types/wallet.rs
@@ -244,18 +244,7 @@ pub struct SendOptions {
 
 impl Default for SendOptions {
     fn default() -> Self {
-        Self {
-            memo: None,
-            conditions: None,
-            amount_split_target: SplitTarget::None,
-            send_kind: SendKind::OnlineExact,
-            include_fee: false,
-            max_proofs: None,
-            metadata: HashMap::new(),
-            use_p2bk: false,
-            p2pk_signing_keys: Vec::new(),
-            p2pk_locked_proof_send_mode: P2PKLockedProofSendMode::Swap,
-        }
+        cdk::wallet::SendOptions::default().into()
     }
 }
 
@@ -410,12 +399,7 @@ impl fmt::Debug for ReceiveOptions {
 
 impl Default for ReceiveOptions {
     fn default() -> Self {
-        Self {
-            amount_split_target: SplitTarget::None,
-            p2pk_signing_keys: Vec::new(),
-            preimages: Vec::new(),
-            metadata: HashMap::new(),
-        }
+        cdk::wallet::ReceiveOptions::default().into()
     }
 }
 

--- a/crates/cdk-ffi/src/wallet.rs
+++ b/crates/cdk-ffi/src/wallet.rs
@@ -708,7 +708,7 @@ impl Wallet {
         &self,
         params: SubscribeParams,
     ) -> Result<std::sync::Arc<ActiveSubscription>, FfiError> {
-        let cdk_params: cdk::nuts::nut17::Params<Arc<String>> = params.clone().into();
+        let cdk_params: cdk::nuts::nut17::Params<Arc<String>> = params.into();
         let sub_id = cdk_params.id.to_string();
         let active_sub = self.inner.subscribe(cdk_params).await?;
         Ok(std::sync::Arc::new(ActiveSubscription::new(

--- a/crates/cdk-ffi/src/wallet_repository.rs
+++ b/crates/cdk-ffi/src/wallet_repository.rs
@@ -16,7 +16,7 @@ use crate::wallet::RateLimit;
 ///
 /// Rate limiting is a repository-wide setting: every wallet the repository
 /// hands out shares one limiter, so there is no per-wallet equivalent.
-#[derive(Debug, Clone, uniffi::Record)]
+#[derive(Debug, Clone, Default, uniffi::Record)]
 pub struct WalletRepositoryConfig {
     /// Proxy used by every mint operation. Omit for a direct connection.
     #[uniffi(default = None)]
@@ -45,28 +45,7 @@ impl WalletRepository {
     /// - `Custom { db }` — foreign-language implementation of `WalletDatabase`
     #[uniffi::constructor]
     pub fn new(mnemonic: String, store: crate::database::WalletStore) -> Result<Self, FfiError> {
-        let db = crate::database::resolve_wallet_store(store)?;
-
-        // Parse mnemonic and generate seed without passphrase
-        let m = Mnemonic::parse(&mnemonic)
-            .map_err(|e| FfiError::internal(format!("Invalid mnemonic: {}", e)))?;
-        let seed = m.to_seed_normalized("");
-
-        // Convert the FFI database trait to a CDK database implementation
-        let localstore = crate::database::create_cdk_database_from_ffi(db);
-
-        let rt = crate::runtime::RuntimeGuard::new().map_err(FfiError::internal)?;
-        let wallet = rt.block_on(async move {
-            WalletRepositoryBuilder::new()
-                .localstore(localstore)
-                .seed(seed)
-                .build()
-                .await
-        })?;
-
-        Ok(Self {
-            inner: Arc::new(wallet),
-        })
+        Self::new_with_config(mnemonic, store, WalletRepositoryConfig::default())
     }
 
     /// Create a new WalletRepository with proxy configuration.
@@ -80,33 +59,14 @@ impl WalletRepository {
         store: crate::database::WalletStore,
         proxy_url: String,
     ) -> Result<Self, FfiError> {
-        let db = crate::database::resolve_wallet_store(store)?;
-
-        // Parse mnemonic and generate seed without passphrase
-        let m = Mnemonic::parse(&mnemonic)
-            .map_err(|e| FfiError::internal(format!("Invalid mnemonic: {}", e)))?;
-        let seed = m.to_seed_normalized("");
-
-        // Convert the FFI database trait to a CDK database implementation
-        let localstore = crate::database::create_cdk_database_from_ffi(db);
-
-        // Parse proxy URL
-        let proxy_url = url::Url::parse(&proxy_url)
-            .map_err(|e| FfiError::internal(format!("Invalid URL: {}", e)))?;
-
-        let rt = crate::runtime::RuntimeGuard::new().map_err(FfiError::internal)?;
-        let wallet = rt.block_on(async move {
-            WalletRepositoryBuilder::new()
-                .localstore(localstore)
-                .seed(seed)
-                .proxy_url(proxy_url)
-                .build()
-                .await
-        })?;
-
-        Ok(Self {
-            inner: Arc::new(wallet),
-        })
+        Self::new_with_config(
+            mnemonic,
+            store,
+            WalletRepositoryConfig {
+                proxy_url: Some(proxy_url),
+                ..Default::default()
+            },
+        )
     }
 
     /// Create a new WalletRepository with proxy and rate-limit configuration.

--- a/crates/cdk-ffi/src/wallet_trait.rs
+++ b/crates/cdk-ffi/src/wallet_trait.rs
@@ -38,36 +38,31 @@ impl WalletTraitDef for Wallet {
     type RecoveryReport = RecoveryReport;
 
     fn mint_url(&self) -> Self::MintUrl {
-        self.inner().mint_url.clone().into()
+        Wallet::mint_url(self)
     }
 
     fn unit(&self) -> Self::CurrencyUnit {
-        self.inner().unit.clone().into()
+        Wallet::unit(self)
     }
 
     async fn total_balance(&self) -> Result<Self::Amount, Self::Error> {
-        let balance = WalletTraitDef::total_balance(self.inner().as_ref()).await?;
-        Ok(balance.into())
+        Wallet::total_balance(self).await
     }
 
     async fn total_pending_balance(&self) -> Result<Self::Amount, Self::Error> {
-        let balance = WalletTraitDef::total_pending_balance(self.inner().as_ref()).await?;
-        Ok(balance.into())
+        Wallet::total_pending_balance(self).await
     }
 
     async fn total_reserved_balance(&self) -> Result<Self::Amount, Self::Error> {
-        let balance = WalletTraitDef::total_reserved_balance(self.inner().as_ref()).await?;
-        Ok(balance.into())
+        Wallet::total_reserved_balance(self).await
     }
 
     async fn fetch_mint_info(&self) -> Result<Option<Self::MintInfo>, Self::Error> {
-        let info = WalletTraitDef::fetch_mint_info(self.inner().as_ref()).await?;
-        Ok(info.map(Into::into))
+        Wallet::fetch_mint_info(self).await
     }
 
     async fn load_mint_info(&self) -> Result<Self::MintInfo, Self::Error> {
-        let info = WalletTraitDef::load_mint_info(self.inner().as_ref()).await?;
-        Ok(info.into())
+        Wallet::load_mint_info(self).await
     }
 
     async fn keysets(
@@ -79,8 +74,7 @@ impl WalletTraitDef for Wallet {
     }
 
     async fn active_keyset(&self) -> Result<Self::KeySetInfo, Self::Error> {
-        let keyset = WalletTraitDef::active_keyset(self.inner().as_ref()).await?;
-        Ok(keyset.into())
+        Wallet::active_keyset(self).await
     }
 
     async fn keyset(
@@ -125,15 +119,7 @@ impl WalletTraitDef for Wallet {
         description: Option<String>,
         extra: Option<String>,
     ) -> Result<Self::MintQuote, Self::Error> {
-        let quote = WalletTraitDef::mint_quote(
-            self.inner().as_ref(),
-            method.into(),
-            amount.map(Into::into),
-            description,
-            extra,
-        )
-        .await?;
-        Ok(quote.into())
+        Wallet::mint_quote(self, method, amount, description, extra).await
     }
 
     async fn melt_quote(
@@ -143,15 +129,7 @@ impl WalletTraitDef for Wallet {
         options: Option<Self::MeltOptions>,
         extra: Option<String>,
     ) -> Result<Self::MeltQuote, Self::Error> {
-        let quote = WalletTraitDef::melt_quote(
-            self.inner().as_ref(),
-            method.into(),
-            request,
-            options.map(Into::into),
-            extra,
-        )
-        .await?;
-        Ok(quote.into())
+        Wallet::melt_quote(self, method, request, options, extra).await
     }
 
     async fn cross_mint_transfer_quote_max(
@@ -199,13 +177,11 @@ impl WalletTraitDef for Wallet {
     }
 
     async fn check_all_pending_proofs(&self) -> Result<Self::Amount, Self::Error> {
-        let amount = WalletTraitDef::check_all_pending_proofs(self.inner().as_ref()).await?;
-        Ok(amount.into())
+        Wallet::check_all_pending_proofs(self).await
     }
 
     async fn recover_incomplete_sagas(&self) -> Result<Self::RecoveryReport, Self::Error> {
-        let report = WalletTraitDef::recover_incomplete_sagas(self.inner().as_ref()).await?;
-        Ok(report.into())
+        Wallet::recover_incomplete_sagas(self).await
     }
 
     async fn check_proofs_spent(
@@ -266,22 +242,15 @@ impl WalletTraitDef for Wallet {
     }
 
     async fn get_pending_sends(&self) -> Result<Vec<String>, Self::Error> {
-        let ids = WalletTraitDef::get_pending_sends(self.inner().as_ref()).await?;
-        Ok(ids.into_iter().map(|id| id.to_string()).collect())
+        Wallet::get_pending_sends(self).await
     }
 
     async fn revoke_send(&self, operation_id: String) -> Result<Self::Amount, Self::Error> {
-        let uuid = uuid::Uuid::parse_str(&operation_id)
-            .map_err(|e| FfiError::internal(format!("Invalid operation ID: {}", e)))?;
-        let amount = WalletTraitDef::revoke_send(self.inner().as_ref(), uuid).await?;
-        Ok(amount.into())
+        Wallet::revoke_send(self, operation_id).await
     }
 
     async fn check_send_status(&self, operation_id: String) -> Result<bool, Self::Error> {
-        let uuid = uuid::Uuid::parse_str(&operation_id)
-            .map_err(|e| FfiError::internal(format!("Invalid operation ID: {}", e)))?;
-        let claimed = WalletTraitDef::check_send_status(self.inner().as_ref(), uuid).await?;
-        Ok(claimed)
+        Wallet::check_send_status(self, operation_id).await
     }
 
     async fn mint(
@@ -301,8 +270,7 @@ impl WalletTraitDef for Wallet {
     }
 
     async fn mint_unissued_quotes(&self) -> Result<Self::Amount, Self::Error> {
-        let amount = WalletTraitDef::mint_unissued_quotes(self.inner().as_ref()).await?;
-        Ok(amount.into())
+        Wallet::mint_unissued_quotes(self).await
     }
 
     async fn check_mint_quote_status(
@@ -383,18 +351,15 @@ impl WalletTraitDef for Wallet {
     }
 
     async fn set_cat(&self, cat: String) -> Result<(), Self::Error> {
-        WalletTraitDef::set_cat(self.inner().as_ref(), cat).await?;
-        Ok(())
+        Wallet::set_cat(self, cat).await
     }
 
     async fn set_refresh_token(&self, refresh_token: String) -> Result<(), Self::Error> {
-        WalletTraitDef::set_refresh_token(self.inner().as_ref(), refresh_token).await?;
-        Ok(())
+        Wallet::set_refresh_token(self, refresh_token).await
     }
 
     async fn refresh_access_token(&self) -> Result<(), Self::Error> {
-        WalletTraitDef::refresh_access_token(self.inner().as_ref()).await?;
-        Ok(())
+        Wallet::refresh_access_token(self).await
     }
 
     async fn mint_blind_auth(
@@ -435,21 +400,11 @@ impl WalletTraitDef for Wallet {
         quote_ids: Vec<String>,
         method: Self::PaymentMethod,
     ) -> Result<Arc<crate::types::ActiveSubscription>, Self::Error> {
-        let cdk_sub = WalletTraitDef::subscribe_mint_quote_state(
-            self.inner().as_ref(),
-            quote_ids,
-            method.into(),
-        )
-        .await?;
-        let sub_id = uuid::Uuid::new_v4().to_string();
-        Ok(Arc::new(crate::types::ActiveSubscription::new(
-            cdk_sub, sub_id,
-        )))
+        Wallet::subscribe_mint_quote_state(self, quote_ids, method).await
     }
 
     fn set_metadata_cache_ttl(&self, ttl_secs: Option<u64>) {
-        let ttl = ttl_secs.map(std::time::Duration::from_secs);
-        self.inner().set_metadata_cache_ttl(ttl);
+        Wallet::set_metadata_cache_ttl(self, ttl_secs);
     }
 
     fn set_rate_limiting_config(&self, config: Option<RateLimitConfig>) {
@@ -457,23 +412,18 @@ impl WalletTraitDef for Wallet {
     }
 
     fn is_rate_limited(&self) -> bool {
-        WalletTraitDef::is_rate_limited(self.inner().as_ref())
+        Wallet::is_rate_limited(self)
     }
 
     async fn flush_rate_limits(&self) {
-        WalletTraitDef::flush_rate_limits(self.inner().as_ref()).await;
+        Wallet::flush_rate_limits(self).await;
     }
 
     async fn subscribe(
         &self,
         params: crate::types::SubscribeParams,
     ) -> Result<Arc<crate::types::ActiveSubscription>, Self::Error> {
-        let cdk_params: cdk_common::subscription::WalletParams = params.into();
-        let sub_id = cdk_params.id.to_string();
-        let active_sub = WalletTraitDef::subscribe(self.inner().as_ref(), cdk_params).await?;
-        Ok(Arc::new(crate::types::ActiveSubscription::new(
-            active_sub, sub_id,
-        )))
+        Wallet::subscribe(self, params).await
     }
 
     #[cfg(all(feature = "bip353", not(target_arch = "wasm32")))]


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----
Consolidate duplicated FFI conversion and wrapper logic so validation,
  defaults, and wallet operations share existing implementations.

  - Centralize ProofInfo conversion across database and JSON paths.
  - Share repository constructors, nested key conversions, and option defaults.
  - Delegate 24 matching Wallet trait methods to existing FFI methods.
  - Reuse error and token helpers; remove unnecessary MintQuote clones.

  Existing FFI signatures, serialized fields, and error handling are preserved.
  Rust trait calls now skip the additional tracing spans in the core trait
  adapter.

  Removes 311 production lines and adds 146 test lines: 165 fewer lines overall.
  
### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
