### PR TITLE
fix(bdk): bound Esplora requests and skip missed sync ticks

### DIFF
--- a/crates/cdk-bdk/README.md
+++ b/crates/cdk-bdk/README.md
@@ -89,6 +89,10 @@ reveal and batch construction are not blocked during long chain catch-ups.
 Chain-source clients are reused across sync iterations and rebuilt only on
 error.
 
+Esplora sync, broadcast, and fee-estimation requests have a 10-second timeout.
+Esplora's `parallel_requests` must be greater than zero. Missed polling ticks
+are skipped so a slow sync does not trigger a burst of catch-up polls.
+
 Fresh Bitcoin Core wallets checkpoint at the current chain tip instead of
 scanning from genesis. When restoring from a mnemonic, set
 `BitcoinRpcConfig::wallet_rescan_from_height` to the wallet's known birthday

--- a/crates/cdk-bdk/src/chain/electrum.rs
+++ b/crates/cdk-bdk/src/chain/electrum.rs
@@ -5,7 +5,7 @@ use bdk_electrum::electrum_client::{Client, ConfigBuilder, ElectrumApi};
 use bdk_electrum::BdkElectrumClient;
 use bdk_wallet::bitcoin::Transaction;
 use cdk_common::redact::url_for_logs;
-use tokio::time::{interval, Duration};
+use tokio::time::{interval, Duration, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 
 use crate::chain::{BroadcastErrorKind, BroadcastFailure, BroadcastOutcome, ElectrumConfig};
@@ -40,6 +40,8 @@ pub(crate) async fn sync_electrum(
     let configured_interval = Duration::from_secs(cdk_bdk.sync_interval_secs);
     let initial_backoff = configured_interval.max(MIN_ELECTRUM_BACKOFF);
     let mut sync_interval = interval(configured_interval);
+    // Skip the backlog after a slow sync to avoid catch-up bursts.
+    sync_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
     let mut electrum_client: Option<Arc<ElectrumClient>> = None;
     let mut consecutive_failures: u32 = 0;
     let mut backoff = initial_backoff;

--- a/crates/cdk-bdk/src/chain/esplora.rs
+++ b/crates/cdk-bdk/src/chain/esplora.rs
@@ -4,7 +4,7 @@ use bdk_esplora::esplora_client::{AsyncClient, Builder};
 use bdk_esplora::EsploraAsyncExt;
 use bdk_wallet::bitcoin::Transaction;
 use cdk_common::redact::url_for_logs;
-use tokio::time::{interval, Duration};
+use tokio::time::{interval, Duration, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 
 use crate::chain::{BroadcastErrorKind, BroadcastFailure, BroadcastOutcome, EsploraConfig};
@@ -13,6 +13,14 @@ use crate::CdkBdk;
 
 const MIN_ESPLORA_BACKOFF: Duration = Duration::from_secs(5);
 const MAX_ESPLORA_BACKOFF: Duration = Duration::from_secs(300);
+
+const ESPLORA_REQUEST_TIMEOUT_SECS: u64 = 10;
+
+fn new_esplora_client(url: &str) -> Result<AsyncClient, bdk_esplora::esplora_client::Error> {
+    Builder::new(url)
+        .timeout(ESPLORA_REQUEST_TIMEOUT_SECS)
+        .build_async()
+}
 
 fn next_esplora_backoff(backoff: &mut Duration) -> Duration {
     let current = *backoff;
@@ -30,6 +38,8 @@ pub(crate) async fn sync_esplora(
     let configured_interval = Duration::from_secs(cdk_bdk.sync_interval_secs);
     let initial_backoff = configured_interval.max(MIN_ESPLORA_BACKOFF);
     let mut sync_interval = interval(configured_interval);
+    // Skip the backlog after a slow sync to avoid catch-up bursts.
+    sync_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
     let warn_ms = cdk_bdk.sync_config.lock_hold_warn_ms;
 
     // Persist Esplora client across sync iterations; re-create on error.
@@ -53,7 +63,7 @@ pub(crate) async fn sync_esplora(
                 let client = match &esplora_client {
                     Some(c) => c.clone(),
                     None => {
-                        match Builder::new(url).build_async() {
+                        match new_esplora_client(url) {
                             Ok(c) => {
                                 esplora_client = Some(c.clone());
                                 c
@@ -216,8 +226,7 @@ pub(crate) async fn broadcast_esplora(
     config: &EsploraConfig,
     tx: Transaction,
 ) -> Result<BroadcastOutcome, BroadcastFailure> {
-    let client = Builder::new(&config.url)
-        .build_async()
+    let client = new_esplora_client(&config.url)
         .map_err(|e| BroadcastFailure::new(BroadcastErrorKind::Transient, e.to_string()))?;
 
     tracing::info!(
@@ -248,9 +257,7 @@ pub(crate) async fn fetch_fee_rate_esplora(
     config: &EsploraConfig,
     target_blocks: u16,
 ) -> Result<f64, Error> {
-    let client = Builder::new(&config.url)
-        .build_async()
-        .map_err(|e| Error::Esplora(e.to_string()))?;
+    let client = new_esplora_client(&config.url).map_err(|e| Error::Esplora(e.to_string()))?;
 
     let estimates = client
         .get_fee_estimates()
@@ -286,7 +293,36 @@ pub(crate) async fn fetch_fee_rate_esplora(
 
 #[cfg(test)]
 mod tests {
+    use tokio::io::AsyncReadExt;
+    use tokio::net::TcpListener;
+    use tokio::time::{pause, timeout, Duration};
+
     use super::*;
+
+    #[tokio::test]
+    async fn stalled_esplora_request_times_out() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("listener");
+        let client = new_esplora_client(&format!(
+            "http://{}",
+            listener.local_addr().expect("address")
+        ))
+        .expect("client");
+        let request = tokio::spawn(async move { client.get_fee_estimates().await });
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        assert!(stream.read(&mut [0; 1024]).await.expect("read request") > 0);
+        // Keep the connection open without sending a response. Pause only
+        // after I/O has started so virtual time cannot race TCP setup.
+        pause();
+        let error = timeout(Duration::from_secs(11), request)
+            .await
+            .expect("request timeout must fire")
+            .expect("request task")
+            .expect_err("stalled request");
+        assert!(
+            matches!(error, bdk_esplora::esplora_client::Error::Reqwest(error) if error.is_timeout())
+        );
+        drop(stream);
+    }
 
     #[test]
     fn classify_esplora_broadcast_errors() {

--- a/crates/cdk-bdk/src/chain/mod.rs
+++ b/crates/cdk-bdk/src/chain/mod.rs
@@ -148,6 +148,12 @@ impl BroadcastFailure {
 impl ChainSource {
     pub(crate) fn validate(&self) -> Result<(), Error> {
         match self {
+            #[cfg(feature = "esplora")]
+            Self::Esplora(config) if config.parallel_requests == 0 => {
+                return Err(Error::InvalidConfig(
+                    "Esplora parallel_requests must be greater than zero".to_string(),
+                ));
+            }
             #[cfg(feature = "electrum")]
             Self::Electrum(config) if config.batch_size == 0 => {
                 return Err(Error::InvalidConfig(
@@ -295,5 +301,20 @@ mod tests {
             .expect_err("zero Electrum batch size should fail");
 
         assert!(matches!(error, Error::InvalidConfig(_)));
+    }
+
+    #[cfg(feature = "esplora")]
+    #[test]
+    fn rejects_zero_esplora_parallel_requests() {
+        for parallel_requests in [0, 1, 4] {
+            let source = ChainSource::Esplora(EsploraConfig {
+                url: "http://127.0.0.1:1".to_owned(),
+                parallel_requests,
+            });
+            match parallel_requests {
+                0 => assert!(matches!(source.validate(), Err(Error::InvalidConfig(_)))),
+                _ => source.validate().expect("positive concurrency"),
+            }
+        }
     }
 }


### PR DESCRIPTION


---

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----
Reject zero Esplora concurrency so sync cannot silently skip script
scanning. Apply a 10-second HTTP request timeout through one client
constructor used by sync, broadcast, and fee estimation.

Skip missed polling ticks in each backend to avoid catch-up bursts after
a slow sync. Document the limits and test invalid concurrency and a
stalled server.

Validated with 139 unit tests, formatting, and Clippy with all backends
enabled together and each backend enabled individually.

### PR stack

1. #2480 — RPC correctness and blocking-pool fixes
2. #2481 — Esplora request limits and polling fixes **(this PR)**

Review and merge in this order. Depends on #2480; this PR currently includes its commit.
    
### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
