### PR TITLE
ci(kotlin): publish armeabi-v7a and x86 Android libraries again

### DIFF
--- a/.github/workflows/kotlin-publish.yml
+++ b/.github/workflows/kotlin-publish.yml
@@ -234,6 +234,12 @@ jobs:
           - target: aarch64-linux-android
             runner: ubuntu-22.04
             artifact: libcdk_ffi_kotlin.so
+          - target: armv7-linux-androideabi
+            runner: ubuntu-22.04
+            artifact: libcdk_ffi_kotlin.so
+          - target: i686-linux-android
+            runner: ubuntu-22.04
+            artifact: libcdk_ffi_kotlin.so
           - target: x86_64-linux-android
             runner: ubuntu-22.04
             artifact: libcdk_ffi_kotlin.so
@@ -313,6 +319,9 @@ jobs:
             bash -c '"$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip" --strip-all '"$FILE"
 
       - name: Verify Android ELF 16 KB alignment
+        # The 16 KB page size requirement applies to 64-bit ABIs only;
+        # 32-bit Android always uses 4 KB pages
+        if: matrix.target == 'aarch64-linux-android' || matrix.target == 'x86_64-linux-android'
         working-directory: cdk-kotlin/rust
         shell: bash
         run: |
@@ -386,6 +395,8 @@ jobs:
         run: |
           declare -A ANDROID_ABI=(
             ["aarch64-linux-android"]="arm64-v8a"
+            ["armv7-linux-androideabi"]="armeabi-v7a"
+            ["i686-linux-android"]="x86"
             ["x86_64-linux-android"]="x86_64"
           )
 


### PR DESCRIPTION
### Description

cdk-android releases on Maven Central shipped four Android ABIs through 0.17.5 (arm64-v8a, armeabi-v7a, x86, x86_64). The rewritten kotlin publish pipeline introduced with 0.18.0-rc.0 only builds `aarch64-linux-android` and `x86_64-linux-android`, so the 32-bit jniLibs silently disappeared from the aar.

This restores them:

* two more legs in the `kotlin-build-native` matrix (`armv7-linux-androideabi`, `i686-linux-android`)
* their entries in the `ANDROID_ABI` map used when distributing native libraries to jniLibs

The `kotlin-build` Nix dev shell already provisions the rust std libraries, NDK linkers and `CC`/`AR` env for both 32-bit targets, so no flake changes are needed. Bindings generation is unaffected; it runs off the arm64 library only.

If dropping 32-bit Android was intentional rather than a side effect of the pipeline rewrite, happy to close this, but in that case it would be good to state it in the release notes so downstream packagers can plan. For context, Zeus currently ships per-ABI release APKs including armeabi-v7a and x86 and is weighing whether to retire them; knowing upstream's direction here would inform that call. 0.17.x aars are also noticeably smaller per ABI since the split cdk-jvm/cdk-android layout carried no bundled bindings, so if aar size was the motivation the 32-bit slices add roughly what the old layout carried per ABI.

-----

### Notes to the reviewers

The 16 KB ELF alignment check is gated to the 64-bit targets: Android's 16 KB page size requirement applies to 64-bit ABIs only, and 32-bit Android always uses 4 KB pages, so the check would fail spuriously on the restored targets.

Workflow-only change; I could not exercise the release pipeline from a fork since it needs the deploy key and repo vars, but the YAML parses and the matrix/map shapes mirror the existing 64-bit legs.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED

#### ADDED

- cdk-android aars on Maven Central again include armeabi-v7a and x86 native libraries, matching the 0.17.x ABI coverage

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing (workflow-only change, no Rust code touched)
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`) (not applicable)
