### PR TITLE
fix(tests): use polling subscriptions in pure integration wallets

### DIFF
--- a/crates/cdk-integration-tests/src/init_pure_tests.rs
+++ b/crates/cdk-integration-tests/src/init_pure_tests.rs
@@ -631,6 +631,7 @@ pub async fn create_test_wallet_for_mint_with_seed(mint: Mint, seed: [u8; 64]) -
         .localstore(localstore)
         .seed(seed)
         .client(connector)
+        .use_http_subscription()
         .build()?;
 
     Ok(wallet)


### PR DESCRIPTION
Use polling with DirectMintConnection to avoid WebSocket connection attempts against fake mint URLs and the resulting DNS error logs.

Code taken from the proposed fix linked here:
https://github.com/cashubtc/cdk/issues/2125#issuecomment-5565909984

Verified test_concurrent_double_spend_swap passes without WebSocket/DNS errors with the memory backend. Formatting check passes.

Fixes #2125

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
