### PR TITLE
Fix releases ffi

### DIFF
--- a/bindings/README.md
+++ b/bindings/README.md
@@ -122,6 +122,26 @@ This runs the **FFI - Publish All Bindings** GitHub Actions workflow
 The `release` just recipe calls `ffi-release-all` automatically after publishing
 Rust crates.
 
+All `ffi-release-*` recipes dispatch with `--ref v<VERSION>`, so GitHub loads
+the workflow definitions from the release tag. The unified workflow's relative
+calls load the language workflows from that same commit. This keeps backport
+releases, such as those from `0.17.x`, on their matching build workflows.
+The `release_tag` and `cdk_ref` inputs control the source checkout; they do not
+select the workflow definition.
+
+For an existing release tag, you can dispatch directly:
+
+```bash
+gh workflow run ffi-publish-all.yml --repo cashubtc/cdk \
+  --ref v0.17.0 --field release_tag=v0.17.0
+```
+
+If a workflow fix was added to `0.17.x` after the tag was created, use
+`--ref 0.17.x` with the same `release_tag` to run the corrected branch workflow
+against the tagged sources. In the Actions UI, select `0.17.x` in **Use workflow
+from** when dispatching manually. Backport workflow fixes before tagging future
+releases so the tag contains the matching workflows.
+
 ### Nightly bindings
 
 The **FFI - Nightly Bindings** workflow (`.github/workflows/ffi-nightly.yml`)
@@ -165,6 +185,7 @@ just ffi-release-go 0.17.0
 ### Prerequisites
 
 - The version tag (e.g. `v0.17.0`) must exist on the remote
+- The tag must contain the dispatchable FFI workflows and their reusable workflows
 - Dart, Go, Kotlin, and Swift stable release workflows check out `refs/tags/<release_tag>`
   and reject `cdk_ref` values that differ from `release_tag`
 - The `FFI_DEPLOY_KEY` GitHub secret must have write access to `cdk-dart`,

--- a/justfile
+++ b/justfile
@@ -751,8 +751,8 @@ release m="":
   # Extract version from the cdk-ffi crate
   VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "cdk-ffi") | .version')
 
-  if ! git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" > /dev/null; then
-    echo "Tag v$VERSION does not exist on origin. Push the release tag before publishing crates."
+  if ! git ls-remote --exit-code --tags upstream "refs/tags/v$VERSION" > /dev/null; then
+    echo "Tag v$VERSION does not exist on upstream. Push the release tag before publishing crates."
     exit 1
   fi
 

--- a/justfile
+++ b/justfile
@@ -1103,6 +1103,7 @@ ffi-release-all VERSION:
 
   gh workflow run "FFI - Publish All Bindings" \
     --repo cashubtc/cdk \
+    --ref "v{{VERSION}}" \
     --field release_tag="v{{VERSION}}" \
     --field cdk_version="{{VERSION}}" \
     --field cdk_ref="v{{VERSION}}"
@@ -1120,6 +1121,7 @@ ffi-release-dart VERSION:
 
   gh workflow run "FFI - Dart Bindings" \
     --repo cashubtc/cdk \
+    --ref "v{{VERSION}}" \
     --field release_tag="v{{VERSION}}" \
     --field cdk_version="{{VERSION}}"
 
@@ -1136,6 +1138,7 @@ ffi-release-swift VERSION:
   # Trigger the workflow using GitHub CLI
   gh workflow run "FFI - Swift Bindings" \
     --repo cashubtc/cdk \
+    --ref "v{{VERSION}}" \
     --field release_tag="v{{VERSION}}" \
     --field cdk_version="{{VERSION}}" \
     --field cdk_ref="v{{VERSION}}"
@@ -1154,6 +1157,7 @@ ffi-release-kotlin VERSION:
   # Trigger the workflow using GitHub CLI
   gh workflow run "FFI - Kotlin Bindings" \
     --repo cashubtc/cdk \
+    --ref "v{{VERSION}}" \
     --field release_tag="v{{VERSION}}" \
     --field cdk_version="{{VERSION}}" \
     --field cdk_ref="v{{VERSION}}"
@@ -1205,6 +1209,7 @@ ffi-release-go VERSION:
 
   gh workflow run "FFI - Go Bindings" \
     --repo cashubtc/cdk \
+    --ref "v{{VERSION}}" \
     --field release_tag="v{{VERSION}}" \
     --field cdk_version="{{VERSION}}" \
     --field cdk_ref="v{{VERSION}}"


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----
 All FFI release recipes now dispatch with --ref v<VERSION>, ensuring backport releases use the workflow definitions from their release tag instead of main. This also applies when just release triggers FFI publishing automatically.

Adds documentation for workflow selection and rerunning releases with workflow fixes from a maintenance branch.

Validation: dry-run checks passed for just release and all five FFI release recipes.
### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
