### PR TITLE
fix(ldk-node): resolve existing BOLT12 dispatch claims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,6 +1581,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "tempfile",
  "thiserror 2.0.20",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -1575,6 +1575,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "tempfile",
  "thiserror 2.0.20",
  "tokio",
  "tokio-stream",

--- a/crates/cdk-ldk-node/Cargo.toml
+++ b/crates/cdk-ldk-node/Cargo.toml
@@ -33,6 +33,7 @@ web-time.workspace = true
 
 [dev-dependencies]
 cdk-sqlite.workspace = true
+tempfile = { version = "3", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/cdk-ldk-node/src/lib.rs
+++ b/crates/cdk-ldk-node/src/lib.rs
@@ -1198,10 +1198,17 @@ impl MintPayment for CdkLdkNode {
                         quote_id = %quote_id,
                         "Could not persist BOLT12 dispatch claim before sending: {err}"
                     );
-                    return Ok(outgoing_payment_failure_response(
-                        unit,
-                        quote_payment_identifier,
-                    ));
+                    if matches!(&err, Error::Bolt12QuoteAlreadyClaimed { .. }) {
+                        // A previous invocation may still settle. Resolve its
+                        // durable state instead of reporting a terminal failure.
+                        let mut response = self
+                            .check_outgoing_payment(&quote_payment_identifier)
+                            .await?;
+                        response.total_spent = response.total_spent.convert_to(unit)?;
+                        return Ok(response);
+                    }
+
+                    return Err(err.into());
                 }
 
                 // BOLT12 payment ids are assigned by `send`, so subscribe
@@ -1978,6 +1985,89 @@ mod tests {
 
     async fn test_kv_store() -> DynKVStore {
         std::sync::Arc::new(cdk_sqlite::mint::memory::empty().await.unwrap())
+    }
+
+    #[tokio::test]
+    async fn duplicate_bolt12_claim_resolves_existing_state() {
+        use ldk_node::lightning::offers::offer::OfferBuilder;
+
+        let storage = tempfile::tempdir().unwrap();
+        let kv_store = test_kv_store().await;
+        let node = CdkLdkNodeBuilder::new(
+            Network::Regtest,
+            ChainSource::Esplora("http://127.0.0.1:1".to_string()),
+            GossipSource::P2P,
+            storage.path().to_str().unwrap().to_string(),
+            FeeReserve {
+                min_fee_reserve: 0.into(),
+                percent_fee_reserve: 0.0,
+            },
+            vec!["127.0.0.1:0".parse().unwrap()],
+            kv_store.clone(),
+        )
+        .build()
+        .unwrap();
+        let offer = OfferBuilder::new(node.inner.node_id())
+            .amount_msats(1_000)
+            .build()
+            .unwrap();
+
+        for (stored, expected) in [
+            (String::new(), Some(MeltQuoteState::Pending)),
+            ("corrupt".to_string(), Some(MeltQuoteState::Unknown)),
+            (hex::encode([7; 32]), None),
+        ] {
+            let quote_id = QuoteId::new();
+            let key = bolt12_quote_payment_id_key(&quote_id).unwrap();
+            let mut tx = kv_store.begin_transaction().await.unwrap();
+            tx.kv_write(
+                LDK_KV_PRIMARY_NAMESPACE,
+                LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+                &key,
+                stored.as_bytes(),
+            )
+            .await
+            .unwrap();
+            tx.commit().await.unwrap();
+
+            let result = node
+                .make_payment(
+                    &CurrencyUnit::Sat,
+                    OutgoingPaymentOptions::Bolt12(Box::new(Bolt12OutgoingPaymentOptions {
+                        offer: offer.clone(),
+                        max_fee_amount: None,
+                        timeout_secs: None,
+                        melt_options: None,
+                        quote_id: quote_id.clone(),
+                    })),
+                )
+                .await;
+
+            match expected {
+                Some(status) => {
+                    let response = result.unwrap();
+                    assert_eq!(response.status, status);
+                    assert_eq!(response.total_spent, Amount::new(0, CurrencyUnit::Sat));
+                    assert_eq!(
+                        response.payment_lookup_id,
+                        PaymentIdentifier::QuoteId(quote_id)
+                    );
+                }
+                None => assert!(result.is_err(), "missing LDK payment must be indeterminate"),
+            }
+            assert_eq!(
+                kv_store
+                    .kv_read(
+                        LDK_KV_PRIMARY_NAMESPACE,
+                        LDK_KV_BOLT12_OUTGOING_SECONDARY_NAMESPACE,
+                        &key,
+                    )
+                    .await
+                    .unwrap(),
+                Some(stored.into_bytes()),
+                "a duplicate must preserve the existing dispatch binding"
+            );
+        }
     }
 
     /// The mapping must resolve Missing before any dispatch, Dispatching


### PR DESCRIPTION
Resolve duplicate claims through the outgoing payment status lookup and convert the response to the requested unit. Propagate other claim errors instead of reporting a terminal failure while a payment may still settle.

Add regression coverage for dispatch sentinels, corrupt bindings, and unresolved payment IDs, including preservation of the existing binding.

Validation: all 30 cdk-ldk-node library tests pass; cargo fmt completed.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
