### PR TITLE
refactor(sql): batch mint quote related data loading

### DIFF
--- a/crates/cdk-common/src/database/mint/test/mint.rs
+++ b/crates/cdk-common/src/database/mint/test/mint.rs
@@ -1996,3 +1996,294 @@ pub async fn concurrent_mint_quote_batches_use_consistent_lock_order(db: DynMint
     assert_eq!(second_quotes[0].as_ref().unwrap().id, quote2.id);
     assert_eq!(second_quotes[1].as_ref().unwrap().id, quote1.id);
 }
+
+/// Test that mint quotes with multiple payments and multiple issuances are reconstructed
+/// accurately without duplicate payments or issuances across single and batch fetches.
+pub async fn mint_quotes_load_payments_and_issuance_without_duplicates<DB>(db: DB)
+where
+    DB: Database<Error> + KeysDatabase<Err = Error>,
+{
+    // Quote 1: 3 payments, 2 issuances (multiple payments AND multiple issuance)
+    let quote1 = MintQuote::new(
+        None,
+        unique_string(),
+        cashu::CurrencyUnit::Sat,
+        None,
+        0,
+        PaymentIdentifier::CustomId(unique_string()),
+        None,
+        Amount::new(1000, cashu::CurrencyUnit::Sat),
+        Amount::new(0, cashu::CurrencyUnit::Sat),
+        cashu::PaymentMethod::Known(KnownMethod::Bolt11),
+        0,
+        0,
+        vec![],
+        vec![],
+        None,
+    );
+
+    // Quote 2: 0 payments, 0 issuances (zero payments + zero issuance)
+    let quote2 = MintQuote::new(
+        None,
+        unique_string(),
+        cashu::CurrencyUnit::Sat,
+        None,
+        0,
+        PaymentIdentifier::CustomId(unique_string()),
+        None,
+        Amount::new(500, cashu::CurrencyUnit::Sat),
+        Amount::new(0, cashu::CurrencyUnit::Sat),
+        cashu::PaymentMethod::Known(KnownMethod::Bolt11),
+        0,
+        0,
+        vec![],
+        vec![],
+        None,
+    );
+
+    // Quote 3: 2 payments, 0 issuances (multiple payments)
+    let quote3 = MintQuote::new(
+        None,
+        unique_string(),
+        cashu::CurrencyUnit::Sat,
+        None,
+        0,
+        PaymentIdentifier::CustomId(unique_string()),
+        None,
+        Amount::new(400, cashu::CurrencyUnit::Sat),
+        Amount::new(0, cashu::CurrencyUnit::Sat),
+        cashu::PaymentMethod::Known(KnownMethod::Bolt11),
+        0,
+        0,
+        vec![],
+        vec![],
+        None,
+    );
+
+    // Quote 4: 0 payments, 2 issuances (multiple issuance)
+    let quote4 = MintQuote::new(
+        None,
+        unique_string(),
+        cashu::CurrencyUnit::Sat,
+        None,
+        0,
+        PaymentIdentifier::CustomId(unique_string()),
+        None,
+        Amount::new(600, cashu::CurrencyUnit::Sat),
+        Amount::new(0, cashu::CurrencyUnit::Sat),
+        cashu::PaymentMethod::Known(KnownMethod::Bolt11),
+        0,
+        0,
+        vec![],
+        vec![],
+        None,
+    );
+
+    // Insert quote1, quote2, quote3, quote4
+    let mut tx = Database::begin_transaction(&db).await.unwrap();
+    let quote1 = tx.add_mint_quote(quote1).await.unwrap();
+    let quote2 = tx.add_mint_quote(quote2).await.unwrap();
+    let quote3 = tx.add_mint_quote(quote3).await.unwrap();
+    let quote4 = tx.add_mint_quote(quote4).await.unwrap();
+    tx.commit().await.unwrap();
+
+    // Add 3 payments and 2 issuances to quote1
+    let mut tx = Database::begin_transaction(&db).await.unwrap();
+    let mut q1 = tx.get_mint_quote(&quote1.id).await.unwrap().unwrap();
+    q1.add_payment(
+        Amount::from(500).with_unit(CurrencyUnit::Sat),
+        "quote1_pay_1".to_string(),
+        Some(100),
+    )
+    .unwrap();
+    q1.add_payment(
+        Amount::from(300).with_unit(CurrencyUnit::Sat),
+        "quote1_pay_2".to_string(),
+        Some(200),
+    )
+    .unwrap();
+    q1.add_payment(
+        Amount::from(200).with_unit(CurrencyUnit::Sat),
+        "quote1_pay_3".to_string(),
+        Some(300),
+    )
+    .unwrap();
+    tx.update_mint_quote(&mut q1).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let mut tx = Database::begin_transaction(&db).await.unwrap();
+    let mut q1 = tx.get_mint_quote(&quote1.id).await.unwrap().unwrap();
+    q1.add_issuance(Amount::from(400).with_unit(CurrencyUnit::Sat))
+        .unwrap();
+    q1.add_issuance(Amount::from(600).with_unit(CurrencyUnit::Sat))
+        .unwrap();
+    tx.update_mint_quote(&mut q1).await.unwrap();
+    tx.commit().await.unwrap();
+
+    // Add 2 payments to quote3
+    let mut tx = Database::begin_transaction(&db).await.unwrap();
+    let mut q3 = tx.get_mint_quote(&quote3.id).await.unwrap().unwrap();
+    q3.add_payment(
+        Amount::from(250).with_unit(CurrencyUnit::Sat),
+        "quote3_pay_1".to_string(),
+        Some(110),
+    )
+    .unwrap();
+    q3.add_payment(
+        Amount::from(150).with_unit(CurrencyUnit::Sat),
+        "quote3_pay_2".to_string(),
+        Some(210),
+    )
+    .unwrap();
+    tx.update_mint_quote(&mut q3).await.unwrap();
+    tx.commit().await.unwrap();
+
+    // Add 1 payment and 2 issuances to quote4
+    let mut tx = Database::begin_transaction(&db).await.unwrap();
+    let mut q4 = tx.get_mint_quote(&quote4.id).await.unwrap().unwrap();
+    q4.add_payment(
+        Amount::from(600).with_unit(CurrencyUnit::Sat),
+        "quote4_pay_1".to_string(),
+        Some(120),
+    )
+    .unwrap();
+    tx.update_mint_quote(&mut q4).await.unwrap();
+    tx.commit().await.unwrap();
+
+    let mut tx = Database::begin_transaction(&db).await.unwrap();
+    let mut q4 = tx.get_mint_quote(&quote4.id).await.unwrap().unwrap();
+    q4.add_issuance(Amount::from(350).with_unit(CurrencyUnit::Sat))
+        .unwrap();
+    q4.add_issuance(Amount::from(250).with_unit(CurrencyUnit::Sat))
+        .unwrap();
+    tx.update_mint_quote(&mut q4).await.unwrap();
+    tx.commit().await.unwrap();
+
+    // Verifiers
+    let verify_q1 = |q: &MintQuote| {
+        assert_eq!(q.id, quote1.id);
+        assert_eq!(q.payments.len(), 3, "quote1 must have exactly 3 payments");
+        assert_eq!(q.payments[0].payment_id, "quote1_pay_1");
+        assert_eq!(q.payments[0].amount.value(), 500);
+        assert_eq!(q.payments[1].payment_id, "quote1_pay_2");
+        assert_eq!(q.payments[1].amount.value(), 300);
+        assert_eq!(q.payments[2].payment_id, "quote1_pay_3");
+        assert_eq!(q.payments[2].amount.value(), 200);
+
+        assert_eq!(q.issuance.len(), 2, "quote1 must have exactly 2 issuances");
+        assert_eq!(q.issuance[0].amount.value(), 400);
+        assert_eq!(q.issuance[1].amount.value(), 600);
+    };
+
+    let verify_q2 = |q: &MintQuote| {
+        assert_eq!(q.id, quote2.id);
+        assert_eq!(q.payments.len(), 0, "quote2 must have 0 payments");
+        assert_eq!(q.issuance.len(), 0, "quote2 must have 0 issuances");
+    };
+
+    let verify_q3 = |q: &MintQuote| {
+        assert_eq!(q.id, quote3.id);
+        assert_eq!(q.payments.len(), 2, "quote3 must have exactly 2 payments");
+        assert_eq!(q.payments[0].payment_id, "quote3_pay_1");
+        assert_eq!(q.payments[0].amount.value(), 250);
+        assert_eq!(q.payments[1].payment_id, "quote3_pay_2");
+        assert_eq!(q.payments[1].amount.value(), 150);
+        assert_eq!(q.issuance.len(), 0, "quote3 must have 0 issuances");
+    };
+
+    let verify_q4 = |q: &MintQuote| {
+        assert_eq!(q.id, quote4.id);
+        assert_eq!(q.payments.len(), 1, "quote4 must have 1 payment");
+        assert_eq!(q.payments[0].payment_id, "quote4_pay_1");
+        assert_eq!(q.payments[0].amount.value(), 600);
+        assert_eq!(q.issuance.len(), 2, "quote4 must have exactly 2 issuances");
+        assert_eq!(q.issuance[0].amount.value(), 350);
+        assert_eq!(q.issuance[1].amount.value(), 250);
+    };
+
+    // 1. Single quote lookups (zero payments/issuance, multiple payments, multiple issuance, multiple of both)
+    let retrieved1 = db.get_mint_quote(&quote1.id).await.unwrap().unwrap();
+    verify_q1(&retrieved1);
+
+    let retrieved2 = db.get_mint_quote(&quote2.id).await.unwrap().unwrap();
+    verify_q2(&retrieved2);
+
+    let retrieved3 = db.get_mint_quote(&quote3.id).await.unwrap().unwrap();
+    verify_q3(&retrieved3);
+
+    let retrieved4 = db.get_mint_quote(&quote4.id).await.unwrap().unwrap();
+    verify_q4(&retrieved4);
+
+    // 2. Transactional get_mint_quote still loads relations correctly (for_update = true)
+    let mut tx = Database::begin_transaction(&db).await.unwrap();
+    let tx_q1 = tx.get_mint_quote(&quote1.id).await.unwrap().unwrap();
+    verify_q1(&tx_q1);
+    tx.commit().await.unwrap();
+
+    // 3. get_mint_quote_by_request
+    let by_req = db
+        .get_mint_quote_by_request(&quote1.request)
+        .await
+        .unwrap()
+        .unwrap();
+    verify_q1(&by_req);
+
+    // 4. get_mint_quote_by_request_lookup_id
+    let by_lookup = db
+        .get_mint_quote_by_request_lookup_id(&quote1.request_lookup_id)
+        .await
+        .unwrap()
+        .unwrap();
+    verify_q1(&by_lookup);
+
+    // 5. get_mint_quotes_by_ids:
+    // - checks several different quotes do not mix related records
+    // - requested ID ordering is preserved
+    // - missing IDs remain None
+    // - repeated IDs preserve upstream semantics
+    let missing_id = QuoteId::new();
+    let ids = vec![
+        quote3.id.clone(),
+        missing_id,
+        quote1.id.clone(),
+        quote4.id.clone(),
+        quote2.id.clone(),
+        quote1.id.clone(),
+    ];
+    let batch = db.get_mint_quotes_by_ids(&ids).await.unwrap();
+    assert_eq!(batch.len(), 6);
+
+    // quote3 at index 0
+    verify_q3(batch[0].as_ref().unwrap());
+
+    // missing at index 1
+    assert!(batch[1].is_none());
+
+    // quote1 at index 2
+    verify_q1(batch[2].as_ref().unwrap());
+
+    // quote4 at index 3
+    verify_q4(batch[3].as_ref().unwrap());
+
+    // quote2 at index 4
+    verify_q2(batch[4].as_ref().unwrap());
+
+    // repeated quote1 at index 5 is None per upstream quote_map.remove semantics
+    assert!(batch[5].is_none());
+
+    // Check another ordering to verify requested ID ordering is preserved
+    let ids_reverse = vec![quote4.id.clone(), quote3.id.clone()];
+    let batch_reverse = db.get_mint_quotes_by_ids(&ids_reverse).await.unwrap();
+    assert_eq!(batch_reverse.len(), 2);
+    verify_q4(batch_reverse[0].as_ref().unwrap());
+    verify_q3(batch_reverse[1].as_ref().unwrap());
+
+    // 6. get_mint_quotes() returns all quotes and does not mix records
+    let all = db.get_mint_quotes().await.unwrap();
+    let all_map: std::collections::HashMap<_, _> =
+        all.into_iter().map(|q| (q.id.clone(), q)).collect();
+    verify_q1(all_map.get(&quote1.id).expect("quote1 found"));
+    verify_q2(all_map.get(&quote2.id).expect("quote2 found"));
+    verify_q3(all_map.get(&quote3.id).expect("quote3 found"));
+    verify_q4(all_map.get(&quote4.id).expect("quote4 found"));
+}

--- a/crates/cdk-common/src/database/mint/test/mod.rs
+++ b/crates/cdk-common/src/database/mint/test/mod.rs
@@ -428,6 +428,7 @@ macro_rules! mint_db_test {
             get_mint_quotes_by_ids,
             get_melt_quotes_by_request_lookup_id,
             lock_melt_quote_and_related,
+            mint_quotes_load_payments_and_issuance_without_duplicates,
         );
     };
     ($make_db_fn:ident, $($name:ident),+ $(,)?) => {

--- a/crates/cdk-sql-common/src/mint/quotes.rs
+++ b/crates/cdk-sql-common/src/mint/quotes.rs
@@ -119,6 +119,80 @@ where
     .collect()
 }
 
+fn rows_to_payments_map(
+    rows: Vec<Vec<Column>>,
+) -> Result<HashMap<String, Vec<RawQuotePayment>>, Error> {
+    let mut map: HashMap<String, Vec<RawQuotePayment>> = HashMap::new();
+    for row in rows {
+        let quote_id = column_as_string!(&row[0]);
+        let payment_id = column_as_string!(&row[1]);
+        let timestamp: u64 = column_as_number!(row[2].clone());
+        let amount: u64 = column_as_number!(row[3].clone());
+
+        map.entry(quote_id).or_default().push(RawQuotePayment {
+            payment_id,
+            timestamp,
+            amount,
+        });
+    }
+
+    Ok(map)
+}
+
+fn rows_to_issuance_map(
+    rows: Vec<Vec<Column>>,
+) -> Result<HashMap<String, Vec<RawQuoteIssuance>>, Error> {
+    let mut map: HashMap<String, Vec<RawQuoteIssuance>> = HashMap::new();
+    for row in rows {
+        let quote_id = column_as_string!(&row[0]);
+        let amount: i64 = column_as_number!(row[1].clone());
+        let timestamp: u64 = column_as_number!(row[2].clone());
+
+        map.entry(quote_id)
+            .or_default()
+            .push(RawQuoteIssuance { amount, timestamp });
+    }
+
+    Ok(map)
+}
+
+fn attach_relations_to_quotes<'a, I>(
+    quotes: I,
+    mut payments: HashMap<String, Vec<RawQuotePayment>>,
+    mut issuance: HashMap<String, Vec<RawQuoteIssuance>>,
+) where
+    I: IntoIterator<Item = &'a mut MintQuote>,
+{
+    for quote in quotes {
+        let quote_id_str = quote.id.to_string();
+        if let Some(raw_payments) = payments.remove(&quote_id_str) {
+            quote.payments = raw_payments
+                .into_iter()
+                .map(|p| {
+                    IncomingPayment::new(
+                        Amount::from(p.amount).with_unit(quote.unit.clone()),
+                        p.payment_id,
+                        p.timestamp,
+                    )
+                })
+                .collect();
+        }
+        if let Some(raw_issuances) = issuance.remove(&quote_id_str) {
+            quote.issuance = raw_issuances
+                .into_iter()
+                .map(|i| {
+                    Issuance::new(
+                        Amount::from_i64(i.amount)
+                            .expect("Is amount when put into db")
+                            .with_unit(quote.unit.clone()),
+                        i.timestamp,
+                    )
+                })
+                .collect();
+        }
+    }
+}
+
 async fn get_mint_quote_payments_for_ids<C>(
     conn: &C,
     quote_ids: &[String],
@@ -148,21 +222,31 @@ where
     .fetch_all(conn)
     .await?;
 
-    let mut map: HashMap<String, Vec<RawQuotePayment>> = HashMap::new();
-    for row in rows {
-        let quote_id = column_as_string!(&row[0]);
-        let payment_id = column_as_string!(&row[1]);
-        let timestamp: u64 = column_as_number!(row[2].clone());
-        let amount: u64 = column_as_number!(row[3].clone());
+    rows_to_payments_map(rows)
+}
 
-        map.entry(quote_id).or_default().push(RawQuotePayment {
+async fn get_all_mint_quote_payments<C>(
+    conn: &C,
+) -> Result<HashMap<String, Vec<RawQuotePayment>>, Error>
+where
+    C: DatabaseExecutor + Send + Sync,
+{
+    let rows = query(
+        r#"
+        SELECT
+            quote_id,
             payment_id,
             timestamp,
-            amount,
-        });
-    }
+            amount
+        FROM
+            mint_quote_payments
+        ORDER BY id
+        "#,
+    )?
+    .fetch_all(conn)
+    .await?;
 
-    Ok(map)
+    rows_to_payments_map(rows)
 }
 
 async fn get_mint_quote_issuance_for_ids<C>(
@@ -193,18 +277,30 @@ where
     .fetch_all(conn)
     .await?;
 
-    let mut map: HashMap<String, Vec<RawQuoteIssuance>> = HashMap::new();
-    for row in rows {
-        let quote_id = column_as_string!(&row[0]);
-        let amount: i64 = column_as_number!(row[1].clone());
-        let timestamp: u64 = column_as_number!(row[2].clone());
+    rows_to_issuance_map(rows)
+}
 
-        map.entry(quote_id)
-            .or_default()
-            .push(RawQuoteIssuance { amount, timestamp });
-    }
+async fn get_all_mint_quote_issuance<C>(
+    conn: &C,
+) -> Result<HashMap<String, Vec<RawQuoteIssuance>>, Error>
+where
+    C: DatabaseExecutor + Send + Sync,
+{
+    let rows = query(
+        r#"
+        SELECT
+            quote_id,
+            amount,
+            timestamp
+        FROM
+            mint_quote_issued
+        ORDER BY id
+        "#,
+    )?
+    .fetch_all(conn)
+    .await?;
 
-    Ok(map)
+    rows_to_issuance_map(rows)
 }
 
 // Inline helper functions that work with both connections and transactions
@@ -465,37 +561,10 @@ where
 
     if !quote_map.is_empty() {
         let found_ids: Vec<String> = quote_map.keys().cloned().collect();
-        let mut payments_by_quote = get_mint_quote_payments_for_ids(executor, &found_ids).await?;
-        let mut issuance_by_quote = get_mint_quote_issuance_for_ids(executor, &found_ids).await?;
+        let payments_by_quote = get_mint_quote_payments_for_ids(executor, &found_ids).await?;
+        let issuance_by_quote = get_mint_quote_issuance_for_ids(executor, &found_ids).await?;
 
-        for quote in quote_map.values_mut() {
-            let quote_id_str = quote.id.to_string();
-            if let Some(raw_payments) = payments_by_quote.remove(&quote_id_str) {
-                quote.payments = raw_payments
-                    .into_iter()
-                    .map(|p| {
-                        IncomingPayment::new(
-                            Amount::from(p.amount).with_unit(quote.unit.clone()),
-                            p.payment_id,
-                            p.timestamp,
-                        )
-                    })
-                    .collect();
-            }
-            if let Some(raw_issuances) = issuance_by_quote.remove(&quote_id_str) {
-                quote.issuance = raw_issuances
-                    .into_iter()
-                    .map(|i| {
-                        Issuance::new(
-                            Amount::from_i64(i.amount)
-                                .expect("Is amount when put into db")
-                                .with_unit(quote.unit.clone()),
-                            i.timestamp,
-                        )
-                    })
-                    .collect();
-            }
-        }
+        attach_relations_to_quotes(quote_map.values_mut(), payments_by_quote, issuance_by_quote);
     }
 
     // Reconstruct in the same order as input IDs
@@ -1504,38 +1573,14 @@ where
         .collect::<Result<Vec<_>, _>>()?;
 
         if !mint_quotes.is_empty() {
-            let quote_ids: Vec<String> = mint_quotes.iter().map(|q| q.id.to_string()).collect();
-            let mut payments_by_quote = get_mint_quote_payments_for_ids(&*conn, &quote_ids).await?;
-            let mut issuance_by_quote = get_mint_quote_issuance_for_ids(&*conn, &quote_ids).await?;
+            let payments_by_quote = get_all_mint_quote_payments(&*conn).await?;
+            let issuance_by_quote = get_all_mint_quote_issuance(&*conn).await?;
 
-            for quote in mint_quotes.as_mut_slice() {
-                let quote_id_str = quote.id.to_string();
-                if let Some(raw_payments) = payments_by_quote.remove(&quote_id_str) {
-                    quote.payments = raw_payments
-                        .into_iter()
-                        .map(|p| {
-                            IncomingPayment::new(
-                                Amount::from(p.amount).with_unit(quote.unit.clone()),
-                                p.payment_id,
-                                p.timestamp,
-                            )
-                        })
-                        .collect();
-                }
-                if let Some(raw_issuances) = issuance_by_quote.remove(&quote_id_str) {
-                    quote.issuance = raw_issuances
-                        .into_iter()
-                        .map(|i| {
-                            Issuance::new(
-                                Amount::from_i64(i.amount)
-                                    .expect("Is amount when put into db")
-                                    .with_unit(quote.unit.clone()),
-                                i.timestamp,
-                            )
-                        })
-                        .collect();
-                }
-            }
+            attach_relations_to_quotes(
+                mint_quotes.as_mut_slice(),
+                payments_by_quote,
+                issuance_by_quote,
+            );
         }
 
         Ok(mint_quotes)

--- a/crates/cdk-sql-common/src/mint/quotes.rs
+++ b/crates/cdk-sql-common/src/mint/quotes.rs
@@ -33,26 +33,38 @@ use crate::{
     unpack_into,
 };
 
+#[derive(Debug)]
+struct RawQuotePayment {
+    payment_id: String,
+    timestamp: u64,
+    amount: u64,
+}
+
+#[derive(Debug)]
+struct RawQuoteIssuance {
+    amount: i64,
+    timestamp: u64,
+}
+
 async fn get_mint_quote_payments<C>(
     conn: &C,
     quote_id: &QuoteId,
+    unit: &CurrencyUnit,
 ) -> Result<Vec<IncomingPayment>, Error>
 where
     C: DatabaseExecutor + Send + Sync,
 {
-    // Get payment IDs and timestamps from the mint_quote_payments table
     query(
         r#"
         SELECT
-            p.payment_id,
-            p.timestamp,
-            p.amount,
-            q.unit
+            payment_id,
+            timestamp,
+            amount
         FROM
-            mint_quote_payments p
-        JOIN mint_quote q ON p.quote_id = q.id
+            mint_quote_payments
         WHERE
-            p.quote_id=:quote_id
+            quote_id = :quote_id
+        ORDER BY id
         "#,
     )?
     .bind("quote_id", quote_id.to_string())
@@ -62,9 +74,8 @@ where
     .map(|row| {
         let amount: u64 = column_as_number!(row[2].clone());
         let time: u64 = column_as_number!(row[1].clone());
-        let unit = column_as_string!(&row[3], CurrencyUnit::from_str);
         Ok(IncomingPayment::new(
-            Amount::from(amount).with_unit(unit),
+            Amount::from(amount).with_unit(unit.clone()),
             column_as_string!(&row[0]),
             time,
         ))
@@ -72,18 +83,25 @@ where
     .collect()
 }
 
-async fn get_mint_quote_issuance<C>(conn: &C, quote_id: &QuoteId) -> Result<Vec<Issuance>, Error>
+async fn get_mint_quote_issuance<C>(
+    conn: &C,
+    quote_id: &QuoteId,
+    unit: &CurrencyUnit,
+) -> Result<Vec<Issuance>, Error>
 where
     C: DatabaseExecutor + Send + Sync,
 {
-    // Get payment IDs and timestamps from the mint_quote_payments table
     query(
         r#"
-SELECT i.amount, i.timestamp, q.unit
-FROM mint_quote_issued i
-JOIN mint_quote q ON i.quote_id = q.id
-WHERE i.quote_id=:quote_id
-            "#,
+        SELECT
+            amount,
+            timestamp
+        FROM
+            mint_quote_issued
+        WHERE
+            quote_id = :quote_id
+        ORDER BY id
+        "#,
     )?
     .bind("quote_id", quote_id.to_string())
     .fetch_all(conn)
@@ -91,15 +109,102 @@ WHERE i.quote_id=:quote_id
     .into_iter()
     .map(|row| {
         let time: u64 = column_as_number!(row[1].clone());
-        let unit = column_as_string!(&row[2], CurrencyUnit::from_str);
         Ok(Issuance::new(
             Amount::from_i64(column_as_number!(row[0].clone()))
                 .expect("Is amount when put into db")
-                .with_unit(unit),
+                .with_unit(unit.clone()),
             time,
         ))
     })
     .collect()
+}
+
+async fn get_mint_quote_payments_for_ids<C>(
+    conn: &C,
+    quote_ids: &[String],
+) -> Result<HashMap<String, Vec<RawQuotePayment>>, Error>
+where
+    C: DatabaseExecutor + Send + Sync,
+{
+    if quote_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let rows = query(
+        r#"
+        SELECT
+            quote_id,
+            payment_id,
+            timestamp,
+            amount
+        FROM
+            mint_quote_payments
+        WHERE
+            quote_id IN (:quote_ids)
+        ORDER BY id
+        "#,
+    )?
+    .bind_vec("quote_ids", quote_ids.to_vec())?
+    .fetch_all(conn)
+    .await?;
+
+    let mut map: HashMap<String, Vec<RawQuotePayment>> = HashMap::new();
+    for row in rows {
+        let quote_id = column_as_string!(&row[0]);
+        let payment_id = column_as_string!(&row[1]);
+        let timestamp: u64 = column_as_number!(row[2].clone());
+        let amount: u64 = column_as_number!(row[3].clone());
+
+        map.entry(quote_id).or_default().push(RawQuotePayment {
+            payment_id,
+            timestamp,
+            amount,
+        });
+    }
+
+    Ok(map)
+}
+
+async fn get_mint_quote_issuance_for_ids<C>(
+    conn: &C,
+    quote_ids: &[String],
+) -> Result<HashMap<String, Vec<RawQuoteIssuance>>, Error>
+where
+    C: DatabaseExecutor + Send + Sync,
+{
+    if quote_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let rows = query(
+        r#"
+        SELECT
+            quote_id,
+            amount,
+            timestamp
+        FROM
+            mint_quote_issued
+        WHERE
+            quote_id IN (:quote_ids)
+        ORDER BY id
+        "#,
+    )?
+    .bind_vec("quote_ids", quote_ids.to_vec())?
+    .fetch_all(conn)
+    .await?;
+
+    let mut map: HashMap<String, Vec<RawQuoteIssuance>> = HashMap::new();
+    for row in rows {
+        let quote_id = column_as_string!(&row[0]);
+        let amount: i64 = column_as_number!(row[1].clone());
+        let timestamp: u64 = column_as_number!(row[2].clone());
+
+        map.entry(quote_id)
+            .or_default()
+            .push(RawQuoteIssuance { amount, timestamp });
+    }
+
+    Ok(map)
 }
 
 // Inline helper functions that work with both connections and transactions
@@ -148,8 +253,8 @@ where
     // Any concurrent writer must wait for our transaction before it can acquire its
     // own lock, so these reads reflect the true committed state.
     if let Some(quote) = mint_quote.as_mut() {
-        let payments = get_mint_quote_payments(executor, quote_id).await?;
-        let issuance = get_mint_quote_issuance(executor, quote_id).await?;
+        let payments = get_mint_quote_payments(executor, quote_id, &quote.unit).await?;
+        let issuance = get_mint_quote_issuance(executor, quote_id, &quote.unit).await?;
         quote.payments = payments;
         quote.issuance = issuance;
     }
@@ -199,8 +304,8 @@ where
         .transpose()?;
 
     if let Some(quote) = mint_quote.as_mut() {
-        let payments = get_mint_quote_payments(executor, &quote.id).await?;
-        let issuance = get_mint_quote_issuance(executor, &quote.id).await?;
+        let payments = get_mint_quote_payments(executor, &quote.id, &quote.unit).await?;
+        let issuance = get_mint_quote_issuance(executor, &quote.id, &quote.unit).await?;
         quote.issuance = issuance;
         quote.payments = payments;
     }
@@ -252,8 +357,8 @@ where
         .transpose()?;
 
     if let Some(quote) = mint_quote.as_mut() {
-        let payments = get_mint_quote_payments(executor, &quote.id).await?;
-        let issuance = get_mint_quote_issuance(executor, &quote.id).await?;
+        let payments = get_mint_quote_payments(executor, &quote.id, &quote.unit).await?;
+        let issuance = get_mint_quote_issuance(executor, &quote.id, &quote.unit).await?;
         quote.issuance = issuance;
         quote.payments = payments;
     }
@@ -358,12 +463,39 @@ where
         quote_map.insert(quote.id.to_string(), quote);
     }
 
-    // Now fetch payments and issuance for each found quote
-    for quote in quote_map.values_mut() {
-        let payments = get_mint_quote_payments(executor, &quote.id).await?;
-        let issuance = get_mint_quote_issuance(executor, &quote.id).await?;
-        quote.payments = payments;
-        quote.issuance = issuance;
+    if !quote_map.is_empty() {
+        let found_ids: Vec<String> = quote_map.keys().cloned().collect();
+        let mut payments_by_quote = get_mint_quote_payments_for_ids(executor, &found_ids).await?;
+        let mut issuance_by_quote = get_mint_quote_issuance_for_ids(executor, &found_ids).await?;
+
+        for quote in quote_map.values_mut() {
+            let quote_id_str = quote.id.to_string();
+            if let Some(raw_payments) = payments_by_quote.remove(&quote_id_str) {
+                quote.payments = raw_payments
+                    .into_iter()
+                    .map(|p| {
+                        IncomingPayment::new(
+                            Amount::from(p.amount).with_unit(quote.unit.clone()),
+                            p.payment_id,
+                            p.timestamp,
+                        )
+                    })
+                    .collect();
+            }
+            if let Some(raw_issuances) = issuance_by_quote.remove(&quote_id_str) {
+                quote.issuance = raw_issuances
+                    .into_iter()
+                    .map(|i| {
+                        Issuance::new(
+                            Amount::from_i64(i.amount)
+                                .expect("Is amount when put into db")
+                                .with_unit(quote.unit.clone()),
+                            i.timestamp,
+                        )
+                    })
+                    .collect();
+            }
+        }
     }
 
     // Reconstruct in the same order as input IDs
@@ -1371,11 +1503,39 @@ where
         .map(|row| sql_row_to_mint_quote(row, vec![], vec![]))
         .collect::<Result<Vec<_>, _>>()?;
 
-        for quote in mint_quotes.as_mut_slice() {
-            let payments = get_mint_quote_payments(&*conn, &quote.id).await?;
-            let issuance = get_mint_quote_issuance(&*conn, &quote.id).await?;
-            quote.issuance = issuance;
-            quote.payments = payments;
+        if !mint_quotes.is_empty() {
+            let quote_ids: Vec<String> = mint_quotes.iter().map(|q| q.id.to_string()).collect();
+            let mut payments_by_quote = get_mint_quote_payments_for_ids(&*conn, &quote_ids).await?;
+            let mut issuance_by_quote = get_mint_quote_issuance_for_ids(&*conn, &quote_ids).await?;
+
+            for quote in mint_quotes.as_mut_slice() {
+                let quote_id_str = quote.id.to_string();
+                if let Some(raw_payments) = payments_by_quote.remove(&quote_id_str) {
+                    quote.payments = raw_payments
+                        .into_iter()
+                        .map(|p| {
+                            IncomingPayment::new(
+                                Amount::from(p.amount).with_unit(quote.unit.clone()),
+                                p.payment_id,
+                                p.timestamp,
+                            )
+                        })
+                        .collect();
+                }
+                if let Some(raw_issuances) = issuance_by_quote.remove(&quote_id_str) {
+                    quote.issuance = raw_issuances
+                        .into_iter()
+                        .map(|i| {
+                            Issuance::new(
+                                Amount::from_i64(i.amount)
+                                    .expect("Is amount when put into db")
+                                    .with_unit(quote.unit.clone()),
+                                i.timestamp,
+                            )
+                        })
+                        .collect();
+                }
+            }
         }
 
         Ok(mint_quotes)


### PR DESCRIPTION
### Description

Closes #2435

Eliminates the N+1 query pattern when fetching mint quotes in `cdk-sql-common` by batch loading related child records (`mint_quote_payments` and `mint_quote_issued`) using constant queries instead of looping per quote.

Before: $1 + 2N$ queries for $N$ quotes.  
After: $3$ queries constant (1 for parent quotes, 1 for payments belonging to those quotes, 1 for issuances belonging to those quotes).

Key details:
- Avoids multi-table JOINs and Cartesian row multiplication ($P \times I$ rows) between payments and issuance tables.
- Directly uses the loaded parent quote's `CurrencyUnit` for child payments and issuances, avoiding redundant joins back to `mint_quote`.
- Groups child records by `quote_id` in Rust (`HashMap<String, Vec<...>>`) and attaches them to each `MintQuote`.
- Preserves input order, missing `None`, and repeated ID semantics in `get_mint_quotes_inner`.
- Preserves single-quote locking semantics: `SELECT ... FOR UPDATE` acquires row locks on `mint_quote` first, and relations are read while the lock is held.
- Keeps `crates/cdk-sqlite/src/async_sqlite.rs` unchanged.

-----

### Notes to the reviewers

- Added comprehensive database integration tests in `crates/cdk-common/src/database/mint/test/mint.rs` (`mint_quotes_load_payments_and_issuance_without_duplicates`) covering:
  1. Zero payments and zero issuance
  2. Multiple payments only
  3. Multiple issuance only
  4. Multiple payments and multiple issuance (3 payments, 2 issuances)
  5. Cross-quote isolation (ensuring quotes do not mix related records)
  6. Requested ID ordering preservation
  7. Missing IDs returning `None`
  8. Transactional `get_mint_quote` relations loading with row locking

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

#### CHANGED
- Batch load mint quote payments and issuance in `cdk-sql-common` to resolve N+1 queries (#2435).

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [x] I ran `just quick-check` before committing
* [x] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
