### PR TITLE
fix(mint): round CLN and LDK sat payments conservatively

### DIFF
--- a/crates/cdk-cln/src/lib.rs
+++ b/crates/cdk-cln/src/lib.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bitcoin::hashes::sha256;
-use cdk_common::amount::Amount;
+use cdk_common::amount::{Amount, MSAT_IN_SAT};
 use cdk_common::common::FeeReserve;
 use cdk_common::database::DynKVStore;
 use cdk_common::nuts::{CurrencyUnit, MeltOptions, MeltQuoteState};
@@ -365,8 +365,14 @@ impl MintPayment for Cln {
                         .into()
                 };
                 // Convert to target unit
-                let amount =
-                    Amount::new(amount_msat.into(), CurrencyUnit::Msat).convert_to(unit)?;
+                let amount = match unit {
+                    // The quote must cover the entire millisatoshi principal.
+                    CurrencyUnit::Sat => Amount::new(
+                        u64::from(amount_msat).div_ceil(MSAT_IN_SAT),
+                        CurrencyUnit::Sat,
+                    ),
+                    _ => Amount::new(amount_msat.into(), CurrencyUnit::Msat).convert_to(unit)?,
+                };
 
                 // Calculate fee
                 let relative_fee_reserve =
@@ -404,7 +410,13 @@ impl MintPayment for Cln {
                 };
 
                 // Convert to target unit
-                let amount = Amount::new(amount_msat, CurrencyUnit::Msat).convert_to(unit)?;
+                let amount = match unit {
+                    // The quote must cover the entire millisatoshi principal.
+                    CurrencyUnit::Sat => {
+                        Amount::new(amount_msat.div_ceil(MSAT_IN_SAT), CurrencyUnit::Sat)
+                    }
+                    _ => Amount::new(amount_msat, CurrencyUnit::Msat).convert_to(unit)?,
+                };
 
                 // Calculate fee
                 let relative_fee_reserve =
@@ -560,13 +572,12 @@ impl MintPayment for Cln {
             })
             .await;
 
-        let response = match cln_response {
+        let mut response = match cln_response {
             Ok(pay_response) => MakePaymentResponse {
                 payment_lookup_id,
                 payment_proof: Some(hex::encode(pay_response.payment_preimage.to_vec())),
                 status: MeltQuoteState::Paid,
-                total_spent: Amount::new(pay_response.amount_sent_msat.msat(), CurrencyUnit::Msat)
-                    .convert_to(unit)?,
+                total_spent: Amount::new(pay_response.amount_sent_msat.msat(), CurrencyUnit::Msat),
             },
             Err(err) => {
                 tracing::warn!("xpay returned an error: {}", err);
@@ -641,6 +652,16 @@ impl MintPayment for Cln {
 
                 response
             }
+        };
+
+        // Both xpay and reconciliation report principal plus fees in Msat.
+        // Return the quote unit and round the combined total only once.
+        response.total_spent = match unit {
+            CurrencyUnit::Sat => Amount::new(
+                response.total_spent.value().div_ceil(MSAT_IN_SAT),
+                CurrencyUnit::Sat,
+            ),
+            _ => response.total_spent.convert_to(unit)?,
         };
 
         Ok(response)
@@ -1824,6 +1845,130 @@ mod tests {
     fn test_invoice() -> Bolt11Invoice {
         Bolt11Invoice::from_str("lnbc100n1pnvpufspp5djn8hrq49r8cghwye9kqw752qjncwyfnrprhprpqk43mwcy4yfsqdq5g9kxy7fqd9h8vmmfvdjscqzzsxqyz5vqsp5uhpjt36rj75pl7jq2sshaukzfkt7uulj456s4mh7uy7l6vx7lvxs9qxpqysgqedwz08acmqwtk8g4vkwm2w78suwt2qyzz6jkkwcgrjm3r3hs6fskyhvud4fan3keru7emjm8ygqpcrwtlmhfjfmer3afs5hhwamgr4cqtactdq")
             .expect("test invoice must parse")
+    }
+
+    #[tokio::test]
+    async fn payment_quotes_round_up_sat_principals() {
+        for (msat, sat) in [
+            (1, 1),
+            (999, 1),
+            (1_000, 1),
+            (1_999, 2),
+            (2_000, 2),
+            (u64::MAX, u64::MAX / 1_000 + 1),
+        ] {
+            for (unit, expected) in [(CurrencyUnit::Sat, sat), (CurrencyUnit::Msat, msat)] {
+                let quote = test_cln()
+                    .get_payment_quote(
+                        &unit,
+                        OutgoingPaymentOptions::Bolt11(Box::new(Bolt11OutgoingPaymentOptions {
+                            bolt11: test_invoice(),
+                            max_fee_amount: None,
+                            timeout_secs: None,
+                            melt_options: Some(MeltOptions::new_mpp(msat)),
+                            quote_id: QuoteId::new(),
+                        })),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(quote.amount, Amount::new(expected, unit.clone()));
+                let quote = test_cln()
+                    .get_payment_quote(
+                        &unit,
+                        OutgoingPaymentOptions::Bolt12(Box::new(
+                            payment::Bolt12OutgoingPaymentOptions {
+                                offer:
+                                    "lno1zcss9mk8y3wkklfvevcrszlmu23kfrxh49px20665dqwmn4p72pksese"
+                                        .parse()
+                                        .unwrap(),
+                                max_fee_amount: None,
+                                timeout_secs: None,
+                                melt_options: Some(MeltOptions::new_amountless(msat)),
+                                quote_id: QuoteId::new(),
+                            },
+                        )),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(quote.amount, Amount::new(expected, unit));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn synchronous_payment_rounds_up_total_for_sat_quotes() {
+        for reconcile in [false, true] {
+            tokio::time::timeout(Duration::from_secs(5), async {
+                let socket = TestRpcSocket::new();
+                let listener = UnixListener::bind(&socket.0).unwrap();
+                let mut cln = test_cln();
+                cln.rpc_socket = socket.0.clone();
+                let payment = cln.make_payment(
+                    &CurrencyUnit::Sat,
+                    OutgoingPaymentOptions::Bolt11(Box::new(Bolt11OutgoingPaymentOptions {
+                        bolt11: test_invoice(),
+                        max_fee_amount: None,
+                        timeout_secs: None,
+                        melt_options: None,
+                        quote_id: QuoteId::new(),
+                    })),
+                );
+                let server = async {
+                    // make_payment opens its xpay connection before checking listpays.
+                    let (connection, _) = listener.accept().await.unwrap();
+                    let mut pay = Framed::new(connection, cln_rpc::codec::JsonCodec::default());
+                    let (connection, _) = listener.accept().await.unwrap();
+                    let mut check = Framed::new(connection, cln_rpc::codec::JsonCodec::default());
+                    let request = check.next().await.unwrap().unwrap();
+                    assert_eq!(request["method"], "listpays");
+                    check
+                        .send(serde_json::json!({
+                            "jsonrpc": "2.0", "id": request["id"], "result": {"pays": []}
+                        }))
+                        .await
+                        .unwrap();
+                    let request = pay.next().await.unwrap().unwrap();
+                    assert_eq!(request["method"], "xpay");
+                    if reconcile {
+                        pay.send(serde_json::json!({
+                            "jsonrpc": "2.0", "id": request["id"],
+                            "error": {"code": 219, "message": "already paid"}
+                        }))
+                        .await
+                        .unwrap();
+                        let (connection, _) = listener.accept().await.unwrap();
+                        let mut check =
+                            Framed::new(connection, cln_rpc::codec::JsonCodec::default());
+                        let request = check.next().await.unwrap().unwrap();
+                        assert_eq!(request["method"], "listpays");
+                        let mut payment = test_listpays_payment(1, ListpaysPaysStatus::COMPLETE);
+                        payment.amount_sent_msat = Some(CLN_Amount::from_msat(10001));
+                        check
+                            .send(serde_json::json!({
+                                "jsonrpc": "2.0", "id": request["id"], "result": {"pays": [payment]}
+                            }))
+                            .await
+                            .unwrap();
+                    } else {
+                        pay.send(serde_json::json!({
+                            "jsonrpc": "2.0", "id": request["id"], "result": {
+                                "amount_msat": 10000, "amount_sent_msat": 10001,
+                                "failed_parts": 0, "successful_parts": 1,
+                                "payment_preimage": "01".repeat(32)
+                            }
+                        }))
+                        .await
+                        .unwrap();
+                    }
+                };
+                let (response, ()) = tokio::join!(payment, server);
+                let response = response.unwrap();
+                assert_eq!(response.status, MeltQuoteState::Paid);
+                assert_eq!(response.total_spent, Amount::new(11, CurrencyUnit::Sat));
+            })
+            .await
+            .expect("mock payment must complete promptly");
+        }
     }
 
     #[tokio::test]

--- a/crates/cdk-common/src/payment.rs
+++ b/crates/cdk-common/src/payment.rs
@@ -591,6 +591,10 @@ pub struct MakePaymentResponse {
     pub status: MeltQuoteState,
     /// Total amount spent, including fees. Only authoritative when `status`
     /// is [`MeltQuoteState::Paid`]; otherwise backends return `0`.
+    /// Successful [`MintPayment::make_payment`] responses must use the requested
+    /// quote unit, rounding the combined principal and fees up when necessary.
+    /// [`MintPayment::check_outgoing_payment`] may return the backend's native
+    /// unit; the mint converts it conservatively for settlement.
     pub total_spent: Amount<CurrencyUnit>,
 }
 

--- a/crates/cdk-ldk-node/src/lib.rs
+++ b/crates/cdk-ldk-node/src/lib.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use bip39::Mnemonic;
+use cdk_common::amount::MSAT_IN_SAT;
 use cdk_common::common::FeeReserve;
 use cdk_common::database::DynKVStore;
 use cdk_common::payment::{self, *};
@@ -456,7 +457,13 @@ impl CdkLdkNode {
                 .amount_msat
                 .ok_or(Error::CouldNotGetAmountSpent)?
                 + payment_details.fee_paid_msat.unwrap_or_default();
-            Amount::new(total_spent, CurrencyUnit::Msat).convert_to(unit)?
+            // Round the principal and routing fees together, only once.
+            match unit {
+                CurrencyUnit::Sat => {
+                    Amount::new(total_spent.div_ceil(MSAT_IN_SAT), CurrencyUnit::Sat)
+                }
+                _ => Amount::new(total_spent, CurrencyUnit::Msat).convert_to(unit)?,
+            }
         } else {
             Amount::new(0, unit.clone())
         };
@@ -991,8 +998,14 @@ impl MintPayment for CdkLdkNode {
                         .into(),
                 };
 
-                let amount =
-                    Amount::new(amount_msat.into(), CurrencyUnit::Msat).convert_to(unit)?;
+                let amount = match unit {
+                    // The quote must cover the entire millisatoshi principal.
+                    CurrencyUnit::Sat => Amount::new(
+                        u64::from(amount_msat).div_ceil(MSAT_IN_SAT),
+                        CurrencyUnit::Sat,
+                    ),
+                    _ => Amount::new(amount_msat.into(), CurrencyUnit::Msat).convert_to(unit)?,
+                };
 
                 let relative_fee_reserve =
                     (self.fee_reserve.percent_fee_reserve * amount.value() as f32) as u64;
@@ -1035,8 +1048,14 @@ impl MintPayment for CdkLdkNode {
                         }
                     }
                 };
-                let amount =
-                    Amount::new(amount_msat.into(), CurrencyUnit::Msat).convert_to(unit)?;
+                let amount = match unit {
+                    // The quote must cover the entire millisatoshi principal.
+                    CurrencyUnit::Sat => Amount::new(
+                        u64::from(amount_msat).div_ceil(MSAT_IN_SAT),
+                        CurrencyUnit::Sat,
+                    ),
+                    _ => Amount::new(amount_msat.into(), CurrencyUnit::Msat).convert_to(unit)?,
+                };
 
                 let relative_fee_reserve =
                     (self.fee_reserve.percent_fee_reserve * amount.value() as f32) as u64;
@@ -1793,6 +1812,96 @@ mod tests {
 
         assert_eq!(response.status, MeltQuoteState::Pending);
         assert_eq!(response.total_spent, Amount::new(0, CurrencyUnit::Msat));
+    }
+
+    #[tokio::test]
+    async fn payment_quotes_round_up_sat_principals() {
+        let storage = std::env::temp_dir().join(format!("cdk-ldk-rounding-{}", QuoteId::new()));
+        let node = CdkLdkNodeBuilder::new(
+            Network::Regtest,
+            ChainSource::Esplora("http://127.0.0.1:1".to_owned()),
+            GossipSource::P2P,
+            storage.to_str().unwrap().to_owned(),
+            FeeReserve {
+                min_fee_reserve: Amount::ZERO,
+                percent_fee_reserve: 0.0,
+            },
+            vec!["127.0.0.1:0".parse().unwrap()],
+            test_kv_store().await,
+        )
+        .build()
+        .unwrap();
+        for (msat, sat) in [(1, 1), (999, 1), (1_000, 1), (1_999, 2), (2_000, 2)] {
+            let invoice = node
+                .inner
+                .bolt11_payment()
+                .receive(
+                    msat,
+                    &Bolt11InvoiceDescription::Direct(
+                        Description::new("rounding".to_owned()).unwrap(),
+                    ),
+                    3600,
+                )
+                .unwrap();
+            let offer = ldk_node::lightning::offers::offer::OfferBuilder::new(node.inner.node_id())
+                .amount_msats(msat)
+                .build()
+                .unwrap();
+            for (unit, expected) in [(CurrencyUnit::Sat, sat), (CurrencyUnit::Msat, msat)] {
+                for options in [
+                    OutgoingPaymentOptions::Bolt11(Box::new(Bolt11OutgoingPaymentOptions {
+                        bolt11: invoice.clone(),
+                        max_fee_amount: None,
+                        timeout_secs: None,
+                        melt_options: None,
+                        quote_id: QuoteId::new(),
+                    })),
+                    OutgoingPaymentOptions::Bolt12(Box::new(Bolt12OutgoingPaymentOptions {
+                        offer: offer.clone(),
+                        max_fee_amount: None,
+                        timeout_secs: None,
+                        melt_options: None,
+                        quote_id: QuoteId::new(),
+                    })),
+                ] {
+                    let quote = node.get_payment_quote(&unit, options).await.unwrap();
+                    assert_eq!(quote.amount, Amount::new(expected, unit.clone()));
+                }
+            }
+        }
+        drop(node);
+        std::fs::remove_dir_all(storage).unwrap();
+    }
+
+    #[test]
+    fn paid_payment_response_rounds_total_once_for_sat_quotes() {
+        for (principal, fee, expected_sat) in
+            [(1_999, 0, 2), (2_000, 1, 3), (1_999, 1, 2), (2_000, 0, 2)]
+        {
+            let mut details = test_payment_details(PaymentStatus::Succeeded, Some(principal));
+            details.fee_paid_msat = Some(fee);
+            let payment_id = PaymentIdentifier::PaymentId([2; 32]);
+            let synchronous = CdkLdkNode::make_payment_response_from_details(
+                &CurrencyUnit::Sat,
+                payment_id.clone(),
+                &details,
+            )
+            .unwrap();
+            let recovered = CdkLdkNode::make_payment_response_from_details(
+                &CurrencyUnit::Msat,
+                payment_id,
+                &details,
+            )
+            .unwrap();
+            assert_eq!(
+                synchronous.total_spent,
+                Amount::new(expected_sat, CurrencyUnit::Sat)
+            );
+            assert_eq!(
+                recovered.total_spent,
+                Amount::new(principal + fee, CurrencyUnit::Msat)
+            );
+        }
     }
 
     #[test]

--- a/crates/cdk/src/mint/melt/melt_saga/mod.rs
+++ b/crates/cdk/src/mint/melt/melt_saga/mod.rs
@@ -836,6 +836,18 @@ impl MeltSaga<SetupComplete> {
             .await
         {
             Ok(pay) if pay.status == MeltQuoteState::Paid => {
+                if pay.total_spent.unit() != &quote.unit {
+                    // Payment already succeeded. Preserve the paid handoff so
+                    // rejecting the response cannot release the input proofs.
+                    self.persist_paid_payment(&pay).await?;
+                    tracing::error!(
+                        quote_id = %quote.id,
+                        expected_unit = %quote.unit,
+                        actual_unit = %pay.total_spent.unit(),
+                        "successful payment response uses the wrong quote unit",
+                    );
+                    return Err(Error::UnitMismatch);
+                }
                 tracing::info!(
                     quote_id = %quote.id,
                     saga_id = %self.operation_id,

--- a/crates/cdk/src/mint/melt/tests/pending_async_melt_tests.rs
+++ b/crates/cdk/src/mint/melt/tests/pending_async_melt_tests.rs
@@ -31,6 +31,7 @@ struct NoEventPendingBackend {
     strip_quote_lookup_id: bool,
     amount_mismatch_dispatch_error: bool,
     stall_status_checks: AtomicBool,
+    spent_msat: Option<u64>,
 }
 
 impl NoEventPendingBackend {
@@ -55,6 +56,7 @@ impl NoEventPendingBackend {
             strip_quote_lookup_id: false,
             amount_mismatch_dispatch_error: false,
             stall_status_checks: AtomicBool::new(false),
+            spent_msat: None,
         }
     }
 
@@ -114,6 +116,9 @@ impl MintPayment for NoEventPendingBackend {
 
         let mut response = self.inner.make_payment(unit, options).await?;
         response.status = self.dispatch_status;
+        if let Some(spent_msat) = self.spent_msat {
+            response.total_spent = Amount::new(spent_msat, CurrencyUnit::Msat);
+        }
         if self.dispatch_status != MeltQuoteState::Paid {
             response.payment_proof = None;
             response.total_spent = Amount::new(0, CurrencyUnit::Sat);
@@ -169,6 +174,9 @@ impl MintPayment for NoEventPendingBackend {
         };
 
         response.status = final_status;
+        if let Some(spent_msat) = self.spent_msat {
+            response.total_spent = Amount::new(spent_msat, CurrencyUnit::Msat);
+        }
         if final_status != MeltQuoteState::Paid {
             response.payment_proof = None;
             response.total_spent = Amount::new(0, CurrencyUnit::Sat);
@@ -296,6 +304,80 @@ async fn acknowledged_pending_dispatch_rolls_back_after_terminal_poll() {
         .await
         .unwrap();
     assert!(saga.is_none());
+}
+
+#[tokio::test]
+async fn paid_response_with_wrong_unit_preserves_paid_handoff() {
+    let mut backend = NoEventPendingBackend::new(1, Some(MeltQuoteState::Paid))
+        .with_dispatch_status(MeltQuoteState::Paid);
+    backend.spent_msat = Some(9_000_001);
+    let mint = create_pending_test_mint(Arc::new(backend)).await.unwrap();
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let input_ys = proofs.ys().unwrap();
+    let quote = create_test_melt_quote(&mint, Amount::from(9_000)).await;
+    let request = create_test_melt_request(&proofs, &quote);
+
+    let pending = mint.melt(&request).await.unwrap();
+    assert!(matches!(pending.await, Err(Error::UnitMismatch)));
+    let saga = mint
+        .localstore()
+        .get_melt_saga_by_quote_id(&quote.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        saga.state,
+        cdk_common::mint::SagaStateEnum::Melt(cdk_common::mint::MeltSagaState::Finalizing)
+    );
+    assert_eq!(
+        saga.finalization_data.unwrap().total_spent,
+        Amount::new(9_000_001, CurrencyUnit::Msat)
+    );
+    let states = mint
+        .localstore()
+        .get_proofs_states(&input_ys)
+        .await
+        .unwrap();
+    assert!(states
+        .iter()
+        .all(|state| *state == Some(cdk_common::State::Pending)));
+
+    // Recovery may convert the preserved backend amount, but must never refund
+    // proofs for a payment whose synchronous response was already paid.
+    let checked = mint.check_melt_quote(&quote.id).await.unwrap();
+    assert_eq!(checked.state(), MeltQuoteState::Paid);
+    let states = mint
+        .localstore()
+        .get_proofs_states(&input_ys)
+        .await
+        .unwrap();
+    assert!(states
+        .iter()
+        .all(|state| *state == Some(cdk_common::State::Spent)));
+}
+
+#[tokio::test]
+async fn status_check_rounds_msat_spend_up_before_signing_change() {
+    let mut backend = NoEventPendingBackend::new(2, Some(MeltQuoteState::Paid));
+    backend.spent_msat = Some(9_000_001);
+    let mint = create_pending_test_mint(Arc::new(backend)).await.unwrap();
+    let proofs = mint_test_proofs(&mint, Amount::from(10_000)).await.unwrap();
+    let quote = create_test_melt_quote(&mint, Amount::from(9_000)).await;
+    let (outputs, _) =
+        crate::test_helpers::mint::create_test_blinded_messages(&mint, Amount::from(1_023))
+            .await
+            .unwrap();
+    let request = cdk_common::nuts::MeltRequest::new(quote.id.clone(), proofs, Some(outputs));
+
+    let pending = mint.melt(&request).await.unwrap();
+    let checked = mint.check_melt_quote(&quote.id).await.unwrap();
+    assert_eq!(checked.state(), MeltQuoteState::Paid);
+    let response = pending.await.unwrap();
+    let change = response.change().expect("payment should leave change");
+    assert_eq!(
+        Amount::try_sum(change.iter().map(|sig| sig.amount)).unwrap(),
+        Amount::from(999)
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Round BOLT11 and BOLT12 quote principals up to whole sats. Return payment totals in the quote unit, rounding principal plus actual fees up once. Keep native-unit status checks and ceiling conversion during mint recovery.

Validate the unit on synchronous paid responses while preserving the paid handoff on mismatch so input proofs cannot be released after payment.

Cover quote boundaries, synchronous and reconciled CLN responses, LDK combined totals, wrong-unit recovery, and change rounding in status checks. Adapter and pending-payment tests, formatting, and spelling checks pass. Clippy passes with the existing wallet recursion warning.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

-----

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

#### REMOVED

#### FIXED

----

### Checklist

* [ ] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just quick-check` before committing
* [ ] If the Wallet API was modified (added/removed/changed), I have reflected those changes in the FFI bindings (`crates/cdk-ffi`)
