### PR TITLE
fix(wallet): preserve exact recipient amounts after redemption fees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,6 +1545,7 @@ version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "bip39",
  "bitcoin",
  "bitcoincore-rpc",

--- a/crates/cdk-common/src/wallet/mod.rs
+++ b/crates/cdk-common/src/wallet/mod.rs
@@ -463,7 +463,10 @@ pub struct SendOptions {
     pub memo: Option<SendMemo>,
     /// Spending conditions
     pub conditions: Option<SpendingConditions>,
-    /// Amount split target
+    /// Amount split target.
+    ///
+    /// Preparation replaces this with the complete outgoing denomination plan
+    /// for fee-inclusive exact sends; confirmation preserves that plan.
     pub amount_split_target: SplitTarget,
     /// Send kind
     pub send_kind: SendKind,

--- a/crates/cdk-ffi/src/types/wallet.rs
+++ b/crates/cdk-ffi/src/types/wallet.rs
@@ -223,7 +223,7 @@ pub struct SendOptions {
     pub memo: Option<SendMemo>,
     /// Spending conditions
     pub conditions: Option<SpendingConditions>,
-    /// Amount split target
+    /// Amount split target. Fee-inclusive exact sends prepare an exact denomination plan.
     pub amount_split_target: SplitTarget,
     /// Send kind
     pub send_kind: SendKind,

--- a/crates/cdk-integration-tests/Cargo.toml
+++ b/crates/cdk-integration-tests/Cargo.toml
@@ -61,6 +61,7 @@ getrandom = { version = "0.4", features = ["wasm_js"] }
 uuid = { workspace = true, features = ["js"] }
 
 [dev-dependencies]
+axum = { workspace = true }
 bip39 = { workspace = true, features = ["rand"] }
 anyhow.workspace = true
 cdk-axum = { workspace = true }

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -17,6 +17,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use axum::{routing::post, Json, Router};
 use bip39::Mnemonic;
 use cashu::amount::SplitTarget;
 use cashu::dhke::construct_proofs;
@@ -25,7 +26,8 @@ use cashu::nuts::nut10::Conditions;
 use cashu::nuts::SigFlag;
 use cashu::{
     CurrencyUnit, Id, KeySet, KeySetInfo, MeltRequest, NotificationPayload, PaymentMethod,
-    PreMintSecrets, ProofState, SecretKey, SpendingConditions, State, SwapRequest,
+    PaymentRequest, PaymentRequestPayload, PreMintSecrets, ProofState, SecretKey,
+    SpendingConditions, State, SwapRequest, Token, Transport, TransportType,
 };
 use cdk::mint::Mint;
 use cdk::nuts::nut00::ProofsMethods;
@@ -56,6 +58,217 @@ fn to_keyset_infos(keysets: &[KeySet]) -> Vec<KeySetInfo> {
             final_expiry: ks.final_expiry,
         })
         .collect()
+}
+
+/// Receiver fee coverage must use the denominations actually sent to the recipient.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_send_include_fee_covers_actual_redemption() {
+    assert_send_receiver_fee(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_ffi_send_exact_receiver_fee() {
+    assert_send_receiver_fee(true).await;
+}
+
+async fn assert_send_receiver_fee(ffi_confirm: bool) {
+    let mint = create_mint_with_fee(1000).await.unwrap();
+    let sender = create_test_wallet_for_mint(mint.clone()).await.unwrap();
+    let receiver = create_test_wallet_for_mint(mint).await.unwrap();
+    fund_wallet(sender.clone(), 100, None).await.unwrap();
+
+    let requested = Amount::from(21);
+    let prepared = sender
+        .prepare_send(
+            requested,
+            SendOptions {
+                include_fee: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let quoted_debit = requested + prepared.fee();
+    let token: Token = if ffi_confirm {
+        Arc::new(cdk_ffi::PreparedSend::new(
+            Arc::new(sender.clone()),
+            &prepared,
+        ))
+        .confirm(None)
+        .await
+        .unwrap()
+        .into()
+    } else {
+        prepared.confirm(None).await.unwrap()
+    };
+    let received = receiver
+        .receive(&token.to_string(), ReceiveOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        received, requested,
+        "The recipient must redeem the exact requested amount"
+    );
+    assert_eq!(receiver.total_balance().await.unwrap(), received);
+    assert_eq!(
+        sender.total_balance().await.unwrap() + quoted_debit,
+        Amount::from(100),
+        "Confirmation must honor the debit quoted during preparation"
+    );
+}
+
+/// Reusing proofs from an expensive inactive keyset must not underfund redemption.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_send_include_fee_covers_reused_keyset_fees() {
+    let mint = create_mint_with_fee(4000).await.unwrap();
+    let sender = create_test_wallet_for_mint(mint.clone()).await.unwrap();
+    let receiver = create_test_wallet_for_mint(mint.clone()).await.unwrap();
+    fund_wallet(
+        sender.clone(),
+        100,
+        Some(SplitTarget::Value(Amount::from(16))),
+    )
+    .await
+    .unwrap();
+    mint.rotate_keyset(
+        CurrencyUnit::Sat,
+        cdk_integration_tests::standard_keyset_amounts(32),
+        1000,
+        true,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // This tests mixed-keyset fee accounting with current metadata; detecting
+    // a rotation through the wallet's cache policy is a separate concern.
+    sender
+        .keysets(cdk_common::wallet::KeysetLoadPolicy::Refresh)
+        .await
+        .unwrap();
+    let requested = Amount::from(21);
+    let prepared = sender
+        .prepare_send(
+            requested,
+            SendOptions {
+                include_fee: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let quoted_debit = requested + prepared.fee();
+    let token = prepared.confirm(None).await.unwrap();
+    let received = receiver
+        .receive(&token.to_string(), ReceiveOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(received, requested);
+    assert_eq!(receiver.total_balance().await.unwrap(), received);
+    assert_eq!(
+        sender.total_balance().await.unwrap() + quoted_debit,
+        Amount::from(100)
+    );
+}
+
+async fn assert_payment_request_receiver_fee(fixed_amount: bool) {
+    let (deliveries, mut received_payloads) = tokio::sync::mpsc::channel(1);
+    let app = Router::new().route(
+        "/receive",
+        post(move |Json(payload): Json<PaymentRequestPayload>| {
+            let deliveries = deliveries.clone();
+            async move { deliveries.send(payload).await.unwrap() }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let target = format!("http://{}/receive", listener.local_addr().unwrap());
+    let (stop, stopped) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                stopped.await.ok();
+            })
+            .await
+            .unwrap();
+    });
+
+    // Cover a full swap, reuse of existing denominations, fractional input fees,
+    // and the zero-fee control with independently funded wallets in each case.
+    for (fee_ppk, funding_split) in [
+        (1000, SplitTarget::None),
+        (1000, SplitTarget::Value(Amount::from(8))),
+        (1000, SplitTarget::Value(Amount::from(16))),
+        (100, SplitTarget::Value(Amount::from(16))),
+        (0, SplitTarget::None),
+    ] {
+        let mint = create_mint_with_fee(fee_ppk).await.unwrap();
+        let sender = create_test_wallet_for_mint(mint.clone()).await.unwrap();
+        let receiver = create_test_wallet_for_mint(mint).await.unwrap();
+        fund_wallet(sender.clone(), 100, Some(funding_split))
+            .await
+            .unwrap();
+
+        let requested = Amount::from(21);
+        let mut request = PaymentRequest::builder()
+            .payment_id("receiver-fee-regression")
+            .unit(CurrencyUnit::Sat)
+            .add_mint(sender.mint_url.clone())
+            .add_transport(Transport {
+                _type: TransportType::HttpPost,
+                target: target.clone(),
+                tags: vec![],
+            })
+            .build();
+        request.amount = fixed_amount.then_some(requested);
+        let prepared = sender
+            .prepare_pay_request(request, (!fixed_amount).then_some(requested))
+            .await
+            .unwrap();
+        let quoted_debit = prepared.total_amount();
+        prepared.confirm().await.unwrap();
+
+        let payload = tokio::time::timeout(Duration::from_secs(5), received_payloads.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(payload.id.as_deref(), Some("receiver-fee-regression"));
+        assert_eq!(payload.mint, sender.mint_url);
+        assert_eq!(payload.unit, CurrencyUnit::Sat);
+        let token = Token::new(payload.mint, payload.proofs, payload.memo, payload.unit);
+        let received = receiver
+            .receive(&token.to_string(), ReceiveOptions::default())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            received, requested,
+            "Incorrect net payment at {fee_ppk} ppk"
+        );
+        assert_eq!(receiver.total_balance().await.unwrap(), received);
+        assert_eq!(
+            sender.total_balance().await.unwrap() + quoted_debit,
+            Amount::from(100)
+        );
+        if fee_ppk == 0 {
+            assert_eq!(received, requested);
+            assert_eq!(quoted_debit, requested);
+        }
+    }
+
+    stop.send(()).unwrap();
+    server.await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_fixed_payment_request_receiver_fee() {
+    assert_payment_request_receiver_fee(true).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_amountless_payment_request_receiver_fee() {
+    assert_payment_request_receiver_fee(false).await;
 }
 
 /// Tests the token swap and send functionality:
@@ -1530,7 +1743,7 @@ async fn test_p2pk_send_force_swap_with_fees_include_fee() {
     let secret = SecretKey::generate();
     let spending_conditions = SpendingConditions::new_p2pk(secret.public_key(), None);
 
-    let send_amount = Amount::from(10);
+    let send_amount = Amount::from(21);
 
     // Send with include_fee=true so token covers the redemption fee
     let prepared = wallet_sender
@@ -2189,7 +2402,7 @@ async fn test_p2bk_send_and_receive() {
     let secret = SecretKey::generate();
     let spending_conditions = SpendingConditions::new_p2pk(secret.public_key(), None);
 
-    let send_amount = Amount::from(10);
+    let send_amount = Amount::from(21);
 
     // Send with include_fee=true and use_p2bk=true so token uses NUT-28 P2BK privacy
     let prepared = wallet_sender

--- a/crates/cdk/src/wallet/melt/saga/mod.rs
+++ b/crates/cdk/src/wallet/melt/saga/mod.rs
@@ -760,6 +760,7 @@ impl<'a> MeltSaga<'a, Prepared> {
                         None,
                         false,
                         false,
+                        None,
                     )
                     .await?
                 {

--- a/crates/cdk/src/wallet/payment_request.rs
+++ b/crates/cdk/src/wallet/payment_request.rs
@@ -125,7 +125,7 @@ impl PreparedPaymentRequest {
         self.swap_fee
     }
 
-    /// Mint input fee added so the receiver obtains the full payment amount.
+    /// Mint input fee added so the receiver obtains exactly the full payment amount.
     pub fn send_fee(&self) -> Amount {
         self.send_fee
     }

--- a/crates/cdk/src/wallet/receive/saga/mod.rs
+++ b/crates/cdk/src/wallet/receive/saga/mod.rs
@@ -346,6 +346,7 @@ impl<'a> ReceiveSaga<'a, Prepared> {
                 false,
                 &fee_breakdown,
                 ProofReservation::Skip,
+                None,
             )
             .await?;
 

--- a/crates/cdk/src/wallet/send/fees.rs
+++ b/crates/cdk/src/wallet/send/fees.rs
@@ -1,0 +1,205 @@
+//! Fee-inclusive output splitting without recombining the prepared denominations.
+
+use cdk_common::amount::FeeAndAmounts;
+
+use crate::{Amount, Error};
+
+pub(super) fn split_exact_with_fee(
+    amount: Amount,
+    fees: &FeeAndAmounts,
+    budget: Amount,
+    max_proofs: Option<usize>,
+) -> Result<(Vec<Amount>, Amount), Error> {
+    if amount > budget {
+        return Err(Error::InsufficientFunds);
+    }
+    if amount == Amount::ZERO || fees.fee() == 0 {
+        let split = amount.split(fees)?;
+        return match max_proofs.is_none_or(|max| split.len() <= max) {
+            true => Ok((split, Amount::ZERO)),
+            false => Err(Error::InsufficientFunds),
+        };
+    }
+    let mut denominations = fees.amounts().to_vec();
+    denominations.sort_unstable();
+    denominations.dedup();
+    denominations.retain(|value| *value <= budget.to_u64());
+    let largest = *denominations.last().ok_or(Error::InsufficientFunds)?;
+    if denominations.contains(&0) {
+        return Err(Error::InsufficientFunds);
+    }
+    let max_net_ppk = largest
+        .checked_mul(1000)
+        .ok_or(Error::AmountOverflow)?
+        .checked_sub(fees.fee())
+        .filter(|value| *value > 0)
+        .ok_or(Error::InsufficientFunds)?;
+    let first = amount
+        .to_u64()
+        .checked_mul(1000)
+        .ok_or(Error::AmountOverflow)?
+        .div_ceil(max_net_ppk);
+
+    // Try a bounded number of proof counts. Unlike an exhaustive denomination
+    // search, this also terminates promptly for unsupported sparse keysets.
+    let last = first
+        .saturating_add(u64::BITS as u64 - 1)
+        .min(max_proofs.unwrap_or(usize::MAX) as u64);
+    for count in first..=last {
+        let fee = Amount::from(
+            count
+                .checked_mul(fees.fee())
+                .ok_or(Error::AmountOverflow)?
+                .div_ceil(1000),
+        );
+        let gross = amount.checked_add(fee).ok_or(Error::AmountOverflow)?;
+        if gross > budget {
+            return Err(Error::InsufficientFunds);
+        }
+
+        // Count the ordinary split before allocating any proofs.
+        let mut remaining = gross.to_u64();
+        let mut copies = vec![0; denominations.len()];
+        for index in (0..denominations.len()).rev() {
+            copies[index] = remaining / denominations[index];
+            remaining %= denominations[index];
+        }
+        let mut size: u64 = copies.iter().sum();
+        if remaining != 0 || size > count {
+            continue;
+        }
+
+        // Preserve the quoted fee by splitting existing denominations until
+        // the output count matches it: e.g. [16, 8] becomes [16, 4, 4].
+        while size < count {
+            let Some(index) = (1..denominations.len()).find(|&index| {
+                copies[index] > 0
+                    && denominations[index] % denominations[index - 1] == 0
+                    && denominations[index] / denominations[index - 1] - 1 <= count - size
+            }) else {
+                break;
+            };
+            let ratio = denominations[index] / denominations[index - 1];
+            let splits = copies[index].min((count - size) / (ratio - 1));
+            copies[index] -= splits;
+            copies[index - 1] += splits * ratio;
+            size += splits * (ratio - 1);
+        }
+        if size == count {
+            let split = denominations
+                .iter()
+                .zip(copies)
+                .flat_map(|(value, copies)| {
+                    std::iter::repeat_n(Amount::from(*value), copies as usize)
+                })
+                .collect();
+            return Ok((split, fee));
+        }
+    }
+    Err(Error::Custom(
+        "Cannot construct an exact fee-inclusive split with these denominations and proof limit"
+            .to_owned(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_exact_with_fee;
+    use crate::{Amount, Error};
+
+    #[test]
+    fn overflowing_fee_calculations_return_an_error() {
+        for (amount, denominations, fee_ppk) in [
+            (21, vec![1, 1u64 << 63], 1000),
+            (u64::MAX / 1000 + 1, vec![1, 1 << 32], 1000),
+            (21, vec![1, 1 << 40], (1u64 << 40) * 1000 - 1),
+        ] {
+            let fees = (fee_ppk, denominations).into();
+            assert!(matches!(
+                split_exact_with_fee(amount.into(), &fees, u64::MAX.into(), None),
+                Err(Error::AmountOverflow)
+            ));
+        }
+    }
+
+    #[test]
+    fn exact_net_amount_across_fee_rounding_boundaries() {
+        for fee_ppk in [0, 1, 100, 500, 999, 1000, 1500, 2000, 4000] {
+            let fees = (fee_ppk, (0..16).map(|i| 1 << i).collect()).into();
+            for amount in 1..=128 {
+                let (split, fee) =
+                    split_exact_with_fee(Amount::from(amount), &fees, Amount::from(1024), Some(32))
+                        .unwrap();
+                assert_eq!(fee.to_u64(), (split.len() as u64 * fee_ppk).div_ceil(1000));
+                assert_eq!(Amount::try_sum(split).unwrap() - fee, Amount::from(amount));
+            }
+        }
+    }
+
+    #[test]
+    fn exact_net_with_few_and_many_proofs() {
+        // With outputs capped at 1024, these amounts require the stated count.
+        // Counts above 64 also exercise the distinction between the candidate
+        // search bound and the number of proofs in a valid result.
+        for fee_ppk in [0, 1, 100, 500, 999, 1000, 1500, 2000, 4000] {
+            let fees = (fee_ppk, (0..=10).map(|i| 1 << i).collect()).into();
+            for count in [1usize, 2, 31, 32, 63, 64, 65, 128] {
+                let gross = count as u64 * 1024;
+                let expected_fee = (count as u64 * fee_ppk).div_ceil(1000);
+                let amount = gross - expected_fee;
+                let (split, fee) =
+                    split_exact_with_fee(amount.into(), &fees, gross.into(), Some(count))
+                        .unwrap_or_else(|error| {
+                            panic!("count={count}, fee_ppk={fee_ppk}: {error}")
+                        });
+                assert_eq!(split, vec![Amount::from(1024); count]);
+                assert_eq!(fee, Amount::from(expected_fee));
+                assert_eq!(Amount::try_sum(split).unwrap() - fee, Amount::from(amount));
+                assert!(
+                    split_exact_with_fee(amount.into(), &fees, gross.into(), Some(count - 1))
+                        .is_err()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn large_amount_can_need_only_one_proof() {
+        let gross = 1u64 << 40;
+        for fee_ppk in [0u64, 1, 100, 500, 999, 1000, 1500, 2000, 4000] {
+            let fees = (fee_ppk, (0..=40).map(|i| 1 << i).collect()).into();
+            let expected_fee = fee_ppk.div_ceil(1000);
+            let amount = gross - expected_fee;
+            let (split, fee) =
+                split_exact_with_fee(amount.into(), &fees, gross.into(), Some(1)).unwrap();
+            assert_eq!(split, vec![Amount::from(gross)]);
+            assert_eq!(fee, Amount::from(expected_fee));
+            assert_eq!(Amount::try_sum(split).unwrap() - fee, Amount::from(amount));
+        }
+    }
+
+    #[test]
+    fn twenty_one_sats_preserves_the_fee_and_funding_limits() {
+        let fees = (1000, (0..8).map(|i| 1 << i).collect()).into();
+        let (split, fee) = split_exact_with_fee(21.into(), &fees, 24.into(), Some(3)).unwrap();
+        assert_eq!(split, vec![4.into(), 4.into(), 16.into()]);
+        assert_eq!(fee, Amount::from(3));
+        assert!(split_exact_with_fee(21.into(), &fees, 23.into(), None).is_err());
+        assert!(split_exact_with_fee(21.into(), &fees, 100.into(), Some(2)).is_err());
+    }
+
+    #[test]
+    fn supported_sparse_split_is_exact() {
+        let fees = (1000, vec![2, 8, 32]).into();
+        let (split, fee) = split_exact_with_fee(21.into(), &fees, 100.into(), None).unwrap();
+        assert_eq!(split, vec![8.into(); 3]);
+        assert_eq!(Amount::try_sum(split).unwrap() - fee, Amount::from(21));
+    }
+
+    #[test]
+    fn unpayable_sparse_keyset_does_not_search_the_funding_balance() {
+        let budget = 1u64 << 32;
+        let fees = (1001, vec![1, budget]).into();
+        assert!(split_exact_with_fee(21.into(), &fees, budget.into(), None).is_err());
+    }
+}

--- a/crates/cdk/src/wallet/send/mod.rs
+++ b/crates/cdk/src/wallet/send/mod.rs
@@ -14,6 +14,7 @@ use crate::nuts::nut00::ProofsMethods;
 use crate::nuts::{Proofs, Token};
 use crate::{Amount, Error, Wallet};
 
+mod fees;
 pub(crate) mod saga;
 
 use saga::SendSaga;
@@ -46,7 +47,7 @@ impl PreparedSend<'_> {
         self.amount
     }
 
-    /// Send options
+    /// Prepared send options, including the denomination plan for fee-inclusive exact sends.
     pub fn options(&self) -> &SendOptions {
         &self.options
     }
@@ -66,7 +67,7 @@ impl PreparedSend<'_> {
         &self.proofs_to_send
     }
 
-    /// Fee the recipient will pay to redeem the token
+    /// Fee the recipient will pay to redeem an exact send.
     pub fn send_fee(&self) -> Amount {
         self.send_fee
     }

--- a/crates/cdk/src/wallet/send/saga/mod.rs
+++ b/crates/cdk/src/wallet/send/saga/mod.rs
@@ -74,6 +74,7 @@ use cdk_common::Id;
 use tracing::instrument;
 
 use self::state::{Initial, Prepared, TokenCreated};
+use super::fees::split_exact_with_fee;
 use super::{split_proofs_for_send, SendMemo, SendOptions};
 use crate::amount::SplitTarget;
 use crate::fees::calculate_fee;
@@ -504,7 +505,14 @@ impl<'a> SendSaga<'a, Initial> {
             }
         }
 
-        let send_amounts = if opts.include_fee {
+        let send_amounts = if opts.include_fee && opts.send_kind.is_exact() {
+            split_exact_with_fee(
+                amount,
+                &fee_and_amounts,
+                available_proofs.total_amount()?,
+                opts.max_proofs,
+            )?
+        } else if opts.include_fee {
             let send_split = amount.split_with_fee(&fee_and_amounts)?;
             let send_fee = self
                 .wallet
@@ -591,7 +599,7 @@ impl<'a> SendSaga<'a, Initial> {
     async fn internal_prepare(
         mut self,
         amount: Amount,
-        opts: SendOptions,
+        mut opts: SendOptions,
         proofs: Proofs,
         force_swap: bool,
         keyset_policy: KeysetLoadPolicy,
@@ -609,7 +617,14 @@ impl<'a> SendSaga<'a, Initial> {
             .cloned()
             .ok_or(Error::UnknownKeySet)?;
 
-        let (send_amounts, send_fee) = if opts.include_fee {
+        let (send_amounts, send_fee) = if opts.include_fee && opts.send_kind.is_exact() {
+            split_exact_with_fee(
+                amount,
+                &fee_and_amounts,
+                proofs.total_amount()?,
+                opts.max_proofs,
+            )?
+        } else if opts.include_fee {
             let send_split = amount.split_with_fee(&fee_and_amounts)?;
             let send_fee = self
                 .wallet
@@ -619,17 +634,13 @@ impl<'a> SendSaga<'a, Initial> {
                         .collect(),
                 )
                 .await?;
-            (send_split, send_fee)
+            (send_split, send_fee.total)
         } else {
             let send_split = amount.split(&fee_and_amounts)?;
-            let send_fee = crate::fees::ProofsFeeBreakdown {
-                total: Amount::ZERO,
-                per_keyset: std::collections::HashMap::new(),
-            };
-            (send_split, send_fee)
+            (send_split, Amount::ZERO)
         };
 
-        let mut exact_proofs = proofs.total_amount()? == amount + send_fee.total;
+        let mut exact_proofs = proofs.total_amount()? == amount + send_fee;
         if let Some(max_proofs) = opts.max_proofs {
             exact_proofs &= proofs.len() <= max_proofs;
         }
@@ -646,18 +657,31 @@ impl<'a> SendSaga<'a, Initial> {
             .map(|(key, values)| (*key, values.fee()))
             .collect();
 
+        // Reused proofs must have the same fee rate as the planned outputs.
+        // Reissue mixed-rate inputs rather than quoting a different redemption fee.
+        let force_swap = force_swap
+            || (opts.include_fee
+                && opts.send_kind.is_exact()
+                && proofs.iter().any(|proof| {
+                    keyset_fees.get(&proof.keyset_id) != keyset_fees.get(&active_keyset_id)
+                }));
+
         let split_result = split_proofs_for_send_respecting_p2pk_locks(
             proofs,
             opts.p2pk_locked_proof_send_mode,
             SendSplitContext {
                 send_amounts: &send_amounts,
                 amount,
-                send_fee: send_fee.total,
+                send_fee,
                 keyset_fees: &keyset_fees,
                 force_swap,
                 is_exact_or_offline,
             },
         )?;
+
+        if opts.include_fee && opts.send_kind.is_exact() {
+            opts.amount_split_target = SplitTarget::Values(send_amounts);
+        }
 
         let mut proof_ys = split_result.proofs_to_swap.ys()?;
         proof_ys.extend(split_result.proofs_to_send.ys()?);
@@ -706,7 +730,7 @@ impl<'a> SendSaga<'a, Initial> {
                 proofs_to_swap: split_result.proofs_to_swap,
                 swap_fee: split_result.swap_fee,
                 proofs_to_send: split_result.proofs_to_send,
-                send_fee: send_fee.total,
+                send_fee,
                 saga,
             },
         })
@@ -868,6 +892,22 @@ impl<'a> SendSaga<'a, Prepared> {
                 }
 
                 let keyset_id = self.wallet.active_keyset().await?.id;
+                let send_split_target = if options.include_fee && options.send_kind.is_exact() {
+                    let SplitTarget::Values(mut outputs) = options.amount_split_target.clone()
+                    else {
+                        return Err(Error::InvalidOperationState);
+                    };
+                    for proof in &final_proofs_to_send {
+                        let index = outputs
+                            .iter()
+                            .position(|amount| *amount == proof.amount)
+                            .ok_or(Error::InvalidOperationState)?;
+                        outputs.remove(index);
+                    }
+                    Some(SplitTarget::Values(outputs))
+                } else {
+                    None
+                };
 
                 // Capture counter start before swap
                 counter_start = Some(
@@ -886,6 +926,7 @@ impl<'a> SendSaga<'a, Prepared> {
                         options.conditions.clone(),
                         false,
                         options.use_p2bk,
+                        send_split_target,
                     )
                     .await?
                 {
@@ -903,6 +944,21 @@ impl<'a> SendSaga<'a, Prepared> {
 
             if amount > final_proofs_to_send.total_amount()? {
                 return Err(Error::InsufficientFunds);
+            }
+
+            if options.include_fee && options.send_kind.is_exact() {
+                let keyset_fees = self
+                    .wallet
+                    .keysets(KeysetLoadPolicy::CacheOnly)
+                    .await?
+                    .into_iter()
+                    .map(|keyset| (keyset.id, keyset.input_fee_ppk))
+                    .collect();
+                let fee =
+                    calculate_fee(&final_proofs_to_send.count_by_keyset(), &keyset_fees)?.total;
+                if final_proofs_to_send.total_amount()?.checked_sub(fee) != Some(amount) {
+                    return Err(Error::InsufficientFunds);
+                }
             }
 
             self.wallet
@@ -1058,6 +1114,7 @@ impl<'a> SendSaga<'a, TokenCreated> {
                 None,
                 false,
                 false,
+                None,
             )
             .await;
 

--- a/crates/cdk/src/wallet/swap/mod.rs
+++ b/crates/cdk/src/wallet/swap/mod.rs
@@ -53,6 +53,7 @@ impl Wallet {
             include_fees,
             use_p2bk,
             ProofReservation::Reserve,
+            None,
         )
         .await
     }
@@ -72,6 +73,7 @@ impl Wallet {
         spending_conditions: Option<SpendingConditions>,
         include_fees: bool,
         use_p2bk: bool,
+        send_split_target: Option<SplitTarget>,
     ) -> Result<Option<Proofs>, Error> {
         self.swap_internal(
             amount,
@@ -81,6 +83,7 @@ impl Wallet {
             include_fees,
             use_p2bk,
             ProofReservation::Skip,
+            send_split_target,
         )
         .await
     }
@@ -96,6 +99,7 @@ impl Wallet {
         include_fees: bool,
         use_p2bk: bool,
         proof_reservation: ProofReservation,
+        send_split_target: Option<SplitTarget>,
     ) -> Result<Option<Proofs>, Error> {
         tracing::info!("Swapping");
 
@@ -110,6 +114,7 @@ impl Wallet {
                     use_p2bk,
                     include_fees,
                     proof_reservation,
+                    send_split_target.clone(),
                 )
                 .await?;
             let saga = saga.execute().await?;
@@ -134,8 +139,19 @@ impl Wallet {
         use_p2bk: bool,
         proofs_fee_breakdown: &ProofsFeeBreakdown,
         proof_reservation: ProofReservation,
+        send_split_target: Option<&SplitTarget>,
     ) -> Result<PreSwap, Error> {
         tracing::info!("Creating swap");
+        let send_split_target = send_split_target.unwrap_or(&SplitTarget::None);
+        if let SplitTarget::Values(values) = send_split_target {
+            if Amount::try_sum(values.iter().copied())? != amount.unwrap_or(Amount::ZERO)
+                || values
+                    .iter()
+                    .any(|value| !fee_and_amounts.amounts().contains(&value.to_u64()))
+            {
+                return Err(Error::InvalidOperationState);
+            }
+        }
 
         // Desired amount is either amount passed or value of all proof
         let proofs_total = proofs.total_amount()?;
@@ -201,7 +217,7 @@ impl Wallet {
                 // For no spending conditions, count both send and change secrets
                 let send_count = send_amount
                     .unwrap_or(Amount::ZERO)
-                    .split_targeted(&SplitTarget::default(), fee_and_amounts)?
+                    .split_targeted(send_split_target, fee_and_amounts)?
                     .len() as u32;
                 let change_count = change_amount
                     .split_targeted(&change_split_target, fee_and_amounts)?
@@ -251,7 +267,7 @@ impl Wallet {
                             .is_some_and(|c| c.sig_flag == crate::nuts::nut11::SigFlag::SigAll);
                         let amount_split = send_amount
                             .unwrap_or(Amount::ZERO)
-                            .split_targeted(&SplitTarget::default(), fee_and_amounts)?;
+                            .split_targeted(send_split_target, fee_and_amounts)?;
                         let keys_count = if is_sig_all { 1 } else { amount_split.len() };
                         let ephemeral_keys: Vec<_> = (0..keys_count)
                             .map(|_| crate::nuts::nut01::SecretKey::generate())
@@ -260,7 +276,7 @@ impl Wallet {
                             PreMintSecrets::with_p2bk(
                                 active_keyset_id,
                                 send_amount.unwrap_or(Amount::ZERO),
-                                &SplitTarget::default(),
+                                send_split_target,
                                 data,
                                 conditions,
                                 &ephemeral_keys,
@@ -276,7 +292,7 @@ impl Wallet {
                         PreMintSecrets::with_conditions(
                             active_keyset_id,
                             send_amount.unwrap_or(Amount::ZERO),
-                            &SplitTarget::default(),
+                            send_split_target,
                             &conditions,
                             fee_and_amounts,
                         )?,
@@ -293,7 +309,7 @@ impl Wallet {
                     count,
                     &self.seed,
                     send_amount.unwrap_or(Amount::ZERO),
-                    &SplitTarget::default(),
+                    send_split_target,
                     fee_and_amounts,
                 )?;
 

--- a/crates/cdk/src/wallet/swap/saga/mod.rs
+++ b/crates/cdk/src/wallet/swap/saga/mod.rs
@@ -102,6 +102,7 @@ impl<'a> SwapSaga<'a, Initial> {
         use_p2bk: bool,
         include_fees: bool,
         proof_reservation: ProofReservation,
+        send_split_target: Option<SplitTarget>,
     ) -> Result<SwapSaga<'a, Prepared>, Error> {
         tracing::info!(
             "Preparing swap with operation {}",
@@ -137,6 +138,7 @@ impl<'a> SwapSaga<'a, Initial> {
                 use_p2bk,
                 &fee_breakdown,
                 proof_reservation,
+                send_split_target.as_ref(),
             )
             .await?;
 
@@ -192,7 +194,7 @@ impl<'a> SwapSaga<'a, Initial> {
             state_data: Prepared {
                 operation_id: self.state_data.operation_id,
                 amount,
-                amount_split_target,
+                amount_split_target: send_split_target.unwrap_or(amount_split_target),
                 input_ys,
                 spending_conditions,
                 pre_swap,
@@ -437,6 +439,7 @@ mod tests {
                 false,
                 false,
                 ProofReservation::Reserve,
+                None,
             )
             .await
             .unwrap();
@@ -500,6 +503,7 @@ mod tests {
                 false,
                 false,
                 ProofReservation::Reserve,
+                None,
             )
             .await;
 
@@ -556,6 +560,7 @@ mod tests {
                 false,
                 false,
                 ProofReservation::Skip,
+                None,
             )
             .await
             .unwrap();
@@ -601,6 +606,7 @@ mod tests {
                 false,
                 false,
                 ProofReservation::Reserve,
+                None,
             )
             .await
             .expect("prepare swap saga");


### PR DESCRIPTION
Plan fee-inclusive exact sends from their output proof count and preserve those denominations through confirmation. Validate the final net amount so payment requests deliver the requested value after redemption fees.

Add coverage for fee rates, proof counts, and independent recipient redemption of fixed and amountless payment requests. Document broader follow-up work.

Fixes https://github.com/cashubtc/cdk/issues/2493

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
