### PR TITLE
fix(bdk): box wallet sync future to simplify Send checks

### DIFF
--- a/crates/cdk-bdk/src/sync.rs
+++ b/crates/cdk-bdk/src/sync.rs
@@ -1,3 +1,4 @@
+use futures::future::BoxFuture;
 use tokio_util::sync::CancellationToken;
 
 use crate::error::Error;
@@ -56,7 +57,12 @@ impl CdkBdk {
         }
     }
 
-    pub(crate) async fn sync_wallet(&self, cancel_token: CancellationToken) -> Result<(), Error> {
-        self.chain_source.sync_wallet(self, cancel_token).await
+    pub(crate) fn sync_wallet(
+        &self,
+        cancel_token: CancellationToken,
+    ) -> BoxFuture<'_, Result<(), Error>> {
+        // Erase the nested chain-sync future so the supervisor's Send check
+        // does not recurse through every backend's future type.
+        Box::pin(self.chain_source.sync_wallet(self, cancel_token))
     }
 }


### PR DESCRIPTION
Erase the nested chain-sync future at the supervisor boundary so its Send check does not recurse through every backend future type.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
