### PR TITLE
fix(bdk): preserve RPC progress and avoid blocking async workers

### DIFF
--- a/crates/cdk-bdk/README.md
+++ b/crates/cdk-bdk/README.md
@@ -95,6 +95,16 @@ scanning from genesis. When restoring from a mnemonic, set
 height. This setting only affects wallet creation and never rewinds persisted
 wallet state.
 
+On reorgs, Bitcoin Core sync follows the orphaned branch's block headers to
+find the actual common ancestor, including ancestors absent from the wallet's
+stored checkpoints. It then replays all replacement blocks after that ancestor,
+even below the original birthday. The birthday controls wallet creation, not
+reorg recovery. Normal catch-up still resumes from the latest checkpoint.
+Missing headers or required block data fail the sync tick and are retried; sync
+does not skip affected blocks or substitute a genesis rescan for missing history.
+A rollback with no replacement block is retried rather than reported as completed
+recovery.
+
 ## Finality and Confirmation Policy
 
 - Finalization is policy-based: once a send or receive reaches `num_confs`, it is

--- a/crates/cdk-bdk/src/chain/bitcoin_rpc.rs
+++ b/crates/cdk-bdk/src/chain/bitcoin_rpc.rs
@@ -1,12 +1,14 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use bdk_bitcoind_rpc::bitcoincore_rpc::json::GetBlockHeaderResult;
 use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client, Error as BitcoinRpcError, RawTx, RpcApi};
-use bdk_bitcoind_rpc::{BlockEvent, Emitter, NO_EXPECTED_MEMPOOL_TXS};
+use bdk_bitcoind_rpc::BlockEvent;
 use bdk_wallet::bitcoin::{Block, Transaction};
-use bdk_wallet::chain::BlockId;
+use bdk_wallet::chain::{BlockId, CheckPoint};
+use bdk_wallet::Update;
 use tokio::sync::Mutex;
-use tokio::time::{interval, Duration};
+use tokio::time::{interval, Duration, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 
 use crate::chain::{BitcoinRpcConfig, BroadcastErrorKind, BroadcastFailure, BroadcastOutcome};
@@ -46,31 +48,172 @@ pub(crate) fn initial_checkpoint(config: &BitcoinRpcConfig) -> Result<BlockId, E
     Ok(BlockId { height, hash })
 }
 
+/// A replacement block may need additional old-chain checkpoints so BDK can
+/// invalidate an orphaned tip even when the new block is below its height.
+struct RpcBlock {
+    event: BlockEvent<Block>,
+    connection: Option<CheckPoint>,
+}
+
+/// Fetch blocks using headers to recover ancestors missing from sparse wallet
+/// checkpoints. The configured birthday only determines the initial checkpoint.
+struct RpcBlockFetcher<C> {
+    client: Arc<C>,
+    checkpoint: CheckPoint,
+    last_header: Option<GetBlockHeaderResult>,
+}
+
+impl<C> RpcBlockFetcher<C>
+where
+    C: RpcApi,
+{
+    fn next_block(&mut self, cancel: &CancellationToken) -> Result<Option<RpcBlock>, Error> {
+        if cancel.is_cancelled() {
+            return Ok(None);
+        }
+        let mut block_id = self.checkpoint.block_id();
+        let mut header = match self.last_header.take() {
+            Some(header) => header,
+            None => self.client.get_block_header_info(&block_id.hash)?,
+        };
+        let mut orphaned = Vec::new();
+        loop {
+            if cancel.is_cancelled() {
+                return Ok(None);
+            }
+            if header.hash != block_id.hash || header.height != block_id.height as usize {
+                return Err(Error::Wallet(format!(
+                    "Bitcoin RPC returned an inconsistent header for {} at height {}",
+                    block_id.hash, block_id.height
+                )));
+            }
+            if header.confirmations >= 0 {
+                break;
+            }
+            orphaned.push(block_id);
+            block_id = BlockId {
+                height: block_id.height.checked_sub(1).ok_or_else(|| {
+                    Error::Wallet("Bitcoin RPC reports an orphaned genesis block".to_owned())
+                })?,
+                hash: header.previous_block_hash.ok_or_else(|| {
+                    Error::Wallet("Bitcoin RPC header is missing its parent hash".to_owned())
+                })?,
+            };
+            // Do not jump to the next sparse checkpoint (possibly genesis).
+            // Walk the old branch's headers to the actual common ancestor.
+            header = self.client.get_block_header_info(&block_id.hash)?;
+        }
+
+        let next_hash = match header.next_block_hash {
+            Some(hash) => hash,
+            None if orphaned.is_empty() => return Ok(None),
+            None => {
+                // BDK needs a conflicting replacement block to invalidate the
+                // old tip. Do not reconcile against it after a pure rollback.
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "Bitcoin RPC reorg has no replacement block yet; retry sync",
+                )
+                .into());
+            }
+        };
+        let next_header = self.client.get_block_header_info(&next_hash)?;
+        if cancel.is_cancelled() {
+            return Ok(None);
+        }
+        let next_height = block_id
+            .height
+            .checked_add(1)
+            .ok_or_else(|| Error::Wallet("Bitcoin RPC block height exceeds u32".to_owned()))?;
+        if next_header.hash != next_hash
+            || next_header.confirmations < 0
+            || next_header.previous_block_hash != Some(block_id.hash)
+            || next_header.height != next_height as usize
+        {
+            // The chain changed between RPC calls. Keep any earlier fetched
+            // blocks, then rediscover the fork from the persisted tip next tick.
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "Bitcoin RPC chain changed during block fetch; retry sync",
+            )
+            .into());
+        }
+        let block = self.client.get_block(&next_hash)?;
+        if block.block_hash() != next_hash || block.header.prev_blockhash != block_id.hash {
+            return Err(Error::Wallet(
+                "Bitcoin RPC returned an inconsistent block".to_owned(),
+            ));
+        }
+
+        let (base, connection) = match orphaned.is_empty() {
+            true => (self.checkpoint.clone(), None),
+            false => {
+                let base = self.checkpoint.floor_at(block_id.height).ok_or_else(|| {
+                    Error::Wallet("Wallet has no checkpoint below the reorg".to_owned())
+                })?;
+                if base.height() == block_id.height && base.hash() != block_id.hash {
+                    return Err(Error::Wallet(
+                        "Bitcoin RPC ancestry conflicts with wallet checkpoint".to_owned(),
+                    ));
+                }
+                let base = base.insert(block_id);
+                let connection = base
+                    .clone()
+                    .extend(orphaned.into_iter().rev())
+                    .map_err(|_| {
+                        Error::Wallet("Bitcoin RPC ancestors are out of order".to_owned())
+                    })?;
+                (base, Some(connection))
+            }
+        };
+        self.checkpoint = base
+            .push(BlockId {
+                height: next_height,
+                hash: next_hash,
+            })
+            .map_err(|_| Error::Wallet("Bitcoin RPC blocks are out of order".to_owned()))?;
+        self.last_header = Some(next_header);
+        Ok(Some(RpcBlock {
+            event: BlockEvent {
+                block,
+                checkpoint: self.checkpoint.clone(),
+            },
+            connection,
+        }))
+    }
+}
+
 /// Apply a chunk of blocks to the wallet under a single lock acquisition,
 /// then persist.
-pub(crate) async fn apply_and_persist_chunk(
+async fn apply_and_persist_chunk(
     wallet: &Arc<Mutex<WalletWithDb>>,
-    chunk: &mut Vec<BlockEvent<Block>>,
+    chunk: &mut Vec<RpcBlock>,
     warn_ms: u64,
 ) -> Result<(), Error> {
-    if chunk.is_empty() {
-        return Ok(());
-    }
-
-    let start = Instant::now();
     let chunk_len = chunk.len();
 
+    let elapsed_ms;
     {
         let mut w = wallet.lock().await;
+        let start = Instant::now();
         for block in chunk.drain(..) {
+            if let Some(connection) = block.connection {
+                w.wallet
+                    .apply_update(Update {
+                        chain: Some(connection),
+                        ..Default::default()
+                    })
+                    .map_err(|error| Error::Wallet(error.to_string()))?;
+            }
+            let block = block.event;
             w.wallet
                 .apply_block_connected_to(&block.block, block.block_height(), block.connected_to())
                 .map_err(|e| Error::Wallet(e.to_string()))?;
         }
         w.persist()?;
+        elapsed_ms = start.elapsed().as_millis() as u64;
     }
 
-    let elapsed_ms = start.elapsed().as_millis() as u64;
     if elapsed_ms > warn_ms {
         tracing::warn!(
             held_ms = elapsed_ms,
@@ -83,12 +226,77 @@ pub(crate) async fn apply_and_persist_chunk(
     Ok(())
 }
 
+/// Fetch blocks without occupying a runtime worker or holding the wallet lock.
+/// Returns whether any blocks were applied during this tick.
+async fn sync_rpc_once<C>(
+    wallet: &Arc<Mutex<WalletWithDb>>,
+    client: Arc<C>,
+    chunk_size: usize,
+    warn_ms: u64,
+    cancel_token: &CancellationToken,
+) -> Result<bool, Error>
+where
+    C: RpcApi + Send + Sync + 'static,
+{
+    // Also stop fetching if the supervisor drops this future. A running
+    // blocking RPC call cannot be aborted, but it never owns the wallet.
+    let cancel = cancel_token.child_token();
+    let _cancel_on_drop = cancel.clone().drop_guard();
+
+    // A prior apply may have advanced the in-memory checkpoint before a
+    // database error. Retry those staged changes even when there are no blocks.
+    apply_and_persist_chunk(wallet, &mut Vec::new(), warn_ms).await?;
+    let checkpoint = wallet.lock().await.wallet.latest_checkpoint();
+    let mut fetcher = RpcBlockFetcher {
+        client,
+        checkpoint,
+        last_header: None,
+    };
+    let chunk_size = chunk_size.max(1);
+    let mut any_applied = false;
+
+    loop {
+        if cancel.is_cancelled() {
+            return Ok(false);
+        }
+        let fetch_cancel = cancel.clone();
+        let fetch = tokio::task::spawn_blocking(move || {
+            let mut chunk = Vec::with_capacity(chunk_size);
+            let result = (|| {
+                while chunk.len() < chunk_size && !fetch_cancel.is_cancelled() {
+                    match fetcher.next_block(&fetch_cancel)? {
+                        Some(block) => chunk.push(block),
+                        None => return Ok(true),
+                    }
+                }
+                Ok::<_, Error>(false)
+            })();
+            (fetcher, chunk, result)
+        });
+
+        let (next_fetcher, mut chunk, result) = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Ok(false),
+            result = fetch => result.map_err(std::io::Error::other)?,
+        };
+        fetcher = next_fetcher;
+        any_applied |= !chunk.is_empty();
+        // Preserve successfully fetched blocks even if a later RPC failed.
+        apply_and_persist_chunk(wallet, &mut chunk, warn_ms).await?;
+        if result? {
+            return Ok(any_applied);
+        }
+    }
+}
+
 pub(crate) async fn sync_bitcoin_rpc(
     cdk_bdk: &CdkBdk,
     config: &BitcoinRpcConfig,
     cancel_token: CancellationToken,
 ) -> Result<(), Error> {
     let mut sync_interval = interval(Duration::from_secs(cdk_bdk.sync_interval_secs));
+    // Skip the backlog after a slow sync to avoid catch-up bursts.
+    sync_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
     let apply_chunk_size = cdk_bdk.sync_config.apply_chunk_size.max(1);
     let warn_ms = cdk_bdk.sync_config.lock_hold_warn_ms;
 
@@ -139,94 +347,30 @@ pub(crate) async fn sync_bitcoin_rpc(
                     }
                 };
 
-                // Snapshot the wallet checkpoint under a brief lock.
-                let checkpoint = {
-                    let w = cdk_bdk.wallet_with_db.lock().await;
-                    w.wallet.latest_checkpoint()
-                };
-                let start_height = checkpoint.height();
-
-                let mut emitter = Emitter::new(
-                    client.as_ref(),
-                    checkpoint,
-                    start_height,
-                    NO_EXPECTED_MEMPOOL_TXS,
-                );
-
-                let mut any_applied = false;
-                let mut had_tick_error = false;
-                let mut chunk: Vec<bdk_bitcoind_rpc::BlockEvent<Block>> = Vec::with_capacity(apply_chunk_size);
-
-                loop {
-                    match emitter.next_block() {
-                        Ok(Some(block)) => {
-                            chunk.push(block);
-                            if chunk.len() >= apply_chunk_size {
-                                if let Err(e) = apply_and_persist_chunk(
-                                    &cdk_bdk.wallet_with_db,
-                                    &mut chunk,
-                                    warn_ms,
-                                )
-                                .await
-                                {
-                                    had_tick_error = true;
-                                    consecutive_failures =
-                                        consecutive_failures.saturating_add(1);
-                                    crate::sync::log_sync_failure(
-                                        "Failed to apply block chunk",
-                                        &e,
-                                        consecutive_failures,
-                                    );
-                                    // Drop the RPC client so it is rebuilt next tick.
-                                    rpc_client = None;
-                                    break;
-                                }
-                                any_applied = true;
-                            }
-                        }
-                        Ok(None) => break,
-                        Err(e) => {
-                            had_tick_error = true;
-                            consecutive_failures =
-                                consecutive_failures.saturating_add(1);
-                            if consecutive_failures >= crate::sync::SUSTAINED_FAILURE_THRESHOLD {
-                                tracing::error!(
-                                    consecutive_failures,
-                                    "Bitcoin RPC error during sync: {e}; will retry next tick"
-                                );
-                            } else {
-                                tracing::warn!(
-                                    consecutive_failures,
-                                    "Bitcoin RPC error during sync: {e}; will retry next tick"
-                                );
-                            }
-                            rpc_client = None;
-                            break;
-                        }
-                    }
+                let result = sync_rpc_once(
+                    &cdk_bdk.wallet_with_db,
+                    client,
+                    apply_chunk_size,
+                    warn_ms,
+                    &cancel_token,
+                )
+                .await;
+                if cancel_token.is_cancelled() {
+                    break;
                 }
-
-                if !chunk.is_empty() {
-                    if let Err(e) = apply_and_persist_chunk(
-                        &cdk_bdk.wallet_with_db,
-                        &mut chunk,
-                        warn_ms,
-                    )
-                    .await
-                    {
-                        had_tick_error = true;
-                        consecutive_failures =
-                            consecutive_failures.saturating_add(1);
+                let any_applied = match result {
+                    Ok(any_applied) => any_applied,
+                    Err(error) => {
+                        consecutive_failures = consecutive_failures.saturating_add(1);
                         crate::sync::log_sync_failure(
-                            "Failed to apply final block chunk",
-                            &e,
+                            "Bitcoin RPC sync failed",
+                            &error,
                             consecutive_failures,
                         );
                         rpc_client = None;
-                    } else {
-                        any_applied = true;
+                        continue;
                     }
-                }
+                };
 
                 if any_applied {
                     let tip = {
@@ -240,17 +384,15 @@ pub(crate) async fn sync_bitcoin_rpc(
                     );
                 }
 
-                if !had_tick_error {
-                    if consecutive_failures > 0 {
-                        tracing::info!(
-                            recovered_after = consecutive_failures,
-                            "Bitcoin RPC sync recovered"
-                        );
-                    }
-                    consecutive_failures = 0;
-
-                    cdk_bdk.run_reconciliation().await;
+                if consecutive_failures > 0 {
+                    tracing::info!(
+                        recovered_after = consecutive_failures,
+                        "Bitcoin RPC sync recovered"
+                    );
                 }
+                consecutive_failures = 0;
+
+                cdk_bdk.run_reconciliation().await;
             }
         }
     }
@@ -319,25 +461,35 @@ pub(crate) async fn broadcast_bitcoin_rpc(
     config: &BitcoinRpcConfig,
     tx: Transaction,
 ) -> Result<BroadcastOutcome, BroadcastFailure> {
-    let rpc_client: Client = Client::new(
-        &format!("http://{}:{}", config.host, config.port),
-        Auth::UserPass(config.user.clone(), config.password.clone()),
-    )
-    .map_err(|e| BroadcastFailure::new(BroadcastErrorKind::Transient, e.to_string()))?;
+    let config = config.clone();
+    tokio::task::spawn_blocking(move || {
+        let rpc_client: Client = Client::new(
+            &format!("http://{}:{}", config.host, config.port),
+            Auth::UserPass(config.user, config.password),
+        )
+        .map_err(|e| BroadcastFailure::new(BroadcastErrorKind::Transient, e.to_string()))?;
 
-    tracing::info!(
-        "Broadcasting transaction: {} via bitcoin rpc",
-        tx.compute_txid()
-    );
+        tracing::info!(
+            "Broadcasting transaction: {} via bitcoin rpc",
+            tx.compute_txid()
+        );
 
-    match rpc_client.send_raw_transaction(tx.raw_hex()) {
-        Ok(_) => Ok(BroadcastOutcome::Accepted),
-        Err(e) if is_bitcoin_rpc_already_known(&e) => Ok(BroadcastOutcome::AlreadyKnown),
-        Err(e) => {
-            let kind = classify_bitcoin_rpc_broadcast_error(&e);
-            Err(BroadcastFailure::new(kind, e.to_string()))
+        match rpc_client.send_raw_transaction(tx.raw_hex()) {
+            Ok(_) => Ok(BroadcastOutcome::Accepted),
+            Err(e) if is_bitcoin_rpc_already_known(&e) => Ok(BroadcastOutcome::AlreadyKnown),
+            Err(e) => {
+                let kind = classify_bitcoin_rpc_broadcast_error(&e);
+                Err(BroadcastFailure::new(kind, e.to_string()))
+            }
         }
-    }
+    })
+    .await
+    .map_err(|error| {
+        BroadcastFailure::new(
+            BroadcastErrorKind::Transient,
+            format!("Bitcoin RPC broadcast task failed: {error}"),
+        )
+    })?
 }
 
 pub(crate) async fn fetch_fee_rate_bitcoin_rpc(
@@ -377,15 +529,720 @@ mod tests {
     use std::io::{BufRead, BufReader, Read, Write};
     use std::net::TcpListener;
     use std::str::FromStr;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{mpsc, Mutex as StdMutex};
     use std::thread;
 
-    use bdk_wallet::bitcoin::BlockHash;
+    use bdk_wallet::bitcoin::consensus::encode::serialize_hex;
+    use bdk_wallet::bitcoin::{constants::genesis_block, BlockHash, Network, TxOut};
+    use bdk_wallet::rusqlite::Connection;
+    use bdk_wallet::template::Bip84;
+    use bdk_wallet::{KeychainKind, Wallet};
     use serde_json::{json, Value};
+    use tokio::sync::oneshot;
 
     use super::*;
 
     const TIP_HASH: &str = "1111111111111111111111111111111111111111111111111111111111111111";
     const BIRTHDAY_HASH: &str = "2222222222222222222222222222222222222222222222222222222222222222";
+
+    struct TestRpc {
+        chain: Vec<Block>,
+        stale: Vec<Block>,
+        fail_block: Option<BlockHash>,
+        fail_header: Option<BlockHash>,
+    }
+
+    impl TestRpc {
+        fn new(chain: Vec<Block>) -> Self {
+            Self {
+                chain,
+                stale: Vec::new(),
+                fail_block: None,
+                fail_header: None,
+            }
+        }
+    }
+
+    impl RpcApi for TestRpc {
+        fn call<T>(&self, cmd: &str, args: &[Value]) -> Result<T, BitcoinRpcError>
+        where
+            T: for<'a> serde::Deserialize<'a>,
+        {
+            let response = match cmd {
+                "getblockhash" => {
+                    json!(self.chain[args[0].as_u64().expect("height") as usize].block_hash())
+                }
+                "getblock" | "getblockheader" => {
+                    let hash: BlockHash = serde_json::from_value(args[0].clone())?;
+                    if (cmd == "getblock" && self.fail_block == Some(hash))
+                        || (cmd == "getblockheader" && self.fail_header == Some(hash))
+                    {
+                        return Err(BitcoinRpcError::ReturnedError(format!(
+                            "injected {cmd} failure"
+                        )));
+                    }
+                    let active = self
+                        .chain
+                        .iter()
+                        .position(|block| block.block_hash() == hash);
+                    let (height, block) = match active {
+                        Some(height) => (height, &self.chain[height]),
+                        None => self
+                            .stale
+                            .iter()
+                            .enumerate()
+                            .find(|(_, block)| block.block_hash() == hash)
+                            .expect("known stale block"),
+                    };
+                    let verbosity = match cmd {
+                        "getblockheader" => 1,
+                        _ => args[1].as_u64().expect("verbosity"),
+                    };
+                    match verbosity {
+                        0 => json!(serialize_hex(block)),
+                        1 => json!({
+                            "hash": hash,
+                            "confirmations": if active.is_some() { 1 } else { -1 },
+                            "height": height,
+                            "size": 0, "weight": 0, "version": 1,
+                            "merkleroot": block.header.merkle_root,
+                            "tx": [], "time": block.header.time, "nonce": 0,
+                            "bits": "207fffff", "difficulty": 1.0,
+                            "chainwork": "00", "nTx": block.txdata.len(),
+                            "previousblockhash": block.header.prev_blockhash,
+                            "nextblockhash": active.and_then(|height| self.chain.get(height + 1))
+                                .map(Block::block_hash),
+                        }),
+                        _ => panic!("unexpected verbosity"),
+                    }
+                }
+                _ => panic!("unexpected RPC {cmd}"),
+            };
+            serde_json::from_value(response).map_err(BitcoinRpcError::from)
+        }
+    }
+
+    fn test_wallet() -> Arc<Mutex<WalletWithDb>> {
+        let mut db = Connection::open_in_memory().expect("database");
+        let key = bdk_wallet::bitcoin::bip32::Xpriv::new_master(Network::Regtest, &[42; 32])
+            .expect("master key");
+        let wallet = Wallet::create(
+            Bip84(key, KeychainKind::External),
+            Bip84(key, KeychainKind::Internal),
+        )
+        .network(Network::Regtest)
+        .create_wallet(&mut db)
+        .expect("wallet");
+        Arc::new(Mutex::new(WalletWithDb::new(wallet, db)))
+    }
+
+    fn next_block(previous: &Block, nonce: u32) -> Block {
+        let mut block = previous.clone();
+        block.header.prev_blockhash = previous.block_hash();
+        block.header.nonce = nonce;
+        block.txdata.clear();
+        block
+    }
+
+    fn test_chain(tip: u32) -> Vec<Block> {
+        let mut chain = vec![genesis_block(Network::Regtest)];
+        for height in 1..=tip {
+            chain.push(next_block(chain.last().expect("genesis"), height));
+        }
+        chain
+    }
+
+    async fn wallet_at_checkpoint(block: &Block, height: u32) -> Arc<Mutex<WalletWithDb>> {
+        let wallet = test_wallet();
+        {
+            let mut wallet = wallet.lock().await;
+            let checkpoint = wallet.wallet.latest_checkpoint().insert(BlockId {
+                height,
+                hash: block.block_hash(),
+            });
+            wallet
+                .wallet
+                .apply_update(Update {
+                    chain: Some(checkpoint),
+                    ..Default::default()
+                })
+                .expect("initial checkpoint");
+            wallet.persist().expect("persist checkpoint");
+        }
+        wallet
+    }
+
+    #[tokio::test]
+    async fn rpc_sync_recovers_shorter_replacement_chain_below_birthday() {
+        let original = test_chain(4);
+        let wallet = wallet_at_checkpoint(&original[4], 4).await;
+        let replacement_two = next_block(&original[1], 5);
+        let mut rpc = TestRpc::new(vec![
+            original[0].clone(),
+            original[1].clone(),
+            replacement_two.clone(),
+        ]);
+        rpc.fail_block = Some(original[1].block_hash());
+        rpc.stale = original;
+        let rpc = Arc::new(rpc);
+        let cancel = CancellationToken::new();
+        assert!(sync_rpc_once(&wallet, rpc.clone(), 1, 500, &cancel)
+            .await
+            .expect("shorter reorg"));
+        assert!(!sync_rpc_once(&wallet, rpc, 1, 500, &cancel)
+            .await
+            .expect("idle after shorter reorg"));
+        let mut wallet = wallet.lock().await;
+        let reloaded = Wallet::load()
+            .load_wallet(&mut wallet.db)
+            .expect("reload")
+            .expect("wallet");
+        assert_eq!(
+            reloaded.latest_checkpoint().block_id(),
+            BlockId {
+                height: 2,
+                hash: replacement_two.block_hash()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn rpc_sync_reports_missing_reorg_history_and_retries() {
+        for missing_header in [true, false] {
+            let original = test_chain(3);
+            let wallet = wallet_at_checkpoint(&original[3], 3).await;
+            let replacement_two = next_block(&original[1], 4);
+            let replacement_three = next_block(&replacement_two, 5);
+            let replacement = vec![
+                original[0].clone(),
+                original[1].clone(),
+                replacement_two.clone(),
+                replacement_three.clone(),
+            ];
+            let mut rpc = TestRpc::new(replacement.clone());
+            rpc.stale = original.clone();
+            match missing_header {
+                true => {
+                    rpc.fail_header = Some(original[2].block_hash());
+                    rpc.fail_block = Some(original[1].block_hash());
+                }
+                false => rpc.fail_block = Some(replacement_two.block_hash()),
+            }
+            let error = sync_rpc_once(&wallet, Arc::new(rpc), 16, 500, &CancellationToken::new())
+                .await
+                .expect_err("unavailable recovery history");
+            let expected = match missing_header {
+                true => "injected getblockheader failure",
+                false => "injected getblock failure",
+            };
+            assert!(
+                matches!(error, Error::BitcoinRpc(BitcoinRpcError::ReturnedError(message)) if message == expected)
+            );
+            assert_eq!(
+                wallet.lock().await.wallet.latest_checkpoint().hash(),
+                original[3].block_hash()
+            );
+
+            let mut rpc = TestRpc::new(replacement);
+            rpc.fail_block = Some(original[1].block_hash());
+            rpc.stale = original;
+            sync_rpc_once(&wallet, Arc::new(rpc), 16, 500, &CancellationToken::new())
+                .await
+                .expect("recover once required history is available");
+            assert_eq!(
+                wallet.lock().await.wallet.latest_checkpoint().hash(),
+                replacement_three.block_hash()
+            );
+        }
+    }
+
+    struct ReorgDuringFetchRpc {
+        before: TestRpc,
+        after: TestRpc,
+        trigger: BlockHash,
+        switched: AtomicBool,
+    }
+
+    impl RpcApi for ReorgDuringFetchRpc {
+        fn call<T>(&self, cmd: &str, args: &[Value]) -> Result<T, BitcoinRpcError>
+        where
+            T: for<'a> serde::Deserialize<'a>,
+        {
+            if self.switched.load(Ordering::SeqCst) {
+                return self.after.call(cmd, args);
+            }
+            let result = self.before.call(cmd, args);
+            if cmd == "getblock" && args[0] == json!(self.trigger) {
+                self.switched.store(true, Ordering::SeqCst);
+            }
+            result
+        }
+    }
+
+    #[tokio::test]
+    async fn rpc_sync_retries_a_reorg_during_catch_up_without_skipping_blocks() {
+        let original = test_chain(5);
+        let wallet = wallet_at_checkpoint(&original[3], 3).await;
+        let address = wallet
+            .lock()
+            .await
+            .wallet
+            .reveal_next_address(KeychainKind::External);
+        let mut payment = original[0].txdata[0].clone();
+        payment.output = vec![TxOut {
+            value: bdk_wallet::bitcoin::Amount::from_sat(50_000),
+            script_pubkey: address.address.script_pubkey(),
+        }];
+        let mut two = next_block(&original[1], 6);
+        two.txdata = vec![payment.clone()];
+        two.header.merkle_root = two.compute_merkle_root().expect("merkle root");
+        let three = next_block(&two, 7);
+        let four = next_block(&three, 8);
+        let five = next_block(&four, 9);
+        let mut after = TestRpc::new(vec![
+            original[0].clone(),
+            original[1].clone(),
+            two.clone(),
+            three,
+            four,
+            five.clone(),
+        ]);
+        after.stale = original.clone();
+        after.fail_block = Some(original[1].block_hash());
+        let rpc = Arc::new(ReorgDuringFetchRpc {
+            trigger: original[4].block_hash(),
+            before: TestRpc::new(original.clone()),
+            after,
+            switched: AtomicBool::new(false),
+        });
+        let cancel = CancellationToken::new();
+        assert!(matches!(
+            sync_rpc_once(&wallet, rpc.clone(), 16, 500, &cancel).await,
+            Err(Error::Io(error)) if error.kind() == std::io::ErrorKind::Interrupted
+        ));
+        assert_eq!(
+            wallet.lock().await.wallet.latest_checkpoint().hash(),
+            original[4].block_hash()
+        );
+        sync_rpc_once(&wallet, rpc, 16, 500, &cancel)
+            .await
+            .expect("retry after reorg");
+        let mut wallet = wallet.lock().await;
+        let reloaded = Wallet::load()
+            .load_wallet(&mut wallet.db)
+            .expect("reload")
+            .expect("wallet");
+        assert_eq!(reloaded.latest_checkpoint().hash(), five.block_hash());
+        let tx = reloaded
+            .get_tx(payment.compute_txid())
+            .expect("payment below birthday");
+        assert!(matches!(tx.chain_position,
+            bdk_wallet::chain::ChainPosition::Confirmed { anchor, .. }
+                if anchor.block_id == BlockId { height: 2, hash: two.block_hash() }
+        ));
+    }
+
+    #[tokio::test]
+    async fn rpc_sync_does_not_report_success_for_rollback_without_replacement() {
+        let original = test_chain(2);
+        let wallet = wallet_at_checkpoint(&original[2], 2).await;
+        let mut rpc = TestRpc::new(original[..2].to_vec());
+        rpc.stale = original;
+        assert!(matches!(
+            sync_rpc_once(&wallet, Arc::new(rpc), 16, 500, &CancellationToken::new()).await,
+            Err(Error::Io(error)) if error.kind() == std::io::ErrorKind::Interrupted
+        ));
+    }
+
+    #[tokio::test]
+    async fn rpc_sync_preserves_initial_checkpoint_without_rescanning_history() {
+        let wallet = test_wallet();
+        let genesis = genesis_block(Network::Regtest);
+        let one = next_block(&genesis, 1);
+        let two = next_block(&one, 2);
+        {
+            let mut wallet = wallet.lock().await;
+            let checkpoint = wallet.wallet.latest_checkpoint().insert(BlockId {
+                height: 2,
+                hash: two.block_hash(),
+            });
+            wallet
+                .wallet
+                .apply_update(bdk_wallet::Update {
+                    chain: Some(checkpoint),
+                    ..Default::default()
+                })
+                .expect("initial checkpoint");
+            wallet.persist().expect("persist checkpoint");
+        }
+        let original = vec![genesis.clone(), one.clone(), two];
+        let mut rpc = TestRpc::new(original.clone());
+        // An attempt to scan old history fails, as it could on a pruned node.
+        rpc.fail_block = Some(one.block_hash());
+        assert!(
+            !sync_rpc_once(&wallet, Arc::new(rpc), 16, 500, &CancellationToken::new())
+                .await
+                .expect("already at tip")
+        );
+
+        // A one-block reorg removes the only non-genesis checkpoint.
+        let replacement_two = next_block(&one, 3);
+        let mut rpc = TestRpc::new(vec![genesis, one.clone(), replacement_two.clone()]);
+        rpc.stale = original;
+        rpc.fail_block = Some(one.block_hash());
+        assert!(
+            sync_rpc_once(&wallet, Arc::new(rpc), 16, 500, &CancellationToken::new())
+                .await
+                .expect("shallow reorg without scanning pruned history")
+        );
+        assert_eq!(
+            wallet.lock().await.wallet.latest_checkpoint().hash(),
+            replacement_two.block_hash()
+        );
+    }
+
+    #[tokio::test]
+    async fn rpc_sync_replays_reorg_below_birthday_after_reload() {
+        let wallet = test_wallet();
+        let genesis = genesis_block(Network::Regtest);
+        let one = next_block(&genesis, 1);
+        let two = next_block(&one, 2);
+        let three = next_block(&two, 3);
+        let four = next_block(&three, 4);
+        let mut previous_chain = vec![genesis.clone(), one.clone(), two, three.clone(), four];
+        let address = {
+            let mut wallet = wallet.lock().await;
+            // The wallet has advanced past its birthday, but has no stored
+            // checkpoint at the actual fork point (height 1).
+            let checkpoint = wallet
+                .wallet
+                .latest_checkpoint()
+                .insert(BlockId {
+                    height: 3,
+                    hash: three.block_hash(),
+                })
+                .insert(BlockId {
+                    height: 4,
+                    hash: previous_chain[4].block_hash(),
+                });
+            wallet
+                .wallet
+                .apply_update(bdk_wallet::Update {
+                    chain: Some(checkpoint),
+                    ..Default::default()
+                })
+                .expect("initial checkpoint");
+            let address = wallet.wallet.reveal_next_address(KeychainKind::External);
+            wallet.persist().expect("persist checkpoint and address");
+            address.address
+        };
+        let cancel = CancellationToken::new();
+        sync_rpc_once(
+            &wallet,
+            Arc::new(TestRpc::new(previous_chain.clone())),
+            16,
+            500,
+            &cancel,
+        )
+        .await
+        .expect("already at tip");
+
+        let mut payment = genesis.txdata[0].clone();
+        payment.output = vec![TxOut {
+            value: bdk_wallet::bitcoin::Amount::from_sat(50_000),
+            script_pubkey: address.script_pubkey(),
+        }];
+        let mut before_birthday = payment.clone();
+        before_birthday.output[0].value = bdk_wallet::bitcoin::Amount::from_sat(25_000);
+
+        // Both payments must be discovered, including the one below the
+        // original birthday. Repeat after reloading the persisted checkpoints.
+        for nonce in [5, 8] {
+            let mut replacement_two = next_block(&one, nonce);
+            replacement_two.txdata = vec![before_birthday.clone()];
+            replacement_two.header.merkle_root =
+                replacement_two.compute_merkle_root().expect("merkle root");
+            let mut replacement_three = next_block(&replacement_two, nonce + 1);
+            replacement_three.txdata = vec![payment.clone()];
+            replacement_three.header.merkle_root = replacement_three
+                .compute_merkle_root()
+                .expect("merkle root");
+            let replacement_four = next_block(&replacement_three, nonce + 2);
+            let chain = vec![
+                genesis.clone(),
+                one.clone(),
+                replacement_two.clone(),
+                replacement_three.clone(),
+                replacement_four.clone(),
+            ];
+            let mut rpc = TestRpc::new(chain.clone());
+            rpc.stale = previous_chain;
+            rpc.fail_block = Some(one.block_hash());
+            {
+                let mut wallet = wallet.lock().await;
+                wallet.wallet = Wallet::load()
+                    .load_wallet(&mut wallet.db)
+                    .expect("reload wallet")
+                    .expect("persisted wallet");
+            }
+            sync_rpc_once(&wallet, Arc::new(rpc), 16, 500, &cancel)
+                .await
+                .expect("reorg must not scan pruned history");
+
+            let mut wallet = wallet.lock().await;
+            let reloaded = Wallet::load()
+                .load_wallet(&mut wallet.db)
+                .expect("reload after reorg")
+                .expect("persisted wallet");
+            assert_eq!(
+                reloaded.latest_checkpoint().hash(),
+                replacement_four.block_hash()
+            );
+            let tx = reloaded
+                .get_tx(before_birthday.compute_txid())
+                .expect("payment below original birthday");
+            assert!(matches!(tx.chain_position,
+                bdk_wallet::chain::ChainPosition::Confirmed { anchor, .. }
+                    if anchor.block_id == BlockId { height: 2, hash: replacement_two.block_hash() }
+            ));
+            let tx = reloaded
+                .get_tx(payment.compute_txid())
+                .expect("replacement payment");
+            assert!(matches!(tx.chain_position,
+                bdk_wallet::chain::ChainPosition::Confirmed { anchor, .. }
+                    if anchor.block_id == BlockId { height: 3, hash: replacement_three.block_hash() }
+            ));
+            previous_chain = chain;
+        }
+    }
+
+    #[tokio::test]
+    async fn rpc_sync_replays_payments_below_previous_tip_after_reorg() {
+        let wallet = test_wallet();
+        let genesis = genesis_block(Network::Regtest);
+        let original_one = next_block(&genesis, 1);
+        let original_two = next_block(&original_one, 2);
+        let original = vec![genesis.clone(), original_one, original_two];
+        let cancel = CancellationToken::new();
+        sync_rpc_once(
+            &wallet,
+            Arc::new(TestRpc::new(original.clone())),
+            1,
+            500,
+            &cancel,
+        )
+        .await
+        .expect("initial sync");
+
+        let address = wallet
+            .lock()
+            .await
+            .wallet
+            .reveal_next_address(KeychainKind::External);
+        let mut payment = genesis.txdata[0].clone();
+        payment.output = vec![TxOut {
+            value: bdk_wallet::bitcoin::Amount::from_sat(50_000),
+            script_pubkey: address.address.script_pubkey(),
+        }];
+        let mut replacement_one = next_block(&genesis, 3);
+        replacement_one.txdata = vec![payment.clone()];
+        replacement_one.header.merkle_root =
+            replacement_one.compute_merkle_root().expect("merkle root");
+        let replacement_two = next_block(&replacement_one, 4);
+        let mut rpc = TestRpc::new(vec![
+            genesis,
+            replacement_one.clone(),
+            replacement_two.clone(),
+        ]);
+        rpc.stale = original;
+        sync_rpc_once(&wallet, Arc::new(rpc), 1, 500, &cancel)
+            .await
+            .expect("reorg sync");
+
+        let mut wallet = wallet.lock().await;
+        let reloaded = Wallet::load()
+            .load_wallet(&mut wallet.db)
+            .expect("reload wallet")
+            .expect("persisted wallet");
+        assert_eq!(
+            reloaded.latest_checkpoint().hash(),
+            replacement_two.block_hash()
+        );
+        let tx = reloaded
+            .get_tx(payment.compute_txid())
+            .expect("replacement payment discovered");
+        assert!(matches!(tx.chain_position,
+            bdk_wallet::chain::ChainPosition::Confirmed { anchor, .. }
+                if anchor.block_id == BlockId { height: 1, hash: replacement_one.block_hash() }
+        ));
+    }
+
+    #[tokio::test]
+    async fn rpc_sync_retries_failed_persistence_without_new_blocks() {
+        let wallet = test_wallet();
+        let genesis = genesis_block(Network::Regtest);
+        let block = next_block(&genesis, 1);
+        let rpc = Arc::new(TestRpc::new(vec![genesis, block.clone()]));
+        let cancel = CancellationToken::new();
+        wallet
+            .lock()
+            .await
+            .db
+            .execute_batch("PRAGMA query_only = ON;")
+            .expect("disable writes");
+
+        assert!(matches!(
+            sync_rpc_once(&wallet, rpc.clone(), 16, 500, &cancel).await,
+            Err(Error::Database(_))
+        ));
+        assert_eq!(wallet.lock().await.wallet.latest_checkpoint().height(), 1);
+        // Even an idle tick must keep reporting the persistence failure.
+        assert!(matches!(
+            sync_rpc_once(&wallet, rpc.clone(), 16, 500, &cancel).await,
+            Err(Error::Database(_))
+        ));
+        wallet
+            .lock()
+            .await
+            .db
+            .execute_batch("PRAGMA query_only = OFF;")
+            .expect("enable writes");
+        assert!(!sync_rpc_once(&wallet, rpc, 16, 500, &cancel)
+            .await
+            .expect("idle retry"));
+
+        let mut wallet = wallet.lock().await;
+        assert!(wallet.wallet.staged().is_none());
+        let reloaded = Wallet::load()
+            .load_wallet(&mut wallet.db)
+            .expect("reload wallet")
+            .expect("persisted wallet");
+        assert_eq!(reloaded.latest_checkpoint().hash(), block.block_hash());
+    }
+
+    #[tokio::test]
+    async fn rpc_sync_persists_partial_chunk_before_fetch_error() {
+        let wallet = test_wallet();
+        let genesis = genesis_block(Network::Regtest);
+        let one = next_block(&genesis, 1);
+        let two = next_block(&one, 2);
+        let mut rpc = TestRpc::new(vec![genesis, one.clone(), two.clone()]);
+        rpc.fail_block = Some(two.block_hash());
+        assert!(matches!(
+            sync_rpc_once(&wallet, Arc::new(rpc), 16, 500, &CancellationToken::new()).await,
+            Err(Error::BitcoinRpc(_))
+        ));
+
+        let mut wallet = wallet.lock().await;
+        let reloaded = Wallet::load()
+            .load_wallet(&mut wallet.db)
+            .expect("reload wallet")
+            .expect("persisted wallet");
+        assert_eq!(reloaded.latest_checkpoint().hash(), one.block_hash());
+    }
+
+    struct BlockingRpc {
+        inner: TestRpc,
+        entered: StdMutex<Option<oneshot::Sender<()>>>,
+        release: StdMutex<mpsc::Receiver<()>>,
+        fetched: AtomicUsize,
+        block_method: &'static str,
+    }
+
+    impl RpcApi for BlockingRpc {
+        fn call<T>(&self, cmd: &str, args: &[Value]) -> Result<T, BitcoinRpcError>
+        where
+            T: for<'a> serde::Deserialize<'a>,
+        {
+            let entered = match cmd == self.block_method {
+                true => self.entered.lock().expect("entered lock").take(),
+                false => None,
+            };
+            if let Some(entered) = entered {
+                let _ = entered.send(());
+                // Bound the wait so a regression blocking the test runtime fails
+                // instead of deadlocking the suite.
+                let _ = self
+                    .release
+                    .lock()
+                    .expect("release lock")
+                    .recv_timeout(Duration::from_secs(2));
+            }
+            if cmd == "getblock" && args[1] == 0 {
+                self.fetched.fetch_add(1, Ordering::SeqCst);
+            }
+            self.inner.call(cmd, args)
+        }
+    }
+
+    #[tokio::test]
+    async fn rpc_sync_cancellation_during_fetch_leaves_wallet_unchanged() {
+        for (drop_future, block_method) in [
+            (false, "getblockheader"),
+            (true, "getblockheader"),
+            (false, "getblock"),
+            (true, "getblock"),
+        ] {
+            let wallet = test_wallet();
+            let genesis = genesis_block(Network::Regtest);
+            let one = next_block(&genesis, 1);
+            let two = next_block(&one, 2);
+            let (entered_tx, entered_rx) = oneshot::channel();
+            let (release_tx, release_rx) = mpsc::channel();
+            let rpc = Arc::new(BlockingRpc {
+                inner: TestRpc::new(vec![genesis.clone(), one, two]),
+                entered: StdMutex::new(Some(entered_tx)),
+                release: StdMutex::new(release_rx),
+                fetched: AtomicUsize::new(0),
+                block_method,
+            });
+            let cancel = CancellationToken::new();
+            let task_wallet = wallet.clone();
+            let task_rpc = rpc.clone();
+            let task_cancel = cancel.clone();
+            let started = Instant::now();
+            let task = tokio::spawn(async move {
+                sync_rpc_once(&task_wallet, task_rpc, 16, 500, &task_cancel).await
+            });
+            entered_rx.await.expect("RPC started");
+            // The runtime and wallet must remain available during the RPC.
+            let guard = wallet.try_lock().expect("fetch must not hold wallet lock");
+            drop(guard);
+            match drop_future {
+                true => task.abort(),
+                false => cancel.cancel(),
+            }
+            let result = tokio::time::timeout(Duration::from_secs(1), task)
+                .await
+                .expect("prompt cancellation");
+            assert!(
+                started.elapsed() < Duration::from_secs(1),
+                "RPC blocked the runtime"
+            );
+            match drop_future {
+                true => assert!(result.expect_err("aborted task").is_cancelled()),
+                false => assert!(!result.expect("task").expect("sync")),
+            }
+            release_tx.send(()).expect("release in-flight RPC");
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while Arc::strong_count(&rpc) > 1 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("blocking worker stopped");
+            assert_eq!(
+                rpc.fetched.load(Ordering::SeqCst),
+                usize::from(block_method == "getblock"),
+                "no additional blocks fetched after cancellation"
+            );
+            assert_eq!(
+                wallet.lock().await.wallet.latest_checkpoint().hash(),
+                genesis.block_hash()
+            );
+        }
+    }
 
     fn chain_info(tip: u32) -> Value {
         json!({
@@ -409,6 +1266,13 @@ mod tests {
     }
 
     fn spawn_rpc_server(results: Vec<Value>) -> u16 {
+        spawn_rpc_server_with_handler(results, |_| {})
+    }
+
+    fn spawn_rpc_server_with_handler<F>(results: Vec<Value>, mut before_response: F) -> u16
+    where
+        F: FnMut(&Value) + Send + 'static,
+    {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind test RPC server");
         let port = listener.local_addr().expect("test RPC address").port();
 
@@ -440,6 +1304,7 @@ mod tests {
                     .expect("read test RPC request body");
                 let request: Value =
                     serde_json::from_slice(&request_body).expect("valid JSON-RPC request");
+                before_response(&request);
                 let id = request["id"].clone();
                 drop(reader);
 
@@ -531,6 +1396,43 @@ mod tests {
         assert_eq!(
             classify_bitcoin_rpc_broadcast_message("some new backend error"),
             BroadcastErrorKind::Unknown
+        );
+    }
+
+    #[tokio::test]
+    async fn rpc_broadcast_does_not_block_runtime() {
+        let tx = genesis_block(Network::Regtest).txdata[0].clone();
+        let expected_hex = serialize_hex(&tx);
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let mut entered_tx = Some(entered_tx);
+        let (release_tx, release_rx) = mpsc::channel();
+        let port = spawn_rpc_server_with_handler(vec![json!(tx.compute_txid())], move |request| {
+            assert_eq!(request["method"], "sendrawtransaction");
+            assert_eq!(request["params"][0], expected_hex);
+            entered_tx
+                .take()
+                .expect("single broadcast")
+                .send(())
+                .expect("notify test");
+            // A regression must fail rather than deadlock this single-thread runtime.
+            let _ = release_rx.recv_timeout(Duration::from_secs(2));
+        });
+        let started = Instant::now();
+        let task =
+            tokio::spawn(async move { broadcast_bitcoin_rpc(&rpc_config(port, None), tx).await });
+        entered_rx.await.expect("broadcast started");
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "broadcast blocked runtime"
+        );
+        release_tx.send(()).expect("release RPC");
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), task)
+                .await
+                .expect("broadcast finished")
+                .expect("task")
+                .expect("broadcast"),
+            BroadcastOutcome::Accepted
         );
     }
 }


### PR DESCRIPTION

---

Replay replacement blocks below the previous tip without rescanning history during normal checkpoint-based sync. Retry staged wallet writes on idle ticks before reporting recovery or reconciling payments.

Move bounded block fetching and transaction broadcasting onto the blocking pool. Stop fetching when sync is cancelled or its future is dropped.

Cover reorg payments, persistence retries, partial fetch failures, initial checkpoints, cancellation, and runtime responsiveness during broadcasting.

Validated with 137 unit tests, Clippy, and workspace formatting.

### PR stack

1. #2480 — RPC correctness and blocking-pool fixes **(this PR)**
2. #2481 — Esplora request limits and polling fixes

Review and merge in this order. Follow-up: #2481 builds on this PR.


### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
