### PR TITLE
Add compact state filters

### DIFF
--- a/crates/cashu/src/nuts/mod.rs
+++ b/crates/cashu/src/nuts/mod.rs
@@ -33,6 +33,7 @@ pub mod nut27;
 pub mod nut28;
 pub mod nut29;
 pub mod nut30;
+pub mod state_filters;
 
 mod auth;
 
@@ -94,4 +95,8 @@ pub use nut29::{BatchCheckMintQuoteRequest, BatchMintRequest, Settings as Nut29S
 pub use nut30::{
     MeltOnchainRequest, MeltQuoteOnchainRequest, MeltQuoteOnchainResponse, MintQuoteOnchainRequest,
     MintQuoteOnchainResponse,
+};
+pub use state_filters::{
+    DecodedFilter, Filter, FilterElement, FilterKind, GetFiltersInfoResponse, GetFiltersResponse,
+    PendingFilterResponse, Settings as StateFilterSettings,
 };

--- a/crates/cashu/src/nuts/nut06.rs
+++ b/crates/cashu/src/nuts/nut06.rs
@@ -10,8 +10,8 @@ use super::nut01::PublicKey;
 use super::nut17::SupportedMethods;
 use super::nut19::CachedEndpoint;
 use super::{
-    nut04, nut05, nut15, nut19, nut29, AuthRequired, BlindAuthSettings, ClearAuthSettings,
-    MppMethodSettings, ProtectedEndpoint,
+    nut04, nut05, nut15, nut19, nut29, state_filters, AuthRequired, BlindAuthSettings,
+    ClearAuthSettings, MppMethodSettings, ProtectedEndpoint,
 };
 use crate::util::serde_helpers::deserialize_empty_string_as_none;
 use crate::CurrencyUnit;
@@ -348,6 +348,14 @@ pub struct Nuts {
     #[serde(rename = "29")]
     #[serde(skip_serializing_if = "nut29::Settings::is_empty")]
     pub nut29: nut29::Settings,
+    /// Compact state filter settings
+    ///
+    /// The number is provisional: the NUT has not been assigned one yet, and
+    /// this attribute is the only place it appears.
+    #[serde(default)]
+    #[serde(rename = "31")]
+    #[serde(skip_serializing_if = "state_filters::Settings::is_empty")]
+    pub state_filters: state_filters::Settings,
 }
 
 impl Nuts {
@@ -469,6 +477,14 @@ impl Nuts {
     pub fn nut29(self, settings: nut29::Settings) -> Self {
         Self {
             nut29: settings,
+            ..self
+        }
+    }
+
+    /// Compact state filter settings
+    pub fn state_filters(self, settings: state_filters::Settings) -> Self {
+        Self {
+            state_filters: settings,
             ..self
         }
     }

--- a/crates/cashu/src/nuts/state_filters/codec.rs
+++ b/crates/cashu/src/nuts/state_filters/codec.rs
@@ -1,0 +1,213 @@
+//! Golomb-Rice coded sets.
+//!
+//! Follows the construction of [BIP-158] with two departures that cut the
+//! primitives needed: elements are already SHA-256 digests over a
+//! domain-separated preimage, so there is no SipHash step, and `M` is fixed to
+//! `2^P` rather than `1.497137 * 2^P`, which makes this Rice coding with a
+//! single parameter.
+//!
+//! [BIP-158]: https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki
+
+use super::element::FilterElement;
+use super::Error;
+
+/// Smallest permitted Golomb-Rice parameter.
+///
+/// Decoding stops when fewer than `P + 1` bits remain, and a code is at least
+/// `P + 1` bits long. Padding is at most 7 bits, so `P` below 7 would let
+/// padding complete a code and inflate `N`.
+pub const MIN_P: u8 = 7;
+
+/// Largest Golomb-Rice parameter this implementation accepts.
+///
+/// Bounded below 64 so that `1 << p` and `64 - p` stay well defined. Real
+/// filters use 28; anything near this bound is already absurd.
+pub const MAX_P: u8 = 63;
+
+fn check_p(p: u8) -> Result<(), Error> {
+    if !(MIN_P..=MAX_P).contains(&p) {
+        return Err(Error::InvalidParameter(p));
+    }
+    Ok(())
+}
+
+/// Position of an element in a filter holding `n` distinct elements.
+///
+/// The spec defines this as `(v * n * 2^p) >> 64`. Dividing by `2^64` after
+/// multiplying by `2^p` is the same floor as shifting right by `64 - p`, which
+/// keeps the product inside a `u128` for every `p` this module accepts.
+fn position(element: &[u8; 32], n: u64, p: u8) -> u64 {
+    let mut head = [0u8; 8];
+    head.copy_from_slice(&element[..8]);
+    let v = u64::from_be_bytes(head);
+
+    let scaled = (v as u128) * (n as u128);
+    (scaled >> (64 - p)) as u64
+}
+
+#[derive(Default)]
+struct BitWriter {
+    out: Vec<u8>,
+    acc: u8,
+    used: u8,
+}
+
+impl BitWriter {
+    fn write_bit(&mut self, bit: bool) {
+        self.acc = (self.acc << 1) | u8::from(bit);
+        self.used += 1;
+        if self.used == 8 {
+            self.out.push(self.acc);
+            self.acc = 0;
+            self.used = 0;
+        }
+    }
+
+    fn write_bits(&mut self, value: u64, nbits: u8) {
+        for i in (0..nbits).rev() {
+            self.write_bit((value >> i) & 1 == 1);
+        }
+    }
+
+    fn finish(mut self) -> Vec<u8> {
+        if self.used > 0 {
+            self.out.push(self.acc << (8 - self.used));
+        }
+        self.out
+    }
+}
+
+struct BitReader<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> BitReader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    fn remaining(&self) -> usize {
+        (self.data.len() * 8).saturating_sub(self.pos)
+    }
+
+    fn read_bit(&mut self) -> Result<bool, Error> {
+        if self.pos >= self.data.len() * 8 {
+            return Err(Error::UnexpectedEnd);
+        }
+        let byte = self.data[self.pos / 8];
+        let bit = (byte >> (7 - (self.pos % 8))) & 1 == 1;
+        self.pos += 1;
+        Ok(bit)
+    }
+
+    fn read_bits(&mut self, nbits: u8) -> Result<u64, Error> {
+        let mut value = 0u64;
+        for _ in 0..nbits {
+            value = (value << 1) | u64::from(self.read_bit()?);
+        }
+        Ok(value)
+    }
+
+    fn read_unary(&mut self) -> Result<u64, Error> {
+        let mut count = 0u64;
+        while self.read_bit()? {
+            count = count.checked_add(1).ok_or(Error::PositionOverflow)?;
+        }
+        Ok(count)
+    }
+}
+
+/// Encode a set of elements as a Golomb-Rice coded set.
+///
+/// Duplicate elements are removed, so `n` is recoverable by a decoder. Distinct
+/// elements that land on the same position are kept, encoding as a zero delta.
+pub fn encode(elements: &[FilterElement], p: u8) -> Result<Vec<u8>, Error> {
+    check_p(p)?;
+
+    let mut distinct: Vec<[u8; 32]> = elements.iter().map(|e| *e.as_bytes()).collect();
+    distinct.sort_unstable();
+    distinct.dedup();
+
+    let n = distinct.len() as u64;
+
+    let mut positions: Vec<u64> = distinct.iter().map(|bytes| position(bytes, n, p)).collect();
+    positions.sort_unstable();
+
+    let mut writer = BitWriter::default();
+    let mut previous = 0u64;
+    for pos in positions {
+        let delta = pos - previous;
+        previous = pos;
+
+        let quotient = delta >> p;
+        for _ in 0..quotient {
+            writer.write_bit(true);
+        }
+        writer.write_bit(false);
+
+        writer.write_bits(delta & ((1u64 << p) - 1), p);
+    }
+
+    Ok(writer.finish())
+}
+
+/// A filter whose positions have been read back out.
+///
+/// `n` is not transmitted; it is the number of values the decoder read, which
+/// is why membership can only be tested after decoding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedFilter {
+    n: u64,
+    p: u8,
+    positions: Vec<u64>,
+}
+
+impl DecodedFilter {
+    /// Decode a Golomb-Rice coded set.
+    pub fn decode(data: &[u8], p: u8) -> Result<Self, Error> {
+        check_p(p)?;
+
+        let mut reader = BitReader::new(data);
+        let mut positions = Vec::new();
+        let mut previous = 0u64;
+
+        while reader.remaining() > usize::from(p) {
+            let quotient = reader.read_unary()?;
+            let remainder = reader.read_bits(p)?;
+
+            if quotient > (u64::MAX >> p) {
+                return Err(Error::PositionOverflow);
+            }
+            let delta = (quotient << p)
+                .checked_add(remainder)
+                .ok_or(Error::PositionOverflow)?;
+
+            previous = previous.checked_add(delta).ok_or(Error::PositionOverflow)?;
+            positions.push(previous);
+        }
+
+        Ok(Self {
+            n: positions.len() as u64,
+            p,
+            positions,
+        })
+    }
+
+    /// Number of distinct elements the filter was built from.
+    pub fn n(&self) -> u64 {
+        self.n
+    }
+
+    /// Test an element against the filter.
+    ///
+    /// A `false` is conclusive; a `true` is a match with a `2^-p` chance of
+    /// being spurious, so callers must confirm before acting on it.
+    pub fn contains(&self, element: &FilterElement) -> bool {
+        if self.n == 0 {
+            return false;
+        }
+        let pos = position(element.as_bytes(), self.n, self.p);
+        self.positions.binary_search(&pos).is_ok()
+    }
+}

--- a/crates/cashu/src/nuts/state_filters/element.rs
+++ b/crates/cashu/src/nuts/state_filters/element.rs
@@ -1,0 +1,158 @@
+//! Filter elements.
+//!
+//! One element per object whose observable state changed during an epoch.
+
+use std::fmt;
+use std::str::FromStr;
+
+use bitcoin::hashes::{sha256, Hash};
+use serde::{Deserialize, Serialize};
+
+use super::Error;
+use crate::nuts::{MeltQuoteState, PublicKey, State};
+
+/// Domain separator, hashed as raw ASCII bytes without a length prefix.
+pub const DOMAIN_SEPARATOR: &[u8] = b"Cashu_StateFilter_v1";
+
+/// The kind of object an element describes.
+///
+/// A kind names the operation, not the payment method. Every method shares one
+/// filter sequence; splitting it would shrink the anonymity set and leak the
+/// method on a match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FilterKind {
+    /// A proof changed state.
+    ProofState,
+    /// A mint quote changed.
+    MintQuote,
+    /// A melt quote changed state.
+    MeltQuote,
+}
+
+impl FilterKind {
+    /// The kind as it appears in an element preimage and on the wire.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ProofState => "proof_state",
+            Self::MintQuote => "mint_quote",
+            Self::MeltQuote => "melt_quote",
+        }
+    }
+}
+
+impl fmt::Display for FilterKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl FromStr for FilterKind {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "proof_state" => Ok(Self::ProofState),
+            "mint_quote" => Ok(Self::MintQuote),
+            "melt_quote" => Ok(Self::MeltQuote),
+            other => Err(Error::UnknownKind(other.to_string())),
+        }
+    }
+}
+
+/// A single filter element.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct FilterElement([u8; 32]);
+
+fn len32(value: usize) -> [u8; 4] {
+    (value as u32).to_be_bytes()
+}
+
+impl FilterElement {
+    /// Hash a `(kind, id, state)` triple into an element.
+    ///
+    /// The length prefixes keep the three fields unambiguous, so a new kind
+    /// needs no registry of tags.
+    pub fn new(kind: FilterKind, id: &[u8], state: &[u8]) -> Self {
+        let kind = kind.as_str().as_bytes();
+
+        let mut preimage =
+            Vec::with_capacity(DOMAIN_SEPARATOR.len() + 12 + kind.len() + id.len() + state.len());
+        preimage.extend_from_slice(DOMAIN_SEPARATOR);
+        preimage.extend_from_slice(&len32(kind.len()));
+        preimage.extend_from_slice(kind);
+        preimage.extend_from_slice(&len32(id.len()));
+        preimage.extend_from_slice(id);
+        preimage.extend_from_slice(&len32(state.len()));
+        preimage.extend_from_slice(state);
+
+        Self(sha256::Hash::hash(&preimage).to_byte_array())
+    }
+
+    /// Element for a proof that moved to `state`.
+    ///
+    /// Binding the state into the element is what keeps a proof state private
+    /// end to end: a match reports the new state directly, so the wallet never
+    /// has to send `Y` to learn it.
+    pub fn proof_state(y: &PublicKey, state: State) -> Result<Self, Error> {
+        let state = match state {
+            State::Unspent => "UNSPENT",
+            State::Pending => "PENDING",
+            State::Spent => "SPENT",
+            other => return Err(Error::UnsupportedState(other.to_string())),
+        };
+
+        Ok(Self::new(
+            FilterKind::ProofState,
+            &y.to_bytes(),
+            state.as_bytes(),
+        ))
+    }
+
+    /// Element for a mint quote that changed.
+    ///
+    /// Mint quotes carry no state because their accounting fields would
+    /// disclose amounts, so a match means only that the quote changed.
+    ///
+    /// `id` must be the quote id exactly as it was returned to the wallet,
+    /// neither case-normalized nor stripped of hyphens.
+    pub fn mint_quote(id: &str) -> Self {
+        Self::new(FilterKind::MintQuote, id.as_bytes(), b"")
+    }
+
+    /// Element for a melt quote that moved to `state`.
+    ///
+    /// A failed melt is published as `UNPAID`: the spec's melt enum has three
+    /// values and a fourth string would break interop, and a wallet that
+    /// matches learns the real state from the quote endpoint.
+    pub fn melt_quote(id: &str, state: MeltQuoteState) -> Result<Self, Error> {
+        let state = match state {
+            MeltQuoteState::Unpaid | MeltQuoteState::Failed => "UNPAID",
+            MeltQuoteState::Pending => "PENDING",
+            MeltQuoteState::Paid => "PAID",
+            other => return Err(Error::UnsupportedState(other.to_string())),
+        };
+
+        Ok(Self::new(
+            FilterKind::MeltQuote,
+            id.as_bytes(),
+            state.as_bytes(),
+        ))
+    }
+
+    /// The element digest.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Rebuild an element from a stored digest.
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl fmt::Display for FilterElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", crate::util::hex::encode(self.0))
+    }
+}

--- a/crates/cashu/src/nuts/state_filters/mod.rs
+++ b/crates/cashu/src/nuts/state_filters/mod.rs
@@ -1,0 +1,160 @@
+//! Compact state filters
+//!
+//! Filters over the mint's state changes that the mint publishes for everyone
+//! and that wallets match locally, so a wallet learns that its ecash was spent,
+//! or its quote paid, without telling the mint which.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error as ThisError;
+
+mod codec;
+mod element;
+
+pub use codec::{encode, DecodedFilter, MAX_P, MIN_P};
+pub use element::{FilterElement, FilterKind, DOMAIN_SEPARATOR};
+
+/// Recommended Golomb-Rice parameter.
+pub const DEFAULT_P: u8 = 28;
+
+/// Recommended epoch duration in seconds.
+pub const DEFAULT_EPOCH: u64 = 3600;
+
+/// Recommended number of filters on a full page.
+pub const DEFAULT_PAGE_SIZE: u64 = 50;
+
+/// Smallest Golomb-Rice parameter a mint should publish with.
+///
+/// Below this, false positives stop being rare across the whole history a
+/// wallet tests, even though they stay rare within any one filter.
+pub const RECOMMENDED_MIN_P: u8 = 24;
+
+/// State filter error
+#[derive(Debug, ThisError, PartialEq, Eq)]
+pub enum Error {
+    /// Golomb-Rice parameter outside the range this implementation supports
+    #[error("Golomb-Rice parameter {0} out of range, must be between 7 and 63")]
+    InvalidParameter(u8),
+    /// Filter data ran out in the middle of a code
+    #[error("Filter data ended in the middle of a code")]
+    UnexpectedEnd,
+    /// Filter data encodes a position that does not fit in 64 bits
+    #[error("Filter data encodes an out of range position")]
+    PositionOverflow,
+    /// State has no representation in a filter element
+    #[error("State {0} cannot appear in a state filter")]
+    UnsupportedState(String),
+    /// Unrecognized filter kind
+    #[error("Unknown filter kind: {0}")]
+    UnknownKind(String),
+    /// Filter data was not valid hex
+    #[error("Invalid filter hex: {0}")]
+    Hex(String),
+}
+
+/// A filter covering one epoch.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Filter {
+    /// Unix timestamp at which the epoch began
+    pub start: u64,
+    /// Unix timestamp at which the epoch ended
+    pub end: u64,
+    /// Hex encoded Golomb-Rice coded set
+    pub data: String,
+}
+
+impl Filter {
+    /// Decode the coded set.
+    pub fn decode(&self, p: u8) -> Result<DecodedFilter, Error> {
+        let data = crate::util::hex::decode(&self.data).map_err(|e| Error::Hex(e.to_string()))?;
+        DecodedFilter::decode(&data, p)
+    }
+}
+
+/// The filter of the epoch that is still open.
+///
+/// It has no `end` because its epoch has not closed, and the closed filter
+/// carrying the same `start` supersedes it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PendingFilterResponse {
+    /// Unix timestamp at which the open epoch began
+    pub start: u64,
+    /// Hex encoded Golomb-Rice coded set
+    pub data: String,
+}
+
+impl PendingFilterResponse {
+    /// Decode the coded set.
+    ///
+    /// `data` changes between requests, and so does the `n` decoded from it,
+    /// so callers must recompute every candidate position per response.
+    pub fn decode(&self, p: u8) -> Result<DecodedFilter, Error> {
+        let data = crate::util::hex::decode(&self.data).map_err(|e| Error::Hex(e.to_string()))?;
+        DecodedFilter::decode(&data, p)
+    }
+}
+
+/// Parameters of a mint's filters.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GetFiltersInfoResponse {
+    /// Golomb-Rice parameter
+    pub p: u8,
+    /// Epoch duration in seconds
+    pub epoch: u64,
+    /// Kinds covered by the filters
+    pub kinds: Vec<FilterKind>,
+    /// Number of filters on a full page
+    pub page_size: u64,
+    /// Lowest page number the mint still serves
+    pub first_page: u64,
+    /// Page still being filled; every page below it is complete
+    pub current_page: u64,
+    /// How many filters the current page holds so far
+    pub current_page_count: u64,
+    /// Start of the oldest filter the mint still serves
+    pub earliest_start: u64,
+    /// End of the most recent filter
+    pub latest_end: u64,
+    /// Whether the mint serves the pending filter
+    pub pending: bool,
+}
+
+/// A page of filters, in ascending order of `start`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GetFiltersResponse {
+    /// Page number
+    pub page: u64,
+    /// The filters on this page
+    pub filters: Vec<Filter>,
+}
+
+/// Mint info settings for compact state filters.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub struct Settings {
+    /// Whether the mint publishes filters
+    pub supported: bool,
+    /// Kinds the mint's filters cover
+    ///
+    /// A mint that advertises a kind covers it for every payment method it
+    /// supports. Partial coverage is not expressible, because a match would
+    /// then disclose the method.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub kinds: Vec<FilterKind>,
+}
+
+impl Settings {
+    /// Create new [`Settings`]
+    pub fn new(kinds: Vec<FilterKind>) -> Self {
+        Self {
+            supported: true,
+            kinds,
+        }
+    }
+
+    /// Whether these settings carry nothing worth serializing
+    pub fn is_empty(&self) -> bool {
+        !self.supported && self.kinds.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/cashu/src/nuts/state_filters/tests.rs
+++ b/crates/cashu/src/nuts/state_filters/tests.rs
@@ -1,0 +1,270 @@
+use super::*;
+use crate::nuts::{MeltQuoteState, PublicKey, State};
+
+fn element(seed: &str) -> FilterElement {
+    FilterElement::new(FilterKind::ProofState, seed.as_bytes(), b"SPENT")
+}
+
+fn elements(count: usize) -> Vec<FilterElement> {
+    (0..count).map(|i| element(&format!("e{i}"))).collect()
+}
+
+fn hex_of(element: &FilterElement) -> String {
+    crate::util::hex::encode(*element.as_bytes())
+}
+
+const Y: &str = "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2";
+const QUOTE_ID: &str = "018f3c1a-7b2e-7c4d-9a10-5f6e7d8c9b0a";
+
+#[test]
+fn proof_state_element_matches_vector() {
+    let y = PublicKey::from_hex(Y).expect("valid key");
+
+    assert_eq!(
+        hex_of(&FilterElement::proof_state(&y, State::Spent).expect("supported")),
+        "19f292034075cf6c45502a15b9f1279fae06cbc82ed35ec2f30af29bd081dd5b"
+    );
+    assert_eq!(
+        hex_of(&FilterElement::proof_state(&y, State::Pending).expect("supported")),
+        "c756532bf551d835700576dade33c652c5c97b5c82368f306f9a8ede2713751b"
+    );
+    assert_eq!(
+        hex_of(&FilterElement::proof_state(&y, State::Unspent).expect("supported")),
+        "4d7871735fa4b0370f5dc9495191e339fcd454597df5740d9d08d854bfa6ade2"
+    );
+}
+
+#[test]
+fn quote_elements_match_vectors() {
+    assert_eq!(
+        hex_of(&FilterElement::mint_quote(QUOTE_ID)),
+        "1f440ebb2a45b4a05a95256bcbe52c3cc8ee88902d204fcd0ab27e616252193d"
+    );
+    assert_eq!(
+        hex_of(&FilterElement::melt_quote(QUOTE_ID, MeltQuoteState::Paid).expect("supported")),
+        "09da08ed7532872ec723f43e7cc1803e326c15639f758fde2ea09e746038333a"
+    );
+    assert_eq!(
+        hex_of(&FilterElement::melt_quote(QUOTE_ID, MeltQuoteState::Unpaid).expect("supported")),
+        "a27154c8c2858afd2722a92f868af74ed0bfdc24e423f477533f164172444be0"
+    );
+}
+
+#[test]
+fn failed_melt_is_published_as_unpaid() {
+    assert_eq!(
+        FilterElement::melt_quote(QUOTE_ID, MeltQuoteState::Failed).expect("supported"),
+        FilterElement::melt_quote(QUOTE_ID, MeltQuoteState::Unpaid).expect("supported")
+    );
+}
+
+#[test]
+fn quote_id_is_hashed_verbatim() {
+    let upper = FilterElement::mint_quote(&QUOTE_ID.to_uppercase());
+    let stripped = FilterElement::mint_quote(&QUOTE_ID.replace('-', ""));
+
+    assert_ne!(FilterElement::mint_quote(QUOTE_ID), upper);
+    assert_ne!(FilterElement::mint_quote(QUOTE_ID), stripped);
+}
+
+#[test]
+fn wallet_local_states_have_no_element() {
+    let y = PublicKey::from_hex(Y).expect("valid key");
+
+    assert_eq!(
+        FilterElement::proof_state(&y, State::Reserved),
+        Err(Error::UnsupportedState("RESERVED".to_string()))
+    );
+    assert!(FilterElement::proof_state(&y, State::PendingSpent).is_err());
+    assert!(FilterElement::melt_quote(QUOTE_ID, MeltQuoteState::Unknown).is_err());
+}
+
+#[test]
+fn kinds_round_trip_through_strings() {
+    for kind in [
+        FilterKind::ProofState,
+        FilterKind::MintQuote,
+        FilterKind::MeltQuote,
+    ] {
+        assert_eq!(kind.to_string().parse::<FilterKind>().expect("known"), kind);
+    }
+    assert!("swap".parse::<FilterKind>().is_err());
+}
+
+#[test]
+fn empty_filter_encodes_to_nothing_and_matches_nothing() {
+    let data = encode(&[], DEFAULT_P).expect("valid p");
+    assert!(data.is_empty());
+
+    let decoded = DecodedFilter::decode(&data, DEFAULT_P).expect("valid");
+    assert_eq!(decoded.n(), 0);
+    assert!(!decoded.contains(&element("anything")));
+}
+
+#[test]
+fn every_encoded_element_matches() {
+    for count in [1, 2, 3, 17, 500] {
+        let set = elements(count);
+        let data = encode(&set, DEFAULT_P).expect("valid p");
+        let decoded = DecodedFilter::decode(&data, DEFAULT_P).expect("valid");
+
+        assert_eq!(
+            decoded.n(),
+            count as u64,
+            "n recovered for {count} elements"
+        );
+        for e in &set {
+            assert!(
+                decoded.contains(e),
+                "no false negatives for {count} elements"
+            );
+        }
+    }
+}
+
+#[test]
+fn n_is_recovered_across_every_padding_length() {
+    let mut seen_remainders = std::collections::HashSet::new();
+
+    for count in 1..64usize {
+        let set = elements(count);
+        let data = encode(&set, MIN_P).expect("valid p");
+        let decoded = DecodedFilter::decode(&data, MIN_P).expect("valid");
+
+        assert_eq!(decoded.n(), count as u64);
+        seen_remainders.insert(data.len() % 8);
+    }
+
+    assert!(
+        seen_remainders.len() > 1,
+        "expected varied padding across sizes"
+    );
+}
+
+#[test]
+fn duplicate_elements_are_removed_before_counting() {
+    let e = element("repeated");
+    let data = encode(&[e, e, e], DEFAULT_P).expect("valid p");
+    let decoded = DecodedFilter::decode(&data, DEFAULT_P).expect("valid");
+
+    assert_eq!(decoded.n(), 1);
+    assert!(decoded.contains(&e));
+}
+
+#[test]
+fn colliding_positions_survive_a_round_trip() {
+    let a = FilterElement::from_bytes(
+        crate::util::hex::decode(
+            "84f070e7c9e6a5d301dfc1c8077e7a2785f857df2121cc2d599feb26b0d45717",
+        )
+        .expect("hex")
+        .try_into()
+        .expect("32 bytes"),
+    );
+    let b = FilterElement::from_bytes(
+        crate::util::hex::decode(
+            "8456eb85759144d1d18b4e345261e63f3a178977c92075523da7fd9997bae497",
+        )
+        .expect("hex")
+        .try_into()
+        .expect("32 bytes"),
+    );
+    assert_ne!(a, b);
+
+    let data = encode(&[a, b], MIN_P).expect("valid p");
+    let decoded = DecodedFilter::decode(&data, MIN_P).expect("valid");
+
+    assert_eq!(decoded.n(), 2, "a zero delta still counts as a value");
+    assert!(decoded.contains(&a));
+    assert!(decoded.contains(&b));
+}
+
+#[test]
+fn position_depends_on_the_filter_it_is_tested_against() {
+    let target = element("target");
+
+    let small = encode(&[target], DEFAULT_P).expect("valid p");
+    let large = encode(&[vec![target], elements(400)].concat(), DEFAULT_P).expect("valid p");
+
+    let small = DecodedFilter::decode(&small, DEFAULT_P).expect("valid");
+    let large = DecodedFilter::decode(&large, DEFAULT_P).expect("valid");
+
+    assert_ne!(small.n(), large.n());
+    assert!(small.contains(&target));
+    assert!(large.contains(&target));
+}
+
+#[test]
+fn non_members_rarely_match() {
+    let set = elements(200);
+    let data = encode(&set, DEFAULT_P).expect("valid p");
+    let decoded = DecodedFilter::decode(&data, DEFAULT_P).expect("valid");
+
+    let false_positives = (0..2000)
+        .map(|i| element(&format!("outsider{i}")))
+        .filter(|e| decoded.contains(e))
+        .count();
+
+    assert_eq!(false_positives, 0, "2^-28 should not fire in 2000 tests");
+}
+
+#[test]
+fn out_of_range_parameters_are_rejected() {
+    for p in [0u8, 6, 64, 255] {
+        assert_eq!(encode(&[], p), Err(Error::InvalidParameter(p)));
+        assert_eq!(
+            DecodedFilter::decode(&[], p),
+            Err(Error::InvalidParameter(p))
+        );
+    }
+
+    assert!(encode(&[], MIN_P).is_ok());
+    assert!(encode(&[], MAX_P).is_ok());
+}
+
+#[test]
+fn truncated_code_is_rejected() {
+    let data = encode(&elements(4), DEFAULT_P).expect("valid p");
+    let truncated = &data[..data.len() - 1];
+
+    let decoded = DecodedFilter::decode(truncated, DEFAULT_P);
+    assert!(decoded.is_err() || decoded.expect("checked").n() < 4);
+}
+
+#[test]
+fn runaway_unary_prefix_is_rejected() {
+    let data = vec![0xff; 64];
+    assert_eq!(
+        DecodedFilter::decode(&data, MIN_P),
+        Err(Error::UnexpectedEnd)
+    );
+}
+
+#[test]
+fn filter_decodes_from_hex() {
+    let set = elements(5);
+    let data = encode(&set, DEFAULT_P).expect("valid p");
+
+    let filter = Filter {
+        start: 1701704757,
+        end: 1701708357,
+        data: crate::util::hex::encode(data),
+    };
+
+    let decoded = filter.decode(DEFAULT_P).expect("valid");
+    assert_eq!(decoded.n(), 5);
+    assert!(decoded.contains(&set[0]));
+}
+
+#[test]
+fn settings_hide_when_unsupported() {
+    assert!(Settings::default().is_empty());
+    assert!(!Settings::new(vec![FilterKind::ProofState]).is_empty());
+
+    let settings = Settings::new(vec![FilterKind::ProofState, FilterKind::MeltQuote]);
+    let json = serde_json::to_string(&settings).expect("serializes");
+    assert_eq!(
+        json,
+        r#"{"supported":true,"kinds":["proof_state","melt_quote"]}"#
+    );
+}

--- a/crates/cdk-axum/src/filters_handlers.rs
+++ b/crates/cdk-axum/src/filters_handlers.rs
@@ -1,0 +1,81 @@
+//! Compact state filter endpoints
+//!
+//! Filters are public and byte-identical for every requester, so these routes
+//! carry no authentication. The cache directives are load-bearing: a complete
+//! page never changes again, while the pending filter must never be reused.
+
+use axum::extract::{Path, State};
+use axum::http::header::{HeaderValue, CACHE_CONTROL};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use cdk_common::Error;
+use tracing::instrument;
+
+use crate::router_handlers::into_response;
+use crate::MintState;
+
+/// A complete page never changes again, so it may be held indefinitely. Only
+/// the current page grows, and it grows once per epoch.
+const IMMUTABLE: &str = "public, max-age=31536000, immutable";
+
+fn cached<T: serde::Serialize>(directive: &str, body: T) -> Response {
+    match HeaderValue::from_str(directive) {
+        Ok(value) => ([(CACHE_CONTROL, value)], Json(body)).into_response(),
+        Err(err) => {
+            tracing::error!("Invalid cache directive {directive}: {err}");
+            Json(body).into_response()
+        }
+    }
+}
+
+#[instrument(skip_all)]
+pub(crate) async fn get_filters_info(State(state): State<MintState>) -> Result<Response, Response> {
+    let service = state
+        .mint
+        .state_filter_service()
+        .ok_or_else(|| into_response(Error::FilterNotAvailable))?;
+
+    let info = service.info().await.map_err(into_response)?;
+
+    Ok(cached("public, max-age=60", info))
+}
+
+#[instrument(skip_all, fields(page = ?page))]
+pub(crate) async fn get_filters(
+    State(state): State<MintState>,
+    Path(page): Path<u64>,
+) -> Result<Response, Response> {
+    let service = state
+        .mint
+        .state_filter_service()
+        .ok_or_else(|| into_response(Error::FilterNotAvailable))?;
+
+    let filters = service.page(page).await.map_err(into_response)?;
+
+    let directive = if service
+        .page_is_complete(page)
+        .await
+        .map_err(into_response)?
+    {
+        IMMUTABLE.to_string()
+    } else {
+        let epoch = service.info().await.map_err(into_response)?.epoch;
+        format!("public, max-age={epoch}")
+    };
+
+    Ok(cached(&directive, filters))
+}
+
+#[instrument(skip_all)]
+pub(crate) async fn get_filters_pending(
+    State(state): State<MintState>,
+) -> Result<Response, Response> {
+    let service = state
+        .mint
+        .state_filter_service()
+        .ok_or_else(|| into_response(Error::FilterNotAvailable))?;
+
+    let pending = service.pending().await.map_err(into_response)?;
+
+    Ok(cached("no-store", pending))
+}

--- a/crates/cdk-axum/src/lib.rs
+++ b/crates/cdk-axum/src/lib.rs
@@ -20,6 +20,7 @@ mod auth;
 pub mod cache;
 mod custom_handlers;
 mod custom_router;
+mod filters_handlers;
 mod router_handlers;
 mod ws;
 
@@ -108,6 +109,18 @@ pub async fn create_mint_router_with_custom_cache(
         .route("/checkstate", post(post_check))
         .route("/info", get(get_mint_info))
         .route("/restore", post(post_restore));
+
+    let v1_router = if state.mint.state_filter_service().is_some() {
+        v1_router
+            .route("/filters/info", get(filters_handlers::get_filters_info))
+            .route(
+                "/filters/pending",
+                get(filters_handlers::get_filters_pending),
+            )
+            .route("/filters/{page}", get(filters_handlers::get_filters))
+    } else {
+        v1_router
+    };
 
     let mut mint_router = Router::new().nest("/v1", v1_router);
 

--- a/crates/cdk-common/src/database/mint/mod.rs
+++ b/crates/cdk-common/src/database/mint/mod.rs
@@ -12,8 +12,8 @@ use crate::mint::{
     self, MeltQuote, MintKeySetInfo, MintQuote as MintMintQuote, Operation, ProofsWithState,
 };
 use crate::nuts::{
-    BlindSignature, BlindedMessage, CurrencyUnit, Id, MeltQuoteState, Proof, Proofs, PublicKey,
-    State,
+    BlindSignature, BlindedMessage, CurrencyUnit, Filter, FilterElement, Id, MeltQuoteState, Proof,
+    Proofs, PublicKey, State,
 };
 use crate::payment::PaymentIdentifier;
 
@@ -666,6 +666,75 @@ pub trait CompletedOperationsDatabase {
     async fn get_completed_operations(&self) -> Result<Vec<mint::Operation>, Self::Err>;
 }
 
+/// Persisted parameters of a mint's state filters.
+///
+/// These are fixed for the life of a mint's filter history: changing `p`
+/// changes the false positive rate under wallets that already hold filters, and
+/// changing `epoch_seconds` or `page_size` renumbers pages that wallets have
+/// cached as immutable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StateFilterConfig {
+    /// Unix timestamp at which the mint's first epoch began
+    pub genesis: u64,
+    /// Epoch duration in seconds
+    pub epoch_seconds: u64,
+    /// Golomb-Rice parameter
+    pub p: u8,
+    /// Number of filters on a full page
+    pub page_size: u64,
+}
+
+#[async_trait]
+/// State Filter Transaction trait
+pub trait StateFilterTransaction {
+    /// State Filter Database Error
+    type Err: Into<Error> + From<Error>;
+
+    /// Store the filter parameters, which may only be written once
+    async fn set_state_filter_config(
+        &mut self,
+        config: &StateFilterConfig,
+    ) -> Result<(), Self::Err>;
+
+    /// Record elements for the epoch that is currently open
+    async fn add_filter_elements(
+        &mut self,
+        epoch: u64,
+        elements: &[FilterElement],
+    ) -> Result<(), Self::Err>;
+
+    /// Read and delete every element recorded for an epoch
+    async fn take_filter_elements(&mut self, epoch: u64) -> Result<Vec<FilterElement>, Self::Err>;
+
+    /// Store a built filter
+    async fn add_filter(
+        &mut self,
+        epoch: u64,
+        start: u64,
+        end: u64,
+        data: &[u8],
+    ) -> Result<(), Self::Err>;
+}
+
+#[async_trait]
+/// State Filter Database trait
+pub trait StateFilterDatabase {
+    /// State Filter Database Error
+    type Err: Into<Error> + From<Error>;
+
+    /// Get the stored filter parameters
+    async fn get_state_filter_config(&self) -> Result<Option<StateFilterConfig>, Self::Err>;
+
+    /// Get the highest epoch that has a built filter
+    async fn latest_built_epoch(&self) -> Result<Option<u64>, Self::Err>;
+
+    /// Get built filters starting at an epoch, in ascending order
+    async fn get_filters(&self, first_epoch: u64, limit: u64) -> Result<Vec<Filter>, Self::Err>;
+
+    /// Get the elements recorded so far for an epoch, without removing them
+    async fn get_filter_elements(&self, epoch: u64) -> Result<Vec<FilterElement>, Self::Err>;
+}
+
 /// Base database writer
 ///
 /// Quote advisory locks coordinate transactional quote updates. Callers must
@@ -681,6 +750,7 @@ pub trait Transaction<Error>:
     + KVStoreTransaction<Error>
     + SagaTransaction<Err = Error>
     + CompletedOperationsTransaction<Err = Error>
+    + StateFilterTransaction<Err = Error>
 {
     /// Lock a set of quote identifiers for this transaction.
     ///
@@ -700,6 +770,7 @@ pub trait Database<Error>:
     + SignaturesDatabase<Err = Error>
     + SagaDatabase<Err = Error>
     + CompletedOperationsDatabase<Err = Error>
+    + StateFilterDatabase<Err = Error>
 {
     /// Begins a transaction
     async fn begin_transaction(&self) -> Result<Box<dyn Transaction<Error> + Send + Sync>, Error>;

--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -325,6 +325,15 @@ pub enum Error {
         /// Maximum allowed batch size
         max: usize,
     },
+    /// Filter not available
+    #[error("Filter not available")]
+    FilterNotAvailable,
+    /// Filter page out of range
+    #[error("Filter page out of range")]
+    FilterPageOutOfRange,
+    /// State filter parameters are invalid or cannot be changed
+    #[error("Invalid state filter configuration: {0}")]
+    StateFilterConfig(String),
     /// Proof content too large (secret or witness exceeds max length)
     #[error("Proof content too large: {actual} bytes, max {max}")]
     ProofContentTooLarge {
@@ -537,6 +546,9 @@ pub enum Error {
     /// NUT00 Error
     #[error(transparent)]
     NUT00(#[from] crate::nuts::nut00::Error),
+    /// State filter error
+    #[error(transparent)]
+    StateFilter(#[from] crate::nuts::state_filters::Error),
     /// Nut01 error
     #[error(transparent)]
     NUT01(#[from] crate::nuts::nut01::Error),
@@ -1194,6 +1206,14 @@ impl From<Error> for ErrorResponse {
                 code: ErrorCode::DuplicateQuoteIds,
                 detail: err.to_string(),
             },
+            Error::FilterNotAvailable => ErrorResponse {
+                code: ErrorCode::FilterNotAvailable,
+                detail: err.to_string(),
+            },
+            Error::FilterPageOutOfRange => ErrorResponse {
+                code: ErrorCode::FilterPageOutOfRange,
+                detail: err.to_string(),
+            },
             Error::BatchSizeExceeded { .. } => ErrorResponse {
                 code: ErrorCode::BatchSizeExceeded,
                 detail: err.to_string(),
@@ -1266,6 +1286,8 @@ impl From<ErrorResponse> for Error {
             }
             ErrorCode::DuplicateQuoteIds => Self::DuplicateQuoteIds,
             ErrorCode::BatchSizeExceeded => Self::BatchSizeExceeded { actual: 0, max: 0 },
+            ErrorCode::FilterNotAvailable => Self::FilterNotAvailable,
+            ErrorCode::FilterPageOutOfRange => Self::FilterPageOutOfRange,
             ErrorCode::MultipleUnits => Self::MultipleUnits,
             ErrorCode::UnitMismatch => Self::UnitMismatch,
             ErrorCode::AmountlessInvoiceNotSupported => Self::AmountLessNotAllowed,
@@ -1352,6 +1374,11 @@ pub enum ErrorCode {
     DuplicateQuoteIds,
     /// Batch size exceeds mint limit (11017)
     BatchSizeExceeded,
+
+    /// Filter not available (40001)
+    FilterNotAvailable,
+    /// Filter page out of range (40002)
+    FilterPageOutOfRange,
     // 12xxx - Keyset errors
     /// Keyset is not known (12001)
     KeysetNotFound,
@@ -1427,6 +1454,8 @@ impl ErrorCode {
             11015 => Self::MaxOutputsExceeded,
             11016 => Self::DuplicateQuoteIds,
             11017 => Self::BatchSizeExceeded,
+            40001 => Self::FilterNotAvailable,
+            40002 => Self::FilterPageOutOfRange,
             // 12xxx - Keyset errors
             12001 => Self::KeysetNotFound,
             12002 => Self::KeysetInactive,
@@ -1476,6 +1505,8 @@ impl ErrorCode {
             Self::MaxOutputsExceeded => 11015,
             Self::DuplicateQuoteIds => 11016,
             Self::BatchSizeExceeded => 11017,
+            Self::FilterNotAvailable => 40001,
+            Self::FilterPageOutOfRange => 40002,
             // 12xxx - Keyset errors
             Self::KeysetNotFound => 12001,
             Self::KeysetInactive => 12002,

--- a/crates/cdk-common/src/mint.rs
+++ b/crates/cdk-common/src/mint.rs
@@ -766,6 +766,11 @@ impl MintQuote {
         self.changes.take()
     }
 
+    /// Whether this quote has unpersisted changes.
+    pub fn has_changes(&self) -> bool {
+        self.changes.is_some()
+    }
+
     /// Records a new payment received for this mint quote.
     ///
     /// This method validates the payment, updates the quote's internal state, and records the

--- a/crates/cdk-ffi/src/types/mint.rs
+++ b/crates/cdk-ffi/src/types/mint.rs
@@ -515,6 +515,10 @@ pub struct Nuts {
     pub nut22: Option<BlindAuthSettings>,
     /// NUT29 Settings - Batch minting
     pub nut29: Nut29Settings,
+    /// Compact state filters - whether the mint publishes them
+    pub state_filters_supported: bool,
+    /// Compact state filters - the kinds the mint's filters cover
+    pub state_filters_kinds: Vec<String>,
     /// Supported currency units for minting
     pub mint_units: Vec<CurrencyUnit>,
     /// Supported currency units for melting
@@ -548,6 +552,13 @@ impl From<cdk::nuts::Nuts> for Nuts {
             nut21: nuts.nut21.map(Into::into),
             nut22: nuts.nut22.map(Into::into),
             nut29: nuts.nut29.into(),
+            state_filters_supported: nuts.state_filters.supported,
+            state_filters_kinds: nuts
+                .state_filters
+                .kinds
+                .iter()
+                .map(|kind| kind.to_string())
+                .collect(),
             mint_units,
             melt_units,
         }
@@ -591,6 +602,15 @@ impl TryFrom<Nuts> for cdk::nuts::Nuts {
             nut21: n.nut21.map(|s| s.try_into()).transpose()?,
             nut22: n.nut22.map(|s| s.try_into()).transpose()?,
             nut29: n.nut29.into(),
+            state_filters: cdk::nuts::StateFilterSettings {
+                supported: n.state_filters_supported,
+                kinds: n
+                    .state_filters_kinds
+                    .iter()
+                    .map(|kind| kind.parse())
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(FfiError::internal)?,
+            },
         })
     }
 }
@@ -772,6 +792,7 @@ mod tests {
                 )],
             }),
             nut29: Default::default(),
+            state_filters: Default::default(),
         }
     }
 
@@ -912,6 +933,7 @@ mod tests {
             nut21: None,
             nut22: None,
             nut29: Default::default(),
+            state_filters: Default::default(),
         };
 
         let ffi_nuts: Nuts = cdk_nuts.into();
@@ -944,6 +966,8 @@ mod tests {
             nut21: None,
             nut22: None,
             nut29: Default::default(),
+            state_filters_supported: false,
+            state_filters_kinds: Vec::new(),
             mint_units: vec![],
             melt_units: vec![],
         };
@@ -1107,6 +1131,8 @@ mod tests {
                     }],
                 }),
                 nut29: Nut29Settings::default(),
+                state_filters_supported: false,
+                state_filters_kinds: Vec::new(),
                 mint_units: vec![],
                 melt_units: vec![],
             },

--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::{env, fs};
 
@@ -12,12 +13,13 @@ use cashu::nut00::KnownMethod;
 use cashu::quote_id::QuoteId;
 use cdk::amount::SplitTarget;
 use cdk::cdk_database::{self, WalletDatabase};
-use cdk::mint::{MintBuilder, MintMeltLimits};
+use cdk::mint::{MintBuilder, MintMeltLimits, StateFilterOptions};
 use cdk::nuts::nut00::ProofsMethods;
 use cdk::nuts::{
     BatchCheckMintQuoteRequest, BatchMintRequest, CheckStateRequest, CheckStateResponse,
-    CurrencyUnit, Id, KeySet, KeysetResponse, MeltRequest, MintInfo, MintRequest, MintResponse,
-    PaymentMethod, RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
+    CurrencyUnit, GetFiltersInfoResponse, GetFiltersResponse, Id, KeySet, KeysetResponse,
+    MeltRequest, MintInfo, MintRequest, MintResponse, PaymentMethod, PendingFilterResponse,
+    RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
 };
 use cdk::types::{FeeReserve, QuoteTTL};
 use cdk::util::unix_time;
@@ -32,6 +34,9 @@ use uuid::Uuid;
 pub struct DirectMintConnection {
     pub mint: Mint,
     auth_wallet: Arc<RwLock<Option<AuthWallet>>>,
+    /// Counts the requests that name what the wallet is asking about, so tests
+    /// can assert a filter sweep really did stay quiet.
+    identifying_requests: Arc<AtomicUsize>,
 }
 
 impl DirectMintConnection {
@@ -39,7 +44,13 @@ impl DirectMintConnection {
         Self {
             mint,
             auth_wallet: Arc::new(RwLock::new(None)),
+            identifying_requests: Arc::new(AtomicUsize::new(0)),
         }
+    }
+
+    /// A handle to the counter of requests that name a proof or a quote.
+    pub fn identifying_requests(&self) -> Arc<AtomicUsize> {
+        self.identifying_requests.clone()
     }
 }
 
@@ -89,6 +100,7 @@ impl MintConnector for DirectMintConnection {
         &self,
         request: MintQuoteRequest,
     ) -> Result<MintQuoteResponse<String>, Error> {
+        self.identifying_requests.fetch_add(1, Ordering::Relaxed);
         match request {
             MintQuoteRequest::Bolt11(req) => {
                 let response = self.mint.get_mint_quote(req.into()).await?;
@@ -278,6 +290,7 @@ impl MintConnector for DirectMintConnection {
         method: PaymentMethod,
         quote_id: &str,
     ) -> Result<MeltQuoteResponse<String>, Error> {
+        self.identifying_requests.fetch_add(1, Ordering::Relaxed);
         let response = self
             .mint
             .check_melt_quote(&QuoteId::from_str(quote_id)?)
@@ -359,11 +372,36 @@ impl MintConnector for DirectMintConnection {
         &self,
         request: CheckStateRequest,
     ) -> Result<CheckStateResponse, Error> {
+        self.identifying_requests.fetch_add(1, Ordering::Relaxed);
         self.mint.check_state(&request).await
     }
 
     async fn post_restore(&self, request: RestoreRequest) -> Result<RestoreResponse, Error> {
         self.mint.restore(request).await
+    }
+
+    async fn get_filters_info(&self) -> Result<GetFiltersInfoResponse, Error> {
+        self.mint
+            .state_filter_service()
+            .ok_or(Error::FilterNotAvailable)?
+            .info()
+            .await
+    }
+
+    async fn get_filters(&self, page: u64) -> Result<GetFiltersResponse, Error> {
+        self.mint
+            .state_filter_service()
+            .ok_or(Error::FilterNotAvailable)?
+            .page(page)
+            .await
+    }
+
+    async fn get_filters_pending(&self) -> Result<PendingFilterResponse, Error> {
+        self.mint
+            .state_filter_service()
+            .ok_or(Error::FilterNotAvailable)?
+            .pending()
+            .await
     }
 
     /// Get the auth wallet for the client
@@ -400,6 +438,11 @@ pub fn setup_tracing() {
 
 pub async fn create_and_start_test_mint() -> Result<Mint> {
     create_mint_with_limits(None).await
+}
+
+/// Create a mint that publishes compact state filters.
+pub async fn create_and_start_test_mint_with_filters() -> Result<Mint> {
+    create_mint_with_options(None, Some(StateFilterOptions::default())).await
 }
 
 pub async fn create_mint_with_fee(fee_ppk: u64) -> Result<Mint> {
@@ -487,6 +530,13 @@ pub async fn create_mint_with_fee(fee_ppk: u64) -> Result<Mint> {
 }
 
 pub async fn create_mint_with_limits(limits: Option<(usize, usize)>) -> Result<Mint> {
+    create_mint_with_options(limits, None).await
+}
+
+pub async fn create_mint_with_options(
+    limits: Option<(usize, usize)>,
+    state_filters: Option<StateFilterOptions>,
+) -> Result<Mint> {
     // Read environment variable to determine database type
     let db_type = env::var("CDK_TEST_DB_TYPE").expect("Database type set");
 
@@ -560,6 +610,10 @@ pub async fn create_mint_with_limits(limits: Option<(usize, usize)>) -> Result<M
         mint_builder = mint_builder.with_limits(2000, 2000);
     }
 
+    if let Some(state_filters) = state_filters {
+        mint_builder = mint_builder.with_state_filters(state_filters);
+    }
+
     let quote_ttl = QuoteTTL::new(10000, 10000);
 
     let mint = mint_builder
@@ -582,7 +636,19 @@ pub async fn create_test_wallet_for_mint(mint: Mint) -> Result<Wallet> {
 ///
 /// Useful for restore tests where two wallets must share the same seed.
 pub async fn create_test_wallet_for_mint_with_seed(mint: Mint, seed: [u8; 64]) -> Result<Wallet> {
+    Ok(create_counted_test_wallet_for_mint_with_seed(mint, seed)
+        .await?
+        .0)
+}
+
+/// Create a test wallet alongside a counter of the requests that name what the
+/// wallet is asking about.
+pub async fn create_counted_test_wallet_for_mint_with_seed(
+    mint: Mint,
+    seed: [u8; 64],
+) -> Result<(Wallet, Arc<AtomicUsize>)> {
     let connector = DirectMintConnection::new(mint.clone());
+    let identifying_requests = connector.identifying_requests();
 
     let mint_info = mint.mint_info().await?;
     let mint_url = mint_info
@@ -633,7 +699,7 @@ pub async fn create_test_wallet_for_mint_with_seed(mint: Mint, seed: [u8; 64]) -
         .client(connector)
         .build()?;
 
-    Ok(wallet)
+    Ok((wallet, identifying_requests))
 }
 
 /// Creates a mint quote for the given amount and checks its state in a loop. Returns when

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -14,6 +14,7 @@ use std::collections::{HashMap, HashSet};
 use std::hash::RandomState;
 use std::pin::Pin;
 use std::str::FromStr;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -3852,5 +3853,174 @@ async fn test_p2pk_signing_keys_mixed_locked_and_unlocked_proofs() {
     assert_eq!(
         send_amount, received,
         "Bob should receive exactly the send amount"
+    );
+}
+
+/// A wallet learns that its ecash was spent by testing filters locally, without
+/// ever naming a proof to the mint.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_state_filters_reveal_a_spend_without_naming_it() {
+    setup_tracing();
+    let mint = create_and_start_test_mint_with_filters()
+        .await
+        .expect("Failed to create test mint");
+
+    let seed = Mnemonic::generate(12).unwrap().to_seed_normalized("");
+    let (wallet, identifying_requests) =
+        create_counted_test_wallet_for_mint_with_seed(mint.clone(), seed)
+            .await
+            .expect("Failed to create test wallet");
+
+    fund_wallet(wallet.clone(), 64, None)
+        .await
+        .expect("Failed to fund wallet");
+
+    let prepared = wallet
+        .prepare_send(Amount::from(32), SendOptions::default())
+        .await
+        .expect("prepare send");
+    let sent = prepared.proofs().ys().expect("ys");
+    let token = prepared.confirm(None).await.expect("confirm send");
+
+    let receiver = create_test_wallet_for_mint(mint.clone())
+        .await
+        .expect("Failed to create receiving wallet");
+    let keysets_info = to_keyset_infos(&wallet.keysets(Default::default()).await.unwrap());
+    receiver
+        .receive_proofs(
+            token.proofs(&keysets_info).expect("token proofs"),
+            ReceiveOptions::default(),
+            None,
+            None,
+        )
+        .await
+        .expect("receive");
+
+    let before = identifying_requests.load(Ordering::Relaxed);
+
+    let matches = wallet
+        .sweep_pending_state_filter()
+        .await
+        .expect("filter sweep");
+
+    assert_eq!(
+        identifying_requests.load(Ordering::Relaxed),
+        before,
+        "a filter sweep must not name anything to the mint"
+    );
+
+    for y in &sent {
+        assert!(
+            matches.proofs.contains(y),
+            "the redeemed proof {y} should have matched the mint's filter"
+        );
+    }
+}
+
+/// A wallet with nothing to report learns nothing and says nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_state_filters_stay_quiet_when_nothing_happened() {
+    setup_tracing();
+    let mint = create_and_start_test_mint_with_filters()
+        .await
+        .expect("Failed to create test mint");
+
+    let seed = Mnemonic::generate(12).unwrap().to_seed_normalized("");
+    let (wallet, identifying_requests) =
+        create_counted_test_wallet_for_mint_with_seed(mint.clone(), seed)
+            .await
+            .expect("Failed to create test wallet");
+
+    fund_wallet(wallet.clone(), 64, None)
+        .await
+        .expect("Failed to fund wallet");
+
+    let before = identifying_requests.load(Ordering::Relaxed);
+
+    let matches = wallet.sync_state_filters().await.expect("sync");
+
+    assert!(
+        matches.proofs.is_empty(),
+        "no proof of this wallet has been spent"
+    );
+    assert_eq!(
+        identifying_requests.load(Ordering::Relaxed),
+        before,
+        "nothing matched, so nothing was confirmed"
+    );
+}
+
+/// A seed restore against a filter-publishing mint names only the proofs that
+/// matched, instead of sending every recovered Y.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_restore_through_filters_names_only_what_matched() {
+    setup_tracing();
+    let mint = create_and_start_test_mint_with_filters()
+        .await
+        .expect("Failed to create test mint");
+
+    let seed = Mnemonic::generate(12).unwrap().to_seed_normalized("");
+    let wallet = create_test_wallet_for_mint_with_seed(mint.clone(), seed)
+        .await
+        .expect("Failed to create test wallet");
+
+    fund_wallet(wallet.clone(), 64, None)
+        .await
+        .expect("Failed to fund wallet");
+
+    assert_eq!(wallet.total_balance().await.unwrap(), Amount::from(64));
+
+    let (restored_wallet, identifying_requests) =
+        create_counted_test_wallet_for_mint_with_seed(mint.clone(), seed)
+            .await
+            .expect("Failed to create restore wallet");
+
+    let restored = restored_wallet.restore().await.expect("Restore failed");
+
+    assert_eq!(
+        restored.unspent,
+        Amount::from(64),
+        "restore should recover the full balance"
+    );
+    assert_eq!(
+        restored.spent,
+        Amount::ZERO,
+        "nothing was spent before the restore"
+    );
+    assert_eq!(
+        identifying_requests.load(Ordering::Relaxed),
+        0,
+        "a restore that finds nothing spent must not name a single proof"
+    );
+}
+
+/// The same restore against a mint without filters still works, through NUT-07.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_restore_falls_back_when_the_mint_publishes_no_filters() {
+    setup_tracing();
+    let mint = create_and_start_test_mint()
+        .await
+        .expect("Failed to create test mint");
+
+    let seed = Mnemonic::generate(12).unwrap().to_seed_normalized("");
+    let wallet = create_test_wallet_for_mint_with_seed(mint.clone(), seed)
+        .await
+        .expect("Failed to create test wallet");
+
+    fund_wallet(wallet.clone(), 64, None)
+        .await
+        .expect("Failed to fund wallet");
+
+    let (restored_wallet, identifying_requests) =
+        create_counted_test_wallet_for_mint_with_seed(mint.clone(), seed)
+            .await
+            .expect("Failed to create restore wallet");
+
+    let restored = restored_wallet.restore().await.expect("Restore failed");
+
+    assert_eq!(restored.unspent, Amount::from(64));
+    assert!(
+        identifying_requests.load(Ordering::Relaxed) > 0,
+        "without filters the wallet has to name every recovered proof"
     );
 }

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -383,3 +383,21 @@ max_delay_time = 3
 max_inputs = 1000
 # Maximum number of outputs allowed per transaction (mint/swap/melt)
 max_outputs = 1000
+
+[state_filters]
+# Publish compact state filters, which let a wallet follow its ecash and its
+# quotes without telling the mint which objects it is asking about.
+enabled = false
+# Epoch duration in seconds. One filter is published per epoch.
+epoch = 3600
+# Golomb-Rice parameter. The false positive rate is 2^-p per test, so 28 gives
+# about one spurious match in 268 million. Do not go below 24.
+p = 28
+# Number of filters on a full page. Lower this on a busy mint: at one state
+# change per second a filter is about 13 KB.
+page_size = 50
+# Serve the filter of the epoch that is still open, so wallets do not have to
+# wait a full epoch for an answer.
+pending = true
+# Kinds the filters cover. Defaults to all three.
+# kinds = ["proof_state", "mint_quote", "melt_quote"]

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -1129,6 +1129,9 @@ pub struct Settings {
     /// Transaction limits for DoS protection
     #[serde(default)]
     pub limits: Limits,
+    /// Compact state filters
+    #[serde(default)]
+    pub state_filters: StateFilters,
     #[cfg(feature = "cln")]
     pub cln: Option<Cln>,
     #[cfg(feature = "lnd")]
@@ -1157,6 +1160,62 @@ pub struct Prometheus {
     pub enabled: bool,
     pub address: Option<String>,
     pub port: Option<u16>,
+}
+
+/// Compact state filter configuration
+///
+/// The parameters are fixed the first time the mint runs with filters enabled.
+/// Changing one afterwards is refused at startup rather than renumbering pages
+/// under wallets that already hold history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateFilters {
+    /// Publish compact state filters
+    #[serde(default)]
+    pub enabled: bool,
+    /// Epoch duration in seconds
+    #[serde(default = "default_filter_epoch")]
+    pub epoch: u64,
+    /// Golomb-Rice parameter
+    #[serde(default = "default_filter_p")]
+    pub p: u8,
+    /// Number of filters on a full page
+    #[serde(default = "default_filter_page_size")]
+    pub page_size: u64,
+    /// Serve the filter of the epoch that is still open
+    #[serde(default = "default_filter_pending")]
+    pub pending: bool,
+    /// Kinds the filters cover; every kind by default
+    #[serde(default)]
+    pub kinds: Option<Vec<String>>,
+}
+
+impl Default for StateFilters {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            epoch: default_filter_epoch(),
+            p: default_filter_p(),
+            page_size: default_filter_page_size(),
+            pending: default_filter_pending(),
+            kinds: None,
+        }
+    }
+}
+
+fn default_filter_epoch() -> u64 {
+    cdk::nuts::state_filters::DEFAULT_EPOCH
+}
+
+fn default_filter_p() -> u8 {
+    cdk::nuts::state_filters::DEFAULT_P
+}
+
+fn default_filter_page_size() -> u64 {
+    cdk::nuts::state_filters::DEFAULT_PAGE_SIZE
+}
+
+fn default_filter_pending() -> bool {
+    true
 }
 
 /// Transaction limits configuration

--- a/crates/cdk-mintd/src/env_vars/mod.rs
+++ b/crates/cdk-mintd/src/env_vars/mod.rs
@@ -12,6 +12,7 @@ mod mint_info;
 mod onchain;
 mod payment_backend;
 mod signatory;
+mod state_filters;
 
 mod auth;
 #[cfg(feature = "bdk")]
@@ -117,6 +118,7 @@ impl Settings {
         }
         self.onchain = Some(self.onchain.clone().unwrap_or_default().from_env());
         self.limits = self.limits.clone().from_env();
+        self.state_filters = self.state_filters.clone().from_env();
 
         {
             // Check env vars for auth config even if None

--- a/crates/cdk-mintd/src/env_vars/state_filters.rs
+++ b/crates/cdk-mintd/src/env_vars/state_filters.rs
@@ -1,0 +1,61 @@
+//! Compact state filter environment variables
+
+use std::env;
+
+use crate::config::StateFilters;
+
+pub const ENV_STATE_FILTERS_ENABLED: &str = "CDK_MINTD_STATE_FILTERS_ENABLED";
+pub const ENV_STATE_FILTERS_EPOCH: &str = "CDK_MINTD_STATE_FILTERS_EPOCH";
+pub const ENV_STATE_FILTERS_P: &str = "CDK_MINTD_STATE_FILTERS_P";
+pub const ENV_STATE_FILTERS_PAGE_SIZE: &str = "CDK_MINTD_STATE_FILTERS_PAGE_SIZE";
+pub const ENV_STATE_FILTERS_PENDING: &str = "CDK_MINTD_STATE_FILTERS_PENDING";
+pub const ENV_STATE_FILTERS_KINDS: &str = "CDK_MINTD_STATE_FILTERS_KINDS";
+
+impl StateFilters {
+    /// Override state filter settings with environment variables if set
+    pub fn from_env(&self) -> Self {
+        let mut filters = self.clone();
+
+        if let Ok(enabled) = env::var(ENV_STATE_FILTERS_ENABLED) {
+            if let Ok(enabled) = enabled.parse() {
+                filters.enabled = enabled;
+            }
+        }
+
+        if let Ok(epoch) = env::var(ENV_STATE_FILTERS_EPOCH) {
+            if let Ok(epoch) = epoch.parse() {
+                filters.epoch = epoch;
+            }
+        }
+
+        if let Ok(p) = env::var(ENV_STATE_FILTERS_P) {
+            if let Ok(p) = p.parse() {
+                filters.p = p;
+            }
+        }
+
+        if let Ok(page_size) = env::var(ENV_STATE_FILTERS_PAGE_SIZE) {
+            if let Ok(page_size) = page_size.parse() {
+                filters.page_size = page_size;
+            }
+        }
+
+        if let Ok(pending) = env::var(ENV_STATE_FILTERS_PENDING) {
+            if let Ok(pending) = pending.parse() {
+                filters.pending = pending;
+            }
+        }
+
+        if let Ok(kinds) = env::var(ENV_STATE_FILTERS_KINDS) {
+            filters.kinds = Some(
+                kinds
+                    .split(',')
+                    .map(|kind| kind.trim().to_string())
+                    .filter(|kind| !kind.is_empty())
+                    .collect(),
+            );
+        }
+
+        filters
+    }
+}

--- a/crates/cdk-mintd/src/lib.rs
+++ b/crates/cdk-mintd/src/lib.rs
@@ -15,7 +15,7 @@ use axum::extract::DefaultBodyLimit;
 use axum::Router;
 use bip39::Mnemonic;
 use cdk::cdk_database::{self, KVStore, KVStoreCompareAndSwap, MintDatabase, MintKeysDatabase};
-use cdk::mint::{Mint, MintBuilder, MintMeltLimits};
+use cdk::mint::{Mint, MintBuilder, MintMeltLimits, StateFilterOptions};
 use cdk::nuts::nut00::KnownMethod;
 #[cfg(any(
     feature = "cln",
@@ -27,6 +27,7 @@ use cdk::nuts::nut00::KnownMethod;
 ))]
 use cdk::nuts::nut17::SupportedMethods;
 use cdk::nuts::nut19::{CachedEndpoint, Method as NUT19Method, Path as NUT19Path};
+use cdk::nuts::state_filters::{FilterKind, RECOMMENDED_MIN_P};
 use cdk::nuts::{
     AuthRequired, ContactInfo, Method, MintVersion, PaymentMethod, ProtectedEndpoint, RoutePath,
 };
@@ -1100,6 +1101,8 @@ async fn configure_mint_builder_with_wallet_info(
     let mint_builder =
         mint_builder.with_limits(settings.limits.max_inputs, settings.limits.max_outputs);
 
+    let mint_builder = configure_state_filters(settings, mint_builder)?;
+
     // Verify at least one payment processor is configured
     if mint_builder
         .current_mint_info()
@@ -1673,6 +1676,46 @@ fn units_are_compatible(
 }
 
 /// Configures cache settings with support for custom payment methods
+fn configure_state_filters(
+    settings: &config::Settings,
+    mint_builder: MintBuilder,
+) -> Result<MintBuilder> {
+    if !settings.state_filters.enabled {
+        return Ok(mint_builder);
+    }
+
+    let config = &settings.state_filters;
+
+    let kinds = match &config.kinds {
+        Some(kinds) => kinds
+            .iter()
+            .map(|kind| kind.parse::<FilterKind>())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|err| anyhow::anyhow!("Invalid state filter kind: {err}"))?,
+        None => vec![
+            FilterKind::ProofState,
+            FilterKind::MintQuote,
+            FilterKind::MeltQuote,
+        ],
+    };
+
+    if config.p < RECOMMENDED_MIN_P {
+        tracing::warn!(
+            "State filter parameter p is {}, below the recommended minimum of {}. False positives will be common across a long history.",
+            config.p,
+            RECOMMENDED_MIN_P
+        );
+    }
+
+    Ok(mint_builder.with_state_filters(StateFilterOptions {
+        epoch_seconds: config.epoch,
+        p: config.p,
+        page_size: config.page_size,
+        kinds,
+        pending: config.pending,
+    }))
+}
+
 async fn configure_cache(
     settings: &config::Settings,
     mint_builder: MintBuilder,

--- a/crates/cdk-sql-common/src/mint/migrations/postgres/20260903000000_add_state_filters.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/postgres/20260903000000_add_state_filters.sql
@@ -1,0 +1,25 @@
+-- Compact state filters: parameters, pending elements, and built filters.
+
+CREATE TABLE IF NOT EXISTS state_filter_config (
+    id BIGINT PRIMARY KEY CHECK (id = 0),
+    genesis BIGINT NOT NULL,
+    epoch_seconds BIGINT NOT NULL,
+    p BIGINT NOT NULL,
+    page_size BIGINT NOT NULL
+);
+
+-- The primary key deduplicates elements within an epoch on insert.
+CREATE TABLE IF NOT EXISTS state_filter_element (
+    epoch BIGINT NOT NULL,
+    element BYTEA NOT NULL,
+    PRIMARY KEY (epoch, element)
+);
+
+CREATE TABLE IF NOT EXISTS state_filter (
+    epoch BIGINT PRIMARY KEY,
+    start_time BIGINT NOT NULL,
+    end_time BIGINT NOT NULL,
+    data BYTEA NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_state_filter_start ON state_filter(start_time);

--- a/crates/cdk-sql-common/src/mint/migrations/sqlite/20260903000000_add_state_filters.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/sqlite/20260903000000_add_state_filters.sql
@@ -1,0 +1,25 @@
+-- Compact state filters: parameters, pending elements, and built filters.
+
+CREATE TABLE IF NOT EXISTS state_filter_config (
+    id INTEGER PRIMARY KEY CHECK (id = 0),
+    genesis INTEGER NOT NULL,
+    epoch_seconds INTEGER NOT NULL,
+    p INTEGER NOT NULL,
+    page_size INTEGER NOT NULL
+);
+
+-- The primary key deduplicates elements within an epoch on insert.
+CREATE TABLE IF NOT EXISTS state_filter_element (
+    epoch INTEGER NOT NULL,
+    element BLOB NOT NULL,
+    PRIMARY KEY (epoch, element)
+);
+
+CREATE TABLE IF NOT EXISTS state_filter (
+    epoch INTEGER PRIMARY KEY,
+    start_time INTEGER NOT NULL,
+    end_time INTEGER NOT NULL,
+    data BLOB NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_state_filter_start ON state_filter(start_time);

--- a/crates/cdk-sql-common/src/mint/mod.rs
+++ b/crates/cdk-sql-common/src/mint/mod.rs
@@ -28,6 +28,7 @@ mod proofs;
 mod quotes;
 mod saga;
 mod signatures;
+mod state_filters;
 
 #[rustfmt::skip]
 mod migrations {

--- a/crates/cdk-sql-common/src/mint/state_filters.rs
+++ b/crates/cdk-sql-common/src/mint/state_filters.rs
@@ -1,0 +1,228 @@
+//! State filter database implementation
+
+use async_trait::async_trait;
+use cdk_common::database::mint::{StateFilterConfig, StateFilterDatabase, StateFilterTransaction};
+use cdk_common::database::Error;
+use cdk_common::nuts::{Filter, FilterElement};
+
+use super::{SQLMintDatabase, SQLTransaction};
+use crate::pool::DatabasePool;
+use crate::stmt::{query, Column};
+use crate::{column_as_binary, column_as_number, unpack_into};
+
+fn sql_row_to_element(row: Vec<Column>) -> Result<FilterElement, Error> {
+    unpack_into!(let (element) = row);
+
+    let bytes: Vec<u8> = column_as_binary!(element);
+    let bytes: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| Error::Internal("Filter element is not 32 bytes".to_string()))?;
+
+    Ok(FilterElement::from_bytes(bytes))
+}
+
+fn sql_row_to_filter(row: Vec<Column>) -> Result<Filter, Error> {
+    unpack_into!(let (start_time, end_time, data) = row);
+
+    let data: Vec<u8> = column_as_binary!(data);
+
+    Ok(Filter {
+        start: column_as_number!(start_time),
+        end: column_as_number!(end_time),
+        data: cdk_common::util::hex::encode(data),
+    })
+}
+
+#[async_trait]
+impl<RM> StateFilterTransaction for SQLTransaction<RM>
+where
+    RM: DatabasePool + 'static,
+{
+    type Err = Error;
+
+    async fn set_state_filter_config(
+        &mut self,
+        config: &StateFilterConfig,
+    ) -> Result<(), Self::Err> {
+        query(
+            r#"
+            INSERT INTO state_filter_config (id, genesis, epoch_seconds, p, page_size)
+            VALUES (0, :genesis, :epoch_seconds, :p, :page_size)
+            ON CONFLICT (id) DO NOTHING
+            "#,
+        )?
+        .bind("genesis", config.genesis as i64)
+        .bind("epoch_seconds", config.epoch_seconds as i64)
+        .bind("p", i64::from(config.p))
+        .bind("page_size", config.page_size as i64)
+        .execute(&self.inner)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn add_filter_elements(
+        &mut self,
+        epoch: u64,
+        elements: &[FilterElement],
+    ) -> Result<(), Self::Err> {
+        for element in elements {
+            query(
+                r#"
+                INSERT INTO state_filter_element (epoch, element)
+                VALUES (:epoch, :element)
+                ON CONFLICT (epoch, element) DO NOTHING
+                "#,
+            )?
+            .bind("epoch", epoch as i64)
+            .bind("element", element.as_bytes().to_vec())
+            .execute(&self.inner)
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn take_filter_elements(&mut self, epoch: u64) -> Result<Vec<FilterElement>, Self::Err> {
+        let elements = query(
+            r#"SELECT element FROM state_filter_element WHERE epoch = :epoch ORDER BY element"#,
+        )?
+        .bind("epoch", epoch as i64)
+        .fetch_all(&self.inner)
+        .await?
+        .into_iter()
+        .map(sql_row_to_element)
+        .collect::<Result<Vec<_>, _>>()?;
+
+        query(r#"DELETE FROM state_filter_element WHERE epoch = :epoch"#)?
+            .bind("epoch", epoch as i64)
+            .execute(&self.inner)
+            .await?;
+
+        Ok(elements)
+    }
+
+    async fn add_filter(
+        &mut self,
+        epoch: u64,
+        start: u64,
+        end: u64,
+        data: &[u8],
+    ) -> Result<(), Self::Err> {
+        query(
+            r#"
+            INSERT INTO state_filter (epoch, start_time, end_time, data)
+            VALUES (:epoch, :start_time, :end_time, :data)
+            ON CONFLICT (epoch) DO NOTHING
+            "#,
+        )?
+        .bind("epoch", epoch as i64)
+        .bind("start_time", start as i64)
+        .bind("end_time", end as i64)
+        .bind("data", data.to_vec())
+        .execute(&self.inner)
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<RM> StateFilterDatabase for SQLMintDatabase<RM>
+where
+    RM: DatabasePool + 'static,
+{
+    type Err = Error;
+
+    async fn get_state_filter_config(&self) -> Result<Option<StateFilterConfig>, Self::Err> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
+
+        query(
+            r#"SELECT genesis, epoch_seconds, p, page_size FROM state_filter_config WHERE id = 0"#,
+        )?
+        .fetch_one(&*conn)
+        .await?
+        .map(|row| {
+            unpack_into!(let (genesis, epoch_seconds, p, page_size) = row);
+
+            let p: u64 = column_as_number!(p);
+            let p = u8::try_from(p).map_err(|_| {
+                Error::Internal("Stored filter parameter is out of range".to_string())
+            })?;
+
+            Ok(StateFilterConfig {
+                genesis: column_as_number!(genesis),
+                epoch_seconds: column_as_number!(epoch_seconds),
+                p,
+                page_size: column_as_number!(page_size),
+            })
+        })
+        .transpose()
+    }
+
+    async fn latest_built_epoch(&self) -> Result<Option<u64>, Self::Err> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
+
+        query(r#"SELECT MAX(epoch) FROM state_filter"#)?
+            .fetch_one(&*conn)
+            .await?
+            .map(|row| {
+                unpack_into!(let (epoch) = row);
+                Ok(match epoch {
+                    Column::Null => None,
+                    other => Some(column_as_number!(other)),
+                })
+            })
+            .transpose()
+            .map(Option::flatten)
+    }
+
+    async fn get_filters(&self, first_epoch: u64, limit: u64) -> Result<Vec<Filter>, Self::Err> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
+
+        query(
+            r#"
+            SELECT start_time, end_time, data
+            FROM state_filter
+            WHERE epoch >= :first_epoch
+            ORDER BY epoch ASC
+            LIMIT :limit
+            "#,
+        )?
+        .bind("first_epoch", first_epoch as i64)
+        .bind("limit", limit as i64)
+        .fetch_all(&*conn)
+        .await?
+        .into_iter()
+        .map(sql_row_to_filter)
+        .collect()
+    }
+
+    async fn get_filter_elements(&self, epoch: u64) -> Result<Vec<FilterElement>, Self::Err> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
+
+        query(r#"SELECT element FROM state_filter_element WHERE epoch = :epoch ORDER BY element"#)?
+            .bind("epoch", epoch as i64)
+            .fetch_all(&*conn)
+            .await?
+            .into_iter()
+            .map(sql_row_to_element)
+            .collect()
+    }
+}

--- a/crates/cdk/src/mint/builder.rs
+++ b/crates/cdk/src/mint/builder.rs
@@ -15,6 +15,7 @@ use cdk_signatory::signatory::{RotateKeyArguments, Signatory};
 
 use super::nut17::SupportedMethods;
 use super::nut19::{self, CachedEndpoint};
+use super::state_filters::{StateFilterOptions, StateFilterService};
 use super::verification::validate_custom_payment_method;
 use super::Nuts;
 use crate::amount::Amount;
@@ -22,7 +23,7 @@ use crate::cdk_database;
 use crate::mint::Mint;
 use crate::nuts::{
     AuthRequired, ContactInfo, CurrencyUnit, MeltMethodSettings, MintInfo, MintMethodSettings,
-    MintVersion, MppMethodSettings, PaymentMethod, ProtectedEndpoint,
+    MintVersion, MppMethodSettings, PaymentMethod, ProtectedEndpoint, StateFilterSettings,
 };
 use crate::types::PaymentProcessorKey;
 
@@ -76,6 +77,7 @@ pub struct MintBuilder {
     max_inputs: usize,
     max_outputs: usize,
     max_batch_size: Option<u64>,
+    state_filters: Option<StateFilterOptions>,
     /// Interval at which the built signatory reloads keysets from the shared
     /// database. `None` (the default) disables the reload for a single-instance
     /// deployment that owns its database; set an interval only to run several
@@ -124,6 +126,7 @@ impl MintBuilder {
             max_inputs: 1000,
             max_outputs: 1000,
             max_batch_size: None,
+            state_filters: None,
             keyset_refresh_interval: None,
         }
     }
@@ -345,6 +348,17 @@ impl MintBuilder {
     ) -> Self {
         self.max_batch_size = max_batch_size;
         self.mint_info.nuts.nut29 = cdk_common::nut29::Settings::new(max_batch_size, methods);
+        self
+    }
+
+    /// Publish compact state filters
+    ///
+    /// The parameters are fixed the first time a mint runs with filters
+    /// enabled; a later change is refused at build time rather than
+    /// renumbering pages under wallets that already hold history.
+    pub fn with_state_filters(mut self, options: StateFilterOptions) -> Self {
+        self.mint_info.nuts.state_filters = StateFilterSettings::new(options.kinds.clone());
+        self.state_filters = Some(options);
         self
     }
 
@@ -708,6 +722,21 @@ impl MintBuilder {
             ));
         }
 
+        let state_filter_service = match self.state_filters {
+            Some(options) => Some(Arc::new(
+                StateFilterService::new(
+                    self.localstore.clone(),
+                    options.epoch_seconds,
+                    options.p,
+                    options.page_size,
+                    options.kinds,
+                    options.pending,
+                )
+                .await?,
+            )),
+            None => None,
+        };
+
         if let Some(auth_localstore) = self.auth_localstore {
             let mut protected_endpoints = HashMap::new();
             for endpoint in self.clear_auth_endpoints {
@@ -723,7 +752,7 @@ impl MintBuilder {
                 tx.commit().await?;
             }
 
-            return Mint::new_with_auth(
+            let mut mint = Mint::new_with_auth(
                 self.mint_info,
                 signatory,
                 self.localstore,
@@ -732,9 +761,12 @@ impl MintBuilder {
                 self.max_inputs,
                 self.max_outputs,
             )
-            .await;
+            .await?;
+            mint.set_state_filter_service(state_filter_service);
+            return Ok(mint);
         }
-        Mint::new(
+
+        let mut mint = Mint::new(
             self.mint_info,
             signatory,
             self.localstore,
@@ -742,7 +774,9 @@ impl MintBuilder {
             self.max_inputs,
             self.max_outputs,
         )
-        .await
+        .await?;
+        mint.set_state_filter_service(state_filter_service);
+        Ok(mint)
     }
 
     /// Build the mint with the provided keystore and seed

--- a/crates/cdk/src/mint/check_spendable.rs
+++ b/crates/cdk/src/mint/check_spendable.rs
@@ -112,20 +112,35 @@ mod tests {
             State::Pending => {
                 let mut tx = db.begin_transaction().await.unwrap();
                 let mut acquired = tx.get_proofs(&ys).await.unwrap();
-                Mint::update_proofs_state(&mut tx, &mut acquired, State::Pending)
-                    .await
-                    .unwrap();
+                Mint::update_proofs_state(
+                    &mut tx,
+                    &mint.state_filters(),
+                    &mut acquired,
+                    State::Pending,
+                )
+                .await
+                .unwrap();
                 tx.commit().await.unwrap();
             }
             State::Spent => {
                 let mut tx = db.begin_transaction().await.unwrap();
                 let mut acquired = tx.get_proofs(&ys).await.unwrap();
-                Mint::update_proofs_state(&mut tx, &mut acquired, State::Pending)
-                    .await
-                    .unwrap();
-                Mint::update_proofs_state(&mut tx, &mut acquired, State::Spent)
-                    .await
-                    .unwrap();
+                Mint::update_proofs_state(
+                    &mut tx,
+                    &mint.state_filters(),
+                    &mut acquired,
+                    State::Pending,
+                )
+                .await
+                .unwrap();
+                Mint::update_proofs_state(
+                    &mut tx,
+                    &mint.state_filters(),
+                    &mut acquired,
+                    State::Spent,
+                )
+                .await
+                .unwrap();
                 tx.commit().await.unwrap();
             }
             State::Reserved | State::PendingSpent => {
@@ -184,10 +199,15 @@ mod tests {
         {
             let mut tx = db.begin_transaction().await.unwrap();
             let mut acquired = tx.get_proofs(&ys).await.unwrap();
-            Mint::update_proofs_state(&mut tx, &mut acquired, State::Pending)
-                .await
-                .unwrap();
-            Mint::update_proofs_state(&mut tx, &mut acquired, State::Spent)
+            Mint::update_proofs_state(
+                &mut tx,
+                &mint.state_filters(),
+                &mut acquired,
+                State::Pending,
+            )
+            .await
+            .unwrap();
+            Mint::update_proofs_state(&mut tx, &mint.state_filters(), &mut acquired, State::Spent)
                 .await
                 .unwrap();
             tx.commit().await.unwrap();

--- a/crates/cdk/src/mint/issue/mod.rs
+++ b/crates/cdk/src/mint/issue/mod.rs
@@ -526,9 +526,16 @@ impl Mint {
         #[cfg(feature = "prometheus")]
         let metrics = super::MintMetricGuard::new("pay_mint_quote");
 
-        let result =
-            async { Self::handle_mint_quote_payment(tx, mint_quote, wait_payment_response).await }
-                .await;
+        let result = async {
+            Self::handle_mint_quote_payment(
+                tx,
+                &self.state_filters(),
+                mint_quote,
+                wait_payment_response,
+            )
+            .await
+        }
+        .await;
 
         #[cfg(feature = "prometheus")]
         {
@@ -980,7 +987,7 @@ impl Mint {
                 }
 
                 mint_quote.add_issuance(amount_issued)?;
-                tx.update_mint_quote(&mut mint_quote).await?;
+                Mint::update_mint_quote(&mut tx, &self.state_filters(), &mut mint_quote).await?;
 
                 // Mint operations have no input fees
                 // Only persist operation for non-batch mints (batch operations are persisted above)

--- a/crates/cdk/src/mint/melt/melt_saga/compensation.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/compensation.rs
@@ -9,6 +9,8 @@ use cdk_common::{Error, PublicKey, QuoteId};
 use tracing::instrument;
 use uuid::Uuid;
 
+use crate::mint::melt::shared::Notifiers;
+use crate::mint::state_filters::StateFilters;
 use crate::mint::subscription::PubSubManager;
 
 /// Trait for compensating actions in the saga pattern.
@@ -17,7 +19,12 @@ use crate::mint::subscription::PubSubManager;
 /// order (LIFO) if the saga fails. Each action should be idempotent.
 #[async_trait]
 pub trait CompensatingAction: Send + Sync {
-    async fn execute(&self, db: &DynMintDatabase, pubsub: &PubSubManager) -> Result<(), Error>;
+    async fn execute(
+        &self,
+        db: &DynMintDatabase,
+        pubsub: &PubSubManager,
+        filters: &StateFilters,
+    ) -> Result<(), Error>;
     fn name(&self) -> &'static str;
 }
 
@@ -48,7 +55,12 @@ pub struct RemoveMeltSetup {
 #[async_trait]
 impl CompensatingAction for RemoveMeltSetup {
     #[instrument(skip_all)]
-    async fn execute(&self, db: &DynMintDatabase, pubsub: &PubSubManager) -> Result<(), Error> {
+    async fn execute(
+        &self,
+        db: &DynMintDatabase,
+        pubsub: &PubSubManager,
+        filters: &StateFilters,
+    ) -> Result<(), Error> {
         tracing::info!(
             "Compensation: Removing melt setup for quote {} ({} proofs, {} blinded messages, saga {})",
             self.quote_id,
@@ -59,7 +71,7 @@ impl CompensatingAction for RemoveMeltSetup {
 
         super::super::shared::rollback_melt_quote(
             db,
-            pubsub,
+            Notifiers::new(pubsub, filters),
             &self.quote_id,
             &self.input_ys,
             &self.blinded_secrets,

--- a/crates/cdk/src/mint/melt/melt_saga/mod.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/mod.rs
@@ -272,7 +272,14 @@ impl MeltSaga<Initial> {
 
         let mut proofs = tx.get_proofs(&input_ys).await?;
 
-        if let Err(err) = Mint::update_proofs_state(&mut tx, &mut proofs, State::Pending).await {
+        if let Err(err) = Mint::update_proofs_state(
+            &mut tx,
+            &self.mint.state_filters(),
+            &mut proofs,
+            State::Pending,
+        )
+        .await
+        {
             tx.rollback().await?;
             return Err(err);
         }
@@ -328,14 +335,19 @@ impl MeltSaga<Initial> {
         }
 
         // Update quote state to Pending
-        match tx
-            .update_melt_quote_state(&mut quote, MeltQuoteState::Pending, None)
-            .await
+        match Mint::update_melt_quote_state(
+            &mut tx,
+            &self.mint.state_filters(),
+            &mut quote,
+            MeltQuoteState::Pending,
+            None,
+        )
+        .await
         {
             Ok(_) => {}
             Err(err) => {
                 tx.rollback().await?;
-                return Err(err.into());
+                return Err(err);
             }
         };
 
@@ -583,12 +595,18 @@ impl MeltSaga<SetupComplete> {
         .await?;
 
         mint_quote.add_payment(amount.clone(), self.state_data.quote.id.to_string(), None)?;
-        tx.update_mint_quote(&mut mint_quote).await?;
+        Mint::update_mint_quote(&mut tx, &self.mint.state_filters(), &mut mint_quote).await?;
 
         // Mark the melt quote Paid in the same transaction as the mint quote
         // credit.
-        tx.update_melt_quote_state(&mut melt_quote, MeltQuoteState::Paid, None)
-            .await?;
+        Mint::update_melt_quote_state(
+            &mut tx,
+            &self.mint.state_filters(),
+            &mut melt_quote,
+            MeltQuoteState::Paid,
+            None,
+        )
+        .await?;
 
         // Internally-settled melts never reach a payment backend, so persist
         // the synthetic lookup id the settlement response will use.
@@ -1189,7 +1207,10 @@ impl<S> MeltSaga<S> {
 
         while let Some(compensation) = compensations.pop_front() {
             tracing::debug!("Running compensation: {}", compensation.name());
-            if let Err(e) = compensation.execute(&self.db, &self.pubsub).await {
+            if let Err(e) = compensation
+                .execute(&self.db, &self.pubsub, &self.mint.state_filters())
+                .await
+            {
                 tracing::error!(
                     "Compensation {} failed: {}. Continuing...",
                     compensation.name(),

--- a/crates/cdk/src/mint/melt/melt_saga/tests.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/tests.rs
@@ -27,7 +27,7 @@ use cdk_fake_wallet::{create_fake_invoice, FakeInvoiceDescription};
 
 use crate::mint::melt::melt_saga::{MeltSaga, PaymentOutcome};
 use crate::mint::melt::shared::{
-    finalize_melt_quote, process_melt_change, rollback_melt_quote, MeltChangeResult,
+    finalize_melt_quote, process_melt_change, rollback_melt_quote, MeltChangeResult, Notifiers,
 };
 use crate::test_helpers::mint::{create_test_mint, mint_test_proofs};
 
@@ -604,9 +604,14 @@ async fn test_finalizing_recovery_uses_persisted_payment_fee() {
     .unwrap();
 
     let mut proofs_with_state = tx.get_proofs(&input_ys).await.unwrap();
-    crate::mint::Mint::update_proofs_state(&mut tx, &mut proofs_with_state, State::Spent)
-        .await
-        .unwrap();
+    crate::mint::Mint::update_proofs_state(
+        &mut tx,
+        &mint.state_filters(),
+        &mut proofs_with_state,
+        State::Spent,
+    )
+    .await
+    .unwrap();
     let mut saga = tx
         .get_saga_for_update(&operation_id)
         .await
@@ -1298,7 +1303,7 @@ async fn test_internal_settlement_aborts_after_rollback() {
         .unwrap();
     rollback_melt_quote(
         &mint.localstore(),
-        &mint.pubsub_manager(),
+        Notifiers::new(&mint.pubsub_manager(), &mint.state_filters()),
         &melt_quote.id,
         &input_ys,
         &blinded_secrets,
@@ -1377,7 +1382,7 @@ async fn test_rollback_refused_after_internal_settlement() {
         .unwrap();
     let result = rollback_melt_quote(
         &mint.localstore(),
-        &mint.pubsub_manager(),
+        Notifiers::new(&mint.pubsub_manager(), &mint.state_filters()),
         &melt_quote.id,
         &input_ys,
         &blinded_secrets,
@@ -3424,7 +3429,7 @@ async fn test_rollback_melt_quote_duplicate_failure_is_idempotent() {
 
     rollback_melt_quote(
         &mint.localstore(),
-        &mint.pubsub_manager(),
+        Notifiers::new(&mint.pubsub_manager(), &mint.state_filters()),
         &quote.id,
         &input_ys,
         &blinded_secrets,
@@ -3444,7 +3449,7 @@ async fn test_rollback_melt_quote_duplicate_failure_is_idempotent() {
 
     rollback_melt_quote(
         &mint.localstore(),
-        &mint.pubsub_manager(),
+        Notifiers::new(&mint.pubsub_manager(), &mint.state_filters()),
         &quote.id,
         &input_ys,
         &blinded_secrets,
@@ -3505,7 +3510,7 @@ async fn test_stale_remove_melt_setup_does_not_clobber_retry() {
     // The first rollback completes and deletes saga A.
     rollback_melt_quote(
         &mint.localstore(),
-        &mint.pubsub_manager(),
+        Notifiers::new(&mint.pubsub_manager(), &mint.state_filters()),
         &quote.id,
         &input_ys,
         &blinded_secrets,
@@ -3533,7 +3538,11 @@ async fn test_stale_remove_melt_setup_does_not_clobber_retry() {
     // The delayed stale compensation from saga A executes; it must not tear
     // down saga B's live attempt.
     let _ = stale_compensation
-        .execute(&mint.localstore(), &mint.pubsub_manager())
+        .execute(
+            &mint.localstore(),
+            &mint.pubsub_manager(),
+            &mint.state_filters(),
+        )
         .await;
 
     let quote_after_stale_compensation = mint

--- a/crates/cdk/src/mint/melt/shared.rs
+++ b/crates/cdk/src/mint/melt/shared.rs
@@ -16,6 +16,7 @@ use cdk_common::{Amount, CurrencyUnit, Error, PublicKey, QuoteId};
 use cdk_prometheus::METRICS;
 use cdk_signatory::signatory::SignatoryKeySet;
 
+use crate::mint::state_filters::StateFilters;
 use crate::mint::subscription::PubSubManager;
 use crate::mint::MeltQuote;
 use crate::Mint;
@@ -147,10 +148,29 @@ pub(crate) async fn persist_melt_finalization_handoff(
 ///
 /// Returns database errors if transaction fails, `Error::PaidQuote` if the
 /// quote is already paid, and `Error::UnknownPaymentState` if the saga has
+/// Where a state change is published once it has committed.
+///
+/// The two always travel together: the pubsub is best-effort delivery to live
+/// subscribers, the filters are the durable record.
+#[derive(Clone, Copy)]
+pub struct Notifiers<'a> {
+    /// Live subscribers
+    pub pubsub: &'a PubSubManager,
+    /// Compact state filters
+    pub filters: &'a StateFilters,
+}
+
+impl<'a> Notifiers<'a> {
+    /// Bundle a pubsub manager and a filter recorder.
+    pub fn new(pubsub: &'a PubSubManager, filters: &'a StateFilters) -> Self {
+        Self { pubsub, filters }
+    }
+}
+
 /// already advanced to `Finalizing` and must not be rolled back.
 pub async fn rollback_melt_quote(
     db: &DynMintDatabase,
-    pubsub: &PubSubManager,
+    notifiers: Notifiers<'_>,
     quote_id: &QuoteId,
     input_ys: &[PublicKey],
     blinded_secrets: &[PublicKey],
@@ -164,7 +184,7 @@ pub async fn rollback_melt_quote(
     tx.lock_quotes(std::slice::from_ref(quote_id)).await?;
     rollback_melt_quote_inner(
         tx,
-        pubsub,
+        notifiers,
         quote_id,
         input_ys,
         blinded_secrets,
@@ -177,7 +197,7 @@ pub async fn rollback_melt_quote(
 /// Roll back setup only if the saga still proves payment was never attempted.
 pub(crate) async fn rollback_setup_melt_quote(
     db: &DynMintDatabase,
-    pubsub: &PubSubManager,
+    notifiers: Notifiers<'_>,
     quote_id: &QuoteId,
     input_ys: &[PublicKey],
     blinded_secrets: &[PublicKey],
@@ -191,7 +211,7 @@ pub(crate) async fn rollback_setup_melt_quote(
     tx.lock_quotes(std::slice::from_ref(quote_id)).await?;
     rollback_melt_quote_inner(
         tx,
-        pubsub,
+        notifiers,
         quote_id,
         input_ys,
         blinded_secrets,
@@ -204,7 +224,7 @@ pub(crate) async fn rollback_setup_melt_quote(
 /// Roll back a melt only after an authoritative payment failure was recorded.
 pub(crate) async fn rollback_failed_melt_quote(
     db: &DynMintDatabase,
-    pubsub: &PubSubManager,
+    notifiers: Notifiers<'_>,
     quote_id: &QuoteId,
     input_ys: &[PublicKey],
     blinded_secrets: &[PublicKey],
@@ -218,7 +238,7 @@ pub(crate) async fn rollback_failed_melt_quote(
     tx.lock_quotes(std::slice::from_ref(quote_id)).await?;
     rollback_melt_quote_inner(
         tx,
-        pubsub,
+        notifiers,
         quote_id,
         input_ys,
         blinded_secrets,
@@ -230,7 +250,7 @@ pub(crate) async fn rollback_failed_melt_quote(
 
 async fn rollback_melt_quote_inner(
     mut tx: DynMintTransaction,
-    pubsub: &PubSubManager,
+    notifiers: Notifiers<'_>,
     quote_id: &QuoteId,
     input_ys: &[PublicKey],
     blinded_secrets: &[PublicKey],
@@ -300,8 +320,14 @@ async fn rollback_melt_quote_inner(
     let quote_option = if let Some(mut quote) = locked_quotes.target {
         match quote.state {
             MeltQuoteState::Pending => {
-                tx.update_melt_quote_state(&mut quote, MeltQuoteState::Unpaid, None)
-                    .await?;
+                Mint::update_melt_quote_state(
+                    &mut tx,
+                    notifiers.filters,
+                    &mut quote,
+                    MeltQuoteState::Unpaid,
+                    None,
+                )
+                .await?;
                 Some(quote)
             }
             MeltQuoteState::Unpaid | MeltQuoteState::Failed => {
@@ -341,17 +367,19 @@ async fn rollback_melt_quote_inner(
 
     // Remove input proofs
     if !input_ys.is_empty() {
-        match tx.remove_proofs(input_ys, Some(quote_id.clone())).await {
+        match Mint::remove_proofs(&mut tx, notifiers.filters, input_ys, Some(quote_id.clone()))
+            .await
+        {
             Ok(_) => {
                 proofs_recovered = true;
             }
-            Err(database::Error::AttemptRemoveSpentProof) => {
+            Err(Error::Database(database::Error::AttemptRemoveSpentProof)) => {
                 tracing::warn!(
                     "Proofs already spent or missing during rollback for quote {}",
                     quote_id
                 );
             }
-            Err(e) => return Err(e.into()),
+            Err(e) => return Err(e),
         }
     }
 
@@ -370,12 +398,14 @@ async fn rollback_melt_quote_inner(
     // Publish proof state changes
     if proofs_recovered {
         for pk in input_ys.iter() {
-            pubsub.proof_state((*pk, State::Unspent));
+            notifiers.pubsub.proof_state((*pk, State::Unspent));
         }
     }
 
     if let Some(quote) = quote_option {
-        pubsub.melt_quote_status(&quote, None, None, MeltQuoteState::Unpaid);
+        notifiers
+            .pubsub
+            .melt_quote_status(&quote, None, None, MeltQuoteState::Unpaid);
     }
 
     tracing::info!(
@@ -674,6 +704,7 @@ pub async fn load_melt_quotes_exclusively(
 pub(crate) async fn finalize_melt_core(
     mut tx: Box<dyn database::MintTransaction<database::Error> + Send + Sync>,
     pubsub: &PubSubManager,
+    filters: &StateFilters,
     mut quote: Acquired<MeltQuote>,
     input_ys: &[PublicKey],
     inputs_amount: Amount<CurrencyUnit>,
@@ -744,12 +775,17 @@ pub(crate) async fn finalize_melt_core(
     }
 
     // Update quote state to Paid
-    if let Err(err) = tx
-        .update_melt_quote_state(&mut quote, MeltQuoteState::Paid, payment_proof.clone())
-        .await
+    if let Err(err) = Mint::update_melt_quote_state(
+        &mut tx,
+        filters,
+        &mut quote,
+        MeltQuoteState::Paid,
+        payment_proof.clone(),
+    )
+    .await
     {
         tx.rollback().await?;
-        return Err(err.into());
+        return Err(err);
     }
 
     quote.state = MeltQuoteState::Paid;
@@ -779,7 +815,7 @@ pub(crate) async fn finalize_melt_core(
         }
     };
 
-    if let Err(err) = Mint::update_proofs_state(&mut tx, &mut proofs, State::Spent).await {
+    if let Err(err) = Mint::update_proofs_state(&mut tx, filters, &mut proofs, State::Spent).await {
         tx.rollback().await?;
         return Err(err);
     }
@@ -935,8 +971,13 @@ pub async fn finalize_melt_quote(
         let mut proofs_with_state = tx.get_proofs(&input_ys).await?;
         let spend_pending = proofs_with_state.state == State::Pending;
         if spend_pending {
-            if let Err(err) =
-                Mint::update_proofs_state(&mut tx, &mut proofs_with_state, State::Spent).await
+            if let Err(err) = Mint::update_proofs_state(
+                &mut tx,
+                &mint.state_filters(),
+                &mut proofs_with_state,
+                State::Spent,
+            )
+            .await
             {
                 tx.rollback().await?;
                 return Err(err);
@@ -954,6 +995,7 @@ pub async fn finalize_melt_quote(
         let (proofs, quote) = finalize_melt_core(
             tx,
             pubsub,
+            &mint.state_filters(),
             locked_quote,
             &input_ys,
             melt_request_info.inputs_amount.clone(),

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -36,8 +36,10 @@ mod keysets;
 mod melt;
 mod payment_backend;
 mod proofs;
+mod quotes;
 mod saga_recovery;
 mod start_up_check;
+pub mod state_filters;
 mod subscription;
 mod swap;
 mod verification;
@@ -47,6 +49,7 @@ pub use cdk_common::mint::{MeltQuote, MintKeySetInfo, MintQuote};
 pub use cdk_common::mint_quote::{MintQuoteRequest, MintQuoteResponse};
 pub use issue::MintInput;
 pub use melt::PendingMelt;
+pub use state_filters::{SharedStateFilters, StateFilterOptions, StateFilterService, StateFilters};
 pub use verification::Verification;
 
 const CDK_MINT_PRIMARY_NAMESPACE: &str = "cdk_mint";
@@ -95,6 +98,13 @@ pub struct Mint {
     max_inputs: usize,
     /// Maximum number of outputs allowed per transaction
     max_outputs: usize,
+    /// Builds and serves compact state filters, when the mint publishes them
+    state_filter_service: Option<Arc<StateFilterService>>,
+    /// Records filter elements alongside the state changes that produce them
+    ///
+    /// Shared with the subscription manager, which is built before the filter
+    /// service exists, so the recorder is swapped in rather than passed down.
+    state_filters: SharedStateFilters,
 }
 
 impl std::fmt::Debug for Mint {
@@ -112,6 +122,8 @@ struct TaskState {
     supervisor_handle: Option<JoinHandle<Result<(), Error>>>,
     /// Handle to the keyset drain task
     keyset_drain_handle: Option<JoinHandle<()>>,
+    /// Handle to the state filter epoch builder
+    filter_builder_handle: Option<JoinHandle<()>>,
     /// Keyset subscription retained from construction, drained once by the first
     /// `start()`. `None` after it has been taken; a restart re-subscribes.
     keyset_updates: Option<watch::Receiver<SignatoryKeysets>>,
@@ -166,6 +178,7 @@ impl SupervisedStream for PaymentWaiter {
                 if let Err(e) = Mint::handle_payment_notification(
                     &self.localstore,
                     &self.pubsub_manager,
+                    &self.mint.state_filters(),
                     wait_payment_response,
                 )
                 .await
@@ -385,10 +398,16 @@ impl Mint {
         }
 
         let payment_processors = Arc::new(payment_processors);
+        let state_filters: SharedStateFilters =
+            Arc::new(arc_swap::ArcSwap::from_pointee(StateFilters::disabled()));
 
         Ok(Self {
             signatory,
-            pubsub_manager: PubSubManager::new((localstore.clone(), payment_processors.clone())),
+            pubsub_manager: PubSubManager::new((
+                localstore.clone(),
+                payment_processors.clone(),
+                state_filters.clone(),
+            )),
             localstore,
             oidc_client: computed_info.nuts.nut21.as_ref().map(|nut21| {
                 OidcClient::new(
@@ -407,7 +426,30 @@ impl Mint {
             })),
             max_inputs,
             max_outputs,
+            state_filter_service: None,
+            state_filters,
         })
+    }
+
+    /// Attach the state filter service built from the mint's configuration.
+    pub(crate) fn set_state_filter_service(&mut self, service: Option<Arc<StateFilterService>>) {
+        self.state_filters.store(Arc::new(
+            service
+                .as_ref()
+                .map(|service| service.recorder())
+                .unwrap_or_default(),
+        ));
+        self.state_filter_service = service;
+    }
+
+    /// The recorder that capture points write filter elements through.
+    pub fn state_filters(&self) -> arc_swap::Guard<Arc<StateFilters>> {
+        self.state_filters.load()
+    }
+
+    /// The state filter service, when this mint publishes filters.
+    pub fn state_filter_service(&self) -> Option<&Arc<StateFilterService>> {
+        self.state_filter_service.as_ref()
     }
 
     /// Start the mint's background services and operations
@@ -569,10 +611,37 @@ impl Mint {
             None
         };
 
+        let filter_builder_handle = match self.state_filter_service.clone() {
+            Some(service) => {
+                if let Err(err) = service.build_due_epochs().await {
+                    tracing::error!("Could not build pending state filters: {}", err);
+                }
+
+                let shutdown = shutdown_notify.clone();
+                let interval = service.build_interval();
+                Some(tokio::spawn(async move {
+                    let shutdown_wait = shutdown.notified();
+                    tokio::pin!(shutdown_wait);
+                    loop {
+                        tokio::select! {
+                            _ = &mut shutdown_wait => break,
+                            _ = tokio::time::sleep(interval) => {
+                                if let Err(err) = service.build_due_epochs().await {
+                                    tracing::error!("Could not build state filters: {}", err);
+                                }
+                            }
+                        }
+                    }
+                }))
+            }
+            None => None,
+        };
+
         // Store the handles
         task_state.shutdown_notify = Some(shutdown_notify);
         task_state.supervisor_handle = Some(supervisor_handle);
         task_state.keyset_drain_handle = keyset_drain_handle;
+        task_state.filter_builder_handle = filter_builder_handle;
 
         // Give the background task a tiny bit of time to start waiting
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
@@ -597,6 +666,7 @@ impl Mint {
         let shutdown_notify = task_state.shutdown_notify.take();
         let supervisor_handle = task_state.supervisor_handle.take();
         let keyset_drain_handle = task_state.keyset_drain_handle.take();
+        let filter_builder_handle = task_state.filter_builder_handle.take();
 
         // If nothing to stop, return early
         let (shutdown_notify, supervisor_handle) = match (shutdown_notify, supervisor_handle) {
@@ -632,6 +702,12 @@ impl Mint {
         if let Some(handle) = keyset_drain_handle {
             if let Err(join_error) = handle.await {
                 tracing::error!("Keyset drain task panicked: {:?}", join_error);
+            }
+        }
+
+        if let Some(handle) = filter_builder_handle {
+            if let Err(join_error) = handle.await {
+                tracing::error!("State filter builder task panicked: {:?}", join_error);
             }
         }
 
@@ -1131,6 +1207,7 @@ impl Mint {
     async fn handle_payment_notification(
         localstore: &DynMintDatabase,
         pubsub_manager: &Arc<PubSubManager>,
+        filters: &StateFilters,
         wait_payment_response: WaitPaymentResponse,
     ) -> Result<(), Error> {
         if wait_payment_response.payment_amount.value() == 0 {
@@ -1147,9 +1224,13 @@ impl Mint {
             .get_mint_quote_by_request_lookup_id(&wait_payment_response.payment_identifier)
             .await
         {
-            let notify =
-                Self::handle_mint_quote_payment(&mut tx, &mut mint_quote, wait_payment_response)
-                    .await?;
+            let notify = Self::handle_mint_quote_payment(
+                &mut tx,
+                filters,
+                &mut mint_quote,
+                wait_payment_response,
+            )
+            .await?;
             if notify {
                 Some((mint_quote.clone(), mint_quote.amount_paid()))
             } else {
@@ -1181,6 +1262,7 @@ impl Mint {
     #[instrument(skip_all)]
     async fn handle_mint_quote_payment(
         tx: &mut Box<dyn database::MintTransaction<database::Error> + Send + Sync>,
+        filters: &StateFilters,
         mint_quote: &mut Acquired<MintQuote>,
         wait_payment_response: WaitPaymentResponse,
     ) -> Result<bool, Error> {
@@ -1223,7 +1305,7 @@ impl Mint {
                     None,
                 ) {
                     Ok(()) => {
-                        tx.update_mint_quote(mint_quote).await?;
+                        Mint::update_mint_quote(tx, filters, mint_quote).await?;
                         return Ok(true);
                     }
                     Err(Error::DuplicatePaymentId) => {

--- a/crates/cdk/src/mint/payment_backend.rs
+++ b/crates/cdk/src/mint/payment_backend.rs
@@ -9,6 +9,7 @@ use cdk_common::util::unix_time;
 use cdk_common::MintQuoteState;
 use tracing::instrument;
 
+use super::state_filters::StateFilters;
 use super::subscription::PubSubManager;
 use super::Mint;
 use crate::Error;
@@ -22,6 +23,7 @@ impl Mint {
         localstore: DynMintDatabase,
         payment_processors: Arc<HashMap<PaymentProcessorKey, DynMintPayment>>,
         pubsub_manager: Option<Arc<PubSubManager>>,
+        filters: &StateFilters,
         quote: &mut MintQuote,
     ) -> Result<(), Error> {
         let state = quote.state();
@@ -106,7 +108,7 @@ impl Mint {
 
                 match new_quote.add_payment(amount_paid, payment.payment_id.clone(), None) {
                     Ok(()) => {
-                        tx.update_mint_quote(&mut new_quote).await?;
+                        Mint::update_mint_quote(&mut tx, filters, &mut new_quote).await?;
                         should_notify = true;
                     }
                     Err(crate::Error::DuplicatePaymentId) => {
@@ -143,6 +145,7 @@ impl Mint {
             self.localstore.clone(),
             self.payment_processors.clone(),
             Some(self.pubsub_manager.clone()),
+            &self.state_filters(),
             quote,
         )
         .await

--- a/crates/cdk/src/mint/proofs.rs
+++ b/crates/cdk/src/mint/proofs.rs
@@ -1,9 +1,11 @@
 use cdk_common::database::mint::Acquired;
 use cdk_common::database::DynMintTransaction;
 use cdk_common::mint::ProofsWithState;
+use cdk_common::nuts::ProofsMethods;
 use cdk_common::state::{self, check_state_transition};
-use cdk_common::{Error, State};
+use cdk_common::{Error, PublicKey, State};
 
+use super::state_filters::StateFilters;
 use crate::Mint;
 
 impl Mint {
@@ -20,6 +22,7 @@ impl Mint {
     /// - [`Error::TokenAlreadySpent`] if the database rejects the update (proofs already spent)
     pub async fn update_proofs_state(
         tx: &mut DynMintTransaction,
+        filters: &StateFilters,
         proofs: &mut Acquired<ProofsWithState>,
         new_state: State,
     ) -> Result<(), Error> {
@@ -29,13 +32,33 @@ impl Mint {
             _ => Error::UnexpectedProofState,
         })?;
 
+        let ys = proofs.ys()?;
+
         tx.update_proofs_state(proofs, new_state)
             .await
             .map_err(|err| match err {
                 cdk_common::database::Error::AttemptUpdateSpentProof
                 | cdk_common::database::Error::AttemptRemoveSpentProof => Error::TokenAlreadySpent,
                 err => err.into(),
-            })
+            })?;
+
+        filters.record_proof_states(tx, &ys, new_state).await
+    }
+
+    /// Removes proofs, reverting them to unspent.
+    ///
+    /// This is the compensating path for a swap or melt that did not complete.
+    /// It is a real observable transition, so it publishes a filter element
+    /// even though it publishes no NUT-17 event.
+    pub async fn remove_proofs(
+        tx: &mut DynMintTransaction,
+        filters: &StateFilters,
+        ys: &[PublicKey],
+        quote_id: Option<cdk_common::QuoteId>,
+    ) -> Result<(), Error> {
+        tx.remove_proofs(ys, quote_id).await?;
+
+        filters.record_proof_states(tx, ys, State::Unspent).await
     }
 }
 
@@ -75,9 +98,14 @@ mod tests {
 
         assert_eq!(acquired.state, State::Unspent);
 
-        Mint::update_proofs_state(&mut tx, &mut acquired, State::Pending)
-            .await
-            .unwrap();
+        Mint::update_proofs_state(
+            &mut tx,
+            &mint.state_filters(),
+            &mut acquired,
+            State::Pending,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(acquired.state, State::Pending);
         tx.commit().await.unwrap();
@@ -112,9 +140,14 @@ mod tests {
         {
             let mut tx = db.begin_transaction().await.unwrap();
             let mut acquired = tx.get_proofs(&ys).await.unwrap();
-            Mint::update_proofs_state(&mut tx, &mut acquired, State::Pending)
-                .await
-                .unwrap();
+            Mint::update_proofs_state(
+                &mut tx,
+                &mint.state_filters(),
+                &mut acquired,
+                State::Pending,
+            )
+            .await
+            .unwrap();
             tx.commit().await.unwrap();
         }
 
@@ -124,7 +157,7 @@ mod tests {
 
         assert_eq!(acquired.state, State::Pending);
 
-        Mint::update_proofs_state(&mut tx, &mut acquired, State::Spent)
+        Mint::update_proofs_state(&mut tx, &mint.state_filters(), &mut acquired, State::Spent)
             .await
             .unwrap();
 
@@ -161,9 +194,14 @@ mod tests {
         {
             let mut tx = db.begin_transaction().await.unwrap();
             let mut acquired = tx.get_proofs(&ys).await.unwrap();
-            Mint::update_proofs_state(&mut tx, &mut acquired, State::Pending)
-                .await
-                .unwrap();
+            Mint::update_proofs_state(
+                &mut tx,
+                &mint.state_filters(),
+                &mut acquired,
+                State::Pending,
+            )
+            .await
+            .unwrap();
             tx.commit().await.unwrap();
         }
 
@@ -173,7 +211,13 @@ mod tests {
 
         assert_eq!(acquired.state, State::Pending);
 
-        let result = Mint::update_proofs_state(&mut tx, &mut acquired, State::Pending).await;
+        let result = Mint::update_proofs_state(
+            &mut tx,
+            &mint.state_filters(),
+            &mut acquired,
+            State::Pending,
+        )
+        .await;
 
         assert!(matches!(result, Err(Error::TokenPending)));
     }
@@ -203,10 +247,15 @@ mod tests {
         {
             let mut tx = db.begin_transaction().await.unwrap();
             let mut acquired = tx.get_proofs(&ys).await.unwrap();
-            Mint::update_proofs_state(&mut tx, &mut acquired, State::Pending)
-                .await
-                .unwrap();
-            Mint::update_proofs_state(&mut tx, &mut acquired, State::Spent)
+            Mint::update_proofs_state(
+                &mut tx,
+                &mint.state_filters(),
+                &mut acquired,
+                State::Pending,
+            )
+            .await
+            .unwrap();
+            Mint::update_proofs_state(&mut tx, &mint.state_filters(), &mut acquired, State::Spent)
                 .await
                 .unwrap();
             tx.commit().await.unwrap();
@@ -218,7 +267,13 @@ mod tests {
 
         assert_eq!(acquired.state, State::Spent);
 
-        let result = Mint::update_proofs_state(&mut tx, &mut acquired, State::Pending).await;
+        let result = Mint::update_proofs_state(
+            &mut tx,
+            &mint.state_filters(),
+            &mut acquired,
+            State::Pending,
+        )
+        .await;
 
         assert!(matches!(result, Err(Error::TokenAlreadySpent)));
     }
@@ -252,9 +307,14 @@ mod tests {
         assert_eq!(acquired.state, State::Unspent);
 
         // After update
-        Mint::update_proofs_state(&mut tx, &mut acquired, State::Pending)
-            .await
-            .unwrap();
+        Mint::update_proofs_state(
+            &mut tx,
+            &mint.state_filters(),
+            &mut acquired,
+            State::Pending,
+        )
+        .await
+        .unwrap();
 
         // The wrapper's state field should be updated
         assert_eq!(

--- a/crates/cdk/src/mint/quotes.rs
+++ b/crates/cdk/src/mint/quotes.rs
@@ -1,0 +1,52 @@
+use cdk_common::database::mint::Acquired;
+use cdk_common::database::DynMintTransaction;
+use cdk_common::mint::{MeltQuote, MintQuote};
+use cdk_common::{Error, MeltQuoteState};
+
+use super::state_filters::StateFilters;
+use crate::Mint;
+
+impl Mint {
+    /// Persists a mint quote and publishes the change to the filters.
+    ///
+    /// A mint quote element carries no state, because the quote's accounting
+    /// fields would disclose amounts. A match means only that the quote
+    /// changed, so nothing is published when it did not.
+    pub async fn update_mint_quote(
+        tx: &mut DynMintTransaction,
+        filters: &StateFilters,
+        quote: &mut Acquired<MintQuote>,
+    ) -> Result<(), Error> {
+        let changed = quote.has_changes();
+        let quote_id = quote.id.to_string();
+
+        tx.update_mint_quote(quote).await?;
+
+        if changed {
+            filters.record_mint_quote(tx, &quote_id).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Moves a melt quote to a new state and publishes it to the filters.
+    ///
+    /// Returns the state the quote was in before the update.
+    pub async fn update_melt_quote_state(
+        tx: &mut DynMintTransaction,
+        filters: &StateFilters,
+        quote: &mut Acquired<MeltQuote>,
+        new_state: MeltQuoteState,
+        payment_proof: Option<String>,
+    ) -> Result<MeltQuoteState, Error> {
+        let quote_id = quote.id.to_string();
+
+        let previous = tx
+            .update_melt_quote_state(quote, new_state, payment_proof)
+            .await?;
+
+        filters.record_melt_quote(tx, &quote_id, new_state).await?;
+
+        Ok(previous)
+    }
+}

--- a/crates/cdk/src/mint/saga_recovery.rs
+++ b/crates/cdk/src/mint/saga_recovery.rs
@@ -8,6 +8,8 @@ use cdk_common::nuts::MeltQuoteState;
 use cdk_common::payment::MakePaymentResponse;
 use tracing::instrument;
 
+use crate::mint::melt::shared::Notifiers;
+use crate::mint::state_filters::StateFilters;
 use crate::mint::subscription::PubSubManager;
 use crate::mint::Mint;
 use crate::Error;
@@ -79,7 +81,7 @@ pub(crate) async fn process_melt_saga_outcome(
 
             persist_permanent_payment_failure(saga, quote, db, payment_response).await?;
 
-            recover_recorded_payment_failure(saga, quote, db, pubsub).await
+            recover_recorded_payment_failure(saga, quote, db, pubsub, &mint.state_filters()).await
         }
         MeltQuoteState::Pending => {
             persist_pending_after_dispatch(saga, quote, payment_response, db).await?;
@@ -186,6 +188,7 @@ pub(crate) async fn recover_recorded_payment_failure(
     quote: &mut MeltQuote,
     db: &cdk_common::database::DynMintDatabase,
     pubsub: &PubSubManager,
+    filters: &StateFilters,
 ) -> Result<(), Error> {
     let current_saga = db.get_melt_saga_by_quote_id(&quote.id).await?;
     let Some(saga) = current_saga else {
@@ -214,7 +217,7 @@ pub(crate) async fn recover_recorded_payment_failure(
         .await?;
     let rollback = super::melt::shared::rollback_failed_melt_quote(
         db,
-        pubsub,
+        Notifiers::new(pubsub, filters),
         &quote.id,
         &input_ys,
         &blinded_secrets,

--- a/crates/cdk/src/mint/start_up_check.rs
+++ b/crates/cdk/src/mint/start_up_check.rs
@@ -10,6 +10,7 @@ use cdk_common::mint::{MeltPaymentRequest, OperationKind, Saga};
 use cdk_common::payment::PaymentIdentifier;
 use cdk_common::{PublicKey, QuoteId, State};
 
+use super::melt::shared::Notifiers;
 use super::{Error, Mint};
 use crate::mint::swap::swap_saga::compensation::{CompensatingAction, RemoveSwapSetup};
 use crate::mint::{MeltQuote, MeltQuoteState};
@@ -289,7 +290,11 @@ impl Mint {
 
             // Execute compensation (includes saga deletion)
             if let Err(e) = compensation
-                .execute(&self.localstore, &self.pubsub_manager)
+                .execute(
+                    &self.localstore,
+                    &self.pubsub_manager,
+                    &self.state_filters(),
+                )
                 .await
             {
                 tracing::error!(
@@ -830,7 +835,7 @@ impl Mint {
                     ) => {
                         super::melt::shared::rollback_setup_melt_quote(
                             &self.localstore,
-                            &self.pubsub_manager,
+                            Notifiers::new(&self.pubsub_manager, &self.state_filters()),
                             &quote_id_parsed,
                             &input_ys,
                             &blinded_secrets,
@@ -843,7 +848,7 @@ impl Mint {
                     ) => {
                         super::melt::shared::rollback_failed_melt_quote(
                             &self.localstore,
-                            &self.pubsub_manager,
+                            Notifiers::new(&self.pubsub_manager, &self.state_filters()),
                             &quote_id_parsed,
                             &input_ys,
                             &blinded_secrets,
@@ -913,6 +918,7 @@ impl Mint {
                 quote,
                 &self.localstore,
                 &self.pubsub_manager,
+                &self.state_filters(),
             )
             .await;
         }
@@ -1006,9 +1012,14 @@ mod tests {
         {
             let mut tx = db.begin_transaction().await.unwrap();
             let mut proofs = tx.get_proofs(&input_ys).await.unwrap();
-            Mint::update_proofs_state(&mut tx, &mut proofs, State::Spent)
-                .await
-                .unwrap();
+            Mint::update_proofs_state(
+                &mut tx,
+                &crate::mint::StateFilters::disabled(),
+                &mut proofs,
+                State::Spent,
+            )
+            .await
+            .unwrap();
             tx.commit().await.unwrap();
         }
 

--- a/crates/cdk/src/mint/state_filters/mod.rs
+++ b/crates/cdk/src/mint/state_filters/mod.rs
@@ -1,0 +1,180 @@
+//! Compact state filters
+
+use cdk_common::database::mint::StateFilterConfig;
+use cdk_common::database::DynMintTransaction;
+use cdk_common::nuts::state_filters::{
+    FilterElement, FilterKind, Settings, DEFAULT_EPOCH, DEFAULT_P, DEFAULT_PAGE_SIZE,
+};
+use cdk_common::util::unix_time;
+use cdk_common::{Error, MeltQuoteState, PublicKey, State};
+
+mod service;
+
+pub use service::StateFilterService;
+
+/// How long after an epoch ends before its filter is built.
+///
+/// A transaction that commits on the boundary takes its epoch from the same
+/// clock as the builder, so the grace period keeps a straggler from landing an
+/// element in an epoch that has already been sealed.
+pub const BUILD_GRACE_SECONDS: u64 = 30;
+
+/// A recorder shared between the mint and anything constructed before the
+/// filter service exists, such as the subscription manager.
+pub type SharedStateFilters = std::sync::Arc<arc_swap::ArcSwap<StateFilters>>;
+
+/// How a mint should publish its filters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateFilterOptions {
+    /// Epoch duration in seconds
+    pub epoch_seconds: u64,
+    /// Golomb-Rice parameter
+    pub p: u8,
+    /// Number of filters on a full page
+    pub page_size: u64,
+    /// Kinds the filters cover
+    pub kinds: Vec<FilterKind>,
+    /// Whether to serve the filter of the epoch that is still open
+    pub pending: bool,
+}
+
+impl Default for StateFilterOptions {
+    fn default() -> Self {
+        Self {
+            epoch_seconds: DEFAULT_EPOCH,
+            p: DEFAULT_P,
+            page_size: DEFAULT_PAGE_SIZE,
+            kinds: vec![
+                FilterKind::ProofState,
+                FilterKind::MintQuote,
+                FilterKind::MeltQuote,
+            ],
+            pending: true,
+        }
+    }
+}
+
+/// Records filter elements as part of the transaction that changes state.
+///
+/// A mint that does not publish filters holds a disabled recorder, and every
+/// method is then a no-op.
+#[derive(Debug, Clone, Default)]
+pub struct StateFilters {
+    config: Option<StateFilterConfig>,
+    kinds: Vec<FilterKind>,
+}
+
+impl StateFilters {
+    /// A recorder that captures nothing.
+    pub fn disabled() -> Self {
+        Self::default()
+    }
+
+    /// A recorder for a mint that publishes filters.
+    pub fn new(config: StateFilterConfig, kinds: Vec<FilterKind>) -> Self {
+        Self {
+            config: Some(config),
+            kinds,
+        }
+    }
+
+    /// Whether this mint publishes filters.
+    pub fn enabled(&self) -> bool {
+        self.config.is_some()
+    }
+
+    /// The stored parameters, if filters are enabled.
+    pub fn config(&self) -> Option<&StateFilterConfig> {
+        self.config.as_ref()
+    }
+
+    /// Mint info settings describing what these filters cover.
+    pub fn settings(&self) -> Settings {
+        if self.config.is_none() {
+            return Settings::default();
+        }
+        Settings::new(self.kinds.clone())
+    }
+
+    fn covers(&self, kind: FilterKind) -> Option<&StateFilterConfig> {
+        let config = self.config.as_ref()?;
+        self.kinds.contains(&kind).then_some(config)
+    }
+
+    fn open_epoch(config: &StateFilterConfig, now: u64) -> u64 {
+        now.saturating_sub(config.genesis) / config.epoch_seconds
+    }
+
+    async fn record(
+        tx: &mut DynMintTransaction,
+        config: &StateFilterConfig,
+        elements: Vec<FilterElement>,
+    ) -> Result<(), Error> {
+        if elements.is_empty() {
+            return Ok(());
+        }
+        let epoch = Self::open_epoch(config, unix_time());
+        tx.add_filter_elements(epoch, &elements).await?;
+        Ok(())
+    }
+
+    /// Record that a set of proofs moved to `state`.
+    pub async fn record_proof_states(
+        &self,
+        tx: &mut DynMintTransaction,
+        ys: &[PublicKey],
+        state: State,
+    ) -> Result<(), Error> {
+        let Some(config) = self.covers(FilterKind::ProofState) else {
+            return Ok(());
+        };
+
+        let elements = ys
+            .iter()
+            .map(|y| FilterElement::proof_state(y, state))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Self::record(tx, config, elements).await
+    }
+
+    /// Record that a mint quote changed.
+    pub async fn record_mint_quote(
+        &self,
+        tx: &mut DynMintTransaction,
+        quote_id: &str,
+    ) -> Result<(), Error> {
+        let Some(config) = self.covers(FilterKind::MintQuote) else {
+            return Ok(());
+        };
+
+        Self::record(tx, config, vec![FilterElement::mint_quote(quote_id)]).await
+    }
+
+    /// Record that a melt quote moved to `state`.
+    ///
+    /// `MeltQuoteState::Unknown` has no filter representation and is skipped.
+    pub async fn record_melt_quote(
+        &self,
+        tx: &mut DynMintTransaction,
+        quote_id: &str,
+        state: MeltQuoteState,
+    ) -> Result<(), Error> {
+        let Some(config) = self.covers(FilterKind::MeltQuote) else {
+            return Ok(());
+        };
+
+        if state == MeltQuoteState::Unknown {
+            return Ok(());
+        }
+
+        Self::record(
+            tx,
+            config,
+            vec![FilterElement::melt_quote(quote_id, state)?],
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/cdk/src/mint/state_filters/service.rs
+++ b/crates/cdk/src/mint/state_filters/service.rs
@@ -1,0 +1,217 @@
+//! Building and serving compact state filters
+
+use cdk_common::database::mint::StateFilterConfig;
+use cdk_common::database::DynMintDatabase;
+use cdk_common::nuts::state_filters::{
+    encode, FilterKind, GetFiltersInfoResponse, GetFiltersResponse, PendingFilterResponse,
+};
+use cdk_common::util::unix_time;
+use cdk_common::Error;
+
+use super::{StateFilters, BUILD_GRACE_SECONDS};
+
+/// Builds one filter per epoch and serves the published pages.
+#[derive(Clone)]
+pub struct StateFilterService {
+    db: DynMintDatabase,
+    config: StateFilterConfig,
+    kinds: Vec<FilterKind>,
+    pending: bool,
+}
+
+impl std::fmt::Debug for StateFilterService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StateFilterService")
+            .field("config", &self.config)
+            .field("kinds", &self.kinds)
+            .field("pending", &self.pending)
+            .finish()
+    }
+}
+
+impl StateFilterService {
+    /// Load or establish the filter parameters.
+    ///
+    /// The stored parameters win, and a mismatch is refused rather than
+    /// silently renumbering pages or changing the false positive rate under
+    /// wallets that already hold history. `genesis` is only chosen the first
+    /// time, aligned down to a multiple of the epoch so hourly epochs land on
+    /// the hour.
+    pub async fn new(
+        db: DynMintDatabase,
+        epoch_seconds: u64,
+        p: u8,
+        page_size: u64,
+        kinds: Vec<FilterKind>,
+        pending: bool,
+    ) -> Result<Self, Error> {
+        if epoch_seconds == 0 || page_size == 0 {
+            return Err(Error::StateFilterConfig(
+                "epoch and page size must be non-zero".to_string(),
+            ));
+        }
+
+        let config = match db.get_state_filter_config().await? {
+            Some(stored) => {
+                if stored.epoch_seconds != epoch_seconds
+                    || stored.p != p
+                    || stored.page_size != page_size
+                {
+                    return Err(Error::StateFilterConfig(format!(
+                        "stored parameters (epoch {}, p {}, page size {}) cannot be changed to (epoch {}, p {}, page size {})",
+                        stored.epoch_seconds, stored.p, stored.page_size, epoch_seconds, p, page_size
+                    )));
+                }
+                stored
+            }
+            None => {
+                let now = unix_time();
+                let config = StateFilterConfig {
+                    genesis: now - (now % epoch_seconds),
+                    epoch_seconds,
+                    p,
+                    page_size,
+                };
+
+                let mut tx = db.begin_transaction().await?;
+                tx.set_state_filter_config(&config).await?;
+                tx.commit().await?;
+
+                config
+            }
+        };
+
+        Ok(Self {
+            db,
+            config,
+            kinds,
+            pending,
+        })
+    }
+
+    /// How often the builder should look for epochs to close.
+    ///
+    /// Capped so a mint with a long epoch still closes promptly after the
+    /// grace period rather than a whole epoch late.
+    pub fn build_interval(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.config.epoch_seconds.clamp(1, 60))
+    }
+
+    /// The recorder that capture points write elements through.
+    pub fn recorder(&self) -> StateFilters {
+        StateFilters::new(self.config, self.kinds.clone())
+    }
+
+    fn epoch_start(&self, epoch: u64) -> u64 {
+        self.config
+            .genesis
+            .saturating_add(epoch.saturating_mul(self.config.epoch_seconds))
+    }
+
+    fn epoch_end(&self, epoch: u64) -> u64 {
+        self.epoch_start(epoch.saturating_add(1))
+    }
+
+    fn open_epoch(&self, now: u64) -> u64 {
+        now.saturating_sub(self.config.genesis) / self.config.epoch_seconds
+    }
+
+    async fn built_count(&self) -> Result<u64, Error> {
+        Ok(self
+            .db
+            .latest_built_epoch()
+            .await?
+            .map(|epoch| epoch.saturating_add(1))
+            .unwrap_or(0))
+    }
+
+    /// Close every epoch whose grace period has passed.
+    ///
+    /// An epoch with no elements still gets a filter with empty data, which is
+    /// what keeps the published history contiguous. Running this at startup is
+    /// what closes the epochs that ended while the mint was down.
+    pub async fn build_due_epochs(&self) -> Result<u64, Error> {
+        let now = unix_time();
+        let mut next = self.built_count().await?;
+        let mut built = 0;
+
+        while self.epoch_end(next).saturating_add(BUILD_GRACE_SECONDS) <= now {
+            let mut tx = self.db.begin_transaction().await?;
+
+            let elements = tx.take_filter_elements(next).await?;
+            let data = encode(&elements, self.config.p)?;
+            tx.add_filter(next, self.epoch_start(next), self.epoch_end(next), &data)
+                .await?;
+
+            tx.commit().await?;
+
+            built += 1;
+            next += 1;
+        }
+
+        Ok(built)
+    }
+
+    /// Parameters of the published filters.
+    pub async fn info(&self) -> Result<GetFiltersInfoResponse, Error> {
+        let built = self.built_count().await?;
+        let current_page = built / self.config.page_size;
+
+        let latest_end = match built {
+            0 => self.config.genesis,
+            built => self.epoch_end(built - 1),
+        };
+
+        Ok(GetFiltersInfoResponse {
+            p: self.config.p,
+            epoch: self.config.epoch_seconds,
+            kinds: self.kinds.clone(),
+            page_size: self.config.page_size,
+            first_page: 0,
+            current_page,
+            current_page_count: built - current_page * self.config.page_size,
+            earliest_start: self.config.genesis,
+            latest_end,
+            pending: self.pending,
+        })
+    }
+
+    /// A page of filters, oldest first.
+    ///
+    /// Every page below `current_page` is complete and never changes again.
+    pub async fn page(&self, page: u64) -> Result<GetFiltersResponse, Error> {
+        let built = self.built_count().await?;
+        let current_page = built / self.config.page_size;
+
+        if page > current_page {
+            return Err(Error::FilterPageOutOfRange);
+        }
+
+        let filters = self
+            .db
+            .get_filters(page * self.config.page_size, self.config.page_size)
+            .await?;
+
+        Ok(GetFiltersResponse { page, filters })
+    }
+
+    /// Whether this page is complete and safe to cache forever.
+    pub async fn page_is_complete(&self, page: u64) -> Result<bool, Error> {
+        Ok(page < self.built_count().await? / self.config.page_size)
+    }
+
+    /// The filter of the epoch that is still open.
+    pub async fn pending(&self) -> Result<PendingFilterResponse, Error> {
+        if !self.pending {
+            return Err(Error::FilterNotAvailable);
+        }
+
+        let epoch = self.open_epoch(unix_time());
+        let elements = self.db.get_filter_elements(epoch).await?;
+
+        Ok(PendingFilterResponse {
+            start: self.epoch_start(epoch),
+            data: cdk_common::util::hex::encode(encode(&elements, self.config.p)?),
+        })
+    }
+}

--- a/crates/cdk/src/mint/state_filters/tests.rs
+++ b/crates/cdk/src/mint/state_filters/tests.rs
@@ -1,0 +1,299 @@
+use cdk_common::amount::SplitTarget;
+use cdk_common::database::mint::StateFilterConfig;
+use cdk_common::nuts::{
+    CurrencyUnit, DecodedFilter, FilterElement, FilterKind, PreMintSecrets, ProofsMethods,
+    SwapRequest,
+};
+use cdk_common::util::unix_time;
+use cdk_common::{Amount, MeltQuoteState, State};
+
+use super::{StateFilterOptions, StateFilterService};
+use crate::test_helpers::mint::{create_test_mint_with_state_filters, mint_test_proofs};
+use crate::Mint;
+
+fn options() -> StateFilterOptions {
+    StateFilterOptions {
+        epoch_seconds: 3600,
+        p: 28,
+        page_size: 4,
+        kinds: vec![
+            FilterKind::ProofState,
+            FilterKind::MintQuote,
+            FilterKind::MeltQuote,
+        ],
+        pending: true,
+    }
+}
+
+async fn filter_mint() -> Mint {
+    create_test_mint_with_state_filters(Some(options()))
+        .await
+        .expect("mint with filters")
+}
+
+/// The open epoch's filter, which reflects every element captured so far.
+async fn pending(mint: &Mint) -> DecodedFilter {
+    let service = mint.state_filter_service().expect("filters enabled");
+    let response = service.pending().await.expect("pending filter");
+    response.decode(options().p).expect("decodes")
+}
+
+async fn swap(mint: &Mint, amount: Amount) -> cdk_common::Proofs {
+    let proofs = mint_test_proofs(mint, amount).await.expect("proofs");
+
+    let keyset_id = *mint
+        .get_active_keysets()
+        .get(&CurrencyUnit::Sat)
+        .expect("active keyset");
+    let keys = mint
+        .keyset_pubkeys(&keyset_id)
+        .expect("keys")
+        .keysets
+        .first()
+        .expect("keyset")
+        .keys
+        .clone();
+    let fees: (u64, Vec<u64>) = (0, keys.iter().map(|a| a.0.to_u64()).collect());
+
+    let premint = PreMintSecrets::random(keyset_id, amount, &SplitTarget::None, &fees.into())
+        .expect("premint");
+
+    mint.process_swap_request(SwapRequest::new(proofs.clone(), premint.blinded_messages()))
+        .await
+        .expect("swap");
+
+    proofs
+}
+
+#[tokio::test]
+async fn a_swap_publishes_the_spent_inputs() {
+    let mint = filter_mint().await;
+    let spent = swap(&mint, Amount::from(64)).await;
+
+    let filter = pending(&mint).await;
+
+    for y in spent.ys().expect("ys") {
+        let element = FilterElement::proof_state(&y, State::Spent).expect("supported");
+        assert!(
+            filter.contains(&element),
+            "spent proof {y} is missing from the open epoch"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_swap_publishes_the_pending_transition_too() {
+    let mint = filter_mint().await;
+    let spent = swap(&mint, Amount::from(64)).await;
+
+    let filter = pending(&mint).await;
+
+    for y in spent.ys().expect("ys") {
+        let element = FilterElement::proof_state(&y, State::Pending).expect("supported");
+        assert!(
+            filter.contains(&element),
+            "the pending transition of {y} is missing"
+        );
+    }
+}
+
+#[tokio::test]
+async fn an_untouched_proof_is_absent() {
+    let mint = filter_mint().await;
+    swap(&mint, Amount::from(64)).await;
+
+    let untouched = mint_test_proofs(&mint, Amount::from(16))
+        .await
+        .expect("proofs");
+
+    let filter = pending(&mint).await;
+
+    for y in untouched.ys().expect("ys") {
+        let element = FilterElement::proof_state(&y, State::Spent).expect("supported");
+        assert!(!filter.contains(&element), "unspent proof {y} matched");
+    }
+}
+
+#[tokio::test]
+async fn a_mint_quote_payment_is_published() {
+    let mint = filter_mint().await;
+
+    // Minting drives the quote from unpaid through paid and issued.
+    mint_test_proofs(&mint, Amount::from(32))
+        .await
+        .expect("proofs");
+
+    let quotes = mint.localstore().get_mint_quotes().await.expect("quotes");
+    let quote = quotes.first().expect("one quote");
+
+    let filter = pending(&mint).await;
+    assert!(
+        filter.contains(&FilterElement::mint_quote(&quote.id.to_string())),
+        "mint quote {} is missing from the open epoch",
+        quote.id
+    );
+}
+
+#[tokio::test]
+async fn a_mint_that_does_not_publish_records_nothing() {
+    let mint = create_test_mint_with_state_filters(None)
+        .await
+        .expect("mint");
+
+    assert!(mint.state_filter_service().is_none());
+    assert!(!mint.state_filters().enabled());
+
+    swap(&mint, Amount::from(64)).await;
+
+    let elements = mint
+        .localstore()
+        .get_filter_elements(0)
+        .await
+        .expect("elements");
+    assert!(elements.is_empty(), "a disabled mint captured elements");
+}
+
+#[tokio::test]
+async fn only_advertised_kinds_are_captured() {
+    let mut options = options();
+    options.kinds = vec![FilterKind::MeltQuote];
+
+    let mint = create_test_mint_with_state_filters(Some(options))
+        .await
+        .expect("mint");
+
+    let spent = swap(&mint, Amount::from(64)).await;
+
+    let filter = pending(&mint).await;
+    for y in spent.ys().expect("ys") {
+        let element = FilterElement::proof_state(&y, State::Spent).expect("supported");
+        assert!(
+            !filter.contains(&element),
+            "proof states were captured by a mint that does not advertise them"
+        );
+    }
+}
+
+/// A mint that was down for several epochs still publishes a gapless history.
+#[tokio::test]
+async fn downtime_leaves_no_gap_in_the_history() {
+    let db: cdk_common::database::DynMintDatabase =
+        std::sync::Arc::new(cdk_sqlite::mint::memory::empty().await.expect("db"));
+    let epoch_seconds = 3600;
+    let now = unix_time();
+
+    let genesis = now - (now % epoch_seconds) - epoch_seconds * 10;
+    {
+        let mut tx = db.begin_transaction().await.expect("tx");
+        tx.set_state_filter_config(&StateFilterConfig {
+            genesis,
+            epoch_seconds,
+            p: 28,
+            page_size: 4,
+        })
+        .await
+        .expect("config");
+        tx.commit().await.expect("commit");
+    }
+
+    let service = StateFilterService::new(db.clone(), epoch_seconds, 28, 4, vec![], true)
+        .await
+        .expect("service");
+
+    let built = service.build_due_epochs().await.expect("build");
+    assert_eq!(built, 10, "every closed epoch is built");
+
+    let info = service.info().await.expect("info");
+    assert_eq!(info.first_page, 0);
+    assert_eq!(info.current_page, 2, "ten filters at four per page");
+    assert_eq!(info.current_page_count, 2);
+    assert_eq!(info.earliest_start, genesis);
+    assert_eq!(info.latest_end, genesis + epoch_seconds * 10);
+
+    let mut expected_start = genesis;
+    for page in 0..=info.current_page {
+        for filter in service.page(page).await.expect("page").filters {
+            assert_eq!(filter.start, expected_start, "epochs must be contiguous");
+            assert_eq!(filter.end, expected_start + epoch_seconds);
+            assert!(filter.data.is_empty(), "an empty epoch has an empty filter");
+            expected_start = filter.end;
+        }
+    }
+    assert_eq!(expected_start, info.latest_end);
+}
+
+#[tokio::test]
+async fn a_page_above_the_current_one_is_rejected() {
+    let mint = filter_mint().await;
+    let service = mint.state_filter_service().expect("filters enabled");
+
+    let info = service.info().await.expect("info");
+    assert!(service.page(info.current_page).await.is_ok());
+
+    assert!(matches!(
+        service.page(info.current_page + 1).await,
+        Err(crate::Error::FilterPageOutOfRange)
+    ));
+}
+
+#[tokio::test]
+async fn a_complete_page_is_immutable_but_the_current_one_is_not() {
+    let db: cdk_common::database::DynMintDatabase =
+        std::sync::Arc::new(cdk_sqlite::mint::memory::empty().await.expect("db"));
+    let epoch_seconds = 3600;
+    let now = unix_time();
+    let genesis = now - (now % epoch_seconds) - epoch_seconds * 6;
+
+    {
+        let mut tx = db.begin_transaction().await.expect("tx");
+        tx.set_state_filter_config(&StateFilterConfig {
+            genesis,
+            epoch_seconds,
+            p: 28,
+            page_size: 4,
+        })
+        .await
+        .expect("config");
+        tx.commit().await.expect("commit");
+    }
+
+    let service = StateFilterService::new(db, epoch_seconds, 28, 4, vec![], true)
+        .await
+        .expect("service");
+    service.build_due_epochs().await.expect("build");
+
+    assert!(service.page_is_complete(0).await.expect("page 0"));
+    assert!(!service.page_is_complete(1).await.expect("page 1"));
+}
+
+#[tokio::test]
+async fn changing_the_parameters_is_refused() {
+    let db: cdk_common::database::DynMintDatabase =
+        std::sync::Arc::new(cdk_sqlite::mint::memory::empty().await.expect("db"));
+
+    StateFilterService::new(db.clone(), 3600, 28, 50, vec![], true)
+        .await
+        .expect("first run");
+
+    for (epoch, p, page_size) in [(1800, 28, 50), (3600, 24, 50), (3600, 28, 25)] {
+        let result = StateFilterService::new(db.clone(), epoch, p, page_size, vec![], true).await;
+        assert!(
+            matches!(result, Err(crate::Error::StateFilterConfig(_))),
+            "changing to (epoch {epoch}, p {p}, page size {page_size}) should be refused"
+        );
+    }
+
+    assert!(StateFilterService::new(db, 3600, 28, 50, vec![], true)
+        .await
+        .is_ok());
+}
+
+#[tokio::test]
+async fn a_failed_melt_quote_publishes_unpaid() {
+    let element = FilterElement::melt_quote("quote-id", MeltQuoteState::Failed).expect("supported");
+
+    assert_eq!(
+        element,
+        FilterElement::melt_quote("quote-id", MeltQuoteState::Unpaid).expect("supported")
+    );
+}

--- a/crates/cdk/src/mint/subscription.rs
+++ b/crates/cdk/src/mint/subscription.rs
@@ -18,6 +18,7 @@ use cdk_common::{
     ProofState, PublicKey, QuoteId,
 };
 
+use super::state_filters::SharedStateFilters;
 use super::Mint;
 use crate::event::MintEvent;
 
@@ -27,6 +28,7 @@ use crate::event::MintEvent;
 pub struct MintPubSubSpec {
     db: DynMintDatabase,
     payment_processors: Arc<HashMap<PaymentProcessorKey, DynMintPayment>>,
+    state_filters: SharedStateFilters,
 }
 
 impl MintPubSubSpec {
@@ -52,6 +54,7 @@ impl MintPubSubSpec {
                 self.db.clone(),
                 self.payment_processors.clone(),
                 None,
+                &self.state_filters.load(),
                 &mut quote,
             )
             .await?;
@@ -183,12 +186,14 @@ impl Spec for MintPubSubSpec {
     type Context = (
         DynMintDatabase,
         Arc<HashMap<PaymentProcessorKey, DynMintPayment>>,
+        SharedStateFilters,
     );
 
     fn new_instance(context: Self::Context) -> Arc<Self> {
         Arc::new(Self {
             db: context.0,
             payment_processors: context.1,
+            state_filters: context.2,
         })
     }
 
@@ -214,6 +219,7 @@ impl PubSubManager {
         context: (
             DynMintDatabase,
             Arc<HashMap<PaymentProcessorKey, DynMintPayment>>,
+            SharedStateFilters,
         ),
     ) -> Arc<Self> {
         Arc::new(Self(Pubsub::new(MintPubSubSpec::new_instance(context))))
@@ -424,6 +430,7 @@ mod tests {
         let spec = MintPubSubSpec {
             db,
             payment_processors: Arc::new(HashMap::new()),
+            state_filters: Default::default(),
         };
         let events = spec
             .get_events_from_db(&[

--- a/crates/cdk/src/mint/swap/swap_saga/compensation.rs
+++ b/crates/cdk/src/mint/swap/swap_saga/compensation.rs
@@ -4,11 +4,18 @@ use cdk_common::{Error, PublicKey};
 use tracing::instrument;
 use uuid::Uuid;
 
+use crate::mint::state_filters::StateFilters;
 use crate::mint::subscription::PubSubManager;
+use crate::Mint;
 
 #[async_trait]
 pub trait CompensatingAction: Send + Sync {
-    async fn execute(&self, db: &DynMintDatabase, pubsub: &PubSubManager) -> Result<(), Error>;
+    async fn execute(
+        &self,
+        db: &DynMintDatabase,
+        pubsub: &PubSubManager,
+        filters: &StateFilters,
+    ) -> Result<(), Error>;
     fn name(&self) -> &'static str;
 }
 
@@ -33,7 +40,12 @@ pub struct RemoveSwapSetup {
 #[async_trait]
 impl CompensatingAction for RemoveSwapSetup {
     #[instrument(skip_all)]
-    async fn execute(&self, db: &DynMintDatabase, _pubsub: &PubSubManager) -> Result<(), Error> {
+    async fn execute(
+        &self,
+        db: &DynMintDatabase,
+        _pubsub: &PubSubManager,
+        filters: &StateFilters,
+    ) -> Result<(), Error> {
         if self.blinded_secrets.is_empty() && self.input_ys.is_empty() {
             return Ok(());
         }
@@ -54,7 +66,7 @@ impl CompensatingAction for RemoveSwapSetup {
 
         // Remove proofs (inputs)
         if !self.input_ys.is_empty() {
-            tx.remove_proofs(&self.input_ys, None).await?;
+            Mint::remove_proofs(&mut tx, filters, &self.input_ys, None).await?;
         }
 
         // Delete saga state record

--- a/crates/cdk/src/mint/swap/swap_saga/mod.rs
+++ b/crates/cdk/src/mint/swap/swap_saga/mod.rs
@@ -202,7 +202,13 @@ impl<'a> SwapSaga<'a, Initial> {
             Err(err) => return Err(Error::NUT00(err)),
         };
 
-        if let Err(err) = Mint::update_proofs_state(&mut tx, &mut new_proofs, State::Pending).await
+        if let Err(err) = Mint::update_proofs_state(
+            &mut tx,
+            &self.mint.state_filters(),
+            &mut new_proofs,
+            State::Pending,
+        )
+        .await
         {
             tx.rollback().await?;
             return Err(err);
@@ -407,7 +413,14 @@ impl SwapSaga<'_, Signed> {
             }
         };
 
-        if let Err(err) = Mint::update_proofs_state(&mut tx, &mut proofs, State::Spent).await {
+        if let Err(err) = Mint::update_proofs_state(
+            &mut tx,
+            &self.mint.state_filters(),
+            &mut proofs,
+            State::Spent,
+        )
+        .await
+        {
             tx.rollback().await?;
             self.compensate_all().await?;
             return Err(err);
@@ -467,7 +480,10 @@ impl<S> SwapSaga<'_, S> {
 
         while let Some(compensation) = compensations.pop_front() {
             tracing::debug!("Running compensation: {}", compensation.name());
-            if let Err(e) = compensation.execute(&self.db, &self.pubsub).await {
+            if let Err(e) = compensation
+                .execute(&self.db, &self.pubsub, &self.mint.state_filters())
+                .await
+            {
                 tracing::error!(
                     "Compensation {} failed: {}. Continuing...",
                     compensation.name(),

--- a/crates/cdk/src/test_helpers/mint.rs
+++ b/crates/cdk/src/test_helpers/mint.rs
@@ -18,7 +18,7 @@ use cdk_common::{
 use cdk_fake_wallet::FakeWallet;
 use tokio::time::sleep;
 
-use crate::mint::{Mint, MintBuilder, MintMeltLimits};
+use crate::mint::{Mint, MintBuilder, MintMeltLimits, StateFilterOptions};
 use crate::types::{FeeReserve, QuoteTTL};
 use crate::Error;
 
@@ -74,6 +74,13 @@ pub(crate) fn should_fail_for(operation: &str) -> bool {
 /// }
 /// ```
 pub async fn create_test_mint() -> Result<Mint, Error> {
+    create_test_mint_with_state_filters(None).await
+}
+
+/// Creates and starts a test mint, optionally publishing compact state filters.
+pub async fn create_test_mint_with_state_filters(
+    state_filters: Option<StateFilterOptions>,
+) -> Result<Mint, Error> {
     let db = Arc::new(cdk_sqlite::mint::memory::empty().await?);
 
     let mut mint_builder = MintBuilder::new(db.clone());
@@ -106,6 +113,10 @@ pub async fn create_test_mint() -> Result<Mint, Error> {
         .with_name("test mint".to_string())
         .with_description("test mint for unit tests".to_string())
         .with_urls(vec!["https://test-mint".to_string()]);
+
+    if let Some(state_filters) = state_filters {
+        mint_builder = mint_builder.with_state_filters(state_filters);
+    }
 
     let quote_ttl = QuoteTTL::new(10000, 10000);
 

--- a/crates/cdk/src/wallet/issue/mod.rs
+++ b/crates/cdk/src/wallet/issue/mod.rs
@@ -325,7 +325,10 @@ impl Wallet {
     }
 
     /// Checks the state of a mint quote with the mint
-    async fn check_state(&self, mint_quote: &mut MintQuote) -> Result<(), Error> {
+    pub(crate) async fn check_mint_quote_state(
+        &self,
+        mint_quote: &mut MintQuote,
+    ) -> Result<(), Error> {
         let mint_quote_response: MintQuoteResponse<String> = self
             .client
             .get_mint_quote_status(mint_quote.payment_method.clone(), &mint_quote.id)
@@ -347,7 +350,7 @@ impl Wallet {
     ) -> Result<MintQuote, Error> {
         let quote_id = mint_quote.id.clone();
         // First, check/update the state from the mint
-        self.check_state(&mut mint_quote).await?;
+        self.check_mint_quote_state(&mut mint_quote).await?;
 
         // Check if there's an in-progress saga for this quote
         if let Some(ref operation_id_str) = mint_quote.used_by_operation {
@@ -443,8 +446,17 @@ impl Wallet {
         let mint_quotes = self.localstore.get_unissued_mint_quotes().await?;
         let mut updated_quotes = Vec::new();
 
+        let changed = self.state_filter_quote_candidates().await?;
+
         for mint_quote in mint_quotes {
             if mint_quote.mint_url != self.mint_url || mint_quote.unit != self.unit {
+                continue;
+            }
+
+            if changed
+                .as_ref()
+                .is_some_and(|changed| !changed.contains(&mint_quote.id))
+            {
                 continue;
             }
 

--- a/crates/cdk/src/wallet/issue/saga/resume.rs
+++ b/crates/cdk/src/wallet/issue/saga/resume.rs
@@ -299,7 +299,7 @@ impl Wallet {
             let quote = match self.localstore.get_mint_quote(quote_id).await? {
                 Some(mut quote) => {
                     // Update state from mint
-                    if let Err(e) = self.check_state(&mut quote).await {
+                    if let Err(e) = self.check_mint_quote_state(&mut quote).await {
                         tracing::warn!(
                             "Failed to check quote state for transaction recording: {}",
                             escape_log_value(&e)

--- a/crates/cdk/src/wallet/mint_connector/http_client.rs
+++ b/crates/cdk/src/wallet/mint_connector/http_client.rs
@@ -27,8 +27,9 @@ use crate::nuts::nut00::{KnownMethod, PaymentMethod};
 use crate::nuts::nut22::MintAuthRequest;
 use crate::nuts::{
     AuthToken, BatchCheckMintQuoteRequest, BatchMintRequest, CheckStateRequest, CheckStateResponse,
-    Id, KeySet, KeysResponse, KeysetResponse, MeltOnchainRequest, MeltRequest, MintInfo,
-    MintRequest, MintResponse, RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
+    GetFiltersInfoResponse, GetFiltersResponse, Id, KeySet, KeysResponse, KeysetResponse,
+    MeltOnchainRequest, MeltRequest, MintInfo, MintRequest, MintResponse, PendingFilterResponse,
+    RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
 };
 use crate::wallet::auth::{AuthMintConnector, AuthWallet};
 use crate::OidcClient;
@@ -502,6 +503,31 @@ where
     #[instrument(skip(self), fields(mint_url = %self.mint_url))]
     async fn get_mint_keysets(&self) -> Result<KeysetResponse, Error> {
         let url = self.mint_url.join_paths(&["v1", "keysets"])?;
+        self.transport_http_get(url, None).await
+    }
+
+    /// Get the parameters of the mint's compact state filters
+    ///
+    /// Filters are public and identical for every requester, so this carries no
+    /// auth token and nothing about the caller.
+    #[instrument(skip(self), fields(mint_url = %self.mint_url))]
+    async fn get_filters_info(&self) -> Result<GetFiltersInfoResponse, Error> {
+        let url = self.mint_url.join_paths(&["v1", "filters", "info"])?;
+        self.transport_http_get(url, None).await
+    }
+
+    /// Get a page of compact state filters
+    #[instrument(skip(self), fields(mint_url = %self.mint_url))]
+    async fn get_filters(&self, page: u64) -> Result<GetFiltersResponse, Error> {
+        let page = page.to_string();
+        let url = self.mint_url.join_paths(&["v1", "filters", &page])?;
+        self.transport_http_get(url, None).await
+    }
+
+    /// Get the filter of the epoch that is still open
+    #[instrument(skip(self), fields(mint_url = %self.mint_url))]
+    async fn get_filters_pending(&self) -> Result<PendingFilterResponse, Error> {
+        let url = self.mint_url.join_paths(&["v1", "filters", "pending"])?;
         self.transport_http_get(url, None).await
     }
 

--- a/crates/cdk/src/wallet/mint_connector/mod.rs
+++ b/crates/cdk/src/wallet/mint_connector/mod.rs
@@ -13,9 +13,10 @@ use super::Error;
 // Re-export Lightning address types for trait implementers
 pub use crate::lightning_address::{LnurlPayInvoiceResponse, LnurlPayResponse};
 use crate::nuts::{
-    BatchCheckMintQuoteRequest, BatchMintRequest, CheckStateRequest, CheckStateResponse, Id,
-    KeySet, KeysetResponse, MeltRequest, MintInfo, MintRequest, MintResponse, PaymentMethod,
-    RestoreRequest, RestoreResponse, SwapRequest, SwapResponse,
+    BatchCheckMintQuoteRequest, BatchMintRequest, CheckStateRequest, CheckStateResponse,
+    GetFiltersInfoResponse, GetFiltersResponse, Id, KeySet, KeysetResponse, MeltRequest, MintInfo,
+    MintRequest, MintResponse, PaymentMethod, PendingFilterResponse, RestoreRequest,
+    RestoreResponse, SwapRequest, SwapResponse,
 };
 use crate::wallet::{AuthMintConnector, AuthWallet};
 use crate::OidcClient;
@@ -174,6 +175,15 @@ pub trait MintConnector: Debug {
     ) -> Result<CheckStateResponse, Error>;
     /// Restore request [NUT-13]
     async fn post_restore(&self, request: RestoreRequest) -> Result<RestoreResponse, Error>;
+
+    /// Get the parameters of the mint's compact state filters
+    async fn get_filters_info(&self) -> Result<GetFiltersInfoResponse, Error>;
+
+    /// Get a page of compact state filters
+    async fn get_filters(&self, page: u64) -> Result<GetFiltersResponse, Error>;
+
+    /// Get the filter of the epoch that is still open
+    async fn get_filters_pending(&self) -> Result<PendingFilterResponse, Error>;
 
     /// Get the auth wallet for the client
     async fn get_auth_wallet(&self) -> Option<AuthWallet>;

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -64,6 +64,7 @@ mod reclaim;
 mod recovery;
 pub(crate) mod saga;
 mod send;
+pub mod state_filters;
 #[cfg(not(target_arch = "wasm32"))]
 mod streams;
 pub mod subscription;
@@ -795,7 +796,7 @@ impl Wallet {
 
                 tracing::debug!("Restored {} proofs", proofs.len());
 
-                let states = self.check_proofs_spent(proofs.clone()).await?;
+                let states = self.proof_states_preferring_filters(&proofs).await?;
 
                 let (unspent_proofs, updated_restored) = proofs
                     .into_iter()

--- a/crates/cdk/src/wallet/proofs.rs
+++ b/crates/cdk/src/wallet/proofs.rs
@@ -159,8 +159,8 @@ impl Wallet {
         }
 
         let states = self
-            .check_proofs_spent(
-                orphaned_proofs
+            .proof_states_preferring_filters(
+                &orphaned_proofs
                     .clone()
                     .into_iter()
                     .map(|p| p.proof)

--- a/crates/cdk/src/wallet/state_filters/cursor.rs
+++ b/crates/cdk/src/wallet/state_filters/cursor.rs
@@ -1,0 +1,105 @@
+//! Where a wallet resumes fetching filters.
+//!
+//! Only the cursor is persisted. Filters are tested as they arrive and the
+//! bytes are never needed again, so the wallet stores none of them.
+
+use bitcoin::hashes::{sha256, Hash};
+use cdk_common::nuts::state_filters::GetFiltersInfoResponse;
+use cdk_common::Error;
+
+use crate::Wallet;
+
+const NAMESPACE: &str = "state_filters";
+const CURSOR_KEY: &str = "cursor";
+
+/// The point a wallet resumes from.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Cursor {
+    /// First page still worth fetching
+    pub next_page: u64,
+    /// Start of the first epoch not yet tested
+    pub next_start: u64,
+}
+
+impl Cursor {
+    fn encode(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(16);
+        bytes.extend_from_slice(&self.next_page.to_be_bytes());
+        bytes.extend_from_slice(&self.next_start.to_be_bytes());
+        bytes
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, Error> {
+        if bytes.len() != 16 {
+            return Err(Error::Custom("Malformed state filter cursor".to_string()));
+        }
+
+        let mut page = [0u8; 8];
+        let mut start = [0u8; 8];
+        page.copy_from_slice(&bytes[..8]);
+        start.copy_from_slice(&bytes[8..]);
+
+        Ok(Self {
+            next_page: u64::from_be_bytes(page),
+            next_start: u64::from_be_bytes(start),
+        })
+    }
+}
+
+impl Wallet {
+    /// The KV namespace for this mint's cursor.
+    ///
+    /// A mint URL contains characters the KV store rejects, so it is hashed
+    /// rather than escaped: the value is opaque and only has to be stable.
+    fn cursor_namespace(&self) -> String {
+        let digest = sha256::Hash::hash(self.mint_url.to_string().as_bytes());
+        digest.to_string()
+    }
+
+    /// Where the next sweep should resume.
+    pub async fn state_filter_cursor(&self) -> Result<Cursor, Error> {
+        let stored = self
+            .localstore
+            .kv_read(NAMESPACE, &self.cursor_namespace(), CURSOR_KEY)
+            .await?;
+
+        match stored {
+            Some(bytes) => Cursor::decode(&bytes),
+            None => Ok(Cursor::default()),
+        }
+    }
+
+    /// Record how far a completed sweep got.
+    ///
+    /// The current page is still filling, so the cursor stops at it rather than
+    /// past it, and `next_start` skips the epochs already tested when that page
+    /// is fetched again.
+    pub(crate) async fn advance_state_filter_cursor(
+        &self,
+        info: &GetFiltersInfoResponse,
+    ) -> Result<(), Error> {
+        let cursor = Cursor {
+            next_page: info.current_page,
+            next_start: info.latest_end,
+        };
+
+        self.localstore
+            .kv_write(
+                NAMESPACE,
+                &self.cursor_namespace(),
+                CURSOR_KEY,
+                &cursor.encode(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    /// Forget the cursor, so the next sweep reads the whole retained history.
+    pub async fn reset_state_filter_cursor(&self) -> Result<(), Error> {
+        self.localstore
+            .kv_remove(NAMESPACE, &self.cursor_namespace(), CURSOR_KEY)
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/cdk/src/wallet/state_filters/mod.rs
+++ b/crates/cdk/src/wallet/state_filters/mod.rs
@@ -1,0 +1,410 @@
+//! Following mint state through compact state filters
+//!
+//! Testing a candidate against a filter is local, so the wallet learns "no"
+//! without telling the mint anything. A match is only probably real, so it is
+//! always confirmed through the identifying endpoint before anything acts on
+//! it.
+
+use cdk_common::nuts::state_filters::{
+    DecodedFilter, FilterElement, FilterKind, GetFiltersInfoResponse,
+};
+use cdk_common::nuts::{ProofState, Proofs, ProofsMethods};
+use cdk_common::{Error, MeltQuoteState, PublicKey, State};
+use tracing::instrument;
+
+use crate::Wallet;
+
+mod cursor;
+
+pub use cursor::Cursor;
+
+/// What a sweep found, before confirmation.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Matches {
+    /// Proofs whose `SPENT` or `PENDING` element matched
+    pub proofs: Vec<PublicKey>,
+    /// Mint quotes that changed
+    pub mint_quotes: Vec<String>,
+    /// Melt quotes that changed
+    pub melt_quotes: Vec<String>,
+}
+
+impl Matches {
+    /// Whether anything matched.
+    pub fn is_empty(&self) -> bool {
+        self.proofs.is_empty() && self.mint_quotes.is_empty() && self.melt_quotes.is_empty()
+    }
+}
+
+/// The elements a wallet is watching for, built once per sweep.
+///
+/// Only the position of an element depends on the filter it is tested against,
+/// so the digests are computed once and reused across the whole history.
+#[derive(Debug, Default)]
+struct Candidates {
+    proofs: Vec<(FilterElement, PublicKey)>,
+    mint_quotes: Vec<(FilterElement, String)>,
+    melt_quotes: Vec<(FilterElement, String)>,
+}
+
+impl Candidates {
+    fn is_empty(&self) -> bool {
+        self.proofs.is_empty() && self.mint_quotes.is_empty() && self.melt_quotes.is_empty()
+    }
+
+    fn test(&self, filter: &DecodedFilter, found: &mut Matches) {
+        for (element, y) in &self.proofs {
+            if filter.contains(element) && !found.proofs.contains(y) {
+                found.proofs.push(*y);
+            }
+        }
+        for (element, id) in &self.mint_quotes {
+            if filter.contains(element) && !found.mint_quotes.contains(id) {
+                found.mint_quotes.push(id.clone());
+            }
+        }
+        for (element, id) in &self.melt_quotes {
+            if filter.contains(element) && !found.melt_quotes.contains(id) {
+                found.melt_quotes.push(id.clone());
+            }
+        }
+    }
+}
+
+impl Wallet {
+    /// The mint's filter parameters, if it publishes filters.
+    pub async fn state_filters_info(&self) -> Result<Option<GetFiltersInfoResponse>, Error> {
+        let advertised = self
+            .fetch_mint_info()
+            .await?
+            .is_some_and(|info| info.nuts.state_filters.supported);
+
+        if !advertised {
+            return Ok(None);
+        }
+
+        match self.client.get_filters_info().await {
+            Ok(info) => Ok(Some(info)),
+            Err(Error::FilterNotAvailable) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Build the elements this wallet is watching for.
+    async fn state_filter_candidates(&self, kinds: &[FilterKind]) -> Result<Candidates, Error> {
+        let mut candidates = Candidates::default();
+
+        if kinds.contains(&FilterKind::ProofState) {
+            let proofs = self
+                .localstore
+                .get_proofs(
+                    Some(self.mint_url.clone()),
+                    Some(self.unit.clone()),
+                    Some(vec![
+                        State::Unspent,
+                        State::Pending,
+                        State::Reserved,
+                        State::PendingSpent,
+                    ]),
+                    None,
+                )
+                .await?;
+
+            for proof in proofs {
+                for state in [State::Spent, State::Pending] {
+                    candidates
+                        .proofs
+                        .push((FilterElement::proof_state(&proof.y, state)?, proof.y));
+                }
+            }
+        }
+
+        if kinds.contains(&FilterKind::MintQuote) {
+            for quote in self.localstore.get_unissued_mint_quotes().await? {
+                if quote.mint_url != self.mint_url {
+                    continue;
+                }
+                candidates
+                    .mint_quotes
+                    .push((FilterElement::mint_quote(&quote.id), quote.id));
+            }
+        }
+
+        if kinds.contains(&FilterKind::MeltQuote) {
+            for quote in self.localstore.get_melt_quotes().await? {
+                if quote.mint_url.as_ref() != Some(&self.mint_url) {
+                    continue;
+                }
+                if matches!(quote.state, MeltQuoteState::Paid) {
+                    continue;
+                }
+                for state in [MeltQuoteState::Paid, MeltQuoteState::Pending] {
+                    candidates.melt_quotes.push((
+                        FilterElement::melt_quote(&quote.id, state)?,
+                        quote.id.clone(),
+                    ));
+                }
+            }
+        }
+
+        Ok(candidates)
+    }
+
+    /// Fetch new filters and test this wallet's objects against them.
+    ///
+    /// Resumes from the stored cursor, so a wallet that keeps up pays for one
+    /// page per epoch and skips the epochs it already tested when the current
+    /// page is fetched again. Returns what matched, without confirming it.
+    #[instrument(skip(self))]
+    pub async fn sweep_state_filters(&self) -> Result<Matches, Error> {
+        let Some(info) = self.state_filters_info().await? else {
+            return Ok(Matches::default());
+        };
+
+        let candidates = self.state_filter_candidates(&info.kinds).await?;
+        if candidates.is_empty() {
+            return Ok(Matches::default());
+        }
+
+        let cursor = self.state_filter_cursor().await?;
+        let mut found = Matches::default();
+
+        let first = cursor.next_page.max(info.first_page);
+        for page in first..=info.current_page {
+            let response = self.client.get_filters(page).await?;
+
+            for filter in response.filters {
+                if filter.start < cursor.next_start {
+                    continue;
+                }
+                candidates.test(&filter.decode(info.p)?, &mut found);
+            }
+        }
+
+        self.advance_state_filter_cursor(&info).await?;
+
+        Ok(found)
+    }
+
+    /// Test this wallet's objects against the filter of the open epoch.
+    ///
+    /// The pending filter is rebuilt for every request and its `n` changes with
+    /// it, so nothing about it can be cached.
+    #[instrument(skip(self))]
+    pub async fn sweep_pending_state_filter(&self) -> Result<Matches, Error> {
+        let Some(info) = self.state_filters_info().await? else {
+            return Ok(Matches::default());
+        };
+        if !info.pending {
+            return Ok(Matches::default());
+        }
+
+        let candidates = self.state_filter_candidates(&info.kinds).await?;
+        if candidates.is_empty() {
+            return Ok(Matches::default());
+        }
+
+        let pending = match self.client.get_filters_pending().await {
+            Ok(pending) => pending,
+            Err(Error::FilterNotAvailable) => return Ok(Matches::default()),
+            Err(err) => return Err(err),
+        };
+
+        let mut found = Matches::default();
+        candidates.test(&pending.decode(info.p)?, &mut found);
+
+        Ok(found)
+    }
+
+    /// Confirm matches through the identifying endpoints and apply them.
+    ///
+    /// A filter is never authoritative: a match may be spurious, so nothing
+    /// irreversible happens until the mint has answered for the named object.
+    #[instrument(skip(self, matches))]
+    pub async fn confirm_state_filter_matches(&self, matches: &Matches) -> Result<(), Error> {
+        if !matches.proofs.is_empty() {
+            let proofs = self
+                .localstore
+                .get_proofs_by_ys(matches.proofs.clone())
+                .await?
+                .into_iter()
+                .map(|info| info.proof)
+                .collect::<Vec<_>>();
+
+            if !proofs.is_empty() {
+                self.check_proofs_spent(proofs).await?;
+            }
+        }
+
+        for quote_id in &matches.mint_quotes {
+            if let Some(mut quote) = self.localstore.get_mint_quote(quote_id).await? {
+                if let Err(err) = self.check_mint_quote_state(&mut quote).await {
+                    tracing::warn!("Could not confirm mint quote {quote_id}: {err}");
+                }
+            }
+        }
+
+        for quote_id in &matches.melt_quotes {
+            if let Err(err) = self.check_melt_quote_status(quote_id).await {
+                tracing::warn!("Could not confirm melt quote {quote_id}: {err}");
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Which of these proofs the mint's whole published history mentions.
+    ///
+    /// Every closed page is swept and then the open epoch, because a spend that
+    /// just happened lives only in the pending filter.
+    ///
+    /// Returns `None` when filters cannot answer the question: absence of a
+    /// match means unspent only if the wallet covers every epoch the proof
+    /// could have been spent in, so a mint that does not publish filters, does
+    /// not cover proof states, has pruned its history, or withholds the open
+    /// epoch all fall back to NUT-07.
+    pub async fn state_filter_proof_candidates(
+        &self,
+        ys: &[PublicKey],
+    ) -> Result<Option<Vec<PublicKey>>, Error> {
+        let Some(info) = self.state_filters_info().await? else {
+            return Ok(None);
+        };
+
+        if !info.kinds.contains(&FilterKind::ProofState) || info.first_page > 0 || !info.pending {
+            return Ok(None);
+        }
+
+        let mut elements = Vec::with_capacity(ys.len() * 2);
+        for y in ys {
+            for state in [State::Spent, State::Pending] {
+                elements.push((FilterElement::proof_state(y, state)?, *y));
+            }
+        }
+
+        let mut matched: Vec<PublicKey> = Vec::new();
+        let test = |decoded: &DecodedFilter, matched: &mut Vec<PublicKey>| {
+            for (element, y) in &elements {
+                if decoded.contains(element) && !matched.contains(y) {
+                    matched.push(*y);
+                }
+            }
+        };
+
+        for page in info.first_page..=info.current_page {
+            for filter in self.client.get_filters(page).await?.filters {
+                test(&filter.decode(info.p)?, &mut matched);
+            }
+        }
+
+        let pending = self.client.get_filters_pending().await?;
+        test(&pending.decode(info.p)?, &mut matched);
+
+        Ok(Some(matched))
+    }
+
+    /// The state of each proof, learned through filters when the mint offers
+    /// them and through NUT-07 otherwise.
+    ///
+    /// This is what a seed restore uses instead of sending every recovered `Y`
+    /// to the mint. Only the proofs that matched a filter are ever named, and
+    /// on a fresh seed with nothing spent that is none of them.
+    pub(crate) async fn proof_states_preferring_filters(
+        &self,
+        proofs: &Proofs,
+    ) -> Result<Vec<ProofState>, Error> {
+        let ys = proofs.ys()?;
+
+        let Some(matched) = self.state_filter_proof_candidates(&ys).await? else {
+            return self.check_proofs_spent(proofs.clone()).await;
+        };
+
+        if matched.is_empty() {
+            return Ok(ys
+                .into_iter()
+                .map(|y| ProofState::from((y, State::Unspent)))
+                .collect());
+        }
+
+        let named: Proofs = proofs
+            .iter()
+            .zip(ys.iter())
+            .filter(|(_, y)| matched.contains(y))
+            .map(|(proof, _)| proof.clone())
+            .collect();
+
+        tracing::debug!(
+            "Filters narrowed {} restored proofs down to {} worth naming",
+            ys.len(),
+            named.len()
+        );
+
+        let confirmed = self.check_proofs_spent(named).await?;
+
+        Ok(ys
+            .into_iter()
+            .map(|y| {
+                confirmed
+                    .iter()
+                    .find(|state| state.y == y)
+                    .cloned()
+                    .unwrap_or_else(|| ProofState::from((y, State::Unspent)))
+            })
+            .collect())
+    }
+
+    /// Which mint quotes the mint's published history says changed.
+    ///
+    /// Only the quotes that matched are worth naming, so a wallet whose quotes
+    /// are all quiet names none of them. Returns `None` when filters cannot
+    /// answer, so callers fall back to checking every quote.
+    pub async fn state_filter_quote_candidates(&self) -> Result<Option<Vec<String>>, Error> {
+        let Some(info) = self.state_filters_info().await? else {
+            return Ok(None);
+        };
+
+        if !info.kinds.contains(&FilterKind::MintQuote) || info.first_page > 0 || !info.pending {
+            return Ok(None);
+        }
+
+        let quotes = self.localstore.get_unissued_mint_quotes().await?;
+        let elements: Vec<(FilterElement, String)> = quotes
+            .into_iter()
+            .filter(|quote| quote.mint_url == self.mint_url)
+            .map(|quote| (FilterElement::mint_quote(&quote.id), quote.id))
+            .collect();
+
+        let mut matched: Vec<String> = Vec::new();
+        for page in info.first_page..=info.current_page {
+            for filter in self.client.get_filters(page).await?.filters {
+                let decoded = filter.decode(info.p)?;
+                for (element, id) in &elements {
+                    if decoded.contains(element) && !matched.contains(id) {
+                        matched.push(id.clone());
+                    }
+                }
+            }
+        }
+
+        let pending = self.client.get_filters_pending().await?;
+        let decoded = pending.decode(info.p)?;
+        for (element, id) in &elements {
+            if decoded.contains(element) && !matched.contains(id) {
+                matched.push(id.clone());
+            }
+        }
+
+        Ok(Some(matched))
+    }
+
+    /// Sweep the published filters and confirm anything that matched.
+    ///
+    /// This is the whole loop: almost every sweep confirms nothing and so tells
+    /// the mint nothing.
+    #[instrument(skip(self))]
+    pub async fn sync_state_filters(&self) -> Result<Matches, Error> {
+        let matches = self.sweep_state_filters().await?;
+        self.confirm_state_filter_matches(&matches).await?;
+        Ok(matches)
+    }
+}

--- a/crates/cdk/src/wallet/test_utils.rs
+++ b/crates/cdk/src/wallet/test_utils.rs
@@ -1058,6 +1058,18 @@ impl MintConnector for MockMintConnector {
             .expect("MockMintConnector: post_restore called without configured response")
     }
 
+    async fn get_filters_info(&self) -> Result<crate::nuts::GetFiltersInfoResponse, Error> {
+        Err(Error::FilterNotAvailable)
+    }
+
+    async fn get_filters(&self, _page: u64) -> Result<crate::nuts::GetFiltersResponse, Error> {
+        Err(Error::FilterNotAvailable)
+    }
+
+    async fn get_filters_pending(&self) -> Result<crate::nuts::PendingFilterResponse, Error> {
+        Err(Error::FilterNotAvailable)
+    }
+
     async fn get_auth_wallet(&self) -> Option<crate::wallet::AuthWallet> {
         None
     }


### PR DESCRIPTION


### Description

Following ecash today means naming it: checkstate carries the exact Y values, quote polling carries the quote id, and a seed restore hands the mint every recovered Y including the unspent ones. Compact state filters replace that with public Golomb-Rice filters, published once per epoch and identical for every requester, that a wallet tests locally. A wallet learns that its ecash was spent, or its quote paid, without telling the mint which, and makes an identifying request only when something has probably happened.

The mint records one element per observable state change in the same transaction that makes it, builds one filter per closed epoch, and serves them as pages that never change again. The wallet sweeps new filters, tests its own objects offline, and confirms a match through NUT-07 or the quote endpoint before acting on it, since a filter is never authoritative.  Restore and the pending-proof and quote sweeps prefer filters whenever the mint advertises them and fall back otherwise.

Spec: https://github.com/cashubtc/nuts/pull/433

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
