### PR TITLE
fix(axum): exit WebSocket loop when the stream ends

### DIFF
--- a/crates/cdk-axum/src/ws/mod.rs
+++ b/crates/cdk-axum/src/ws/mod.rs
@@ -111,7 +111,10 @@ pub async fn main_websocket(mut socket: WebSocket, state: MintState) {
                 }
             }
 
-            Some(from_ws) = socket.next() => {
+            from_ws = socket.next() => {
+                let Some(from_ws) = from_ws else {
+                    break;
+                };
                 let text = match from_ws {
                     Ok(Message::Text(text)) => text.to_string(),
                     Ok(Message::Binary(bin)) => String::from_utf8_lossy(&bin).to_string(),


### PR DESCRIPTION
Handle None explicitly so an ended socket stream exits the loop and triggers subscription cleanup, even while the subscriber channel is open.

Validation: formatting check and all five WebSocket unit tests passed.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
