### PR TITLE
fix(wallet): validate mint signatures when receiving proofs

### DIFF
--- a/crates/cdk/src/wallet/receive/saga/mod.rs
+++ b/crates/cdk/src/wallet/receive/saga/mod.rs
@@ -51,6 +51,9 @@ use crate::nuts::nut00::ProofsMethods;
 use crate::nuts::nut10::Kind;
 use crate::nuts::{Conditions, Proofs, PublicKey, SecretKey, SigFlag, State};
 use crate::util::hex;
+use crate::wallet::blind_signature::{
+    validate_mint_response_signatures, SignatureAmountValidation,
+};
 use crate::wallet::saga::{
     add_compensation, clear_compensations, execute_compensations, new_compensations, Compensations,
 };
@@ -424,6 +427,20 @@ impl<'a> ReceiveSaga<'a, Prepared> {
             }
         };
 
+        // Preserve the pending saga on an invalid response: the mint may have
+        // already spent the inputs, so recovery must still be able to retry.
+        validate_mint_response_signatures(
+            self.wallet,
+            &swap_response.signatures,
+            pre_swap
+                .pre_mint_secrets
+                .secrets
+                .iter()
+                .map(|premint| &premint.blinded_message),
+            SignatureAmountValidation::Exact,
+        )
+        .await?;
+
         let recv_proofs = construct_proofs(
             swap_response.signatures,
             pre_swap.pre_mint_secrets.rs(),
@@ -544,5 +561,197 @@ impl<S: std::fmt::Debug> std::fmt::Debug for ReceiveSaga<'_, S> {
         f.debug_struct("ReceiveSaga")
             .field("state_data", &self.state_data)
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use cdk_common::wallet::{ReceiveSagaState, TransactionId, TransactionStatus, WalletSagaState};
+
+    use crate::amount::SplitTarget;
+    use crate::dhke::{hash_to_curve, sign_message};
+    use crate::nuts::{BlindSignature, PreMintSecrets, Proof, SecretKey, State, SwapResponse};
+    use crate::wallet::test_utils::{
+        create_test_db, create_test_wallet_with_mock_seed, test_keyset_id, test_proof,
+        MockMintConnector,
+    };
+    use crate::wallet::ReceiveOptions;
+    use crate::{Amount, Error, Wallet};
+
+    async fn receive_fixture() -> (Wallet, Arc<MockMintConnector>, Proof, BlindSignature) {
+        let db = create_test_db().await;
+        let mock = Arc::new(MockMintConnector::new());
+        mock.enable_mint_signing();
+        let keyset_id = mock.keysets.lock().unwrap()[0].id;
+        let seed = [42; 64];
+        let wallet = create_test_wallet_with_mock_seed(db, mock.clone(), seed).await;
+        let amount = Amount::from(2);
+        let mint_key = mock.mint_signing_keys.lock().unwrap().as_ref().unwrap()[&amount].clone();
+
+        let mut input = test_proof(keyset_id, 2);
+        input.c =
+            sign_message(&mint_key, &hash_to_curve(input.secret.as_bytes()).unwrap()).unwrap();
+
+        let premints = PreMintSecrets::restore_batch(keyset_id, &seed, 0, 1).unwrap();
+        let blinded_message = premints.blinded_messages()[0].blinded_secret;
+        let signature = BlindSignature::new(
+            amount,
+            sign_message(&mint_key, &blinded_message).unwrap(),
+            keyset_id,
+            &blinded_message,
+            &mint_key,
+        )
+        .unwrap();
+
+        (wallet, mock, input, signature)
+    }
+
+    async fn receive_response(
+        wallet: &Wallet,
+        mock: &MockMintConnector,
+        input: &Proof,
+        signatures: Vec<BlindSignature>,
+    ) -> Result<Amount, Error> {
+        mock.set_post_swap_response(Ok(SwapResponse { signatures }));
+        wallet
+            .receive_proofs(
+                vec![input.clone()],
+                ReceiveOptions {
+                    amount_split_target: SplitTarget::Values(vec![Amount::from(2)]),
+                    ..Default::default()
+                },
+                None,
+                None,
+            )
+            .await
+    }
+
+    async fn assert_receive_pending(wallet: &Wallet, input: &Proof) {
+        assert_eq!(wallet.total_balance().await.unwrap(), Amount::ZERO);
+        let sagas = wallet.localstore.get_incomplete_sagas().await.unwrap();
+        assert_eq!(sagas.len(), 1);
+        assert_eq!(
+            sagas[0].state,
+            WalletSagaState::Receive(ReceiveSagaState::SwapRequested)
+        );
+        let proofs = wallet
+            .localstore
+            .get_reserved_proofs(&sagas[0].id)
+            .await
+            .unwrap();
+        assert_eq!(proofs.len(), 1);
+        assert_eq!(proofs[0].proof, *input);
+        assert_eq!(proofs[0].state, State::Pending);
+        let transaction = wallet
+            .localstore
+            .get_transaction(TransactionId::from_saga_id(sagas[0].id))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(transaction.status, TransactionStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn test_receive_rejects_invalid_dleq_and_preserves_recovery() {
+        let (wallet, mock, input, valid_signature) = receive_fixture().await;
+        let mut invalid_signature = valid_signature.clone();
+        invalid_signature.dleq.as_mut().unwrap().e = SecretKey::from_slice(&[3; 32]).unwrap();
+
+        let result = receive_response(&wallet, &mock, &input, vec![invalid_signature]).await;
+        assert!(
+            matches!(result, Err(Error::CouldNotVerifyDleq)),
+            "{result:?}"
+        );
+        assert_receive_pending(&wallet, &input).await;
+
+        // The mint may have spent the inputs even though its response was invalid.
+        // Keep the request so recovery can obtain valid signatures later.
+        mock.set_post_swap_response(Ok(SwapResponse {
+            signatures: vec![valid_signature],
+        }));
+        let report = wallet.recover_incomplete_sagas().await.unwrap();
+        assert_eq!(report.recovered, 1);
+        assert_eq!(wallet.total_balance().await.unwrap(), Amount::from(2));
+        assert!(wallet
+            .localstore
+            .get_incomplete_sagas()
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_receive_rejects_signature_with_mismatched_amount() {
+        let (wallet, mock, input, mut signature) = receive_fixture().await;
+        signature.amount = Amount::from(1);
+        signature.dleq = None;
+
+        let result = receive_response(&wallet, &mock, &input, vec![signature]).await;
+        assert!(
+            matches!(result, Err(Error::InvalidMintResponse(_))),
+            "{result:?}"
+        );
+        assert_receive_pending(&wallet, &input).await;
+    }
+
+    #[tokio::test]
+    async fn test_receive_rejects_signature_with_mismatched_keyset() {
+        let (wallet, mock, input, mut signature) = receive_fixture().await;
+        signature.keyset_id = test_keyset_id();
+        signature.dleq = None;
+
+        let result = receive_response(&wallet, &mock, &input, vec![signature]).await;
+        assert!(
+            matches!(result, Err(Error::InvalidMintResponse(_))),
+            "{result:?}"
+        );
+        assert_receive_pending(&wallet, &input).await;
+    }
+
+    #[tokio::test]
+    async fn test_receive_rejects_signature_count_mismatch() {
+        for extra_signature in [false, true] {
+            let (wallet, mock, input, signature) = receive_fixture().await;
+            let signatures = match extra_signature {
+                true => vec![signature.clone(), signature],
+                false => vec![],
+            };
+            let result = receive_response(&wallet, &mock, &input, signatures).await;
+            assert!(
+                matches!(result, Err(Error::InvalidMintResponse(_))),
+                "{result:?}"
+            );
+            assert_receive_pending(&wallet, &input).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_receive_accepts_valid_signatures_with_optional_dleq() {
+        for include_dleq in [true, false] {
+            let (wallet, mock, input, mut signature) = receive_fixture().await;
+            if !include_dleq {
+                signature.dleq = None;
+            }
+
+            let amount = receive_response(&wallet, &mock, &input, vec![signature])
+                .await
+                .unwrap();
+            assert_eq!(amount, Amount::from(2));
+            assert_eq!(wallet.total_balance().await.unwrap(), amount);
+            assert!(wallet
+                .localstore
+                .get_incomplete_sagas()
+                .await
+                .unwrap()
+                .is_empty());
+            let proofs = wallet.get_unspent_proofs().await.unwrap();
+            assert_eq!(proofs.len(), 1);
+            let mint_key =
+                mock.mint_signing_keys.lock().unwrap().as_ref().unwrap()[&amount].clone();
+            crate::dhke::verify_message(&mint_key, proofs[0].c, proofs[0].secret.as_bytes())
+                .unwrap();
+        }
     }
 }


### PR DESCRIPTION
### Description

Receiving ecash could accept a mint swap response with an invalid DLEQ proof or a mismatched amount or keyset, credit unusable proofs, and delete the recovery record. Validate returned blind signatures against the requested outputs before constructing or storing proofs.

Invalid responses now leave the receive saga and transaction pending so recovery can obtain valid signatures later. Valid responses remain supported with or without optional DLEQ proofs.

### Notes to the reviewers

Reproduced on upstream main `e294f845` before applying the fix. Five regression tests cover invalid DLEQ proofs, amount/keyset/count mismatches, preserved recovery, and valid responses with and without DLEQ proofs. This is independent of #2516, which adds Nostr payment-request validation and operation linkage.

Local validation:

- `cargo fmt --all -- --check`
- `cargo clippy -p cdk --all-targets --offline -- -D warnings`
- `cargo test -p cdk --lib --offline`: 693 tests passed in the sandbox; the three tests requiring local TCP listeners passed when rerun with the necessary permissions (696 total).

### Suggested CHANGELOG Updates

#### FIXED

- Validate mint-returned blind signatures when receiving ecash and preserve recovery state after rejecting an invalid response.

### Checklist

- [x] I followed the code style guidelines.
- [ ] I ran `just quick-check` before committing. Scoped formatting, Clippy, and CDK library tests were run as listed above.
- [x] FFI synchronization checked: no public Wallet API signatures or types changed.
